### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd-platform-production.yaml
+++ b/.github/workflows/cd-platform-production.yaml
@@ -1,5 +1,8 @@
 name: CD - Deploy Platform to Production
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Vectreal/vectreal-platform/security/code-scanning/8](https://github.com/Vectreal/vectreal-platform/security/code-scanning/8)

To fix the problem, explicitly declare `permissions` to restrict the `GITHUB_TOKEN` to the least privilege required. When in doubt and to avoid altering existing behavior, the safest non-breaking starting point is to set read-only permissions for repository contents (`contents: read`), which matches GitHub’s recommended minimal default and is sufficient for most deployment workflows that only need to fetch code or artifacts.

Given the limited context and to avoid accidentally revoking needed write permissions, the best low-risk fix here is:
- Add a `permissions:` block at the workflow root (so it applies to all jobs without their own `permissions`), directly under `name:` and before `on:`.  
- Set `contents: read`, which documents that this workflow only needs read access to repository contents and ensures the token will not gain broader write permissions if defaults change.

Concretely, in `.github/workflows/cd-platform-production.yaml`:
- Insert:

```yaml
permissions:
  contents: read
```

between line 2 (the blank line after `name`) and line 3 (`on:`).  
No imports or additional methods are needed, since this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
