### PR TITLE
fix(publisher): stop redundant asset re-uploads and fix publish sidebar reveal

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
+++ b/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
@@ -31,6 +31,7 @@ import {
 	arePublisherActionsDisabledAtom,
 	controlsOverlayStateAtom,
 	isPreviewModeAtom,
+	lastSavedSceneIdAtom,
 	processAtom,
 	saveLocationAtom
 } from '../../lib/stores/publisher-config-store'
@@ -74,6 +75,10 @@ const OverlayControls = ({
 	// Save location comes from the Jotai atom - initialized in publisher-layout
 	// and updated by the shell-level SceneNameAndLocation picker.
 	const saveLocationTarget = useAtomValue(saveLocationAtom)
+	// Confirmed persisted-save signal (set only after a successful, non-unchanged
+	// save). Used to reveal publish sections immediately on first save, bridging the
+	// gap until the route param updates to the new scene id post-navigation.
+	const sessionSavedSceneId = useAtomValue(lastSavedSceneIdAtom)
 	const { hasUnsavedLocationChange } = useLocationChangeState()
 	const { requestSceneScreenshot } = usePublisherViewerCapture()
 
@@ -161,6 +166,7 @@ const OverlayControls = ({
 		() =>
 			buildPublishSidebarViewModel({
 				sceneId: sceneId ?? undefined,
+				sessionSavedSceneId: sessionSavedSceneId ?? undefined,
 				userId: user?.id,
 				publishedAt,
 				publishedAssetSizeBytes:
@@ -171,6 +177,7 @@ const OverlayControls = ({
 			}),
 		[
 			sceneId,
+			sessionSavedSceneId,
 			user?.id,
 			publishedAt,
 			publishedMeta?.publishedAssetSizeBytes,
@@ -180,7 +187,11 @@ const OverlayControls = ({
 
 	const publishSidebarValue = useMemo(
 		() => ({
-			sceneId: sceneId ?? undefined,
+			// Prefer the session-resolved id so the publish/embed actions (and the
+			// sidebar's own save) operate on the just-saved scene during the window
+			// before the route param catches up, avoiding a redundant re-save and an
+			// empty embed snippet.
+			sceneId: publishSidebarViewModel.publishState.sceneId || undefined,
 			projectId: projectId ?? undefined,
 			userId: user?.id,
 			onRequireAuth: handleRequireAuthForSave,

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/publish-sidebar-view-model.ts
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/publish-sidebar-view-model.ts
@@ -48,12 +48,14 @@ const getSizeDeltaBytes = (
 
 export const buildPublishSidebarViewModel = ({
 	sceneId,
+	sessionSavedSceneId,
 	userId,
 	publishedAt,
 	publishedAssetSizeBytes,
 	resolvedMetrics
 }: {
 	sceneId?: string
+	sessionSavedSceneId?: string
 	userId?: string
 	publishedAt?: string | null
 	publishedAssetSizeBytes?: number | null
@@ -70,9 +72,17 @@ export const buildPublishSidebarViewModel = ({
 	)
 	const isHydratingInitialMetrics = Boolean(metrics?.isInitialMetricsHydrating)
 	const isAuthenticated = Boolean(userId)
-	const hasSavedScene = Boolean(
-		typeof sceneId === 'string' && sceneId.length > 0
-	)
+	// Treat the scene as saved when the route already carries its id OR a save has
+	// been confirmed this session. The latter bridges the window between a first
+	// save completing and the route updating to /publisher/:newId, so the publish
+	// sections reveal immediately instead of flickering or staying on "save".
+	const resolvedSceneId =
+		(typeof sceneId === 'string' && sceneId.length > 0 && sceneId) ||
+		(typeof sessionSavedSceneId === 'string' &&
+			sessionSavedSceneId.length > 0 &&
+			sessionSavedSceneId) ||
+		''
+	const hasSavedScene = resolvedSceneId.length > 0
 
 	return {
 		metrics,
@@ -85,7 +95,7 @@ export const buildPublishSidebarViewModel = ({
 			isInitialMetricsHydrating: isHydratingInitialMetrics
 		},
 		publishState: {
-			sceneId: sceneId ?? '',
+			sceneId: resolvedSceneId,
 			status: publishedAt ? 'published' : 'draft',
 			publishedAt: publishedAt ?? null,
 			publishedAssetId: null,

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
@@ -87,14 +87,18 @@ async function resolveSceneAndProject(
 	userId: string,
 	targetProjectId?: string,
 	projectId?: string
-): Promise<{ sceneId: string; projectId: string }> {
+): Promise<{
+	sceneId: string
+	projectId: string
+	existingProjectId: string | null
+}> {
 	if (sceneId?.trim()) {
 		const existingProjectId =
 			await sceneSettingsService.getProjectIdFromScene(sceneId)
 
 		if (existingProjectId) {
 			const resolvedProjectId = targetProjectId ?? existingProjectId
-			return { sceneId, projectId: resolvedProjectId }
+			return { sceneId, projectId: resolvedProjectId, existingProjectId }
 		}
 
 		const fallbackProjectId = targetProjectId ?? projectId
@@ -104,7 +108,7 @@ async function resolveSceneAndProject(
 				throw new Error('Target project not found or access denied')
 			}
 
-			return { sceneId, projectId: fallbackProjectId }
+			return { sceneId, projectId: fallbackProjectId, existingProjectId: null }
 		}
 
 		throw new Error(`Scene not found with ID: ${sceneId}`)
@@ -117,10 +121,15 @@ async function resolveSceneAndProject(
 			throw new Error('Target project not found or access denied')
 		}
 
-		return { sceneId: randomUUID(), projectId: targetProjectId }
+		return {
+			sceneId: randomUUID(),
+			projectId: targetProjectId,
+			existingProjectId: null
+		}
 	}
 
-	return await createNewScene(userId)
+	const created = await createNewScene(userId)
+	return { ...created, existingProjectId: null }
 }
 
 async function validateSaveLocationTarget(
@@ -195,12 +204,30 @@ export async function prepareSceneUpload(
 		request.projectId
 	)
 
+	// Reuse already-stored assets for same-project saves (the common case), so the
+	// client can content-hash dedupe and skip re-uploading unchanged model assets.
+	// Only a genuine move to a DIFFERENT project must re-upload assets fresh into
+	// that project's storage. Previously ANY targetProjectId disabled dedup — and
+	// the post-save location sync sets targetProjectId on every save after the
+	// first, so identical assets were re-uploaded on every subsequent save.
+	// A targeted save is treated as a cross-project move (no asset reuse) when the
+	// target differs from the scene's established project, OR when the scene has no
+	// established project to compare against. Same-project saves reuse assets.
+	const isCrossProjectMove =
+		!!request.targetProjectId &&
+		(resolved.existingProjectId === null ||
+			request.targetProjectId !== resolved.existingProjectId)
+
 	const existingAssets =
-		request.sceneId?.trim() && !request.targetProjectId
+		request.sceneId?.trim() && !isCrossProjectMove
 			? await sceneSettingsService.getExistingAssetHashes(resolved.sceneId)
 			: {}
 
-	return { ...resolved, existingAssets }
+	return {
+		sceneId: resolved.sceneId,
+		projectId: resolved.projectId,
+		existingAssets
+	}
 }
 
 export async function uploadSceneAsset(


### PR DESCRIPTION


Asset dedup was disabled whenever a targetProjectId was present in the save request. The post-save location sync sets targetProjectId to the scene's own project after the first save, so every subsequent same-project save re-uploaded identical model assets. prepareSceneUpload now reuses stored assets for same-project saves and only skips dedup for a genuine cross-project move.

The publish sidebar derived hasSavedScene solely from the route sceneId, which updates asynchronously after the first save navigates to the new scene, so the publish/embed sections did not reveal (or flickered). It now also honors the confirmed-save signal (lastSavedSceneIdAtom) and feeds the resolved scene id into the sidebar context so publish/embed actions target the just-saved scene during the post-save window.