### PR TITLE
docs: add contributor onboarding files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug Report
+description: Report a reproducible bug in Vectreal Platform or the published packages
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill in as much detail as possible.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project is affected?
+      options:
+        - Platform app (vectreal.com)
+        - "@vctrl/viewer package"
+        - "@vctrl/hooks package"
+        - "@vctrl/core package"
+        - Documentation
+        - CI / Infrastructure
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: "When I do X, Y happens instead of Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Numbered steps to reproduce the issue reliably.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: "I expected ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      placeholder: "Instead, ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in all that apply.
+      value: |
+        - OS:
+        - Browser (if platform app):
+        - Node.js version:
+        - pnpm version:
+        - Package version (if applicable):
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Paste any relevant console output, error messages, or attach screenshots.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/A9a3nPkZw7
+    about: Ask questions and get help from the community
+  - name: Documentation
+    url: https://vectreal.com/docs
+    about: Read the full documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to make Vectreal better? We would love to hear it.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Platform app (vectreal.com)
+        - "@vctrl/viewer package"
+        - "@vctrl/hooks package"
+        - "@vctrl/core package"
+        - Documentation
+        - CI / Infrastructure
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this solve? What is the current limitation?
+      placeholder: "Currently there is no way to ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature or change you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you have tried.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to submit a PR for this feature

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+Closes #<!-- issue number -->
+
+## Changes
+
+<!-- Bullet list of the key changes made. -->
+
+- 
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking, fixes an issue)
+- [ ] New feature (non-breaking, adds functionality)
+- [ ] Breaking change (existing functionality changes)
+- [ ] Documentation update
+- [ ] Refactor / chore (no functional change)
+
+## Testing
+
+<!-- Describe how you tested this change. -->
+
+- [ ] Unit / integration tests added or updated
+- [ ] Tested manually in the browser
+- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
+- [ ] No tests required (explain why)
+
+## Checklist
+
+- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+- [ ] `pnpm nx affected --target=lint` passes
+- [ ] `pnpm nx affected --target=typecheck` passes
+- [ ] `pnpm nx affected --target=test` passes
+- [ ] I updated documentation where needed
+- [ ] I linked the related issue above

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,77 +1,160 @@
 # Contributing to Vectreal Platform
 
-We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
+Thank you for your interest in contributing! This guide will get you from zero to an open PR in under 30 minutes.
 
-- Reporting a bug
-- Discussing the current state of the code
-- Submitting a fix
-- Proposing new features
-- Becoming a maintainer
+***
 
-> For a complete contribution guide, see **[vectreal.com/docs/contributing](https://vectreal.com/docs/contributing)**.
+## Prerequisites
 
-## We Develop with GitHub
+| Tool         | Minimum version | Install                            |
+| ------------ | --------------- | ---------------------------------- |
+| Node.js      | >= 22.x (LTS)  | [nodejs.org](https://nodejs.org)   |
+| pnpm         | >= 10.x        | `npm i -g pnpm`                    |
+| Docker       | any recent      | [docker.com](https://docker.com)   |
+| Supabase CLI | latest          | `npm i -g supabase`                |
+| Git          | any recent      | [git-scm.com](https://git-scm.com) |
 
-We use GitHub to host code, track issues and feature requests, and accept pull requests.
+Optional but recommended: [Nx Console](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) extension for VS Code.
 
-## All Code Changes Happen Through Pull Requests
+***
 
-Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
+## Quick Start (30 minutes or less)
 
-1. Fork the repo and create your branch from `main`.
-2. If you've added code that should be tested, add tests.
-3. If you've changed APIs or added routes/env vars, update the documentation.
-4. Ensure the test suite passes: `pnpm nx affected --target=test`
-5. Make sure your code lints: `pnpm nx affected --target=lint`
-6. Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for your commit messages.
-7. Issue that pull request and link relevant issues and labels!
+```bash
+# 1. Fork then clone your fork
+git clone https://github.com/<your-username>/vectreal-platform.git
+cd vectreal-platform
 
-## Working with Nx
+# 2. Install all workspace dependencies
+pnpm install
 
-1. Always run commands from the repository root.
-2. To run packages/apps: `pnpm nx run <project-name>:<target>` (e.g. `pnpm nx serve vectreal-platform`)
-3. To see all targets for a project: `pnpm nx show project <project-name> --web`
-4. Install the [Nx Console](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) extension for VS Code for a visual interface.
+# 3. Copy the environment template
+cp .env.development.example .env.development
+# Set at minimum: CSRF_SECRET (any long random string)
+# SUPABASE_URL and SUPABASE_KEY will be filled after step 4
 
-## Release ownership and version policy
+# 4. Start local Supabase (requires Docker)
+pnpm supabase start
+# Copy the printed anon key and API URL into .env.development
+
+# 5. Apply DB migrations
+pnpm nx run vectreal-platform:supabase-db-reset
+
+# 6. Start the dev server
+pnpm nx dev vectreal-platform
+# Open http://localhost:4200
+```
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for deeper setup, package workflows, and troubleshooting.
+
+***
+
+## Branching Strategy
+
+| Branch                | Purpose                        |
+| --------------------- | ------------------------------ |
+| `main`                | Production-ready; auto-deploys |
+| `feat/<description>`  | New features                   |
+| `fix/<description>`   | Bug fixes                      |
+| `chore/<description>` | Tooling/config                 |
+| `docs/<description>`  | Docs only                      |
+
+Branch from `main` and open your PR back to `main`.
+
+***
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Release Please reads these to auto-generate changelogs.
+
+```
+<type>(<scope>): <short summary>
+```
+
+**Types:** `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`, `ci`
+
+**Scopes:** `viewer`, `hooks`, `core`, `platform`, `infra`, `docs`
+
+Examples:
+
+```
+feat(viewer): add USDZ drag-and-drop support
+fix(core): handle missing normals in OBJ exporter
+docs: expand local setup guide
+```
+
+Breaking changes: add `!` after the type, e.g. `feat(hooks)!: rename useLoadModel return shape`.
+
+***
+
+## Making Changes
+
+1. Create a branch from `main`.
+2. Write code following existing patterns (Tailwind, Radix/Shadcn, Jotai).
+3. Add or update tests:
+   ```bash
+   pnpm nx affected --target=test
+   ```
+4. Lint and type-check:
+   ```bash
+   pnpm nx affected --target=lint
+   pnpm nx affected --target=typecheck
+   ```
+5. Update docs if you changed a public API, added env vars, or changed a route.
+
+***
+
+## Pull Requests
+
+* Fill in the PR template completely.
+* Link issues with `Closes #<number>` or `Fixes #<number>`.
+* Keep PRs focused: one feature or fix per PR.
+* All CI checks must pass before merge.
+
+***
+
+## Monorepo Commands
+
+```bash
+# Run a target on a specific project
+pnpm nx run <project>:<target>
+
+# Run on all affected projects
+pnpm nx affected --target=<target>
+
+# Explore available targets
+pnpm nx show project <project-name> --web
+
+# Clear Nx cache
+pnpm nx reset
+```
+
+***
+
+## Release Ownership and Version Policy
 
 1. Release Please is the single source of truth for package versions, changelog entries, tags, and GitHub releases.
 2. The canonical package version state is stored in `.release-please-manifest.json` and configured by `release-please-config.json`.
 3. Nx is used to run build and publish targets only. Do not use `nx release` in this repository.
 4. Internal dependencies between co-developed packages must use `workspace:*` unless there is a documented exception.
 5. The app at `apps/vectreal-platform` uses `workspace:*` for `@vctrl/*` dependencies to stay lockstep with local package development.
-6. Published package install compatibility should be validated in a dedicated internal consumer test app/pipeline that installs `@vctrl/*` from the registry.
 
-## Editing documentation
+***
 
-Every docs page on [vectreal.com/docs](https://vectreal.com/docs) is an MDX file in `apps/vectreal-platform/app/routes/docs/`. Click **Edit on GitHub** on any page to jump directly to the source file.
+## Editing Docs
+
+Every page on [vectreal.com/docs](https://vectreal.com/docs) is an MDX file in `apps/vectreal-platform/app/routes/docs/`. Click **Edit on GitHub** on any docs page to jump directly to the source file.
 
 To add a new docs page, see the instructions in [`apps/vectreal-platform/README.md`](apps/vectreal-platform/README.md#docs).
 
-## Any contributions you make will be under the License
+***
 
-In short, when you submit code changes, your submissions are understood to be under the same [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.en.html) that covers the project. Feel free to contact the maintainers if that's a concern.
+## Reporting Bugs
 
-## Report bugs using GitHub Issues
+Use [GitHub Issues](https://github.com/Vectreal/vectreal-platform/issues/new/choose) and select the Bug Report template. Include: steps to reproduce, expected vs actual behavior, environment details, and any console output.
 
-We use [GitHub Issues](https://github.com/Vectreal/vectreal-platform/issues) to track public bugs. Report a bug by [opening a new issue](https://github.com/Vectreal/vectreal-platform/issues/new).
+***
 
-## Write bug reports with detail, background, and sample code
+## License
 
-**Great Bug Reports** tend to have:
-
-- A quick summary and/or background
-- Steps to reproduce
-  - Be specific!
-  - Give sample code if you can.
-- What you expected would happen
-- What actually happens
-- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
-
-## Coding Style
-
-Run `pnpm nx affected --target=lint` to check for lint errors before opening a PR.
-
-## GNU Affero General Public License
-
-By contributing, you agree that your contributions will be licensed under the [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.en.html).
+By contributing, you agree your contributions are licensed under [AGPL-3.0](LICENSE.md). Open an issue before contributing if you have concerns about AGPL requirements.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,214 @@
+# Development Guide
+
+This guide covers everything you need to develop, test, and build the Vectreal Platform locally.
+
+***
+
+## Prerequisites
+
+| Tool         | Version    | Notes                             |
+| ------------ | ---------- | --------------------------------- |
+| Node.js      | >= 22.x   | Use nvm or fnm to manage versions |
+| pnpm         | >= 10.x   | `npm i -g pnpm`                   |
+| Docker       | any recent | Required for local Supabase       |
+| Supabase CLI | latest     | `npm i -g supabase`               |
+
+***
+
+## First-Time Setup
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/Vectreal/vectreal-platform.git
+cd vectreal-platform
+pnpm install
+```
+
+### 2. Environment configuration
+
+```bash
+cp .env.development.example .env.development
+```
+
+Open `.env.development` and configure:
+
+**Required (minimum for local dev):**
+
+| Variable       | How to get it                                                               |
+| -------------- | --------------------------------------------------------------------------- |
+| `SUPABASE_URL` | Printed by `pnpm supabase start` (API URL)                                  |
+| `SUPABASE_KEY` | Printed by `pnpm supabase start` (anon key)                                 |
+| `DATABASE_URL` | Auto-constructed: `postgresql://postgres:postgres@localhost:54322/postgres` |
+| `CSRF_SECRET`  | Any long random string, e.g. `openssl rand -hex 32`                         |
+
+**Optional (for full feature coverage):**
+
+| Variable                                    | Purpose                                                |
+| ------------------------------------------- | ------------------------------------------------------ |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth login                                     |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | GitHub OAuth login                                     |
+| `STRIPE_SECRET_KEY`                         | Billing features                                       |
+| `GOOGLE_CLOUD_STORAGE_*`                    | File upload/download (set to empty to disable locally) |
+
+### 3. Start Supabase
+
+```bash
+pnpm supabase start
+```
+
+This starts a local Postgres + Supabase stack via Docker. After startup, copy the printed **API URL** and **anon key** into `.env.development`.
+
+Access Supabase Studio at `http://localhost:54323`.
+
+### 4. Apply migrations
+
+```bash
+pnpm nx run vectreal-platform:supabase-db-reset
+```
+
+This drops and re-creates the local database and applies all migrations from `apps/vectreal-platform/supabase/migrations/`.
+
+### 5. Start the dev server
+
+```bash
+pnpm nx dev vectreal-platform
+```
+
+App is available at `http://localhost:4200` with HMR enabled.
+
+***
+
+## Common Commands
+
+### Dev server
+
+```bash
+pnpm nx dev vectreal-platform           # Start app with HMR
+pnpm nx build vectreal-platform         # Production build
+pnpm nx typecheck vectreal-platform     # Type-check app only
+```
+
+### Packages
+
+```bash
+pnpm nx build @vctrl/viewer             # Build viewer package
+pnpm nx build @vctrl/hooks              # Build hooks package
+pnpm nx build @vctrl/core               # Build core package
+pnpm nx storybook @vctrl/viewer         # Run Storybook for viewer
+```
+
+### Testing
+
+```bash
+pnpm nx affected --target=test          # Test all affected projects
+pnpm nx test vectreal-platform          # Test app only
+pnpm nx test @vctrl/core                # Test core package only
+pnpm nx e2e vectreal-platform-e2e       # Run Playwright E2E tests
+```
+
+### Code quality
+
+```bash
+pnpm nx affected --target=lint          # Lint affected projects
+pnpm nx affected --target=typecheck     # Type-check affected projects
+```
+
+### Database
+
+```bash
+# Generate SQL migration from Drizzle schema changes
+pnpm nx run vectreal-platform:drizzle-generate
+
+# Reset local DB (drops + re-applies all migrations)
+pnpm nx run vectreal-platform:supabase-db-reset
+
+# Start/stop local Supabase
+pnpm supabase start
+pnpm supabase stop
+```
+
+### NX utilities
+
+```bash
+pnpm nx show project <name> --web       # Visual task graph for a project
+pnpm nx graph                           # Full workspace dependency graph
+pnpm nx reset                           # Clear Nx cache
+pnpm nx affected --target=build --dry-run  # Preview what would run
+```
+
+***
+
+## Repo Structure
+
+```
+vectreal-platform/
+├── apps/
+│   └── vectreal-platform/    # Full-stack React Router v7 app
+│       ├── app/
+│       │   ├── routes/       # File-based routes (docs, dashboard, publisher, preview)
+│       │   ├── components/   # UI components (Shadcn/Radix based)
+│       │   ├── db/           # Drizzle ORM schemas + queries
+│       │   └── hooks/        # App-level React hooks
+│       ├── supabase/         # Migrations + config
+│       └── Dockerfile
+├── packages/
+│   ├── core/                 # @vctrl/core — server-side 3D processing
+│   ├── hooks/                # @vctrl/hooks — React hooks for 3D
+│   └── viewer/               # @vctrl/viewer — React 3D viewer component
+├── shared/                   # Shared UI components and utilities
+├── terraform/                # GCP infrastructure (Cloud Run, GCS, CDN)
+├── .github/workflows/        # CI/CD pipelines
+└── prd/                      # Product requirements docs
+```
+
+***
+
+## Working with Packages vs the App
+
+The three `packages/` projects (`@vctrl/core`, `@vctrl/hooks`, `@vctrl/viewer`) are publishable npm packages. They are also consumed by the platform app.
+
+* Changes to packages are picked up by the app automatically via pnpm workspace linking — no need to rebuild packages during local development.
+* When building for release, Nx runs packages through Rollup before the app build.
+* Run `pnpm nx storybook @vctrl/viewer` to develop viewer components in isolation.
+
+***
+
+## CI/CD Pipelines
+
+| Workflow                      | Trigger         | What it does                           |
+| ----------------------------- | --------------- | -------------------------------------- |
+| `ci-quality.yaml`             | Every PR + push | Lint + typecheck + test                |
+| `cd-packages-release.yaml`    | Push to `main`  | Release Please changelog + npm publish |
+| `cd-platform-staging.yaml`    | Push to `main`  | Deploy to staging Cloud Run            |
+| `cd-platform-production.yaml` | Release tag     | Deploy to production Cloud Run         |
+| `cd-chromatic-viewer.yaml`    | Push            | Visual regression via Chromatic        |
+
+All PRs must pass `ci-quality.yaml` before merge.
+
+***
+
+## Troubleshooting
+
+**`pnpm supabase start` hangs or fails**
+
+* Ensure Docker Desktop is running.
+* Try `pnpm supabase stop --no-backup` then restart.
+
+**Port 4200 already in use**
+
+* Change `VITE_DEV_PORT` in `.env.development`.
+
+**`supabase-db-reset` fails with connection error**
+
+* Confirm Supabase is running: `pnpm supabase status`.
+* Check `DATABASE_URL` in `.env.development` matches the port printed by `supabase status`.
+
+**Nx cache gives stale results**
+
+* Run `pnpm nx reset` to clear the cache.
+
+**TypeScript errors after pulling latest changes**
+
+* Run `pnpm install` — a new package may have been added.
+* Then `pnpm nx reset` if errors persist.


### PR DESCRIPTION
## Summary

Adds comprehensive contributor onboarding documentation created in [VECA-4](/VECA/issues/VECA-4). A new contributor should be able to run the project locally and open a meaningful PR within 30 minutes.

## Changes

- **CONTRIBUTING.md** — expanded with quick-start guide (6 steps), branching strategy table, Conventional Commits guide, PR checklist, and updated release policy section
- **DEVELOPMENT.md** — new file covering full local setup, all common Nx/pnpm commands, repo structure overview, CI/CD pipeline table, and troubleshooting section
- **.github/ISSUE_TEMPLATE/bug_report.yml** — structured bug report form with area dropdown, reproduction steps, environment fields
- **.github/ISSUE_TEMPLATE/feature_request.yml** — structured feature request form
- **.github/ISSUE_TEMPLATE/config.yml** — disables blank issues, adds Discord and docs contact links
- **.github/pull_request_template.md** — PR template with summary, change type, testing, and checklist sections

## Test plan

- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify DEVELOPMENT.md local setup steps work end-to-end
- [ ] Open a new GitHub Issue and confirm templates appear in the chooser
- [ ] Open a new PR and confirm the PR template loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)