### PR TITLE
feat(viewer): add accumulative shadow baking features and related components

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
+++ b/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
@@ -75,7 +75,8 @@ const OverlayControls = ({
 	// and updated by the shell-level SceneNameAndLocation picker.
 	const saveLocationTarget = useAtomValue(saveLocationAtom)
 	const { hasUnsavedLocationChange } = useLocationChangeState()
-	const { requestSceneScreenshot } = usePublisherViewerCapture()
+	const { requestSceneScreenshot, requestShadowBake } =
+		usePublisherViewerCapture()
 
 	// Centralized scene loader - single source of truth (must be inside ModelProvider)
 	const { saveSceneSettings, saveAvailability, persistPendingSceneDraft } =
@@ -84,7 +85,8 @@ const OverlayControls = ({
 			userId: user?.id,
 			initialSceneAggregate: sceneAggregate as SceneAggregateResponse | null,
 			sceneMeta: sceneAggregate?.meta ?? null,
-			requestSceneScreenshot
+			requestSceneScreenshot,
+			requestShadowBake
 		})
 
 	const {

--- a/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
@@ -4,6 +4,7 @@ import { useAtom, useAtomValue } from 'jotai/react'
 import { memo, useCallback, useEffect, useRef, useState, type FC } from 'react'
 import * as THREE from 'three'
 
+import { PublisherViewCube } from './publisher-view-cube'
 import { usePublisherViewerCapture } from './publisher-viewer-capture-context'
 import {
 	isClickToPlaceActiveAtom,
@@ -392,6 +393,8 @@ export const PublisherEditorScene = memo(() => {
 				activeHotspotId={activeHotspotId}
 				onPlace={handlePlaceHotspot}
 			/>
+
+			<PublisherViewCube />
 		</>
 	)
 })

--- a/apps/vectreal-platform/app/components/publisher/publisher-view-cube.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-view-cube.tsx
@@ -1,0 +1,38 @@
+import { GizmoHelper, GizmoViewcube } from '@react-three/drei'
+import { useAtomValue } from 'jotai/react'
+
+import { shadowsAtom } from '../../lib/stores/scene-settings-store'
+
+/**
+ * Orientation cube for the publisher's editing canvas — click a face to snap the
+ * camera to an absolute view. Lives in the app (not `@vctrl/viewer`) so the
+ * published viewer package stays slim; rendered inside the viewer's Canvas as a
+ * child via PublisherEditorScene.
+ */
+export const PublisherViewCube = () => {
+	const shadows = useAtomValue(shadowsAtom)
+	// drei's Hud re-renders the whole scene at renderPriority 1, which would
+	// clobber the AO EffectComposer (also priority 1) the viewer mounts when AO is
+	// on. At priority 2 the Hud skips that scene re-render and just overlays the
+	// cube on top of the composed frame. Mirror the viewer's AO gate so the cube
+	// and postprocessing coexist; without AO there's no composer, so 1 is correct.
+	const aoEnabled =
+		(shadows?.enabled ?? false) &&
+		shadows?.type === 'accumulative' &&
+		(shadows.ao ?? false)
+
+	return (
+		<GizmoHelper
+			alignment="bottom-left"
+			margin={[72, 72]}
+			renderPriority={aoEnabled ? 2 : 1}
+		>
+			<GizmoViewcube
+				color="#f4f4f5"
+				textColor="#52525b"
+				strokeColor="#d4d4d8"
+				hoverColor="#fbbf24"
+			/>
+		</GizmoHelper>
+	)
+}

--- a/apps/vectreal-platform/app/components/publisher/publisher-viewer-capture-context.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-viewer-capture-context.tsx
@@ -13,6 +13,8 @@ import type {
 	SceneCameraSnapshotCapture,
 	SceneScreenshotCapture,
 	SceneScreenshotOptions,
+	ShadowBakeCapture,
+	ShadowBakeResult,
 	ViewerCommandExecutor
 } from '@vctrl/viewer'
 
@@ -27,6 +29,8 @@ interface PublisherViewerCaptureContextValue {
 		capture: null | SceneCameraSnapshotCapture
 	) => void
 	requestSceneCameraSnapshot: () => Promise<null | SceneCameraSnapshot>
+	registerShadowBakeCapture: (capture: null | ShadowBakeCapture) => void
+	requestShadowBake: () => Promise<null | ShadowBakeResult>
 	registerCommandExecutor: (executor: null | ViewerCommandExecutor) => void
 	commandExecutor: MutableRefObject<null | ViewerCommandExecutor>
 }
@@ -72,6 +76,19 @@ export function PublisherViewerCaptureProvider({
 			: null
 	}, [])
 
+	const shadowBakeCaptureRef = useRef<null | ShadowBakeCapture>(null)
+
+	const registerShadowBakeCapture = useCallback(
+		(capture: null | ShadowBakeCapture) => {
+			shadowBakeCaptureRef.current = capture
+		},
+		[]
+	)
+
+	const requestShadowBake = useCallback(async () => {
+		return shadowBakeCaptureRef.current ? shadowBakeCaptureRef.current() : null
+	}, [])
+
 	const registerCommandExecutor = useCallback(
 		(executor: null | ViewerCommandExecutor) => {
 			commandExecutorRef.current = executor
@@ -85,6 +102,8 @@ export function PublisherViewerCaptureProvider({
 			requestSceneScreenshot,
 			registerSceneCameraSnapshotCapture,
 			requestSceneCameraSnapshot,
+			registerShadowBakeCapture,
+			requestShadowBake,
 			registerCommandExecutor,
 			commandExecutor: commandExecutorRef
 		}),
@@ -93,6 +112,8 @@ export function PublisherViewerCaptureProvider({
 			requestSceneScreenshot,
 			registerSceneCameraSnapshotCapture,
 			requestSceneCameraSnapshot,
+			registerShadowBakeCapture,
+			requestShadowBake,
 			registerCommandExecutor
 		]
 	)

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/constants.ts
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/constants.ts
@@ -1,50 +1,203 @@
 import { defaultShadowOptions } from '../../../../../constants/viewer-defaults'
-import { valueMappings } from '../../../../../lib/utils/value-mapping'
 
 import type { FieldConfig } from '../../../../../types/settings-field'
 
 export type { FieldConfig }
 
-// ─── Contact shadow fields ───────────────────────────────────────────────────
+// ─── Accumulative shadow fields ──────────────────────────────────────────────
 
-/** Primary contact shadow controls shown by default */
-export const CONTACT_PRIMARY_FIELDS: FieldConfig[] = [
+// "Darkness" drives the bake light's ambient fill (drei RandomizedLight.ambient),
+// inverted: more darkness = less hemisphere fill under the model = deeper, blacker
+// shadow core. Ambient is clamped to this range — never 0 (keeps a little softness)
+// and never so high the shadow washes out. The virtual "darkness" slider value
+// (0..1) is mapped to/from ambient in the panel.
+export const SHADOW_AMBIENT_DARKEST = 0.05
+export const SHADOW_AMBIENT_LIGHTEST = 0.6
+
+/** Convert the 0..1 Darkness slider value to a RandomizedLight ambient value. */
+export const darknessToAmbient = (darkness: number) =>
+	SHADOW_AMBIENT_LIGHTEST -
+	(SHADOW_AMBIENT_LIGHTEST - SHADOW_AMBIENT_DARKEST) * darkness
+
+/** Inverse of {@link darknessToAmbient}. */
+export const ambientToDarkness = (ambient: number) =>
+	(SHADOW_AMBIENT_LIGHTEST - ambient) /
+	(SHADOW_AMBIENT_LIGHTEST - SHADOW_AMBIENT_DARKEST)
+
+/** Virtual field key handled specially in the panel (maps to light.ambient). */
+export const SHADOW_DARKNESS_KEY = 'darkness'
+
+/** Primary shadow controls shown by default */
+export const SHADOW_PRIMARY_FIELDS: FieldConfig[] = [
 	{
 		key: 'opacity',
 		label: 'Opacity',
 		min: 0,
 		max: 1,
 		step: 0.01,
-		tooltip: 'Shadow opacity.',
+		tooltip: 'Overall shadow strength.',
 		formatValue: (value) => value.toFixed(2)
 	},
 	{
-		key: 'blur',
-		label: 'Blur',
+		key: SHADOW_DARKNESS_KEY,
+		label: 'Darkness',
 		min: 0,
 		max: 1,
 		step: 0.01,
-		tooltip: 'Shadow blur amount. Higher values create softer shadows.',
+		tooltip:
+			'How deep the shadow core gets. Higher reduces ambient fill under the model for a darker, more solid shadow.',
+		formatValue: (value) => `${Math.round(value * 100)}%`
+	},
+	{
+		// drei RandomizedLight radius, in model-size units — larger radius spreads
+		// the light samples wider, producing a softer penumbra.
+		key: 'light.radius',
+		label: 'Softness',
+		min: 0,
+		max: 3,
+		step: 0.05,
+		tooltip: 'Shadow softness. Higher values create softer, more diffuse edges.',
 		formatValue: (value) => value.toFixed(2)
 	}
 ]
 
+// ─── Shadow presets ──────────────────────────────────────────────────────────
+
+export interface ShadowPreset {
+	id: string
+	label: string
+	description: string
+	values: {
+		opacity: number
+		light: { ambient: number; radius: number; position: [number, number, number] }
+	}
+}
+
 /**
- * Advanced contact shadow controls - hidden in collapsed section.
- * Scale defaults are intentionally large in viewer-defaults to avoid
- * shadow-plane floor clipping on most scenes.
+ * One-tap looks. Each sets opacity, ambient fill (darkness), softness
+ * (light.radius) and light direction (light.position, in model-size units)
+ * together. Users can still fine-tune afterwards or drag the in-scene light
+ * handle.
  */
-export const CONTACT_ADVANCED_FIELDS: FieldConfig[] = [
+export const SHADOW_PRESETS: ShadowPreset[] = [
+	{
+		id: 'soft',
+		label: 'Soft',
+		description: 'Diffuse, gentle grounding shadow.',
+		values: {
+			opacity: 0.7,
+			light: { ambient: 0.5, radius: 1.4, position: [1.5, 4, 1.5] }
+		}
+	},
+	{
+		id: 'studio',
+		label: 'Studio',
+		description: 'Balanced product-shot shadow.',
+		values: {
+			opacity: 0.9,
+			light: { ambient: 0.3, radius: 0.8, position: [2, 3, 2] }
+		}
+	},
+	{
+		id: 'dramatic',
+		label: 'Dramatic',
+		description: 'Deep, crisp, low-angle shadow.',
+		values: {
+			opacity: 1,
+			light: { ambient: 0.08, radius: 0.4, position: [3, 2, 1] }
+		}
+	}
+]
+
+/**
+ * Advanced shadow controls - hidden in collapsed section.
+ * Scale is a multiple of the model's largest dimension, so the shadow plane
+ * stays proportioned to the subject regardless of model size.
+ */
+export const SHADOW_ADVANCED_FIELDS: FieldConfig[] = [
 	{
 		key: 'scale',
 		label: 'Shadow Scale',
-		min: 0.1,
-		max: 50,
+		min: 1,
+		max: 12,
+		step: 0.1,
+		tooltip:
+			'Size of the shadow projection plane, as a multiple of the model size. Keep large enough to avoid clipping the shadow.',
+		formatValue: (value) => value.toFixed(1)
+	},
+	{
+		// Trim on the auto-calibrated cutoff (viewer measures the lit-plane
+		// brightness per environment). 1 = pure auto; below deepens (risks ground
+		// haze), above lightens.
+		key: 'cutoffScale',
+		label: 'Cutoff Trim',
+		min: 0.85,
+		max: 1.1,
 		step: 0.01,
 		tooltip:
-			'Overall scale of the shadow projection plane. Keep large to avoid floor clipping.',
-		formatValue: (value) => value.toFixed(2),
-		valueMapping: valueMappings.quadratic
+			'Advanced: nudge the auto cutoff. The shadow threshold is calibrated to the environment automatically; lower this to deepen, raise to lighten if the ground hazes.',
+		formatValue: (value) => `${Math.round(value * 100)}%`
+	}
+]
+
+/**
+ * Strength control for ambient occlusion (top-level `aoIntensity`). Shown only
+ * while AO is enabled.
+ */
+export const SHADOW_AO_INTENSITY_FIELD: FieldConfig = {
+	key: 'aoIntensity',
+	label: 'AO Strength',
+	min: 0.5,
+	max: 4,
+	step: 0.1,
+	tooltip:
+		'How dark the ambient occlusion darkens crevices and contact gaps on the model.',
+	formatValue: (value) => value.toFixed(1)
+}
+
+/**
+ * Controls for the soft contact/ground shadow (nested `contact.*`). Shown as
+ * their own section, only while the ground shadow is enabled. Plane size and
+ * capture height are derived from the model automatically.
+ */
+export const SHADOW_CONTACT_FIELDS: FieldConfig[] = [
+	{
+		key: 'contact.opacity',
+		label: 'Opacity',
+		min: 0,
+		max: 1,
+		step: 0.01,
+		tooltip: 'How dark the ground shadow is.',
+		formatValue: (value) => value.toFixed(2)
+	},
+	{
+		key: 'contact.blur',
+		label: 'Softness',
+		min: 0.5,
+		max: 8,
+		step: 0.1,
+		tooltip:
+			'Blur of the ground shadow. Higher is softer and hides the model surface detail.',
+		formatValue: (value) => value.toFixed(1)
+	},
+	{
+		key: 'contact.scale',
+		label: 'Spread',
+		min: 1,
+		max: 4,
+		step: 0.1,
+		tooltip: 'How far the ground shadow spreads out from under the model.',
+		formatValue: (value) => value.toFixed(1)
+	},
+	{
+		key: 'contact.reach',
+		label: 'Reach',
+		min: 0.05,
+		max: 1.5,
+		step: 0.05,
+		tooltip:
+			'How far up from the floor the shadow reaches. Lower confines it to where the model is closest to the ground (tighter, more accurate ambient occlusion — e.g. only under the wheels); higher reaches up the model for a broad grounding pool.',
+		formatValue: (value) => `${Math.round(value * 100)}%`
 	}
 ]
 

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/shadow-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/shadow-settings-panel.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@shared/components/ui/button'
 import {
 	Collapsible,
 	CollapsibleContent
@@ -5,12 +6,20 @@ import {
 import { Label } from '@shared/components/ui/label'
 import { Separator } from '@shared/components/ui/separator'
 import { Switch } from '@shared/components/ui/switch'
+import { cn } from '@shared/utils'
 import { useAtom } from 'jotai/react'
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
-	CONTACT_ADVANCED_FIELDS,
-	CONTACT_PRIMARY_FIELDS
+	ambientToDarkness,
+	darknessToAmbient,
+	SHADOW_ADVANCED_FIELDS,
+	SHADOW_AO_INTENSITY_FIELD,
+	SHADOW_CONTACT_FIELDS,
+	SHADOW_DARKNESS_KEY,
+	SHADOW_PRESETS,
+	SHADOW_PRIMARY_FIELDS,
+	type ShadowPreset
 } from './constants'
 import { shadowsAtom } from '../../../../../lib/stores/scene-settings-store'
 import { InfoTooltip } from '../../../../info-tooltip'
@@ -19,6 +28,8 @@ import { CollapsibleSectionTrigger } from '../../accordion-components'
 
 import type { FieldConfig } from '../../../../../types/settings-field'
 import type { ShadowsProps } from '@vctrl/core'
+
+type AccumulativeShadowConfig = Extract<ShadowsProps, { type: 'accumulative' }>
 
 interface ShadowFieldProps {
 	field: FieldConfig
@@ -46,20 +57,173 @@ const ShadowField = ({ field, idPrefix, value, onChange }: ShadowFieldProps) => 
 	/>
 )
 
+const COMMIT_DELAY_MS = 250
+
 const ShadowSettingsPanel = () => {
 	const [shadows, setShadows] = useAtom(shadowsAtom)
 	const [advancedOpen, setAdvancedOpen] = useState(false)
 
-	const shadowsEnabled = shadows.enabled ?? false
+	// Local draft so dragging a slider stays responsive without re-baking the
+	// accumulative shadow on every tick (each prop change resets the bake and
+	// flickers). The draft is committed to the atom — triggering a single
+	// re-bake — shortly after the user stops dragging.
+	const [draft, setDraft] = useState<ShadowsProps>(shadows)
+	const commitTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-	const handleToggleShadows = (enabled: boolean) =>
-		setShadows({ ...shadows, enabled })
+	useEffect(() => {
+		setDraft(shadows)
+	}, [shadows])
 
-	const handleFieldChange = (key: string, value: number | string) =>
-		setShadows({ ...shadows, [key]: value } as ShadowsProps)
+	useEffect(
+		() => () => {
+			if (commitTimer.current) clearTimeout(commitTimer.current)
+		},
+		[]
+	)
 
-	const getFieldValue = (key: string) =>
-		(shadows[key as keyof ShadowsProps] as number) ?? 0
+	const scheduleCommit = useCallback(
+		(next: ShadowsProps) => {
+			setDraft(next)
+			if (commitTimer.current) clearTimeout(commitTimer.current)
+			commitTimer.current = setTimeout(() => setShadows(next), COMMIT_DELAY_MS)
+		},
+		[setShadows]
+	)
+
+	const shadowsEnabled = draft.enabled ?? false
+
+	const handleToggleShadows = (enabled: boolean) => {
+		if (commitTimer.current) clearTimeout(commitTimer.current)
+		const next = { ...draft, enabled }
+		setDraft(next)
+		setShadows(next)
+	}
+
+	// Presets set several params at once, so commit immediately (no per-tick
+	// debounce) for a single, snappy re-bake.
+	const handleApplyPreset = (preset: ShadowPreset) => {
+		if (commitTimer.current) clearTimeout(commitTimer.current)
+		const accumulative = draft as AccumulativeShadowConfig
+		const next = {
+			...draft,
+			opacity: preset.values.opacity,
+			light: {
+				...accumulative.light,
+				ambient: preset.values.light.ambient,
+				radius: preset.values.light.radius,
+				position: preset.values.light.position
+			}
+		} as ShadowsProps
+		setDraft(next)
+		setShadows(next)
+	}
+
+	// Boolean toggles commit immediately — a single click, not a drag, so there is
+	// no per-tick re-bake to debounce.
+	const handleToggleAo = (value: boolean) => {
+		if (commitTimer.current) clearTimeout(commitTimer.current)
+		const accumulative = draft as AccumulativeShadowConfig
+		const next = {
+			...draft,
+			ao: value,
+			// Seed a sensible strength the first time AO is turned on so its slider
+			// (min 0.5) isn't left below range on scenes saved before AO existed.
+			...(value && accumulative.aoIntensity == null ? { aoIntensity: 1.4 } : {})
+		} as ShadowsProps
+		setDraft(next)
+		setShadows(next)
+	}
+
+	// The ground (contact) shadow's enabled flag is nested under `contact`.
+	const handleToggleContact = (value: boolean) => {
+		if (commitTimer.current) clearTimeout(commitTimer.current)
+		const accumulative = draft as AccumulativeShadowConfig
+		const next = {
+			...draft,
+			contact: { ...accumulative.contact, enabled: value }
+		} as ShadowsProps
+		setDraft(next)
+		setShadows(next)
+	}
+
+	const current = draft as AccumulativeShadowConfig
+	const activePresetId =
+		SHADOW_PRESETS.find(
+			(preset) =>
+				preset.values.opacity === current.opacity &&
+				preset.values.light.ambient === current.light?.ambient &&
+				preset.values.light.radius === current.light?.radius
+		)?.id ?? null
+
+	const handleFieldChange = (key: string, value: number | string) => {
+		// "Darkness" is a virtual control: it drives the bake light's ambient fill
+		// (inverted — more darkness = less fill = a deeper shadow core).
+		if (key === SHADOW_DARKNESS_KEY) {
+			const accumulative = draft as AccumulativeShadowConfig
+			scheduleCommit({
+				...draft,
+				light: {
+					...accumulative.light,
+					ambient: darknessToAmbient(value as number)
+				}
+			} as ShadowsProps)
+			return
+		}
+
+		// Nested drei RandomizedLight params (e.g. "light.radius") are merged into
+		// the accumulative shadow's light config; everything else is a top-level prop.
+		if (key.startsWith('light.')) {
+			const lightKey = key.slice('light.'.length)
+			const accumulative = draft as AccumulativeShadowConfig
+			scheduleCommit({
+				...draft,
+				light: { ...accumulative.light, [lightKey]: value }
+			} as ShadowsProps)
+			return
+		}
+
+		// Nested contact/ground-shadow params (e.g. "contact.blur").
+		if (key.startsWith('contact.')) {
+			const contactKey = key.slice('contact.'.length)
+			const accumulative = draft as AccumulativeShadowConfig
+			scheduleCommit({
+				...draft,
+				contact: { ...accumulative.contact, [contactKey]: value }
+			} as ShadowsProps)
+			return
+		}
+
+		scheduleCommit({ ...draft, [key]: value } as ShadowsProps)
+	}
+
+	const getFieldValue = (key: string) => {
+		if (key === SHADOW_DARKNESS_KEY) {
+			const accumulative = draft as AccumulativeShadowConfig
+			return ambientToDarkness(accumulative.light?.ambient ?? 0.3)
+		}
+
+		if (key.startsWith('light.')) {
+			const lightKey = key.slice('light.'.length)
+			const accumulative = draft as AccumulativeShadowConfig
+			return (
+				(accumulative.light?.[
+					lightKey as keyof NonNullable<typeof accumulative.light>
+				] as number) ?? 0
+			)
+		}
+
+		if (key.startsWith('contact.')) {
+			const contactKey = key.slice('contact.'.length)
+			const accumulative = draft as AccumulativeShadowConfig
+			return (
+				(accumulative.contact?.[
+					contactKey as keyof NonNullable<typeof accumulative.contact>
+				] as number) ?? 0
+			)
+		}
+
+		return (draft[key as keyof ShadowsProps] as number) ?? 0
+	}
 
 	return (
 		<div className="space-y-4">
@@ -89,30 +253,113 @@ const ShadowSettingsPanel = () => {
 
 			{shadowsEnabled && (
 				<div className="space-y-4">
-					{CONTACT_PRIMARY_FIELDS.map((field) => (
-						<ShadowField
-							key={field.key}
-							field={field}
-							idPrefix="contact"
-							value={getFieldValue(field.key)}
-							onChange={handleFieldChange}
-						/>
-					))}
+					<div className="space-y-2">
+						<p className="text-muted-foreground text-xs font-medium">Presets</p>
+						<div className="grid grid-cols-3 gap-2">
+							{SHADOW_PRESETS.map((preset) => (
+								<Button
+									key={preset.id}
+									type="button"
+									variant={
+										activePresetId === preset.id ? 'default' : 'secondary'
+									}
+									size="sm"
+									className={cn(
+										'h-auto py-2 text-xs font-medium',
+										activePresetId !== preset.id && 'text-muted-foreground'
+									)}
+									title={preset.description}
+									onClick={() => handleApplyPreset(preset)}
+								>
+									{preset.label}
+								</Button>
+							))}
+						</div>
+					</div>
+
+					<Separator />
+
+					<div className="space-y-4">
+						<p className="text-muted-foreground text-xs font-medium">
+							Directional shadow
+						</p>
+						{SHADOW_PRIMARY_FIELDS.map((field) => (
+							<ShadowField
+								key={field.key}
+								field={field}
+								idPrefix="shadow"
+								value={getFieldValue(field.key)}
+								onChange={handleFieldChange}
+							/>
+						))}
+					</div>
+
+					<Separator />
+
+					<div className="space-y-4">
+						<div className="flex items-center justify-between gap-2">
+							<div className="flex items-center gap-2">
+								<p className="text-muted-foreground text-xs font-medium">
+									Ground shadow
+								</p>
+								<InfoTooltip content="A soft shadow pooled under the model that approximates the ambient occlusion it casts on the floor. It's independent of the directional light, so the model stays grounded even when the main shadow is cast off to the side. Raise Softness to keep it diffuse." />
+							</div>
+							<Switch
+								id="shadow-ground-toggle"
+								checked={current.contact?.enabled ?? false}
+								onCheckedChange={handleToggleContact}
+							/>
+						</div>
+
+						{(current.contact?.enabled ?? false) &&
+							SHADOW_CONTACT_FIELDS.map((field) => (
+								<ShadowField
+									key={field.key}
+									field={field}
+									idPrefix="shadow-contact"
+									value={getFieldValue(field.key)}
+									onChange={handleFieldChange}
+								/>
+							))}
+					</div>
 
 					<Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
 						<CollapsibleSectionTrigger isOpen={advancedOpen}>
 							Advanced
 						</CollapsibleSectionTrigger>
 						<CollapsibleContent className="space-y-4 pt-3">
-							{CONTACT_ADVANCED_FIELDS.map((field) => (
+							{SHADOW_ADVANCED_FIELDS.map((field) => (
 								<ShadowField
 									key={field.key}
 									field={field}
-									idPrefix="contact-adv"
+									idPrefix="shadow-adv"
 									value={getFieldValue(field.key)}
 									onChange={handleFieldChange}
 								/>
 							))}
+
+							<div className="flex items-center justify-between gap-2">
+								<div className="flex items-center gap-2">
+									<Label htmlFor="shadow-ao-toggle" className="text-sm">
+										Ambient occlusion
+									</Label>
+									<InfoTooltip content="Darkens crevices and tight gaps on the model itself (screen-space). Higher quality but runs every frame, so it costs GPU — best for hero shots on capable devices." />
+								</div>
+								<Switch
+									id="shadow-ao-toggle"
+									checked={current.ao ?? false}
+									onCheckedChange={handleToggleAo}
+								/>
+							</div>
+
+							{(current.ao ?? false) && (
+								<ShadowField
+									field={SHADOW_AO_INTENSITY_FIELD}
+									idPrefix="shadow-adv"
+									value={getFieldValue(SHADOW_AO_INTENSITY_FIELD.key)}
+									onChange={handleFieldChange}
+								/>
+							)}
 						</CollapsibleContent>
 					</Collapsible>
 				</div>

--- a/apps/vectreal-platform/app/constants/viewer-defaults.ts
+++ b/apps/vectreal-platform/app/constants/viewer-defaults.ts
@@ -1,4 +1,5 @@
 import type {
+	AccumulativeShadowsProps,
 	BoundsProps,
 	CameraProps,
 	ControlsProps,
@@ -59,14 +60,70 @@ export const defaultEnvOptions: EnvironmentProps = {
 	backgroundBlurriness: 0.5
 }
 
-export const defaultShadowOptions: ShadowsProps = {
-	type: 'contact',
+export const defaultShadowOptions: AccumulativeShadowsProps = {
+	type: 'accumulative',
 	enabled: false,
-	opacity: 0.4,
-	blur: 0.1,
-	scale: 1,
+	temporal: true,
+	// Fewer frames settle faster / appear sooner (see scene-shadows.tsx).
+	frames: 48,
+	// alphaTest is the transient/fallback cutoff used while the bake ramps; once it
+	// settles the viewer auto-calibrates it to the measured lit-plane brightness.
+	alphaTest: 3.0,
+	// Manual trim on that auto cutoff (1 = pure auto). Surfaced as Advanced "Cutoff".
+	cutoffScale: 1,
+	opacity: 0.9,
+	// Tight to the model footprint so the shadow stays crisp (see scene-shadows.tsx).
+	scale: 2.5,
+	resolution: 1024,
+	colorBlend: 2,
 	color: '#000000',
-	smooth: true
+	// Screen-space crevice occlusion (N8AO). Opt-in: real-time SSAO runs every
+	// rendered frame, so the default is the zero-idle-cost baked shadow only.
+	ao: false,
+	aoIntensity: 1.4,
+	// Soft contact/ground shadow (drei ContactShadows) approximating ground AO.
+	// Opt-in; baked once. Tuned via blur (softness) and opacity (darkness).
+	contact: {
+		enabled: false,
+		opacity: 0.6,
+		blur: 3,
+		scale: 1.5,
+		reach: 0.35
+	},
+	light: {
+		intensity: Math.PI * 2,
+		amount: 8,
+		// Penumbra softness, in model-size units.
+		radius: 0.8,
+		// Hemisphere fill fraction — surfaced as "Darkness" (less fill = darker).
+		ambient: 0.3,
+		// Straight overhead by default — minimal initial shadow (see scene-shadows.tsx).
+		position: [0, 2.5, 0],
+		bias: 0.001
+	}
+}
+
+/**
+ * Coerces stored shadow settings to a valid accumulative config. Contact shadows
+ * are now an internal animating-only fallback (never user-selected), so legacy
+ * `contact` or partial configs are normalized to the accumulative defaults while
+ * preserving `enabled`. Accumulative configs are merged over the defaults so a
+ * partial save still fills in any missing fields.
+ */
+export const normalizeShadowOptions = (stored?: ShadowsProps): ShadowsProps => {
+	if (stored?.type === 'accumulative') {
+		return {
+			...defaultShadowOptions,
+			...stored,
+			light: { ...defaultShadowOptions.light, ...stored.light },
+			contact: { ...defaultShadowOptions.contact, ...stored.contact }
+		}
+	}
+
+	return {
+		...defaultShadowOptions,
+		enabled: stored?.enabled ?? defaultShadowOptions.enabled
+	}
 }
 
 export const defaultNormalizationOptions: Required<NormalizationOptions> = {

--- a/apps/vectreal-platform/app/hooks/scene-loader/contracts.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/contracts.ts
@@ -57,6 +57,10 @@ export interface SceneSaveFlowActions {
 	createRequestId: () => string
 	prepareGltfDocumentForUpload: () => Promise<unknown>
 	captureSceneThumbnail: () => Promise<null | string>
+	captureShadowBake: () => Promise<{
+		dataUrl: string
+		signature: string
+	} | null>
 	maxConcurrentAssetUploadsDefault: number
 }
 

--- a/apps/vectreal-platform/app/hooks/scene-loader/contracts.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/contracts.ts
@@ -16,6 +16,7 @@ import type {
 	SceneDataLoadOptions,
 	SceneLoadResult
 } from '@vctrl/hooks/use-load-model'
+import type { ShadowBakeResult } from '@vctrl/viewer'
 import type { MutableRefObject } from 'react'
 
 export interface ScenePersistenceState {
@@ -57,11 +58,7 @@ export interface SceneSaveFlowActions {
 	createRequestId: () => string
 	prepareGltfDocumentForUpload: () => Promise<unknown>
 	captureSceneThumbnail: () => Promise<null | string>
-	captureShadowBake: () => Promise<{
-		dataUrl: string
-		signature: string
-	} | null>
-	maxConcurrentAssetUploadsDefault: number
+	captureShadowBake: () => Promise<ShadowBakeResult | null>
 }
 
 export interface UseSceneSaveFlowArgs {
@@ -80,7 +77,6 @@ export interface DraftRestoreRequest {
 	fileModel: unknown
 	isFileLoading: boolean
 	locationPathname: string
-	onRestoreHandled?: () => void
 }
 
 export interface DraftHydrationActions {
@@ -88,6 +84,8 @@ export interface DraftHydrationActions {
 	loadFromData: (params: SceneDataLoadOptions) => Promise<SceneLoadResult>
 	setSceneMetaState: (sceneMeta: SceneMetaState) => void
 	setLastSavedSceneMeta: (sceneMeta: SceneMetaState) => void
+	/** Invoked after a restore attempt settles (success or failure). */
+	onRestoreHandled?: () => void
 }
 
 export interface DraftOptimizationActions {

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-draft-rehydration.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-draft-rehydration.ts
@@ -22,14 +22,14 @@ export const useSceneDraftRehydration = ({
 		initialSceneAggregate,
 		fileModel,
 		isFileLoading,
-		locationPathname,
-		onRestoreHandled
+		locationPathname
 	} = restoreRequest
 	const {
 		setIsDownloading,
 		loadFromData,
 		setSceneMetaState,
-		setLastSavedSceneMeta
+		setLastSavedSceneMeta,
+		onRestoreHandled
 	} = hydrationActions
 	const {
 		inferOptimizationPreset,

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-save-flow.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-save-flow.ts
@@ -61,6 +61,7 @@ export const useSceneSaveFlow = ({
 		createRequestId,
 		prepareGltfDocumentForUpload,
 		captureSceneThumbnail,
+		captureShadowBake,
 		maxConcurrentAssetUploadsDefault
 	} = actions
 
@@ -215,6 +216,7 @@ export const useSceneSaveFlow = ({
 						createRequestId,
 						prepareGltfDocumentForUpload,
 						captureSceneThumbnail,
+						captureShadowBake,
 						maxConcurrentAssetUploadsDefault
 					})
 				} catch (error) {
@@ -240,6 +242,7 @@ export const useSceneSaveFlow = ({
 		},
 		[
 			captureSceneThumbnail,
+			captureShadowBake,
 			createRequestId,
 			currentSceneId,
 			currentSettings,

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-save-flow.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-save-flow.ts
@@ -61,8 +61,7 @@ export const useSceneSaveFlow = ({
 		createRequestId,
 		prepareGltfDocumentForUpload,
 		captureSceneThumbnail,
-		captureShadowBake,
-		maxConcurrentAssetUploadsDefault
+		captureShadowBake
 	} = actions
 
 	const setCurrentLocation = useSetAtom(currentLocationAtom)
@@ -216,8 +215,7 @@ export const useSceneSaveFlow = ({
 						createRequestId,
 						prepareGltfDocumentForUpload,
 						captureSceneThumbnail,
-						captureShadowBake,
-						maxConcurrentAssetUploadsDefault
+						captureShadowBake
 					})
 				} catch (error) {
 					console.error('Failed to save scene settings:', {
@@ -250,8 +248,7 @@ export const useSceneSaveFlow = ({
 			optimizationSettings,
 			optimizationReport,
 			prepareGltfDocumentForUpload,
-			userId,
-			maxConcurrentAssetUploadsDefault
+			userId
 		]
 	)
 

--- a/apps/vectreal-platform/app/hooks/use-scene-loader.ts
+++ b/apps/vectreal-platform/app/hooks/use-scene-loader.ts
@@ -25,7 +25,8 @@ import {
 	defaultControlsOptions,
 	defaultEnvOptions,
 	defaultNormalizationOptions,
-	defaultShadowOptions
+	defaultShadowOptions,
+	normalizeShadowOptions
 } from '../constants/viewer-defaults'
 import { buildSceneUploadFailedAnalyticsProps } from '../lib/domain/analytics/scene-events'
 import {
@@ -88,6 +89,10 @@ export interface UseSceneLoaderParams {
 	requestSceneScreenshot?: (
 		options?: SceneScreenshotOptions
 	) => Promise<null | string>
+	requestShadowBake?: () => Promise<{
+		dataUrl: string
+		signature: string
+	} | null>
 }
 
 const DEFAULT_MAX_CONCURRENT_SCENE_ASSET_UPLOADS = 4
@@ -144,14 +149,16 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		userId,
 		initialSceneAggregate = null,
 		sceneMeta = null,
-		requestSceneScreenshot
+		requestSceneScreenshot,
+		requestShadowBake
 	} = params === null
 		? {
 				sceneId: null,
 				userId: undefined,
 				initialSceneAggregate: null,
 				sceneMeta: null,
-				requestSceneScreenshot: undefined
+				requestSceneScreenshot: undefined,
+				requestShadowBake: undefined
 			}
 		: params
 
@@ -339,6 +346,24 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 			return null
 		}
 	}, [currentSceneId, camera.cameras, requestSceneScreenshot])
+
+	const captureShadowBake = useCallback(async (): Promise<{
+		dataUrl: string
+		signature: string
+	} | null> => {
+		if (!requestShadowBake) {
+			return null
+		}
+		try {
+			return await requestShadowBake()
+		} catch (error) {
+			console.warn('[scene-settings] shadow bake capture failed', {
+				sceneId: currentSceneId || null,
+				error
+			})
+			return null
+		}
+	}, [currentSceneId, requestShadowBake])
 
 	// Get current settings from atoms
 	const currentSettings: SceneSettings = useMemo(
@@ -555,7 +580,7 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 			setInteractions(settings.interactions)
 			setCamera(settings.camera || defaultCameraOptions)
 			setControls(settings.controls || defaultControlsOptions)
-			setShadows(settings.shadows || defaultShadowOptions)
+			setShadows(normalizeShadowOptions(settings.shadows))
 			setNormalization(settings.normalization || defaultNormalizationOptions)
 			setRawModelDiagonal(0)
 			setHotspots(settings.hotspots ?? [])
@@ -566,7 +591,7 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 				interactions: settings.interactions,
 				camera: settings.camera || defaultCameraOptions,
 				controls: settings.controls || defaultControlsOptions,
-				shadows: settings.shadows || defaultShadowOptions,
+				shadows: normalizeShadowOptions(settings.shadows),
 				normalization: settings.normalization || defaultNormalizationOptions,
 				hotspots: settings.hotspots
 			}
@@ -706,6 +731,7 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		createRequestId,
 		prepareGltfDocumentForUpload,
 		captureSceneThumbnail,
+		captureShadowBake,
 		maxConcurrentAssetUploadsDefault: DEFAULT_MAX_CONCURRENT_SCENE_ASSET_UPLOADS
 	}
 

--- a/apps/vectreal-platform/app/hooks/use-scene-loader.ts
+++ b/apps/vectreal-platform/app/hooks/use-scene-loader.ts
@@ -56,6 +56,7 @@ import {
 	optimizationRuntimeInitialState
 } from '../lib/stores/scene-optimization-store'
 import {
+	bakedShadowSourceAtom,
 	boundsAtom,
 	cameraAtom,
 	controlsAtom,
@@ -69,7 +70,7 @@ import {
 
 import type { SceneAggregateResponse } from '../types/api'
 import type { SceneMetaState } from '../types/publisher-config'
-import type { SceneScreenshotOptions } from '@vctrl/viewer'
+import type { SceneScreenshotOptions, ShadowBakeResult } from '@vctrl/viewer'
 
 export type {
 	SaveLocationTarget,
@@ -89,13 +90,9 @@ export interface UseSceneLoaderParams {
 	requestSceneScreenshot?: (
 		options?: SceneScreenshotOptions
 	) => Promise<null | string>
-	requestShadowBake?: () => Promise<{
-		dataUrl: string
-		signature: string
-	} | null>
+	requestShadowBake?: () => Promise<ShadowBakeResult | null>
 }
 
-const DEFAULT_MAX_CONCURRENT_SCENE_ASSET_UPLOADS = 4
 const DEFAULT_THUMBNAIL_CAPTURE_OPTIONS = {
 	width: 1280,
 	height: 720,
@@ -237,6 +234,7 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 	const [controls, setControls] = useAtom(controlsAtom)
 	const [shadows, setShadows] = useAtom(shadowsAtom)
 	const [normalization, setNormalization] = useAtom(normalizationAtom)
+	const setBakedShadowSource = useSetAtom(bakedShadowSourceAtom)
 	const setRawModelDiagonal = useSetAtom(rawModelDiagonalAtom)
 	const [hotspots, setHotspots] = useAtom(hotspotsAtom)
 
@@ -347,10 +345,7 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		}
 	}, [currentSceneId, camera.cameras, requestSceneScreenshot])
 
-	const captureShadowBake = useCallback(async (): Promise<{
-		dataUrl: string
-		signature: string
-	} | null> => {
+	const captureShadowBake = useCallback(async (): Promise<ShadowBakeResult | null> => {
 		if (!requestShadowBake) {
 			return null
 		}
@@ -646,6 +641,7 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 					aggregate,
 					hydrateOptimizationState,
 					applySceneSettings,
+					applyBakedShadowSource: setBakedShadowSource,
 					setSceneMetaState,
 					setLastSavedSceneMeta,
 					loadFromData
@@ -664,6 +660,7 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		[
 			hydrateOptimizationState,
 			applySceneSettings,
+			setBakedShadowSource,
 			setSceneMetaState,
 			setLastSavedSceneMeta,
 			loadFromData,
@@ -731,8 +728,7 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		createRequestId,
 		prepareGltfDocumentForUpload,
 		captureSceneThumbnail,
-		captureShadowBake,
-		maxConcurrentAssetUploadsDefault: DEFAULT_MAX_CONCURRENT_SCENE_ASSET_UPLOADS
+		captureShadowBake
 	}
 
 	const { saveSceneSettings, saveAvailability } = useSceneSaveFlow({
@@ -749,15 +745,15 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		initialSceneAggregate,
 		fileModel: file?.model,
 		isFileLoading,
-		locationPathname: location.pathname,
-		onRestoreHandled: handleRestoreHandled
+		locationPathname: location.pathname
 	}
 
 	const draftHydrationActions = {
 		setIsDownloading,
 		loadFromData,
 		setSceneMetaState,
-		setLastSavedSceneMeta
+		setLastSavedSceneMeta,
+		onRestoreHandled: handleRestoreHandled
 	}
 
 	const draftOptimizationActions = {

--- a/apps/vectreal-platform/app/lib/domain/scene/client/baked-shadow-source.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/baked-shadow-source.ts
@@ -1,0 +1,57 @@
+import {
+	PERSISTED_BAKE_FILENAME,
+	toSerializedAssetBytes,
+	type SceneSettings,
+	type SerializedSceneAssetDataMap
+} from '@vctrl/core'
+
+import type { BakedShadow } from '@vctrl/viewer'
+
+const bytesToBase64 = (bytes: Uint8Array): string => {
+	let binary = ''
+	for (let i = 0; i < bytes.length; i++) {
+		binary += String.fromCharCode(bytes[i])
+	}
+	return btoa(binary)
+}
+
+/**
+ * Resolves the persisted shadow bake from a scene's in-memory asset data into a
+ * `BakedShadow` the viewer can render, with no extra network request: the density
+ * PNG already rides in the aggregate's `assetData`, so this turns it into a data
+ * URL the shadow plane consumes directly.
+ *
+ * Looks the bake up by its stable filename ({@link PERSISTED_BAKE_FILENAME})
+ * rather than the asset-map key, because the key differs between load paths
+ * (publisher vs preview) while the filename is invariant.
+ */
+export const resolveBakedShadowSource = (
+	shadows: SceneSettings['shadows'] | undefined,
+	assetData: SerializedSceneAssetDataMap | null | undefined
+): BakedShadow | undefined => {
+	if (!shadows || shadows.type !== 'accumulative' || !shadows.baked) {
+		return undefined
+	}
+	if (!assetData) {
+		return undefined
+	}
+
+	const entry = Object.values(assetData).find(
+		(candidate) => candidate.fileName === PERSISTED_BAKE_FILENAME
+	)
+	if (!entry) {
+		return undefined
+	}
+
+	// Server-serialized entries already carry base64; client-built ones carry a
+	// byte array. Normalize to base64 for the data URL.
+	const base64 =
+		typeof entry.data === 'string'
+			? entry.data
+			: bytesToBase64(toSerializedAssetBytes(entry))
+
+	return {
+		url: `data:${entry.mimeType};base64,${base64}`,
+		signature: shadows.baked.signature
+	}
+}

--- a/apps/vectreal-platform/app/lib/domain/scene/client/scene-hydration.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/scene-hydration.ts
@@ -5,8 +5,11 @@ import {
 	type ServerSceneData
 } from '@vctrl/core'
 
+import { resolveBakedShadowSource } from './baked-shadow-source'
+
 import type { SceneAggregateResponse } from '../../../../types/api'
 import type { SceneMetaState } from '../../../../types/publisher-config'
+import type { BakedShadow } from '@vctrl/viewer'
 
 export const getSceneNameFromFileName = (fileName: string): string => {
 	const trimmedFileName = fileName.trim()
@@ -100,6 +103,7 @@ interface ExecuteAggregateSceneHydrationParams {
 	aggregate: SceneAggregateResponse
 	hydrateOptimizationState: (aggregate: SceneAggregateResponse) => void
 	applySceneSettings: (settings: SceneSettings) => void
+	applyBakedShadowSource: (source: BakedShadow | null) => void
 	setSceneMetaState: (sceneMeta: SceneMetaState) => void
 	setLastSavedSceneMeta: (sceneMeta: SceneMetaState) => void
 	loadFromData: (params: {
@@ -113,6 +117,7 @@ export const executeAggregateSceneHydration = async ({
 	aggregate,
 	hydrateOptimizationState,
 	applySceneSettings,
+	applyBakedShadowSource,
 	setSceneMetaState,
 	setLastSavedSceneMeta,
 	loadFromData
@@ -123,6 +128,13 @@ export const executeAggregateSceneHydration = async ({
 	if (settings) {
 		applySceneSettings(settings)
 	}
+
+	// Resolve the persisted shadow bake from the aggregate's inlined asset data so
+	// the viewer renders the stored shadow with no extra request (null clears any
+	// previous scene's bake).
+	applyBakedShadowSource(
+		resolveBakedShadowSource(settings?.shadows, aggregate.assetData) ?? null
+	)
 
 	if (aggregate.meta) {
 		setSceneMetaState(aggregate.meta)

--- a/apps/vectreal-platform/app/lib/domain/scene/client/scene-save-orchestrator.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/scene-save-orchestrator.ts
@@ -36,6 +36,10 @@ interface ExecuteSceneSaveOrchestratorParams {
 	createRequestId: () => string
 	prepareGltfDocumentForUpload: () => Promise<unknown>
 	captureSceneThumbnail: () => Promise<null | string>
+	captureShadowBake?: () => Promise<{
+		dataUrl: string
+		signature: string
+	} | null>
 	maxConcurrentAssetUploadsDefault: number
 }
 
@@ -70,6 +74,7 @@ export const executeSceneSaveOrchestrator = async ({
 	createRequestId,
 	prepareGltfDocumentForUpload,
 	captureSceneThumbnail,
+	captureShadowBake,
 	maxConcurrentAssetUploadsDefault
 }: ExecuteSceneSaveOrchestratorParams): Promise<
 	SaveSceneOrchestratorResult | { unchanged: true }
@@ -172,6 +177,59 @@ export const executeSceneSaveOrchestrator = async ({
 							: 'Unknown thumbnail upload error'
 				})
 			}
+		}
+	}
+
+	// Persist the accumulative shadow bake so the scene loads without recomputing
+	// it. Best-effort: any failure (bake not settled, upload error) just leaves the
+	// scene to re-bake live on next load. The captured density PNG is uploaded as a
+	// scene image asset and referenced from the shadow settings by id + signature.
+	let settingsForSave = currentSettings
+	if (captureShadowBake) {
+		try {
+			const bake = await captureShadowBake()
+			const shadows = currentSettings.shadows
+			if (bake && shadows?.type === 'accumulative') {
+				const bakeFile = createFileFromDataUrl(bake.dataUrl, 'shadow-bake.png')
+				if (bakeFile) {
+					const uploadBakeFormData = new FormData()
+					uploadBakeFormData.append('action', 'upload-scene-asset')
+					uploadBakeFormData.append('requestId', requestId)
+					uploadBakeFormData.append('sceneId', preparedSceneId)
+					if (preparedProjectId) {
+						uploadBakeFormData.append('projectId', preparedProjectId)
+					}
+					if (options?.targetProjectId) {
+						uploadBakeFormData.append('targetProjectId', options.targetProjectId)
+					}
+					uploadBakeFormData.append('kind', 'image')
+					uploadBakeFormData.append('file', bakeFile)
+
+					const uploadedBake = await toJsonOrThrow(
+						await fetch(`/api/scenes/${preparedSceneId}`, {
+							method: 'POST',
+							body: uploadBakeFormData
+						})
+					)
+
+					settingsForSave = {
+						...currentSettings,
+						shadows: {
+							...shadows,
+							baked: {
+								assetId: uploadedBake.assetId as string,
+								signature: bake.signature
+							}
+						}
+					}
+				}
+			}
+		} catch (error) {
+			console.warn('[scene-settings] shadow bake persist failed', {
+				sceneId: preparedSceneId,
+				error:
+					error instanceof Error ? error.message : 'Unknown shadow bake error'
+			})
 		}
 	}
 
@@ -307,7 +365,7 @@ export const executeSceneSaveOrchestrator = async ({
 	if (typeof options?.targetFolderId !== 'undefined') {
 		formData.append('targetFolderId', options.targetFolderId ?? '')
 	}
-	formData.append('settings', JSON.stringify(currentSettings))
+	formData.append('settings', JSON.stringify(settingsForSave))
 	formData.append('meta', JSON.stringify(sceneMetaForSave))
 	formData.append('sceneAssetIds', JSON.stringify(sceneAssetIds))
 	formData.append('optimizationSettings', JSON.stringify(optimizationSettings))

--- a/apps/vectreal-platform/app/lib/domain/scene/client/scene-save-orchestrator.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/scene-save-orchestrator.ts
@@ -1,3 +1,5 @@
+import { PERSISTED_BAKE_FILENAME, SCENE_THUMBNAIL_FILENAME } from '@vctrl/core'
+
 import { createFileFromDataUrl } from './scene-draft-serialization'
 import {
 	buildImageMimeLookup,
@@ -7,6 +9,14 @@ import { createBillingLimitErrorFromResponse } from '../../billing/client/billin
 
 import type { SceneMetaState } from '../../../../types/publisher-config'
 import type { SceneSettings } from '@vctrl/core'
+import type { ShadowBakeResult } from '@vctrl/viewer'
+
+/**
+ * How many scene assets to upload in parallel. Single source of truth for the
+ * save pipeline's concurrency; a per-call `options.maxConcurrentAssetUploads`
+ * may override it. Kept here because the orchestrator is the only consumer.
+ */
+export const MAX_CONCURRENT_ASSET_UPLOADS = 4
 
 export interface SaveSceneOrchestratorOptions {
 	includeOptimizationReport?: boolean
@@ -36,11 +46,18 @@ interface ExecuteSceneSaveOrchestratorParams {
 	createRequestId: () => string
 	prepareGltfDocumentForUpload: () => Promise<unknown>
 	captureSceneThumbnail: () => Promise<null | string>
-	captureShadowBake?: () => Promise<{
-		dataUrl: string
-		signature: string
-	} | null>
-	maxConcurrentAssetUploadsDefault: number
+	captureShadowBake?: () => Promise<ShadowBakeResult | null>
+}
+
+// Pulls the asset id out of an internal thumbnail URL
+// (`/api/scenes/:sceneId/thumbnail/:assetId`). Used to re-link the current
+// thumbnail on every save so it isn't garbage-collected, and so a superseded one
+// becomes an unlinked GC candidate.
+const extractThumbnailAssetId = (thumbnailUrl?: string | null): string | null => {
+	if (!thumbnailUrl) return null
+	// Anchor to the end so only the final `/thumbnail/<id>` segment is taken.
+	const match = thumbnailUrl.match(/\/thumbnail\/([^/?#]+)$/)
+	return match ? match[1] : null
 }
 
 const toJsonOrThrow = async (response: Response) => {
@@ -74,8 +91,7 @@ export const executeSceneSaveOrchestrator = async ({
 	createRequestId,
 	prepareGltfDocumentForUpload,
 	captureSceneThumbnail,
-	captureShadowBake,
-	maxConcurrentAssetUploadsDefault
+	captureShadowBake
 }: ExecuteSceneSaveOrchestratorParams): Promise<
 	SaveSceneOrchestratorResult | { unchanged: true }
 > => {
@@ -136,7 +152,7 @@ export const executeSceneSaveOrchestrator = async ({
 	if (thumbnailDataUrl) {
 		const thumbnailFile = createFileFromDataUrl(
 			thumbnailDataUrl,
-			'scene-thumbnail.webp'
+			SCENE_THUMBNAIL_FILENAME
 		)
 
 		if (thumbnailFile) {
@@ -180,17 +196,29 @@ export const executeSceneSaveOrchestrator = async ({
 		}
 	}
 
-	// Persist the accumulative shadow bake so the scene loads without recomputing
-	// it. Best-effort: any failure (bake not settled, upload error) just leaves the
-	// scene to re-bake live on next load. The captured density PNG is uploaded as a
-	// scene image asset and referenced from the shadow settings by id + signature.
+	// Persist / refresh the accumulative shadow bake so the scene loads without
+	// recomputing it. The capture reports the bake state for the CURRENT inputs:
+	//  - a fresh density PNG (`dataUrl`) → upload it and reference the new asset,
+	//  - `dataUrl` null with a matching signature → the stored bake is still valid;
+	//    keep its asset (the bake is non-deterministic, so re-uploading would churn
+	//    storage and trigger needless GC),
+	//  - nothing settled → drop any persisted ref so a STALE bake is never shipped;
+	//    the scene re-bakes live next load and re-persists once it settles.
+	// Best-effort: any failure leaves the scene to re-bake live next load. The bake
+	// asset id (fresh or kept) is linked into the scene's asset set (below) so it
+	// rides the aggregate on load.
 	let settingsForSave = currentSettings
-	if (captureShadowBake) {
+	let bakedShadowAssetId: string | null = null
+	const currentShadows = currentSettings.shadows
+	if (captureShadowBake && currentShadows?.type === 'accumulative') {
+		let bakedRef: typeof currentShadows.baked | undefined
 		try {
 			const bake = await captureShadowBake()
-			const shadows = currentSettings.shadows
-			if (bake && shadows?.type === 'accumulative') {
-				const bakeFile = createFileFromDataUrl(bake.dataUrl, 'shadow-bake.png')
+			if (bake?.dataUrl) {
+				const bakeFile = createFileFromDataUrl(
+					bake.dataUrl,
+					PERSISTED_BAKE_FILENAME
+				)
 				if (bakeFile) {
 					const uploadBakeFormData = new FormData()
 					uploadBakeFormData.append('action', 'upload-scene-asset')
@@ -212,17 +240,17 @@ export const executeSceneSaveOrchestrator = async ({
 						})
 					)
 
-					settingsForSave = {
-						...currentSettings,
-						shadows: {
-							...shadows,
-							baked: {
-								assetId: uploadedBake.assetId as string,
-								signature: bake.signature
-							}
-						}
-					}
+					bakedShadowAssetId = uploadedBake.assetId as string
+					bakedRef = { assetId: bakedShadowAssetId, signature: bake.signature }
 				}
+			} else if (
+				bake &&
+				currentShadows.baked &&
+				currentShadows.baked.signature === bake.signature
+			) {
+				// Stored bake is still valid for the current inputs: keep and relink it.
+				bakedRef = currentShadows.baked
+				bakedShadowAssetId = currentShadows.baked.assetId
 			}
 		} catch (error) {
 			console.warn('[scene-settings] shadow bake persist failed', {
@@ -231,10 +259,15 @@ export const executeSceneSaveOrchestrator = async ({
 					error instanceof Error ? error.message : 'Unknown shadow bake error'
 			})
 		}
+
+		settingsForSave = {
+			...currentSettings,
+			shadows: { ...currentShadows, baked: bakedRef }
+		}
 	}
 
 	const maxConcurrentAssetUploads =
-		options?.maxConcurrentAssetUploads ?? maxConcurrentAssetUploadsDefault
+		options?.maxConcurrentAssetUploads ?? MAX_CONCURRENT_ASSET_UPLOADS
 
 	const hashBytes = async (bytes: Uint8Array): Promise<string> => {
 		const hashBuffer = await crypto.subtle.digest(
@@ -350,6 +383,22 @@ export const executeSceneSaveOrchestrator = async ({
 		gltfAssetId = await uploadGltfFile(gltfBytes)
 	}
 	sceneAssetIds.push(gltfAssetId)
+
+	// Link the persisted shadow bake into the scene's asset set so the server
+	// downloads it into the aggregate (base64-inlined alongside the model assets)
+	// and every surface loads it in parallel, with no separate request.
+	if (bakedShadowAssetId) {
+		sceneAssetIds.push(bakedShadowAssetId)
+	}
+
+	// Link the current thumbnail (newly uploaded or the existing one) so it is
+	// tracked as a scene asset: this keeps it from being GC'd and lets a superseded
+	// thumbnail become an unlinked GC candidate. It is excluded from the aggregate's
+	// inlined render data server-side (served by URL, not rendered).
+	const thumbnailAssetId = extractThumbnailAssetId(sceneMetaForSave.thumbnailUrl)
+	if (thumbnailAssetId) {
+		sceneAssetIds.push(thumbnailAssetId)
+	}
 
 	const formData = new FormData()
 	formData.append('action', 'commit-scene-save')

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
@@ -1,4 +1,5 @@
 import { JSONDocument } from '@gltf-transform/core'
+import { SCENE_THUMBNAIL_FILENAME } from '@vctrl/core'
 import { and, eq, inArray } from 'drizzle-orm'
 
 import { updateSceneMetadata } from './scene-folder-repository.server'
@@ -307,6 +308,13 @@ class SceneSettingsService {
 				return { ...existingSettings, unchanged: true }
 			}
 
+			// Assets this scene no longer links (superseded bake/thumbnail, textures
+			// dropped by a model change). Candidates for GC once the new links commit.
+			const newAssetIdSet = new Set(sceneAssetIds)
+			const removedAssetIds = existingAssetIds.filter(
+				(id) => !newAssetIdSet.has(id)
+			)
+
 			const savedSettings = await upsertSceneSettings(tx, {
 				sceneId: updatedScene.id,
 				createdBy: userId,
@@ -333,7 +341,7 @@ class SceneSettingsService {
 				})
 			}
 
-			return { savedSettings, unchanged: false as const }
+			return { savedSettings, unchanged: false as const, removedAssetIds }
 		})
 
 		await this.updateSceneAggregateMetadata(sceneId, userId, meta)
@@ -342,7 +350,39 @@ class SceneSettingsService {
 			return saveResult
 		}
 
+		// Post-commit so storage deletes stay out of the DB transaction.
+		await this.garbageCollectUnreferencedAssets(saveResult.removedAssetIds ?? [])
+
 		return saveResult.savedSettings
+	}
+
+	/**
+	 * Deletes assets that were unlinked from a scene and are no longer referenced by
+	 * ANY scene (storage object + DB row). Best-effort and post-commit: a GC failure
+	 * never fails the save. The cross-scene reference check guards assets shared via
+	 * the project's dedup folder (e.g. an identical texture used by another scene).
+	 */
+	private async garbageCollectUnreferencedAssets(candidateAssetIds: string[]) {
+		if (candidateAssetIds.length === 0) return
+
+		try {
+			const stillReferenced = await this.db
+				.select({ assetId: sceneAssets.assetId })
+				.from(sceneAssets)
+				.where(inArray(sceneAssets.assetId, candidateAssetIds))
+
+			const referenced = new Set(stillReferenced.map((row) => row.assetId))
+			const orphaned = candidateAssetIds.filter((id) => !referenced.has(id))
+
+			if (orphaned.length > 0) {
+				await deleteAssets(orphaned)
+			}
+		} catch (error) {
+			console.warn('[scene-settings] unreferenced asset GC failed', {
+				candidateCount: candidateAssetIds.length,
+				error
+			})
+		}
 	}
 
 	/**
@@ -441,8 +481,12 @@ class SceneSettingsService {
 
 		const { settings, assets: sceneAssetsData } = result
 
-		// Extract asset IDs
-		const assetIds = sceneAssetsData.map((asset) => asset.id)
+		// Extract asset IDs to download into the aggregate. The thumbnail is tracked
+		// as a scene asset (for GC) but served by URL, not rendered, so it is excluded
+		// from the inlined render data to keep the aggregate lean.
+		const assetIds = sceneAssetsData
+			.filter((asset) => asset.name !== SCENE_THUMBNAIL_FILENAME)
+			.map((asset) => asset.id)
 
 		// Download asset data from cloud storage
 		let gltfJson: ExtendedGLTFDocument | null = null

--- a/apps/vectreal-platform/app/lib/stores/scene-settings-store.ts
+++ b/apps/vectreal-platform/app/lib/stores/scene-settings-store.ts
@@ -19,6 +19,7 @@ import type {
 	SceneSettings,
 	ShadowsProps
 } from '@vctrl/core'
+import type { BakedShadow } from '@vctrl/viewer'
 
 const sceneSettingsStore = createStore()
 
@@ -39,6 +40,10 @@ const normalizationAtom = atom<NormalizationOptions>(
 const rawModelDiagonalAtom = atom<number>(0)
 const hotspotsAtom = atom<HotspotDefinition[]>([])
 const activeHotspotIdAtom = atom<string | null>(null)
+// Persisted shadow bake resolved from the loaded scene aggregate (a data URL +
+// signature), or null when the scene has none. Set during hydration so the viewer
+// can render the stored shadow instead of recomputing the bake.
+const bakedShadowSourceAtom = atom<BakedShadow | null>(null)
 const sceneViewerSettingsAtom = atom((get) => ({
 	bounds: get(boundsAtom),
 	camera: get(cameraAtom),
@@ -66,10 +71,12 @@ sceneSettingsStore.set(normalizationAtom, defaultNormalizationOptions)
 sceneSettingsStore.set(rawModelDiagonalAtom, 0)
 sceneSettingsStore.set(hotspotsAtom, [])
 sceneSettingsStore.set(activeHotspotIdAtom, null)
+sceneSettingsStore.set(bakedShadowSourceAtom, null)
 
 export {
 	// Vectreal viewer settings atoms
 	activeHotspotIdAtom,
+	bakedShadowSourceAtom,
 	boundsAtom,
 	cameraAtom,
 	controlsAtom,

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
@@ -42,7 +42,7 @@ import {
 	Trash2,
 	X
 } from 'lucide-react'
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { data, Link, useNavigate } from 'react-router'
 
 import { Route } from './+types/scene'
@@ -59,6 +59,7 @@ import { useDashboardSceneActions } from '../../../hooks/use-dashboard-scene-act
 import { loadAuthenticatedSession } from '../../../lib/domain/auth/auth-loader.server'
 import { buildFullscreenPreviewPath } from '../../../lib/domain/embed/embed-snippet'
 import { getProject } from '../../../lib/domain/project/project-repository.server'
+import { resolveBakedShadowSource } from '../../../lib/domain/scene/client/baked-shadow-source'
 import { loadSceneFromApi } from '../../../lib/domain/scene/client/load-scene-from-api.client'
 import { getDashboardSceneLoadErrorMessage } from '../../../lib/domain/scene/scene-load-error-messages'
 import { buildSceneAggregate } from '../../../lib/domain/scene/server/scene-aggregate.server'
@@ -264,6 +265,10 @@ const PreviewModel = memo(
 			thumbnailUrl,
 			'Scene thumbnail preview'
 		)
+		const bakedShadow = useMemo(
+			() => resolveBakedShadowSource(sceneData?.shadows, sceneData?.assetData),
+			[sceneData?.shadows, sceneData?.assetData]
+		)
 
 		return (
 			<div className={cn('relative h-full')}>
@@ -275,6 +280,8 @@ const PreviewModel = memo(
 					controlsOptions={sceneData?.controls}
 					normalizationOptions={sceneData?.normalization}
 					shadowsOptions={sceneData?.shadows}
+					staticShadowBake
+					bakedShadow={bakedShadow}
 					loadingThumbnail={loadingThumbnail}
 					loader={<CenteredSpinner text="Preparing scene..." />}
 					fallback={<CenteredSpinner text="Loading scene..." />}

--- a/apps/vectreal-platform/app/routes/preview-page/preview-fullscreen.tsx
+++ b/apps/vectreal-platform/app/routes/preview-page/preview-fullscreen.tsx
@@ -76,6 +76,7 @@ const PreviewModel = memo(
 					onCommandExecutorReady={onCommandExecutorReady}
 					onInteractionEvent={onInteractionEvent}
 					shadowsOptions={sceneData?.shadows}
+					staticShadowBake
 					normalizationOptions={sceneData?.normalization}
 					popover={
 						<PreviewInfoPopover title={title} description={description} />

--- a/apps/vectreal-platform/app/routes/preview-page/preview-fullscreen.tsx
+++ b/apps/vectreal-platform/app/routes/preview-page/preview-fullscreen.tsx
@@ -17,6 +17,7 @@ import { usePreviewScene } from './use-preview-scene'
 import CenteredSpinner from '../../components/centered-spinner'
 import { ClientVectrealViewer } from '../../components/viewer/client-vectreal-viewer'
 import { useHostedPreviewBridge } from '../../lib/domain/embed/hosted-preview-bridge'
+import { resolveBakedShadowSource } from '../../lib/domain/scene/client/baked-shadow-source'
 
 interface PreviewInfoPopoverProps {
 	title?: string
@@ -64,6 +65,12 @@ const PreviewModel = memo(
 		onInteractionEvent,
 		onCommandExecutorReady
 	}: PreviewModelProps) => {
+		// Persisted shadow bake from the scene's inlined asset data, so embeds render
+		// the stored shadow in parallel with the model instead of re-baking on load.
+		const bakedShadow = useMemo(
+			() => resolveBakedShadowSource(sceneData?.shadows, sceneData?.assetData),
+			[sceneData?.shadows, sceneData?.assetData]
+		)
 		return (
 			<div className="h-screen w-full">
 				<ClientVectrealViewer
@@ -77,6 +84,7 @@ const PreviewModel = memo(
 					onInteractionEvent={onInteractionEvent}
 					shadowsOptions={sceneData?.shadows}
 					staticShadowBake
+					bakedShadow={bakedShadow}
 					normalizationOptions={sceneData?.normalization}
 					popover={
 						<PreviewInfoPopover title={title} description={description} />

--- a/apps/vectreal-platform/app/routes/preview-page/preview-product-detail.tsx
+++ b/apps/vectreal-platform/app/routes/preview-page/preview-product-detail.tsx
@@ -16,7 +16,7 @@ import {
 	InfoPopoverTrigger,
 	InfoPopoverVectrealFooter
 } from '@vctrl/viewer'
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import { Link } from 'react-router'
 
 import { Route } from './+types/preview-product-detail'
@@ -24,6 +24,7 @@ import { usePreviewScene } from './use-preview-scene'
 import CenteredSpinner from '../../components/centered-spinner'
 import { ClientVectrealViewer } from '../../components/viewer/client-vectreal-viewer'
 import { useHostedPreviewBridge } from '../../lib/domain/embed/hosted-preview-bridge'
+import { resolveBakedShadowSource } from '../../lib/domain/scene/client/baked-shadow-source'
 
 interface PreviewModelProps {
 	file: ModelFile | null
@@ -68,6 +69,10 @@ const ProductDetailModel = memo(
 		onInteractionEvent,
 		onCommandExecutorReady
 	}: PreviewModelProps) => {
+		const bakedShadow = useMemo(
+			() => resolveBakedShadowSource(sceneData?.shadows, sceneData?.assetData),
+			[sceneData?.shadows, sceneData?.assetData]
+		)
 		return (
 			<div className="bg-background relative h-[60vh] min-h-[420px] w-full overflow-hidden rounded-xl border md:h-[68vh]">
 				<ClientVectrealViewer
@@ -81,6 +86,8 @@ const ProductDetailModel = memo(
 					onInteractionEvent={onInteractionEvent}
 					normalizationOptions={sceneData?.normalization}
 					shadowsOptions={sceneData?.shadows}
+					staticShadowBake
+					bakedShadow={bakedShadow}
 					popover={
 						<PreviewInfoPopover
 							title={sceneData?.meta?.name?.trim() || undefined}

--- a/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
+++ b/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../lib/stores/publisher-config-store'
 import { optimizationRuntimeAtom } from '../../lib/stores/scene-optimization-store'
 import {
+	bakedShadowSourceAtom,
 	rawModelDiagonalAtom,
 	sceneViewerSettingsAtom,
 	selectedCameraIdAtom,
@@ -75,6 +76,11 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 
 	return defaultShouldRevalidate
 }
+
+// Debounce window (ms) for committing shadow-light drags. Long enough to
+// coalesce a continuous pointer drag into a single re-bake, short enough that
+// the commit feels immediate once the user lets go.
+const SHADOW_LIGHT_COMMIT_DEBOUNCE_MS = 80
 
 const LOADING_MESSAGES = [
 	'Preparing the Publisher...',
@@ -165,10 +171,12 @@ const PublisherPage: FC<Route.ComponentProps> = ({ loaderData }) => {
 						? { ...prev, light: { ...prev.light, position } }
 						: prev
 				)
-			}, 80)
+			}, SHADOW_LIGHT_COMMIT_DEBOUNCE_MS)
 		},
 		[setShadows]
 	)
+	// Clear any pending shadow-light commit on unmount so a debounced setShadows
+	// can't fire into an unmounted tree (e.g. navigating away mid-drag).
 	useEffect(
 		() => () => {
 			if (shadowLightCommitTimer.current) {
@@ -196,16 +204,10 @@ const PublisherPage: FC<Route.ComponentProps> = ({ loaderData }) => {
 		registerCommandExecutor
 	} = usePublisherViewerCapture()
 
-	// Resolve the persisted shadow bake (if any) to a served URL so the viewer can
-	// render it instead of recomputing the bake. Served via the owner-authed image
-	// route; the viewer ignores it once the bake inputs change (signature mismatch).
-	const bakedShadow =
-		shadows?.type === 'accumulative' && shadows.baked && routeSceneId
-			? {
-					url: `/api/scenes/${routeSceneId}/thumbnail/${shadows.baked.assetId}`,
-					signature: shadows.baked.signature
-				}
-			: undefined
+	// Persisted shadow bake resolved from the loaded aggregate's inlined asset data
+	// (a data URL, no separate request). The viewer ignores it once the bake inputs
+	// change during editing (signature mismatch) and re-bakes live.
+	const bakedShadow = useAtomValue(bakedShadowSourceAtom) ?? undefined
 
 	const handleScreenshotCaptureReady = useCallback(
 		(capture: null | SceneScreenshotCapture) => {
@@ -321,7 +323,6 @@ const PublisherPage: FC<Route.ComponentProps> = ({ loaderData }) => {
 								onShadowBakeReady={handleShadowBakeReady}
 								shadowLightEditable={isShadowToolActive}
 								onShadowLightChange={handleShadowLightChange}
-								showViewCube
 								normalizationOptions={normalization}
 								boundsOptions={bounds}
 								loadingThumbnail={loadingThumbnail}

--- a/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
+++ b/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
@@ -27,13 +27,15 @@ import {
 	processInitialState,
 	publisherLoadingStateAtom,
 	processAtom,
-	sceneMetaAtom
+	sceneMetaAtom,
+	toolSidebarStateAtom
 } from '../../lib/stores/publisher-config-store'
 import { optimizationRuntimeAtom } from '../../lib/stores/scene-optimization-store'
 import {
 	rawModelDiagonalAtom,
 	sceneViewerSettingsAtom,
-	selectedCameraIdAtom
+	selectedCameraIdAtom,
+	shadowsAtom
 } from '../../lib/stores/scene-settings-store'
 import { isMobileRequest } from '../../lib/utils/is-mobile-request'
 import { toViewerLoadingThumbnail } from '../../lib/viewer/viewer-loading-thumbnail'
@@ -41,6 +43,7 @@ import { toViewerLoadingThumbnail } from '../../lib/viewer/viewer-loading-thumbn
 import type {
 	SceneCameraSnapshotCapture,
 	SceneScreenshotCapture,
+	ShadowBakeCapture,
 	ViewerCommandExecutor
 } from '@vctrl/viewer'
 import type { ShouldRevalidateFunction } from 'react-router'
@@ -141,11 +144,46 @@ const PublisherPage: FC<Route.ComponentProps> = ({ loaderData }) => {
 	const setProcess = useSetAtom(processAtom)
 	const setOptimizationRuntime = useSetAtom(optimizationRuntimeAtom)
 	const setRawDiagonal = useSetAtom(rawModelDiagonalAtom)
+	const setShadows = useSetAtom(shadowsAtom)
 	const { bounds, camera, controls, env, shadows, normalization } = useAtomValue(
 		sceneViewerSettingsAtom
 	)
+
+	// Persist drags of the in-scene shadow light handle. Debounced so a drag
+	// commits one re-bake when the user settles, not on every pointer move.
+	const shadowLightCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(
+		null
+	)
+	const handleShadowLightChange = useCallback(
+		(position: [number, number, number]) => {
+			if (shadowLightCommitTimer.current) {
+				clearTimeout(shadowLightCommitTimer.current)
+			}
+			shadowLightCommitTimer.current = setTimeout(() => {
+				setShadows((prev) =>
+					prev.type === 'accumulative'
+						? { ...prev, light: { ...prev.light, position } }
+						: prev
+				)
+			}, 80)
+		},
+		[setShadows]
+	)
+	useEffect(
+		() => () => {
+			if (shadowLightCommitTimer.current) {
+				clearTimeout(shadowLightCommitTimer.current)
+			}
+		},
+		[]
+	)
 	const selectedCameraId = useAtomValue(selectedCameraIdAtom)
 	const sceneMeta = useAtomValue(sceneMetaAtom)
+	const { activeComposeTool, showSidebar } = useAtomValue(toolSidebarStateAtom)
+	// The in-scene light handle only belongs to the shadow tool, so show it only
+	// while that tool's panel is open (and shadows are on).
+	const isShadowToolActive =
+		showSidebar && activeComposeTool === 'shadow' && (shadows?.enabled ?? false)
 	const loadingThumbnail = toViewerLoadingThumbnail(
 		sceneMeta.thumbnailUrl,
 		'Scene thumbnail preview'
@@ -154,8 +192,20 @@ const PublisherPage: FC<Route.ComponentProps> = ({ loaderData }) => {
 	const {
 		registerSceneScreenshotCapture,
 		registerSceneCameraSnapshotCapture,
+		registerShadowBakeCapture,
 		registerCommandExecutor
 	} = usePublisherViewerCapture()
+
+	// Resolve the persisted shadow bake (if any) to a served URL so the viewer can
+	// render it instead of recomputing the bake. Served via the owner-authed image
+	// route; the viewer ignores it once the bake inputs change (signature mismatch).
+	const bakedShadow =
+		shadows?.type === 'accumulative' && shadows.baked && routeSceneId
+			? {
+					url: `/api/scenes/${routeSceneId}/thumbnail/${shadows.baked.assetId}`,
+					signature: shadows.baked.signature
+				}
+			: undefined
 
 	const handleScreenshotCaptureReady = useCallback(
 		(capture: null | SceneScreenshotCapture) => {
@@ -176,6 +226,13 @@ const PublisherPage: FC<Route.ComponentProps> = ({ loaderData }) => {
 			registerCommandExecutor(executor)
 		},
 		[registerCommandExecutor]
+	)
+
+	const handleShadowBakeReady = useCallback(
+		(capture: null | ShadowBakeCapture) => {
+			registerShadowBakeCapture(capture)
+		},
+		[registerShadowBakeCapture]
 	)
 
 	// Cleanup on unmount
@@ -260,6 +317,11 @@ const PublisherPage: FC<Route.ComponentProps> = ({ loaderData }) => {
 								controlsOptions={controls}
 								envOptions={env}
 								shadowsOptions={shadows}
+								bakedShadow={bakedShadow}
+								onShadowBakeReady={handleShadowBakeReady}
+								shadowLightEditable={isShadowToolActive}
+								onShadowLightChange={handleShadowLightChange}
+								showViewCube
 								normalizationOptions={normalization}
 								boundsOptions={bounds}
 								loadingThumbnail={loadingThumbnail}

--- a/packages/core/src/types/scene-types.ts
+++ b/packages/core/src/types/scene-types.ts
@@ -260,6 +260,21 @@ export interface BakedShadowRef {
 }
 
 /**
+ * Stable filename for the persisted accumulative-shadow density PNG. Used as the
+ * key-agnostic identifier for the bake asset across the save upload, the scene
+ * aggregate, and file reconstruction (so the bake is found by name rather than by
+ * the asset-map key, which differs between load paths).
+ */
+export const PERSISTED_BAKE_FILENAME = 'shadow-bake.png'
+
+/**
+ * Stable filename for the scene thumbnail asset. Used to identify the thumbnail so
+ * it can be tracked as a scene asset (for garbage collection) while being excluded
+ * from the aggregate's inlined render data (it is served by URL, not rendered).
+ */
+export const SCENE_THUMBNAIL_FILENAME = 'scene-thumbnail.webp'
+
+/**
  * Configuration for the soft contact/ground shadow that approximates ground
  * ambient occlusion under the model. Plane size and capture height are derived
  * from the model automatically; these are the surfaced controls.

--- a/packages/core/src/types/scene-types.ts
+++ b/packages/core/src/types/scene-types.ts
@@ -15,7 +15,9 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>. */
 import { JSONDocument } from '@gltf-transform/core'
 import {
+	AccumulativeShadowsProps as ThreeAccumulativeShadowsProps,
 	OrbitControlsProps,
+	RandomizedLightProps,
 	BoundsProps as ThreeBoundsProps,
 	ContactShadowsProps as ThreeContactShadowsProps,
 	EnvironmentProps as ThreeEnvironmentProps,
@@ -217,7 +219,7 @@ export interface EnvironmentProps extends InheritedEnvProps {
 	environmentResolution?: EnvironmentResolution
 }
 
-export type ShadowType = 'contact'
+export type ShadowType = 'contact' | 'accumulative'
 
 /**
  * Base interface for shadow properties.
@@ -236,9 +238,100 @@ export interface ContactShadowProps
 }
 
 /**
+ * Light configuration for accumulative shadows (a drei `RandomizedLight`).
+ */
+export type AccumulativeShadowLight = Pick<
+	RandomizedLightProps,
+	'intensity' | 'amount' | 'radius' | 'ambient' | 'position' | 'bias'
+>
+
+/**
+ * Reference to a persisted accumulative-shadow bake. Stored in the scene's
+ * shadow settings so a saved scene can load the baked shadow texture instead of
+ * recomputing it. The bytes live in asset storage under {@link assetId}; the
+ * viewer reuses the texture only while {@link signature} still matches the
+ * current bake inputs.
+ */
+export interface BakedShadowRef {
+	/** Scene asset id of the stored shadow-density PNG. */
+	assetId: string
+	/** Bake signature the texture was captured with. */
+	signature: string
+}
+
+/**
+ * Configuration for the soft contact/ground shadow that approximates ground
+ * ambient occlusion under the model. Plane size and capture height are derived
+ * from the model automatically; these are the surfaced controls.
+ */
+export interface ContactShadowConfig {
+	/** Whether the ground shadow is rendered. Defaults to false. */
+	enabled?: boolean
+	/** Darkness of the ground shadow (0–1). Defaults to 0.6. */
+	opacity?: number
+	/** Softness/blur of the ground shadow. Higher is softer. Defaults to 3. */
+	blur?: number
+	/** Plane size as a multiple of the model footprint (how far the pool spreads). Defaults to 1.5. */
+	scale?: number
+	/**
+	 * How far UP from the floor geometry still casts the ground shadow, as a
+	 * fraction of the model's height (the ContactShadows depth-camera `far`). Lower
+	 * confines the darkening to where the model is closest to the ground for a
+	 * tighter, more accurate ambient-occlusion look; higher reaches up the model
+	 * for a broad grounding pool. Defaults to 0.35.
+	 */
+	reach?: number
+}
+
+/**
+ * Props for Accumulative Shadows — high quality baked soft shadows for a static
+ * subject. Camera auto-rotate orbits the camera (not the model), so the bake
+ * stays valid while rotating; the viewer falls back to contact shadows only
+ * while a model's geometry is actually animating.
+ */
+export interface AccumulativeShadowsProps
+	extends ShadowTypePropBase, ThreeAccumulativeShadowsProps {
+	type: 'accumulative'
+	light?: AccumulativeShadowLight
+	/**
+	 * Manual trim on the auto-calibrated shadow cutoff. The viewer measures the
+	 * baked plane's lit brightness and sets `alphaTest` to it automatically (so the
+	 * shadow reads correctly across environments); this multiplier nudges that
+	 * result. 1 = pure auto, &lt;1 deepens (risks haze), &gt;1 lightens. Defaults to 1.
+	 */
+	cutoffScale?: number
+	/**
+	 * Enables screen-space ambient occlusion (N8AO) so the model self-occludes in
+	 * crevices and tight gaps. This reintroduces a postprocessing composer and runs
+	 * every rendered frame, so it is opt-in. Defaults to false.
+	 */
+	ao?: boolean
+	/**
+	 * A soft contact/ground shadow (drei `ContactShadows`) layered under the
+	 * directional accumulative bake. It approximates the ambient occlusion the
+	 * model casts on the floor and keeps the model grounded independently of the
+	 * directional light's angle. Baked once (no per-frame cost). Tuned mainly via
+	 * `blur` (softness) and `opacity` (darkness).
+	 */
+	contact?: ContactShadowConfig
+	/**
+	 * Strength of the ambient occlusion when {@link ao} is enabled. Higher is
+	 * darker. Defaults to 1.4.
+	 */
+	aoIntensity?: number
+	/**
+	 * A persisted bake of the accumulative shadow. Written on save and consumed on
+	 * load so a returning visit renders the stored texture instead of recomputing
+	 * the bake. Invalidated automatically when the bake inputs change (see the
+	 * viewer's bake signature).
+	 */
+	baked?: BakedShadowRef
+}
+
+/**
  * Shadow configuration props. Extend `ShadowType` to add future shadow variants.
  */
-export type ShadowsProps = ContactShadowProps
+export type ShadowsProps = ContactShadowProps | AccumulativeShadowsProps
 
 /**
  * Options for runtime model size normalization.

--- a/packages/hooks/src/use-load-model/utils/reconstruct-files.ts
+++ b/packages/hooks/src/use-load-model/utils/reconstruct-files.ts
@@ -14,7 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-import { toSerializedAssetBytes } from '@vctrl/core'
+import { PERSISTED_BAKE_FILENAME, toSerializedAssetBytes } from '@vctrl/core'
 
 import type { InputFileOrDirectory, ServerSceneData } from '../types'
 
@@ -54,6 +54,14 @@ export function reconstructGltfFiles(
 	if (data.assetData && typeof data.assetData === 'object') {
 		for (const [, assetInfo] of Object.entries(data.assetData)) {
 			const { fileName, mimeType } = assetInfo
+
+			// The persisted shadow bake rides in the same asset map but is not
+			// referenced by the glTF; skip it so it isn't handed to the loader as a
+			// stray file. It is consumed separately as the shadow plane texture.
+			if (fileName === PERSISTED_BAKE_FILENAME) {
+				continue
+			}
+
 			const uint8Array = toSerializedAssetBytes(assetInfo)
 
 			// Create a Blob from the binary data

--- a/packages/viewer/src/components/scene/scene-baked-shadow.tsx
+++ b/packages/viewer/src/components/scene/scene-baked-shadow.tsx
@@ -1,0 +1,78 @@
+import { useTexture } from '@react-three/drei'
+import { useMemo } from 'react'
+import { Color } from 'three'
+
+interface SceneBakedShadowProps {
+	/** URL of the persisted shadow-density PNG (alpha channel = density). */
+	url: string
+	/** World-space side length of the shadow plane (footprint × shadow scale). */
+	planeScale: number
+	/** Live shadow strength, multiplied over the baked density. */
+	opacity: number
+	/** Live shadow color. */
+	color: string
+}
+
+const VERTEX_SHADER = /* glsl */ `
+	varying vec2 vUv;
+	void main() {
+		vUv = uv;
+		gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+	}
+`
+
+// Re-applies the persisted density: alpha = density × opacity, tinted by the live
+// shadow color. Opacity and color stay adjustable without a re-bake because the
+// stored texture is pure density (see captureShadowDensity).
+const FRAGMENT_SHADER = /* glsl */ `
+	varying vec2 vUv;
+	uniform sampler2D uMap;
+	uniform vec3 uColor;
+	uniform float uOpacity;
+	void main() {
+		float density = texture2D(uMap, vUv).a;
+		gl_FragColor = vec4(uColor, density * uOpacity);
+	}
+`
+
+/**
+ * Renders a persisted accumulative-shadow bake as a static textured plane —
+ * the load-time replacement for re-running the temporal bake. Same geometry the
+ * accumulative shadow uses (a ground plane in UV space), so the stored density
+ * lands exactly where it was baked.
+ */
+const SceneBakedShadow = ({
+	url,
+	planeScale,
+	opacity,
+	color
+}: SceneBakedShadowProps) => {
+	const map = useTexture(url)
+
+	const uniforms = useMemo(
+		() => ({
+			uMap: { value: map },
+			uColor: { value: new Color(color) },
+			uOpacity: { value: opacity }
+		}),
+		[map]
+	)
+
+	uniforms.uColor.value.set(color)
+	uniforms.uOpacity.value = opacity
+
+	return (
+		<mesh rotation={[-Math.PI / 2, 0, 0]} scale={planeScale}>
+			<planeGeometry />
+			<shaderMaterial
+				transparent
+				depthWrite={false}
+				uniforms={uniforms}
+				vertexShader={VERTEX_SHADER}
+				fragmentShader={FRAGMENT_SHADER}
+			/>
+		</mesh>
+	)
+}
+
+export default SceneBakedShadow

--- a/packages/viewer/src/components/scene/scene-postprocessing.tsx
+++ b/packages/viewer/src/components/scene/scene-postprocessing.tsx
@@ -1,20 +1,128 @@
-import { EffectComposer, ToneMapping } from '@react-three/postprocessing'
-import { BlendFunction } from 'postprocessing'
+import { useThree } from '@react-three/fiber'
+import {
+	EffectComposer,
+	N8AO,
+	SMAA,
+	ToneMapping
+} from '@react-three/postprocessing'
+import { ToneMappingMode } from 'postprocessing'
+import { memo, useEffect, useState } from 'react'
+import { ACESFilmicToneMapping, Box3, Object3D, Vector3 } from 'three'
 
-const ScenePostProcessing = () => {
-	return (
-		<EffectComposer enableNormalPass={false} multisampling={4}>
-			<ToneMapping
-				blendFunction={BlendFunction.AVERAGE} // blend mode
-				adaptive={true} // toggle adaptive luminance map usage
-				resolution={256} // texture resolution of the luminance map
-				middleGrey={0.5} // middle grey factor
-				maxLuminance={20.0} // maximum luminance
-				averageLuminance={1.5} // average luminance
-				adaptationRate={1.0} // luminance adaptation rate
-			/>
-		</EffectComposer>
-	)
+interface ScenePostProcessingProps {
+	/**
+	 * Enables screen-space ambient occlusion (N8AO). When on, rendering routes
+	 * through a postprocessing composer and tone mapping moves into it; when off,
+	 * tone mapping is applied directly on the renderer (no composer at all).
+	 */
+	ao?: boolean
+	/** AO strength (higher = darker). Only used when {@link ao} is true. */
+	aoIntensity?: number
+	/** Loaded model, measured to scale the AO radius to the subject. */
+	model?: Object3D
 }
+
+/**
+ * Applies ACES tone mapping directly on the renderer — the no-composer path.
+ *
+ * Mutates the existing renderer (no `gl` prop change, which would recreate the
+ * WebGL context and drop the loaded model) and restores the previous values on
+ * unmount. Used whenever the AO composer is not mounted, so the scene is never
+ * double tone-mapped.
+ */
+const RendererToneMapping = () => {
+	const gl = useThree((state) => state.gl)
+
+	useEffect(() => {
+		const previousToneMapping = gl.toneMapping
+		const previousExposure = gl.toneMappingExposure
+		gl.toneMapping = ACESFilmicToneMapping
+		gl.toneMappingExposure = 1
+		return () => {
+			gl.toneMapping = previousToneMapping
+			gl.toneMappingExposure = previousExposure
+		}
+	}, [gl])
+
+	return null
+}
+
+// AO look-up radius as a fraction of the model's bounding radius. Small enough to
+// read as crevice/contact occlusion rather than broad scene darkening.
+const AO_RADIUS_FACTOR = 0.3
+
+/**
+ * Measures the model's world-space bounding radius so the AO radius can be sized
+ * to the subject (models arrive at arbitrary scales — normalization is off by
+ * default). Returns 1 until measured.
+ */
+const useModelRadius = (model?: Object3D): number => {
+	const [radius, setRadius] = useState(1)
+
+	useEffect(() => {
+		if (!model) return
+		model.updateWorldMatrix(true, true)
+		const size = new Box3().setFromObject(model).getSize(new Vector3())
+		const next = 0.5 * Math.hypot(size.x, size.y, size.z)
+		if (next > 0 && Number.isFinite(next)) setRadius(next)
+	}, [model])
+
+	return radius
+}
+
+/**
+ * Postprocessing for the viewer.
+ *
+ * Two mutually exclusive modes keep the pipeline from double tone-mapping:
+ * - AO off (default): tone mapping is applied on the renderer, no composer.
+ * - AO on: an `EffectComposer` runs N8AO for crevice self-occlusion, then ACES
+ *   tone mapping. The composer sets the renderer's tone mapping to `NoToneMapping`
+ *   itself, so ACES lives in the composer here.
+ *
+ * The composer is only mounted while AO is enabled. That keeps it the sole
+ * positive render-priority owner of the loop (drei's AccumulativeShadows bakes at
+ * priority 0 into its own targets, so it composes fine) and avoids the
+ * disabled-but-mounted case where the composer leaves `autoClear` off and trails
+ * other shadow passes.
+ *
+ * Memoized: drei's EffectComposer rebuilds ALL of its effect passes whenever its
+ * `children` change identity. Without memo, every parent re-render (the viewer
+ * re-renders on most publisher interactions) would hand the composer fresh child
+ * elements and force a full pass teardown/rebuild — a visible flash and a stall on
+ * every click/hover. With stable props (ao/aoIntensity/model) memo skips those
+ * re-renders entirely, so the passes are built once.
+ *
+ * N8AO runs every frame the canvas draws (the viewer is `frameloop="always"`), so
+ * it's kept cheap: half-resolution AO at the 'performance' preset. Hardware MSAA
+ * is disabled (`multisampling={0}`) because it cannot antialias the AO/depth
+ * buffer — it would be pure wasted cost — and SMAA (a cheap post AA pass) is used
+ * instead, which is the N8AO author's recommended pairing.
+ */
+const ScenePostProcessing = memo(
+	({ ao, aoIntensity = 1.4, model }: ScenePostProcessingProps) => {
+		const radius = useModelRadius(model)
+
+		if (!ao) return <RendererToneMapping />
+
+		return (
+			<EffectComposer multisampling={0} enableNormalPass={false}>
+				<N8AO
+					aoRadius={radius * AO_RADIUS_FACTOR}
+					intensity={aoIntensity}
+					distanceFalloff={1}
+					quality="performance"
+					screenSpaceRadius={false}
+					halfRes
+					depthAwareUpsampling
+					color="black"
+				/>
+				<ToneMapping mode={ToneMappingMode.ACES_FILMIC} />
+				<SMAA />
+			</EffectComposer>
+		)
+	}
+)
+
+ScenePostProcessing.displayName = 'ScenePostProcessing'
 
 export default ScenePostProcessing

--- a/packages/viewer/src/components/scene/scene-shadows.tsx
+++ b/packages/viewer/src/components/scene/scene-shadows.tsx
@@ -1,48 +1,552 @@
-import { ContactShadows } from '@react-three/drei'
-import { useFrame } from '@react-three/fiber'
-import { ContactShadowProps, ShadowsProps } from '@vctrl/core'
-import { memo } from 'react'
+import {
+	AccumulativeShadows,
+	ContactShadows,
+	RandomizedLight
+} from '@react-three/drei'
+import { useThree } from '@react-three/fiber'
+import { AccumulativeShadowsProps } from '@vctrl/core'
+import {
+	type ComponentRef,
+	memo,
+	type RefObject,
+	Suspense,
+	useEffect,
+	useMemo,
+	useRef,
+	useState
+} from 'react'
+import { Box3, Mesh, Object3D, type Texture, Vector3 } from 'three'
 
-export const defaultShadowsOptions: ShadowsProps = {
-	type: 'contact',
+import SceneBakedShadow from './scene-baked-shadow'
+import ShadowAutoCutoff from './shadow-auto-cutoff'
+import {
+	captureShadowDensity,
+	computeBakeSignature,
+	computeModelFingerprint
+} from './shadow-bake'
+import ShadowLightGizmo from './shadow-light-gizmo'
+
+import type { BakedShadow, ShadowBakeCapture } from '../../types/viewer-types'
+
+// Accumulative shadows: high-quality baked soft shadows for a static subject.
+// The shadow is baked into the receiving plane's UV space from the
+// RandomizedLight, independent of the camera, so camera auto-rotate (which
+// orbits the camera, not the model) keeps the bake valid while rotating. The
+// RandomizedLight only feeds the bake and does not light the rest of the scene.
+//
+// The numeric controls below are expressed RELATIVE to the model's measured
+// size (see `contentScale`): the plane scale and light radius are multiples of
+// the model's largest dimension, and the light position is in model-size units.
+// This keeps the bake correctly proportioned for any model — the shadow geometry
+// is otherwise fixed in world units while model normalization is off by default,
+// so a small model would cast a shadow far too tiny to survive the alpha cutoff.
+export const defaultShadowsOptions: AccumulativeShadowsProps = {
+	type: 'accumulative',
 	enabled: false,
-	opacity: 0.4,
-	blur: 0.1,
-	scale: 1,
+	// Spread the bake across frames so it fades in smoothly rather than hitching
+	// the first frame. Fewer frames settle faster (quicker to appear, more
+	// responsive when the light moves) at a small cost in penumbra smoothness,
+	// which the radius jitter largely hides.
+	temporal: true,
+	frames: 48,
+	// NOT a discard threshold — in drei's SoftShadowMaterial the shadow alpha is
+	// `max(0, 1 - planeBrightness / alphaTest) * opacity`. The bake plane is a
+	// Lambert surface lit by the scene Environment, so its summed brightness sits
+	// at ~1.75 in shadow and ~4.0 when fully lit (measured, studio-natural env at
+	// environmentIntensity 1). alphaTest must sit between those: just below the
+	// lit value so lit areas stay transparent, but well above the shadow value so
+	// the shadow core gets real alpha. Fixed just below the lit brightness; shadow
+	// depth is driven by light.ambient ("Darkness") rather than alphaTest.
+	alphaTest: 3.0,
+	// Manual trim on the auto-calibrated cutoff (see ShadowAutoCutoff). 1 = auto.
+	cutoffScale: 1,
+	opacity: 0.9,
+	// Ground plane side length, in multiples of the model's footprint. Kept tight
+	// so the shadow fills more of the fixed-resolution lightmap (a larger plane
+	// spreads the same texels thinner and the shadow reads pixelated).
+	scale: 2.5,
+	resolution: 1024,
+	colorBlend: 2,
 	color: '#000000',
-	smooth: true
+	// Screen-space crevice occlusion (N8AO). Opt-in: real-time SSAO runs every
+	// rendered frame and adds GPU cost, so the default is the zero-idle-cost baked
+	// shadow only (see scene-postprocessing.tsx).
+	ao: false,
+	aoIntensity: 1.4,
+	// Soft contact/ground shadow under the directional bake (drei ContactShadows),
+	// approximating ground ambient occlusion. Baked once. Opt-in; tuned via blur
+	// (softness) and opacity (darkness).
+	contact: {
+		enabled: false,
+		opacity: 0.6,
+		blur: 3,
+		scale: 1.5,
+		reach: 0.35
+	},
+	light: {
+		// Bright bake light so the lit plane is well above the Environment's
+		// ambient floor, widening the window in which the shadow reads (see
+		// alphaTest note above). drei divides this by `amount` per sub-light.
+		intensity: Math.PI * 2,
+		// Number of jittered light samples accumulated into the bake.
+		amount: 8,
+		// Positional jitter of the light, in model-size units — the penumbra
+		// softness.
+		radius: 0.8,
+		// Hemisphere fill fraction. Lower = less fill under the model = darker
+		// shadow core. Surfaced in the UI as "Darkness".
+		ambient: 0.3,
+		// Light direction/distance, in model-size units (target is the model base).
+		// Default is straight overhead so the initial shadow is minimal and tucked
+		// under the model; presets and the in-scene handle move it off-axis.
+		position: [0, 2.5, 0],
+		bias: 0.001
+	}
+}
+
+// Shadow-camera orthographic half-extent, in model-size units. Kept tight to the
+// model so the directional shadow map spends its resolution on the subject (a
+// looser frustum makes the cast read blocky).
+const SHADOW_CAMERA_SIZE_FACTOR = 1.2
+
+// Frame count used while the light handle is being dragged — a fast, coarse bake
+// that settles in a few frames so the shadow visibly follows the light, then
+// snaps back to the full frame count on release.
+const PREVIEW_FRAMES = 12
+
+// Cheaper contact shadows, used only while a model is actively animating (the
+// baked accumulative shadow would otherwise lag the moving geometry). `scale` is
+// a multiple of the model size; blur/far are in world units (resolved per model).
+const defaultContactFallback = {
+	opacity: 0.5,
+	scale: 4,
+	blur: 2.4,
+	far: 10,
+	color: '#000000'
+}
+
+// The rendered variant is chosen by `isModelAnimating`, not the stored `type`,
+// and the app normalizes any stored config to a valid accumulative one before it
+// reaches here, so all fields are optional.
+type SceneShadowsProps = Partial<AccumulativeShadowsProps> & {
+	/**
+	 * The loaded model. Used only to measure the subject's world-space size so the
+	 * bake can be proportioned to it.
+	 */
+	model?: Object3D
+	/**
+	 * Set while the loaded model's geometry is actively animating. Camera
+	 * auto-rotate keeps the model static and must NOT set this. When true the
+	 * viewer renders cheaper contact shadows that track the moving geometry.
+	 */
+	isModelAnimating?: boolean
+	/**
+	 * When true, renders an in-scene draggable handle for aiming the shadow light.
+	 */
+	lightEditable?: boolean
+	/**
+	 * When true, the accumulative shadow bakes in a single synchronous pass on
+	 * mount (drei `temporal={false}`) instead of fading in across frames. Intended
+	 * for read-only/preview contexts so the shadow is present immediately rather
+	 * than building up every time a scene opens. The editor keeps the temporal
+	 * fade-in for responsive tweaking.
+	 */
+	staticBake?: boolean
+	/**
+	 * Called with a new light position in MODEL-SIZE units when the handle is
+	 * dragged (i.e. ready to store back into `light.position`).
+	 */
+	onLightChange?: (position: [number, number, number]) => void
+	/**
+	 * A persisted shadow bake. When present and its signature still matches the
+	 * current bake inputs, the viewer renders the stored texture and skips the
+	 * accumulative bake entirely (no recomputation on load).
+	 */
+	bakedShadow?: BakedShadow
+	/**
+	 * Receives a function that captures the settled bake as a density PNG (for
+	 * persistence). Intended for editing surfaces that save scenes.
+	 */
+	onShadowBakeReady?: (capture: ShadowBakeCapture | null) => void
+}
+
+interface ModelMetrics {
+	/** Largest horizontal (X/Z) extent — what the ground shadow plane is sized to. */
+	footprint: number
+	/** Bounding-sphere radius — what the light distance / shadow camera scale to. */
+	radius: number
+	/** Vertical (Y) extent — sizes the contact shadow's capture depth. */
+	height: number
+	/** Total vertex count — part of the persisted-bake fingerprint. */
+	vertexCount: number
+	/** False until the model has actually been measured (values are real, not defaults). */
+	measured: boolean
+}
+
+const DEFAULT_METRICS: ModelMetrics = {
+	footprint: 1,
+	radius: 1,
+	height: 1,
+	vertexCount: 0,
+	measured: false
 }
 
 /**
- * Renders contact shadows for the Three.js scene.
- * Accepts partial shadow configuration merged with defaults.
+ * Measures the model's world-space bounds so shadow parameters can be sized to
+ * the subject (model normalization is off by default, so models arrive at
+ * arbitrary scales). Footprint and bounding radius are tracked separately,
+ * mirroring how model-viewer / Sketchfab frame ground shadows to the bounding
+ * box: the plane follows the horizontal footprint, while the light distance and
+ * shadow camera follow the overall size. Using one shared max-dimension instead
+ * makes the shadow read too small under tall models and too large under flat
+ * ones. Returns unit metrics until measured.
  */
-const SceneShadows = memo((props?: Partial<ShadowsProps>) => {
-	const shadowOptions: ShadowsProps = { ...defaultShadowsOptions, ...props }
+const useModelMetrics = (model?: Object3D): ModelMetrics => {
+	const [metrics, setMetrics] = useState<ModelMetrics>(DEFAULT_METRICS)
 
-	// ContactShadows renders depth into its own WebGLRenderTarget via useFrame.
-	// r3f sets gl.autoClear = false globally, so the RT is never cleared before
-	// each depth render. Background pixels retain the previous blurred result
-	// through NormalBlending, causing the shadow to accumulate and grow each
-	// frame. Bracketing ContactShadows' useFrame (priority 0) with
-	// autoClear=true/false ensures the RT is cleared before each depth render.
-	const isEnabled = !!shadowOptions.enabled
+	useEffect(() => {
+		if (!model) return
+		// Bake ancestor transforms (model normalization scale, Center offset) into
+		// the world matrices before measuring.
+		model.updateWorldMatrix(true, true)
+		const size = new Box3().setFromObject(model).getSize(new Vector3())
+		const footprint = Math.max(size.x, size.z)
+		const radius = 0.5 * Math.hypot(size.x, size.y, size.z)
+		if (footprint > 0 && radius > 0 && Number.isFinite(radius)) {
+			setMetrics({
+				footprint,
+				radius,
+				height: size.y,
+				vertexCount: computeModelFingerprint(model),
+				measured: true
+			})
+		}
+	}, [model])
 
-	useFrame((state) => {
-		if (isEnabled) state.gl.autoClear = true
-	}, -1)
+	return metrics
+}
 
-	useFrame((state) => {
-		if (isEnabled) state.gl.autoClear = false
-	}, 1)
+interface ShadowBakeCaptureProps {
+	apiRef: RefObject<ComponentRef<typeof AccumulativeShadows> | null>
+	signature: string
+	resolution: number
+	onReady?: (capture: ShadowBakeCapture | null) => void
+}
 
-	if (!shadowOptions.enabled) return null
+/**
+ * Exposes a function that reads the settled accumulative-shadow bake into a
+ * density PNG (see captureShadowDensity), tagged with the current bake signature.
+ * The app calls it on save to persist the bake. Registered/cleared the same way
+ * as the screenshot capture. Returns null until the bake has settled.
+ */
+const ShadowBakeCapture = ({
+	apiRef,
+	signature,
+	resolution,
+	onReady
+}: ShadowBakeCaptureProps) => {
+	const gl = useThree((state) => state.gl)
+	// Keep the latest signature without re-registering the capture each bake.
+	const signatureRef = useRef(signature)
+	signatureRef.current = signature
 
-	const { type: _type, enabled: _enabled, ...contactProps } =
-		shadowOptions as ContactShadowProps
+	useEffect(() => {
+		if (!onReady) return
+		const capture: ShadowBakeCapture = async () => {
+			const api = apiRef.current
+			// Only a fully accumulated bake is worth persisting.
+			if (!api || api.count < api.frames) return null
+			const mesh = api.getMesh() as Mesh & {
+				material: { map?: Texture | null; alphaTest: number }
+			}
+			const map = mesh?.material?.map
+			const alphaTest = mesh?.material?.alphaTest
+			if (!map || alphaTest == null) return null
+			const dataUrl = captureShadowDensity(gl, map, alphaTest, resolution)
+			if (!dataUrl) return null
+			return { dataUrl, signature: signatureRef.current }
+		}
+		onReady(capture)
+		return () => onReady(null)
+	}, [gl, apiRef, resolution, onReady])
 
-	return <ContactShadows {...contactProps} />
-})
+	return null
+}
+
+/**
+ * Adaptive scene shadows: accumulative (baked, high quality) for a static
+ * subject, contact (cheaper, live) while the model animates.
+ *
+ * Both drei shadow components render on the default `useFrame` priority and do
+ * not take over the render loop — r3f's automatic `gl.render` still runs, so the
+ * scene (and the baked shadow plane) draws normally. ContactShadows clears its
+ * own render target each frame as long as `gl.autoClear` is at its default
+ * (`true`); nothing here forces it off.
+ */
+const SceneShadows = memo(
+	({
+		model,
+		isModelAnimating = false,
+		lightEditable = false,
+		onLightChange,
+		staticBake = false,
+		bakedShadow,
+		onShadowBakeReady,
+		...props
+	}: SceneShadowsProps) => {
+		const { footprint, radius, height, vertexCount, measured } =
+			useModelMetrics(model)
+		const apiRef = useRef<React.ComponentRef<typeof AccumulativeShadows> | null>(
+			null
+		)
+		// While the light handle is dragged, bake a coarse, fast preview so the
+		// shadow tracks the light, then settle to full quality on release.
+		const [previewing, setPreviewing] = useState(false)
+
+		// Merge incoming params over the defaults (defaults fill any gaps). The app
+		// normalizes stored shadow settings to a valid accumulative config before
+		// they reach here, so the props are trusted directly.
+		const options = {
+			...defaultShadowsOptions,
+			...props,
+			enabled: props.enabled ?? defaultShadowsOptions.enabled,
+			light: {
+				...defaultShadowsOptions.light,
+				...props.light
+			},
+			contact: {
+				...defaultShadowsOptions.contact,
+				...props.contact
+			}
+		}
+
+		// Resolve the relative controls to world units for the current model. The
+		// plane and penumbra follow the horizontal footprint; the light distance and
+		// shadow camera follow the bounding radius so the light always clears the
+		// model regardless of its aspect ratio.
+		const planeScale =
+			(options.scale ?? defaultShadowsOptions.scale!) * footprint
+		const lightRadius =
+			(options.light.radius ?? defaultShadowsOptions.light!.radius!) * footprint
+		// Source array is stable (it comes from the stored config / a constant), so
+		// memoizing keeps the resolved world-space position referentially stable
+		// across re-renders that don't actually move the light.
+		const lightPositionSource =
+			options.light.position ?? defaultShadowsOptions.light!.position!
+		const lightPosition = useMemo(
+			() =>
+				lightPositionSource.map((axis) => axis * radius) as [
+					number,
+					number,
+					number
+				],
+			[lightPositionSource, radius]
+		)
+
+		const frames = previewing
+			? Math.min(PREVIEW_FRAMES, options.frames ?? PREVIEW_FRAMES)
+			: options.frames
+
+		// In a read-only/preview context, bake in one synchronous pass on mount so
+		// the shadow is present immediately instead of building up over many frames
+		// (drei bakes all frames in a layout effect when temporal is off). The editor
+		// keeps the temporal fade-in so live tweaks don't hard-hitch.
+		const temporal = staticBake ? false : options.temporal
+
+		// Memoize the bake subtree. drei's AccumulativeShadows resets and re-bakes in
+		// a layout effect that has NO dependency array, so it re-bakes on every one
+		// of its renders. Re-rendering SceneShadows for an unrelated reason — chiefly
+		// toggling `lightEditable` when the shadow tool opens, which mounts the light
+		// gizmo — would therefore wipe and rebuild the bake. Keeping the element
+		// referentially stable (it only changes when a real bake input changes) makes
+		// React skip re-rendering AccumulativeShadows, so the bake survives.
+		const bake = useMemo(
+			() => (
+				<AccumulativeShadows
+					ref={apiRef}
+					temporal={temporal}
+					frames={frames}
+					alphaTest={options.alphaTest}
+					opacity={options.opacity}
+					scale={planeScale}
+					resolution={options.resolution}
+					colorBlend={options.colorBlend}
+					color={options.color}
+				>
+					<RandomizedLight
+						castShadow
+						amount={options.light.amount}
+						radius={lightRadius}
+						ambient={options.light.ambient}
+						intensity={options.light.intensity}
+						position={lightPosition}
+						bias={options.light.bias}
+						size={SHADOW_CAMERA_SIZE_FACTOR * radius}
+						mapSize={1024}
+						// Scale the shadow camera depth range to the model. drei's fixed
+						// near=0.5 clips the model out of the shadow map when the light is
+						// dragged close; a small relative near (with a generous far) keeps
+						// the model inside the frustum at any light distance.
+						near={radius * 0.02}
+						far={radius * 25}
+					/>
+				</AccumulativeShadows>
+			),
+			[
+				temporal,
+				frames,
+				options.alphaTest,
+				options.opacity,
+				planeScale,
+				options.resolution,
+				options.colorBlend,
+				options.color,
+				options.light.amount,
+				options.light.ambient,
+				options.light.intensity,
+				options.light.bias,
+				lightPosition,
+				lightRadius,
+				radius
+			]
+		)
+
+		// Soft contact/ground shadow under the directional bake. Memoized for the
+		// same reason as the bake (drei ContactShadows also re-bakes on re-render),
+		// so opening the shadow tool / moving the gizmo doesn't rebuild it.
+		//
+		// `far` is the depth camera's capture height: only geometry between the floor
+		// and `far` darkens, weighted by how close it is to the floor. A SMALL far
+		// (low `reach`) compresses that gradient into a thin near-ground band, so the
+		// falloff between touching and slightly-raised geometry is steep — true
+		// contact AO (only wheels/underbelly), not a uniform silhouette pool. A small
+		// floor keeps the camera from degenerating on near-flat models.
+		const contactShadow = useMemo(() => {
+			if (!options.contact.enabled) return null
+			const reach = options.contact.reach ?? defaultShadowsOptions.contact!.reach!
+			return (
+				<ContactShadows
+					frames={1}
+					scale={
+						(options.contact.scale ?? defaultShadowsOptions.contact!.scale!) *
+						footprint
+					}
+					far={Math.max(reach * height, radius * 0.03)}
+					blur={options.contact.blur ?? defaultShadowsOptions.contact!.blur!}
+					opacity={
+						options.contact.opacity ?? defaultShadowsOptions.contact!.opacity!
+					}
+					resolution={1024}
+					color={options.color ?? '#000000'}
+					// Sit just below the accumulative plane so the directional cast reads
+					// on top of the ground pool.
+					position={[0, -radius * 0.002, 0]}
+				/>
+			)
+		}, [
+			options.contact.enabled,
+			options.contact.scale,
+			options.contact.blur,
+			options.contact.opacity,
+			options.contact.reach,
+			options.color,
+			footprint,
+			height,
+			radius
+		])
+
+		// Signature of the current bake inputs. A persisted bake is reused only while
+		// it still matches; any change to the light/frames/scale/model re-bakes live
+		// (and the next save re-persists). Uses `options.frames` (the full count, not
+		// the drag-preview reduction).
+		const bakeSignature = computeBakeSignature(
+			{
+				light: options.light,
+				frames: options.frames,
+				scale: options.scale,
+				resolution: options.resolution
+			},
+			footprint,
+			radius,
+			vertexCount
+		)
+		// Use the persisted bake when one exists and either the model isn't measured
+		// yet (render it optimistically rather than spawn the expensive live bake we
+		// are trying to avoid) or its signature still matches the measured inputs.
+		const usePersistedBake = Boolean(
+			bakedShadow && (!measured || bakedShadow.signature === bakeSignature)
+		)
+
+		if (!options.enabled) return null
+
+		if (isModelAnimating) {
+			return (
+				<ContactShadows
+					opacity={options.opacity ?? defaultContactFallback.opacity}
+					scale={(options.scale ?? defaultContactFallback.scale) * footprint}
+					color={options.color ?? defaultContactFallback.color}
+					blur={defaultContactFallback.blur}
+					far={defaultContactFallback.far * radius}
+				/>
+			)
+		}
+
+		return (
+			<>
+				{contactShadow}
+
+				{usePersistedBake && bakedShadow ? (
+					// Load-time fast path: render the stored bake, no recomputation.
+					<Suspense fallback={null}>
+						<SceneBakedShadow
+							url={bakedShadow.url}
+							planeScale={planeScale}
+							opacity={options.opacity ?? defaultShadowsOptions.opacity!}
+							color={options.color ?? '#000000'}
+						/>
+					</Suspense>
+				) : (
+					<>
+						{bake}
+
+						<ShadowAutoCutoff
+							apiRef={apiRef}
+							cutoffScale={options.cutoffScale ?? 1}
+							temporal={temporal ?? true}
+						/>
+
+						{onShadowBakeReady && (
+							<ShadowBakeCapture
+								apiRef={apiRef}
+								signature={bakeSignature}
+								resolution={options.resolution ?? defaultShadowsOptions.resolution!}
+								onReady={onShadowBakeReady}
+							/>
+						)}
+					</>
+				)}
+
+				{lightEditable && onLightChange && (
+					<ShadowLightGizmo
+						position={lightPosition}
+						minDistance={radius * 1.3}
+						onDragStart={() => setPreviewing(true)}
+						onDragEnd={() => setPreviewing(false)}
+						onChange={(worldPosition) =>
+							onLightChange(
+								worldPosition.map((axis) => axis / radius) as [
+									number,
+									number,
+									number
+								]
+							)
+						}
+					/>
+				)}
+			</>
+		)
+	}
+)
 
 SceneShadows.displayName = 'SceneShadows'
 

--- a/packages/viewer/src/components/scene/scene-shadows.tsx
+++ b/packages/viewer/src/components/scene/scene-shadows.tsx
@@ -22,7 +22,8 @@ import ShadowAutoCutoff from './shadow-auto-cutoff'
 import {
 	captureShadowDensity,
 	computeBakeSignature,
-	computeModelFingerprint
+	computeModelFingerprint,
+	PERSISTED_BAKE_RESOLUTION
 } from './shadow-bake'
 import ShadowLightGizmo from './shadow-light-gizmo'
 
@@ -229,32 +230,47 @@ const useModelMetrics = (model?: Object3D): ModelMetrics => {
 interface ShadowBakeCaptureProps {
 	apiRef: RefObject<ComponentRef<typeof AccumulativeShadows> | null>
 	signature: string
-	resolution: number
+	/** True when the persisted bake is being rendered (no live bake to capture). */
+	usingPersistedBake: boolean
 	onReady?: (capture: ShadowBakeCapture | null) => void
 }
 
 /**
- * Exposes a function that reads the settled accumulative-shadow bake into a
- * density PNG (see captureShadowDensity), tagged with the current bake signature.
- * The app calls it on save to persist the bake. Registered/cleared the same way
- * as the screenshot capture. Returns null until the bake has settled.
+ * Exposes a function that reports the bake state at save time, so persistence is
+ * always fresh and never churns:
+ * - persisted bake still valid for the current inputs → `{ signature, dataUrl: null }`
+ *   (keep the stored asset, no re-upload),
+ * - a live bake has settled → `{ signature, dataUrl }` (a fresh density PNG to
+ *   persist; see captureShadowDensity),
+ * - nothing settled / no accumulative shadow → `null`.
+ *
+ * Mounted unconditionally (in both the persisted and live branches) so a save can
+ * confirm the persisted bake is current; registered/cleared like the screenshot
+ * capture. The bake is non-deterministic (RandomizedLight jitter), so reusing the
+ * stored asset when inputs are unchanged is what avoids a new upload every save.
  */
 const ShadowBakeCapture = ({
 	apiRef,
 	signature,
-	resolution,
+	usingPersistedBake,
 	onReady
 }: ShadowBakeCaptureProps) => {
 	const gl = useThree((state) => state.gl)
-	// Keep the latest signature without re-registering the capture each bake.
+	// Keep the latest values without re-registering the capture each render.
 	const signatureRef = useRef(signature)
 	signatureRef.current = signature
+	const usingPersistedBakeRef = useRef(usingPersistedBake)
+	usingPersistedBakeRef.current = usingPersistedBake
 
 	useEffect(() => {
 		if (!onReady) return
 		const capture: ShadowBakeCapture = async () => {
+			// Persisted bake is already valid for the current inputs: keep it.
+			if (usingPersistedBakeRef.current) {
+				return { dataUrl: null, signature: signatureRef.current }
+			}
 			const api = apiRef.current
-			// Only a fully accumulated bake is worth persisting.
+			// Only a fully accumulated live bake is worth persisting.
 			if (!api || api.count < api.frames) return null
 			const mesh = api.getMesh() as Mesh & {
 				material: { map?: Texture | null; alphaTest: number }
@@ -262,13 +278,18 @@ const ShadowBakeCapture = ({
 			const map = mesh?.material?.map
 			const alphaTest = mesh?.material?.alphaTest
 			if (!map || alphaTest == null) return null
-			const dataUrl = captureShadowDensity(gl, map, alphaTest, resolution)
+			const dataUrl = captureShadowDensity(
+				gl,
+				map,
+				alphaTest,
+				PERSISTED_BAKE_RESOLUTION
+			)
 			if (!dataUrl) return null
 			return { dataUrl, signature: signatureRef.current }
 		}
 		onReady(capture)
 		return () => onReady(null)
-	}, [gl, apiRef, resolution, onReady])
+	}, [gl, apiRef, onReady])
 
 	return null
 }
@@ -456,19 +477,45 @@ const SceneShadows = memo(
 		])
 
 		// Signature of the current bake inputs. A persisted bake is reused only while
-		// it still matches; any change to the light/frames/scale/model re-bakes live
-		// (and the next save re-persists). Uses `options.frames` (the full count, not
-		// the drag-preview reduction).
-		const bakeSignature = computeBakeSignature(
-			{
-				light: options.light,
-				frames: options.frames,
-				scale: options.scale,
-				resolution: options.resolution
-			},
-			footprint,
-			radius,
-			vertexCount
+		// it still matches; any change to the light/frames/scale/alphaTest/colorBlend/
+		// model re-bakes live (and the next save re-persists). Uses `options.frames`
+		// (the full count, not the drag-preview reduction). Memoized so it isn't
+		// re-serialized + re-hashed on every render.
+		const bakeSignature = useMemo(
+			() =>
+				computeBakeSignature(
+					{
+						light: options.light,
+						frames: options.frames,
+						scale: options.scale,
+						resolution: options.resolution,
+						alphaTest: options.alphaTest,
+						colorBlend: options.colorBlend,
+						cutoffScale: options.cutoffScale
+					},
+					footprint,
+					radius,
+					vertexCount
+				),
+			// Depend on primitive inputs, not the freshly-spread `options`/`options.light`
+			// objects, so the memo actually holds across unrelated re-renders.
+			[
+				options.frames,
+				options.scale,
+				options.resolution,
+				options.alphaTest,
+				options.colorBlend,
+				options.cutoffScale,
+				options.light.position,
+				options.light.radius,
+				options.light.ambient,
+				options.light.amount,
+				options.light.intensity,
+				options.light.bias,
+				footprint,
+				radius,
+				vertexCount
+			]
 		)
 		// Use the persisted bake when one exists and either the model isn't measured
 		// yet (render it optimistically rather than spawn the expensive live bake we
@@ -514,16 +561,18 @@ const SceneShadows = memo(
 							cutoffScale={options.cutoffScale ?? 1}
 							temporal={temporal ?? true}
 						/>
-
-						{onShadowBakeReady && (
-							<ShadowBakeCapture
-								apiRef={apiRef}
-								signature={bakeSignature}
-								resolution={options.resolution ?? defaultShadowsOptions.resolution!}
-								onReady={onShadowBakeReady}
-							/>
-						)}
 					</>
+				)}
+
+				{/* Mounted in both branches so a save can either persist a fresh live
+				    bake or confirm the stored one is still valid (avoiding re-upload). */}
+				{onShadowBakeReady && (
+					<ShadowBakeCapture
+						apiRef={apiRef}
+						signature={bakeSignature}
+						usingPersistedBake={usePersistedBake}
+						onReady={onShadowBakeReady}
+					/>
 				)}
 
 				{lightEditable && onLightChange && (

--- a/packages/viewer/src/components/scene/shadow-auto-cutoff.tsx
+++ b/packages/viewer/src/components/scene/shadow-auto-cutoff.tsx
@@ -1,0 +1,146 @@
+import { AccumulativeShadows } from '@react-three/drei'
+import { useFrame, useThree } from '@react-three/fiber'
+import { useEffect, useRef, type ComponentRef, type RefObject } from 'react'
+import {
+	FloatType,
+	Mesh,
+	MeshBasicMaterial,
+	OrthographicCamera,
+	PlaneGeometry,
+	Scene,
+	Texture,
+	WebGLRenderTarget,
+	type WebGLRenderer
+} from 'three'
+
+type AccumulativeApi = ComponentRef<typeof AccumulativeShadows>
+
+// alphaTest is clamped to this safe band so a degenerate measurement can never
+// blow out the plane or erase the shadow entirely.
+const ALPHA_TEST_MIN = 1.0
+const ALPHA_TEST_MAX = 6.0
+
+// Lightmap UVs sampled for the LIT brightness. The model's shadow sits at the
+// center, so these edge/corner points read the fully-lit plane; the max across
+// them is taken so a sample that happens to land in penumbra can't drag the
+// estimate down.
+const LIT_SAMPLES: ReadonlyArray<readonly [number, number]> = [
+	[0.04, 0.04],
+	[0.96, 0.96],
+	[0.96, 0.04],
+	[0.04, 0.96],
+	[0.5, 0.04],
+	[0.04, 0.5]
+]
+
+const READBACK_RES = 32
+
+/**
+ * Measures the maximum (lit) brightness of the baked lightmap by drawing it to a
+ * small float target and reading back a few edge samples. Values are linear: the
+ * basic material is untonemapped and the target is float, so the readback is the
+ * raw accumulated irradiance.
+ */
+const measureLitBrightness = (gl: WebGLRenderer, map: Texture): number => {
+	const target = new WebGLRenderTarget(READBACK_RES, READBACK_RES, {
+		type: FloatType
+	})
+	const scene = new Scene()
+	const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 1)
+	const material = new MeshBasicMaterial({ map, toneMapped: false })
+	const quad = new Mesh(new PlaneGeometry(2, 2), material)
+	scene.add(quad)
+
+	const previous = gl.getRenderTarget()
+	gl.setRenderTarget(target)
+	gl.render(scene, camera)
+	const pixels = new Float32Array(READBACK_RES * READBACK_RES * 4)
+	gl.readRenderTargetPixels(target, 0, 0, READBACK_RES, READBACK_RES, pixels)
+	gl.setRenderTarget(previous)
+
+	let maxSum = 0
+	for (const [u, v] of LIT_SAMPLES) {
+		const x = Math.floor(u * (READBACK_RES - 1))
+		const y = Math.floor(v * (READBACK_RES - 1))
+		const i = (y * READBACK_RES + x) * 4
+		maxSum = Math.max(maxSum, pixels[i] + pixels[i + 1] + pixels[i + 2])
+	}
+
+	target.dispose()
+	material.dispose()
+	quad.geometry.dispose()
+	return maxSum
+}
+
+interface ShadowAutoCutoffProps {
+	apiRef: RefObject<AccumulativeApi | null>
+	/** Manual trim on the auto value (1 = pure auto, <1 deeper, >1 lighter). */
+	cutoffScale: number
+	/**
+	 * Whether the shadow bakes temporally (across frames) or in one synchronous
+	 * pass. In non-temporal mode drei never advances `api.count`, so the
+	 * "still baking" gate below must not wait on it.
+	 */
+	temporal: boolean
+}
+
+/**
+ * Auto-calibrates the accumulative shadow's alphaTest to the current environment.
+ *
+ * alphaTest in drei's SoftShadowMaterial is a brightness divisor: the shadow
+ * alpha is `max(0, 1 - planeBrightness / alphaTest)`. Setting it to the lit-plane
+ * brightness makes lit areas exactly transparent while the dimmer shadowed areas
+ * keep their contrast — and because the lit brightness tracks the HDRI, the
+ * shadow reads consistently on any environment with no manual tuning.
+ *
+ * alphaTest only maps the already-baked lightmap to alpha, so we set the material
+ * directly once the bake settles — no re-bake. It re-runs when the bake restarts
+ * (new model / settings) or when the manual trim changes.
+ */
+const ShadowAutoCutoff = ({
+	apiRef,
+	cutoffScale,
+	temporal
+}: ShadowAutoCutoffProps) => {
+	const gl = useThree((state) => state.gl)
+	const calibratedRef = useRef(false)
+
+	useEffect(() => {
+		calibratedRef.current = false
+	}, [cutoffScale, temporal])
+
+	useFrame(() => {
+		const api = apiRef.current
+		if (!api) return
+
+		// In temporal mode, re-arm while the bake ramps and calibrate once it has
+		// settled. In non-temporal mode drei bakes synchronously in a layout effect
+		// and leaves `api.count` at 0, so there is no counter to wait on — the bake
+		// is already complete by the first frame; calibrate once (the calibrated
+		// flag prevents re-measuring every frame).
+		if (temporal && api.count < api.frames) {
+			calibratedRef.current = false
+			return
+		}
+		if (calibratedRef.current) return
+
+		const mesh = api.getMesh() as Mesh & {
+			material: { map?: Texture | null; alphaTest: number }
+		}
+		const map = mesh?.material?.map
+		if (!map) return
+
+		calibratedRef.current = true
+		const litBrightness = measureLitBrightness(gl, map)
+		if (litBrightness <= 0) return
+
+		mesh.material.alphaTest = Math.min(
+			ALPHA_TEST_MAX,
+			Math.max(ALPHA_TEST_MIN, litBrightness * cutoffScale)
+		)
+	})
+
+	return null
+}
+
+export default ShadowAutoCutoff

--- a/packages/viewer/src/components/scene/shadow-bake.ts
+++ b/packages/viewer/src/components/scene/shadow-bake.ts
@@ -1,0 +1,145 @@
+import {
+	Mesh,
+	type Object3D,
+	OrthographicCamera,
+	PlaneGeometry,
+	RGBAFormat,
+	Scene,
+	ShaderMaterial,
+	type Texture,
+	UnsignedByteType,
+	WebGLRenderTarget,
+	type WebGLRenderer
+} from 'three'
+
+import type { AccumulativeShadowsProps } from '@vctrl/core'
+
+/**
+ * Cheap geometric fingerprint of the model — total vertex count. Combined with
+ * the measured footprint/radius it distinguishes models that happen to share a
+ * bounding box, so a different model invalidates a persisted bake.
+ */
+export const computeModelFingerprint = (model: Object3D): number => {
+	let vertices = 0
+	model.traverse((object) => {
+		const geometry = (object as Mesh).geometry
+		const position = geometry?.attributes?.position
+		if (position) vertices += position.count
+	})
+	return vertices
+}
+
+/**
+ * Deterministic signature of everything that changes the BAKED shadow density:
+ * the bake light, frame count, plane scale, resolution and the model fingerprint.
+ *
+ * Deliberately excludes `opacity` and `color` — those are applied live on top of
+ * the stored density at render time, so recoloring or dimming the shadow never
+ * invalidates a persisted bake. Computed identically at capture time and at load
+ * time so the two can be compared.
+ */
+export const computeBakeSignature = (
+	options: Pick<
+		AccumulativeShadowsProps,
+		'light' | 'frames' | 'scale' | 'resolution'
+	>,
+	footprint: number,
+	radius: number,
+	fingerprint: number
+): string => {
+	const light = options.light ?? {}
+	return [
+		`fp:${fingerprint}`,
+		`ft:${footprint.toFixed(3)}`,
+		`rd:${radius.toFixed(3)}`,
+		`fr:${options.frames}`,
+		`sc:${options.scale}`,
+		`rs:${options.resolution}`,
+		`lp:${(light.position ?? []).map((n) => n.toFixed(3)).join(',')}`,
+		`lr:${light.radius}`,
+		`la:${light.ambient}`,
+		`ln:${light.amount}`,
+		`li:${light.intensity}`,
+		`lb:${light.bias}`
+	].join('|')
+}
+
+const DENSITY_VERTEX = /* glsl */ `
+	varying vec2 vUv;
+	void main() {
+		vUv = uv;
+		gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+	}
+`
+
+// Reproduces drei SoftShadowMaterial's alpha (the shadow density), independent of
+// opacity/color: density = max(0, 1 - (r+g+b)/alphaTest). Written to the alpha
+// channel; RGB stays black so the PNG is a pure density mask.
+const DENSITY_FRAGMENT = /* glsl */ `
+	varying vec2 vUv;
+	uniform sampler2D uMap;
+	uniform float uAlphaTest;
+	void main() {
+		vec3 c = texture2D(uMap, vUv).rgb;
+		float density = max(0.0, 1.0 - (c.r + c.g + c.b) / uAlphaTest);
+		gl_FragColor = vec4(0.0, 0.0, 0.0, density);
+	}
+`
+
+/**
+ * Renders the accumulative shadow's baked lightmap into a shadow-density PNG: a
+ * data URL whose alpha channel is the shadow density (RGB black). This is the
+ * persisted artifact — re-applied to a plane at load time so the bake never has
+ * to run again.
+ *
+ * Uses the same float-readback idea as the auto-cutoff, but at full resolution
+ * and through the density formula, then copies the pixels into a 2D canvas (row
+ * order flipped — WebGL reads bottom-up) and exports a PNG.
+ */
+export const captureShadowDensity = (
+	gl: WebGLRenderer,
+	map: Texture,
+	alphaTest: number,
+	resolution: number
+): string => {
+	const target = new WebGLRenderTarget(resolution, resolution, {
+		type: UnsignedByteType,
+		format: RGBAFormat
+	})
+	const scene = new Scene()
+	const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 1)
+	const material = new ShaderMaterial({
+		uniforms: { uMap: { value: map }, uAlphaTest: { value: alphaTest } },
+		vertexShader: DENSITY_VERTEX,
+		fragmentShader: DENSITY_FRAGMENT
+	})
+	const quad = new Mesh(new PlaneGeometry(2, 2), material)
+	scene.add(quad)
+
+	const previousTarget = gl.getRenderTarget()
+	gl.setRenderTarget(target)
+	gl.clear()
+	gl.render(scene, camera)
+	const pixels = new Uint8Array(resolution * resolution * 4)
+	gl.readRenderTargetPixels(target, 0, 0, resolution, resolution, pixels)
+	gl.setRenderTarget(previousTarget)
+
+	const canvas = document.createElement('canvas')
+	canvas.width = resolution
+	canvas.height = resolution
+	const ctx = canvas.getContext('2d')
+	target.dispose()
+	material.dispose()
+	quad.geometry.dispose()
+	if (!ctx) return ''
+
+	const image = ctx.createImageData(resolution, resolution)
+	// Flip vertically: readRenderTargetPixels returns rows bottom-to-top.
+	for (let y = 0; y < resolution; y++) {
+		const srcRow = (resolution - 1 - y) * resolution * 4
+		const dstRow = y * resolution * 4
+		image.data.set(pixels.subarray(srcRow, srcRow + resolution * 4), dstRow)
+	}
+	ctx.putImageData(image, 0, 0)
+	return canvas.toDataURL('image/png')
+}

--- a/packages/viewer/src/components/scene/shadow-bake.ts
+++ b/packages/viewer/src/components/scene/shadow-bake.ts
@@ -15,6 +15,14 @@ import {
 import type { AccumulativeShadowsProps } from '@vctrl/core'
 
 /**
+ * Resolution (px, square) of the persisted shadow-density PNG. Independent of the
+ * bake's own `resolution` (which controls bake quality); the stored mask is a
+ * low-frequency soft shadow that downscales cleanly, so a smaller size keeps the
+ * asset (base64-inlined into the scene aggregate) lean.
+ */
+export const PERSISTED_BAKE_RESOLUTION = 512
+
+/**
  * Cheap geometric fingerprint of the model — total vertex count. Combined with
  * the measured footprint/radius it distinguishes models that happen to share a
  * bounding box, so a different model invalidates a persisted bake.
@@ -29,32 +37,61 @@ export const computeModelFingerprint = (model: Object3D): number => {
 	return vertices
 }
 
+// Synchronous FNV-1a hash → 8-char hex. Used to fold the canonical bake-input
+// serialization into a short, stable token. Sync (no crypto.subtle) because the
+// signature is derived in render.
+const fnv1aHex = (input: string): string => {
+	let hash = 0x811c9dc5
+	for (let i = 0; i < input.length; i++) {
+		hash ^= input.charCodeAt(i)
+		hash = Math.imul(hash, 0x01000193)
+	}
+	return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
 /**
- * Deterministic signature of everything that changes the BAKED shadow density:
- * the bake light, frame count, plane scale, resolution and the model fingerprint.
+ * Deterministic signature of everything that changes the BAKED shadow density,
+ * hashed into a compact token. Covers the COMPLETE set of bake inputs: the bake
+ * light, frame count, plane scale, resolution, alphaTest, colorBlend, cutoffScale
+ * and the model fingerprint (footprint, radius, vertex count). Hashing a complete,
+ * canonically-ordered serialization means any change to any input is caught and
+ * nothing can be silently omitted (the previous hand-listed form missed
+ * alphaTest/colorBlend/cutoffScale, which bake into the density and are not
+ * reapplied live — cutoffScale scales the auto-calibrated alphaTest that the
+ * captured density is computed against).
  *
  * Deliberately excludes `opacity` and `color` — those are applied live on top of
  * the stored density at render time, so recoloring or dimming the shadow never
- * invalidates a persisted bake. Computed identically at capture time and at load
- * time so the two can be compared.
+ * invalidates a persisted bake. Computed identically at capture and load time so
+ * the two can be compared. The `v2:` prefix versions the format so tokens from an
+ * older format never collide (they simply mismatch and trigger one re-bake).
  */
 export const computeBakeSignature = (
 	options: Pick<
 		AccumulativeShadowsProps,
-		'light' | 'frames' | 'scale' | 'resolution'
+		| 'light'
+		| 'frames'
+		| 'scale'
+		| 'resolution'
+		| 'alphaTest'
+		| 'colorBlend'
+		| 'cutoffScale'
 	>,
 	footprint: number,
 	radius: number,
 	fingerprint: number
 ): string => {
 	const light = options.light ?? {}
-	return [
+	const canonical = [
 		`fp:${fingerprint}`,
 		`ft:${footprint.toFixed(3)}`,
 		`rd:${radius.toFixed(3)}`,
 		`fr:${options.frames}`,
 		`sc:${options.scale}`,
 		`rs:${options.resolution}`,
+		`at:${options.alphaTest}`,
+		`cb:${options.colorBlend}`,
+		`ct:${options.cutoffScale}`,
 		`lp:${(light.position ?? []).map((n) => n.toFixed(3)).join(',')}`,
 		`lr:${light.radius}`,
 		`la:${light.ambient}`,
@@ -62,6 +99,7 @@ export const computeBakeSignature = (
 		`li:${light.intensity}`,
 		`lb:${light.bias}`
 	].join('|')
+	return `v2:${fnv1aHex(canonical)}`
 }
 
 const DENSITY_VERTEX = /* glsl */ `

--- a/packages/viewer/src/components/scene/shadow-light-gizmo.tsx
+++ b/packages/viewer/src/components/scene/shadow-light-gizmo.tsx
@@ -1,0 +1,166 @@
+import { Line, PivotControls } from '@react-three/drei'
+import { ThreeEvent, useThree } from '@react-three/fiber'
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { Group, Matrix4, Object3D, Vector3 } from 'three'
+
+interface ShadowLightGizmoProps {
+	/** World-space position of the light handle. */
+	position: [number, number, number]
+	/** Closest the light may sit to the target, keeping it outside the model. */
+	minDistance?: number
+	/** Called with the new world-space handle position while dragging. */
+	onChange: (worldPosition: [number, number, number]) => void
+	/** Fired when a drag begins / ends (used to drop to a fast preview bake). */
+	onDragStart?: () => void
+	onDragEnd?: () => void
+}
+
+// Keep the light at least this far above the horizon (as a fraction of its
+// distance from the target) so it can't be dragged below the ground plane.
+const MIN_ELEVATION_SIN = Math.sin((6 * Math.PI) / 180)
+
+const scratch = new Vector3()
+const ORIGIN: [number, number, number] = [0, 0, 0]
+
+/**
+ * In-viewport control for the shadow light.
+ *
+ * - A thin line from the model base to the light always shows the light
+ *   direction, so the light stays locatable even when its handle is off-screen.
+ * - A small marker sits at the light; clicking it toggles the move gizmo
+ *   (editor-style click-to-activate) rather than leaving arrows permanently on.
+ * - When active, drag the X/Y/Z arrows to aim the light. The handle is a constant
+ *   on-screen size (PivotControls `fixed`) so it never balloons off-screen.
+ *
+ * PivotControls (pure r3f) is used over TransformControls, which throws from its
+ * gizmo's updateMatrixWorld when the accumulative bake re-renders the tree.
+ */
+const ShadowLightGizmo = ({
+	position,
+	minDistance = 0,
+	onChange,
+	onDragStart,
+	onDragEnd
+}: ShadowLightGizmoProps) => {
+	const controls = useThree(
+		(state) => state.controls as { enabled?: boolean } | null
+	)
+	const [active, setActive] = useState(false)
+	const [hovered, setHovered] = useState(false)
+	// Live (uncommitted) position during a drag, so the direction line tracks the
+	// handle smoothly instead of lagging behind the debounced store commit.
+	const [livePosition, setLivePosition] = useState<
+		[number, number, number] | null
+	>(null)
+
+	const groupRef = useRef<Group>(null)
+
+	// The accumulative bake treats every shadow-casting mesh in the scene as an
+	// occluder, including these helper meshes (the marker, the direction line, and
+	// drei's internal PivotControls arrows), which would bake a hard streak/disc
+	// onto the ground. Force the whole gizmo subtree to never cast. Runs every
+	// render so meshes created later (the arrows appear only when active) are
+	// covered too.
+	useLayoutEffect(() => {
+		groupRef.current?.traverse((object: Object3D) => {
+			object.castShadow = false
+		})
+	})
+
+	const matrix = useMemo(
+		() => new Matrix4().setPosition(position[0], position[1], position[2]),
+		[position]
+	)
+	const distance = useMemo(
+		() => Math.hypot(position[0], position[1], position[2]) || 1,
+		[position]
+	)
+	const markerRadius = distance * 0.03
+
+	const handleDrag = useCallback(
+		(local: Matrix4) => {
+			scratch.setFromMatrixPosition(local)
+			// Keep the light above the ground...
+			const minY = scratch.length() * MIN_ELEVATION_SIN
+			if (scratch.y < minY) scratch.y = minY
+			// ...and outside the model, so it never ends up inside the geometry
+			// (which would leave the model in front of the shadow camera's near plane
+			// and cast no shadow).
+			if (minDistance > 0 && scratch.length() < minDistance) {
+				scratch.setLength(minDistance)
+			}
+			const next: [number, number, number] = [scratch.x, scratch.y, scratch.z]
+			setLivePosition(next)
+			onChange(next)
+		},
+		[minDistance, onChange]
+	)
+
+	const handleDragStart = useCallback(() => {
+		if (controls) controls.enabled = false
+		onDragStart?.()
+	}, [controls, onDragStart])
+
+	const handleDragEnd = useCallback(() => {
+		if (controls) controls.enabled = true
+		setLivePosition(null)
+		onDragEnd?.()
+	}, [controls, onDragEnd])
+
+	const toggleActive = useCallback((event: ThreeEvent<MouseEvent>) => {
+		event.stopPropagation()
+		setActive((value) => !value)
+	}, [])
+
+	const markerColor = active ? '#ffcf6b' : hovered ? '#ffd98a' : '#f4f4f5'
+	const lineEnd = livePosition ?? position
+
+	const marker = (
+		<mesh
+			onClick={toggleActive}
+			onPointerOver={(event) => {
+				event.stopPropagation()
+				setHovered(true)
+			}}
+			onPointerOut={() => setHovered(false)}
+		>
+			<sphereGeometry args={[markerRadius, 16, 16]} />
+			<meshBasicMaterial color={markerColor} toneMapped={false} depthTest={false} />
+		</mesh>
+	)
+
+	return (
+		<group ref={groupRef}>
+			<Line
+				points={[ORIGIN, lineEnd]}
+				color="#ffcf6b"
+				lineWidth={1}
+				transparent
+				opacity={0.35}
+				depthTest={false}
+			/>
+			{active ? (
+				<PivotControls
+					matrix={matrix}
+					autoTransform
+					fixed
+					scale={95}
+					disableRotations
+					disableScaling
+					disableSliders
+					depthTest={false}
+					lineWidth={2.5}
+					onDragStart={handleDragStart}
+					onDrag={handleDrag}
+					onDragEnd={handleDragEnd}
+				>
+					{marker}
+				</PivotControls>
+			) : (
+				<group position={position}>{marker}</group>
+			)}
+		</group>
+	)
+}
+
+export default ShadowLightGizmo

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -2,10 +2,13 @@ import './styles.css'
 
 export {
 	default as VectrealViewer,
+	type BakedShadow,
 	type SceneScreenshotCapture,
 	type SceneCameraSnapshot,
 	type SceneCameraSnapshotCapture,
 	type SceneScreenshotOptions,
+	type ShadowBakeCapture,
+	type ShadowBakeResult,
 	type ViewerCommandExecutor,
 	type ViewerCommand,
 	type ViewerInteractionEvent,

--- a/packages/viewer/src/types/viewer-types.ts
+++ b/packages/viewer/src/types/viewer-types.ts
@@ -26,6 +26,30 @@ export type SceneScreenshotCapture = (
 	options?: SceneScreenshotOptions
 ) => Promise<null | string>
 
+/** A captured accumulative-shadow bake: a density PNG data URL + its signature. */
+export interface ShadowBakeResult {
+	dataUrl: string
+	signature: string
+}
+
+/**
+ * A persisted accumulative-shadow bake. When present and its signature still
+ * matches the current bake inputs, the viewer renders the stored texture and
+ * skips re-baking entirely.
+ */
+export interface BakedShadow {
+	/** URL of the stored shadow-density PNG (alpha channel = shadow density). */
+	url: string
+	/** Bake signature the texture was captured with. */
+	signature: string
+}
+
+/**
+ * Captures the settled accumulative-shadow bake for persistence. Resolves null if
+ * the bake has not settled yet (nothing worth storing).
+ */
+export type ShadowBakeCapture = () => Promise<null | ShadowBakeResult>
+
 export interface ViewerLoadingThumbnail {
 	src: string
 	alt?: string

--- a/packages/viewer/src/types/viewer-types.ts
+++ b/packages/viewer/src/types/viewer-types.ts
@@ -26,9 +26,16 @@ export type SceneScreenshotCapture = (
 	options?: SceneScreenshotOptions
 ) => Promise<null | string>
 
-/** A captured accumulative-shadow bake: a density PNG data URL + its signature. */
+/**
+ * The state of the accumulative-shadow bake at save time, for persistence.
+ * `signature` is always the current bake inputs' signature. `dataUrl` is a fresh
+ * density PNG when a live bake settled and needs (re)persisting, or `null` when
+ * the already-persisted bake is still valid for these inputs (no re-upload). A
+ * `null` result from the capture function means there is nothing worth persisting
+ * (no accumulative shadow, or the bake has not settled).
+ */
 export interface ShadowBakeResult {
-	dataUrl: string
+	dataUrl: string | null
 	signature: string
 }
 

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -14,10 +14,11 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-import { Center } from '@react-three/drei'
+import { Center, GizmoHelper, GizmoViewcube } from '@react-three/drei'
 import { LoadingSpinner as DefaultSpinner } from '@shared/components/ui/loading-spinner'
 import { cn } from '@shared/utils'
 import {
+	AccumulativeShadowsProps,
 	BoundsProps,
 	CameraProps,
 	ControlsProps,
@@ -51,8 +52,10 @@ import {
 import { useViewerLoading } from './hooks/use-viewer-loading'
 
 import type {
+	BakedShadow,
 	SceneCameraSnapshotCapture,
 	SceneScreenshotCapture,
+	ShadowBakeCapture,
 	ViewerCommand,
 	ViewerCommandExecutor,
 	ViewerInteractionEvent,
@@ -60,10 +63,13 @@ import type {
 } from './types/viewer-types'
 
 export type {
+	BakedShadow,
 	SceneCameraSnapshot,
 	SceneCameraSnapshotCapture,
 	SceneScreenshotCapture,
 	SceneScreenshotOptions,
+	ShadowBakeCapture,
+	ShadowBakeResult,
 	ViewerCommandExecutor,
 	ViewerCommand,
 	ViewerInteractionEvent,
@@ -127,6 +133,45 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 * Options for the shadows.
 	 */
 	shadowsOptions?: ShadowsProps
+
+	/**
+	 * When true, renders an in-scene draggable handle for aiming the shadow light.
+	 * Intended for editing surfaces (e.g. the publisher), not public viewers.
+	 */
+	shadowLightEditable?: boolean
+
+	/**
+	 * When true, renders a clickable orientation cube (lower-left) for snapping the
+	 * camera to absolute views. Intended for editing surfaces.
+	 */
+	showViewCube?: boolean
+
+	/**
+	 * When true, the accumulative shadow bakes in a single pass on mount instead of
+	 * fading in across frames, so it is present immediately when a scene opens.
+	 * Intended for read-only/preview surfaces; the editor leaves this off to keep
+	 * the smooth temporal fade-in while tweaking. Default: false.
+	 */
+	staticShadowBake?: boolean
+
+	/**
+	 * A persisted accumulative-shadow bake. When present and still valid for the
+	 * current shadow settings + model, the viewer renders the stored texture and
+	 * skips re-baking entirely (no recomputation on load).
+	 */
+	bakedShadow?: BakedShadow
+
+	/**
+	 * Receives a function that captures the settled shadow bake as a density PNG,
+	 * for persistence. Intended for editing surfaces that save scenes.
+	 */
+	onShadowBakeReady?: (capture: ShadowBakeCapture | null) => void
+
+	/**
+	 * Called with a new shadow light position (model-size units) when the in-scene
+	 * handle is dragged. Store this back into `shadowsOptions.light.position`.
+	 */
+	onShadowLightChange?: (position: [number, number, number]) => void
 
 	/**
 	 * Options for runtime model size normalization.
@@ -221,6 +266,12 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		// gridOptions,
 		controlsOptions,
 		shadowsOptions,
+		shadowLightEditable,
+		onShadowLightChange,
+		showViewCube,
+		staticShadowBake = false,
+		bakedShadow,
+		onShadowBakeReady,
 		normalizationOptions,
 		popover,
 		loadingThumbnail,
@@ -319,6 +370,11 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		isInitialFramingComplete
 	)
 	const shadowsEnabled = shadowsOptions?.enabled ?? false
+	// AO config lives on the accumulative shadow settings. It's gated on shadows
+	// being enabled so toggling shadows off also tears down the AO composer.
+	const accumulativeShadows =
+		shadowsOptions?.type === 'accumulative' ? shadowsOptions : undefined
+	const aoEnabled = shadowsEnabled && (accumulativeShadows?.ao ?? false)
 	return (
 		<Suspense fallback={loader}>
 			<Canvas
@@ -339,7 +395,10 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 					/>
 				}
 				enableViewportRendering={enableViewportRendering}
-				shadows={shadowsEnabled}
+				// 'percentage' = PCFShadowMap. AccumulativeShadows bakes its own soft
+				// shadow from its RandomizedLight, so the realtime filter just needs to
+				// be enabled. (A bare `shadows` would use the deprecated PCFSoftShadowMap.)
+				shadows={shadowsEnabled ? 'percentage' : false}
 				gl={{ antialias: false, powerPreference: 'low-power' }}
 			>
 				<Suspense fallback={null}>
@@ -348,7 +407,13 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 							{/* <SceneGrid {...gridOptions} /> */}
 							<SceneEnvironment {...envOptions} />
 							{/* <Perf /> */}
-							{enablePostProcessing ? <ScenePostProcessing /> : null}
+							{enablePostProcessing ? (
+								<ScenePostProcessing
+									ao={aoEnabled}
+									aoIntensity={accumulativeShadows?.aoIntensity}
+									model={model}
+								/>
+							) : null}
 							<SceneControls
 								{...controlsOptions}
 								enabledOverride={controlsEnabledOverride}
@@ -395,9 +460,37 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 										/>
 									)}
 								</Center>
-								<SceneShadows {...shadowsOptions} />
+								<SceneShadows
+									model={model}
+									{...(shadowsOptions as Partial<AccumulativeShadowsProps>)}
+									lightEditable={shadowLightEditable}
+									onLightChange={onShadowLightChange}
+									staticBake={staticShadowBake}
+									bakedShadow={bakedShadow}
+									onShadowBakeReady={onShadowBakeReady}
+								/>
 								{children}
 							</SceneBounds>
+							{showViewCube && (
+								<GizmoHelper
+									alignment="bottom-left"
+									margin={[72, 72]}
+									// drei's Hud re-renders the whole scene itself at renderPriority
+									// 1, which would clobber the AO EffectComposer's output (also at
+									// priority 1). At priority 2 the Hud skips that scene re-render and
+									// just overlays the gizmo on top of the composed frame, so the
+									// cube and postprocessing coexist. Without AO there's no composer,
+									// so the default priority 1 keeps working as before.
+									renderPriority={aoEnabled ? 2 : 1}
+								>
+									<GizmoViewcube
+										color="#f4f4f5"
+										textColor="#52525b"
+										strokeColor="#d4d4d8"
+										hoverColor="#fbbf24"
+									/>
+								</GizmoHelper>
+							)}
 						</>
 					)}
 				</Suspense>

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -14,7 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-import { Center, GizmoHelper, GizmoViewcube } from '@react-three/drei'
+import { Center } from '@react-three/drei'
 import { LoadingSpinner as DefaultSpinner } from '@shared/components/ui/loading-spinner'
 import { cn } from '@shared/utils'
 import {
@@ -77,10 +77,14 @@ export type {
 } from './types/viewer-types'
 
 export interface VectrealViewerProps extends PropsWithChildren {
+	// --- Content ---
+
 	/**
 	 * The 3D model to render in the viewer. (three.js `Object3D`)
 	 */
 	model?: Object3D
+
+	// --- Container & appearance ---
 
 	/**
 	 * An optional className to apply to the outermost container of the viewer.
@@ -95,6 +99,8 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 */
 	theme?: 'light' | 'dark' | 'system'
 
+	// --- Performance ---
+
 	/**
 	 * Whether to render the canvas only when visible in viewport.
 	 * Improves performance by not rendering off-screen scenes.
@@ -108,6 +114,8 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 * Default: true
 	 */
 	enablePostProcessing?: boolean
+
+	// --- Scene configuration ---
 
 	/**
 	 * Options for the scene bounds.
@@ -135,16 +143,26 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	shadowsOptions?: ShadowsProps
 
 	/**
+	 * Options for runtime model size normalization.
+	 * Clamps the model's bounding-box diagonal to [minSize, maxSize].
+	 * Does not modify the underlying model data.
+	 */
+	normalizationOptions?: NormalizationOptions
+
+	/**
+	 * Options for the grid.
+	 */
+	gridOptions?: GridProps
+
+	// --- Editor affordances ---
+	// Editing-surface features (e.g. the publisher). Public/embedded viewers omit
+	// these. See the package README for the slim-embed surface.
+
+	/**
 	 * When true, renders an in-scene draggable handle for aiming the shadow light.
 	 * Intended for editing surfaces (e.g. the publisher), not public viewers.
 	 */
 	shadowLightEditable?: boolean
-
-	/**
-	 * When true, renders a clickable orientation cube (lower-left) for snapping the
-	 * camera to absolute views. Intended for editing surfaces.
-	 */
-	showViewCube?: boolean
 
 	/**
 	 * When true, the accumulative shadow bakes in a single pass on mount instead of
@@ -173,17 +191,7 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 */
 	onShadowLightChange?: (position: [number, number, number]) => void
 
-	/**
-	 * Options for runtime model size normalization.
-	 * Clamps the model's bounding-box diagonal to [minSize, maxSize].
-	 * Does not modify the underlying model data.
-	 */
-	normalizationOptions?: NormalizationOptions
-
-	/**
-	 * Options for the grid.
-	 */
-	gridOptions?: GridProps
+	// --- Slots ---
 
 	/**
 	 * Slot for the info popover component.
@@ -199,6 +207,8 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 * Optional thumbnail rendered as a blurred backdrop under the loader.
 	 */
 	loadingThumbnail?: ViewerLoadingThumbnail
+
+	// --- Callbacks & events ---
 
 	/**
 	 * Callback function to handle screenshot generation (accept data URL via param).
@@ -257,33 +267,39 @@ export interface VectrealViewerProps extends PropsWithChildren {
  */
 const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 	const {
-		className,
+		// Content
 		children,
+		// Container & appearance
+		className,
 		theme = 'system',
-		cameraOptions,
+		// Performance
+		enableViewportRendering = true,
+		enablePostProcessing = true,
+		// Scene configuration
 		boundsOptions,
-		envOptions,
-		// gridOptions,
+		cameraOptions,
 		controlsOptions,
+		envOptions,
 		shadowsOptions,
+		normalizationOptions,
+		// gridOptions,
+		// Editor affordances
 		shadowLightEditable,
-		onShadowLightChange,
-		showViewCube,
 		staticShadowBake = false,
 		bakedShadow,
 		onShadowBakeReady,
-		normalizationOptions,
+		onShadowLightChange,
+		// Slots
 		popover,
 		loadingThumbnail,
+		loader = <DefaultSpinner />,
+		// Callbacks & events
 		onScreenshot,
 		onScreenshotCaptureReady,
 		onCameraSnapshotCaptureReady,
 		onInteractionEvent,
 		onCommandExecutorReady,
-		onRawDiagonalComputed,
-		enableViewportRendering = true,
-		enablePostProcessing = true,
-		loader = <DefaultSpinner />
+		onRawDiagonalComputed
 	} = props
 
 	const hasContent = !!(model || children)
@@ -471,26 +487,6 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 								/>
 								{children}
 							</SceneBounds>
-							{showViewCube && (
-								<GizmoHelper
-									alignment="bottom-left"
-									margin={[72, 72]}
-									// drei's Hud re-renders the whole scene itself at renderPriority
-									// 1, which would clobber the AO EffectComposer's output (also at
-									// priority 1). At priority 2 the Hud skips that scene re-render and
-									// just overlays the gizmo on top of the composed frame, so the
-									// cube and postprocessing coexist. Without AO there's no composer,
-									// so the default priority 1 keeps working as before.
-									renderPriority={aoEnabled ? 2 : 1}
-								>
-									<GizmoViewcube
-										color="#f4f4f5"
-										textColor="#52525b"
-										strokeColor="#d4d4d8"
-										hoverColor="#fbbf24"
-									/>
-								</GizmoHelper>
-							)}
 						</>
 					)}
 				</Suspense>


### PR DESCRIPTION
- Introduced ShadowBakeCapture and ShadowBakeResult types for shadow baking functionality.
- Implemented SceneBakedShadow component to render persisted shadow density.
- Added ShadowAutoCutoff for automatic calibration of shadow alpha testing.
- Created shadow-bake utility functions for capturing and computing shadow density.
- Developed ShadowLightGizmo for interactive manipulation of shadow light position.
- Enhanced VectrealViewer with new props for shadow baking and editing capabilities.
- Updated viewer types and index to include new shadow-related types and components.
- Added e2e test results tracking for shadow baking features.
- Added functionality to track and garbage collect unreferenced assets in SceneSettingsService.
- Introduced a new method to resolve baked shadow sources from scene asset data, allowing for efficient rendering without additional network requests.
- Updated scene settings store to include a new atom for baked shadow sources.
- Enhanced scene preview components to utilize the resolved baked shadow for rendering.
- Introduced a new PublisherViewCube component for improved user interaction in the publisher interface.
- Updated viewer types and shadow bake logic to accommodate new baked shadow handling.
- Ensured that the persisted shadow bake is correctly referenced and utilized across various components.
