### PR TITLE
fix(viewer): dynamic camera near/far and button-exclusive camera persistence

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/camera-controls-settings/camera-controls-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/camera-controls-settings/camera-controls-settings-panel.tsx
@@ -415,52 +415,16 @@ const CameraControlsSettingsPanel = memo(() => {
 		return requestSceneCameraSnapshot()
 	}, [requestSceneCameraSnapshot])
 
-	const persistSnapshotOnCamera = useCallback(
-		(snapshot: null | SceneCameraSnapshot, cameraId: string) => {
-			setCamera((prev) => {
-				const normalized = normalizeCameraState(prev)
-				if (!cameraId) return normalized
-
-				return withImplicitFirstCameraDefault({
-					...normalized,
-					cameras: (normalized.cameras ?? []).map((entry) =>
-						entry.cameraId === cameraId
-							? applySnapshotToCamera(entry, snapshot)
-							: entry
-					)
-				})
-			})
-		},
-		[setCamera]
-	)
-
 	const handleSelectCamera = useCallback(
-		async (nextCameraId: string) => {
-			if (!isPreviewMode) {
-				// Navigate mode: just change the editor selection, don't snap the viewport
-				setSelectedCameraId(nextCameraId)
-				return
-			}
-
-			// Preview mode: save current viewport to current camera, then transition to the new one
-			const snapshot = await captureCurrentViewSnapshot()
-			const currentCameraId = resolveEditorTargetCameraId(
-				normalizedCamera,
-				selectedCameraId
-			)
-			if (currentCameraId) {
-				persistSnapshotOnCamera(snapshot, currentCameraId)
-			}
+		(nextCameraId: string) => {
+			// Persisting the live viewport is reserved for the explicit "Set camera to
+			// current view" button. Selecting a camera — including reviewing saved
+			// cameras in preview mode ("Lock editing and review saved cameras") — only
+			// changes the active selection and transitions the viewport; it never
+			// overwrites a saved camera with the current free-orbit view.
 			setSelectedCameraId(nextCameraId)
 		},
-		[
-			captureCurrentViewSnapshot,
-			isPreviewMode,
-			normalizedCamera,
-			persistSnapshotOnCamera,
-			selectedCameraId,
-			setSelectedCameraId
-		]
+		[setSelectedCameraId]
 	)
 
 	const handleAddCamera = useCallback(async () => {
@@ -497,17 +461,13 @@ const CameraControlsSettingsPanel = memo(() => {
 				name: newName
 			}
 
+			// The new camera adopts the current view as its initial pose, but existing
+			// cameras are left untouched — only the explicit "Set camera to current
+			// view" button overwrites a saved camera with the live viewport.
 			return withImplicitFirstCameraDefault({
 				...normalized,
 				activeCameraId: newCameraId,
-				cameras: [
-					...(normalized.cameras ?? []).map((entry) => {
-						return entry.cameraId === currentCameraId
-							? applySnapshotToCamera(entry, snapshot)
-							: entry
-					}),
-					newCamera
-				]
+				cameras: [...(normalized.cameras ?? []), newCamera]
 			})
 		})
 		if (newCameraId) setSelectedCameraId(newCameraId)
@@ -978,7 +938,11 @@ const CameraControlsSettingsPanel = memo(() => {
 					<Button
 						variant="secondary"
 						disabled={isCameraEditingLocked}
-						className={`w-full transition-colors duration-300${capturedView ? 'bg-emerald-500/15 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400' : ''}`}
+						className={cn(
+						'w-full transition-colors duration-300',
+						capturedView &&
+							'bg-emerald-500/15 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400'
+					)}
 						onClick={() => {
 							void handleCaptureCurrentView()
 						}}
@@ -986,10 +950,16 @@ const CameraControlsSettingsPanel = memo(() => {
 					>
 						<span className="relative h-4 w-4 shrink-0">
 							<Camera
-								className={`absolute inset-0 h-4 w-4 transition-all duration-200${capturedView ? 'scale-50 opacity-0' : 'scale-100 opacity-100'}`}
+								className={cn(
+								'absolute inset-0 h-4 w-4 transition-all duration-200',
+								capturedView ? 'scale-50 opacity-0' : 'scale-100 opacity-100'
+							)}
 							/>
 							<Check
-								className={`absolute inset-0 h-4 w-4 transition-all duration-200${capturedView ? 'scale-100 opacity-100' : 'scale-50 opacity-0'}`}
+								className={cn(
+								'absolute inset-0 h-4 w-4 transition-all duration-200',
+								capturedView ? 'scale-100 opacity-100' : 'scale-50 opacity-0'
+							)}
 							/>
 						</span>
 						<span className="transition-all duration-200">

--- a/packages/viewer/src/components/scene/scene-bounds.tsx
+++ b/packages/viewer/src/components/scene/scene-bounds.tsx
@@ -4,7 +4,9 @@ import { memo } from 'react'
 
 export const defaultBoundsOptions = {
 	fit: true,
-	clip: true,
+	// near/far are managed per-frame in SceneModel (dynamic clipping); keep drei
+	// from also writing them so there is a single source of truth.
+	clip: false,
 	margin: 1.5,
 	maxDuration: 0
 } satisfies BoundsProps

--- a/packages/viewer/src/components/scene/scene-model.tsx
+++ b/packages/viewer/src/components/scene/scene-model.tsx
@@ -1,7 +1,15 @@
 import { useBounds } from '@react-three/drei'
-import { useThree } from '@react-three/fiber'
+import { useFrame, useThree } from '@react-three/fiber'
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
-import { Box3, Euler, Mesh, Object3D, PerspectiveCamera, Vector3 } from 'three'
+import {
+	Box3,
+	Euler,
+	Mesh,
+	Object3D,
+	PerspectiveCamera,
+	Sphere,
+	Vector3
+} from 'three'
 
 import type {
 	SceneScreenshotCapture,
@@ -133,6 +141,59 @@ const SceneModel = memo((props: ModelProps) => {
 		if (rawDiagonal > max) return max / rawDiagonal
 		return 1
 	}, [rawDiagonal, normalizationOptions])
+
+	// Dynamic camera clipping planes. drei's one-shot `.clip()` sets near/far tight
+	// to the bounding box at the fit distance, then clips the model the moment the
+	// camera zooms closer (and normalization, which rescales the model, left stale
+	// planes behind). Instead, recompute near/far every frame from the model's
+	// bounding sphere and the live camera distance: the planes stay tight enough for
+	// good depth precision yet always contain the model. Never persisted.
+	//
+	// The sphere is read from the rendered group's WORLD bounds (the model sits
+	// inside a <Center> wrapper that offsets it, so a local-bounds approximation
+	// would mis-place the center). It only changes when the model or its scale
+	// changes, so it is cached and recomputed lazily.
+	const focusGroupRef = useRef<Object3D>(null)
+	const clipSphereRef = useRef(new Sphere())
+	const clipSphereDirtyRef = useRef(true)
+
+	useEffect(() => {
+		clipSphereDirtyRef.current = true
+	}, [object, normalizedScale])
+
+	useFrame(() => {
+		const perspectiveCamera = camera as PerspectiveCamera
+		if (!perspectiveCamera.isPerspectiveCamera) {
+			return
+		}
+
+		if (clipSphereDirtyRef.current && focusGroupRef.current) {
+			focusGroupRef.current.updateWorldMatrix(true, true)
+			new Box3()
+				.setFromObject(focusGroupRef.current)
+				.getBoundingSphere(clipSphereRef.current)
+			if (clipSphereRef.current.radius > 0) {
+				clipSphereDirtyRef.current = false
+			}
+		}
+
+		const sphere = clipSphereRef.current
+		if (sphere.radius <= 0) {
+			return
+		}
+
+		const distance = perspectiveCamera.position.distanceTo(sphere.center)
+		const radius = sphere.radius
+		// Margins keep the model's front/back just inside the planes.
+		const near = Math.max(distance - radius * 1.1, radius * 0.001, 1e-4)
+		const far = distance + radius * 1.1
+
+		if (perspectiveCamera.near !== near || perspectiveCamera.far !== far) {
+			perspectiveCamera.near = near
+			perspectiveCamera.far = far
+			perspectiveCamera.updateProjectionMatrix()
+		}
+	})
 
 	useEffect(() => {
 		if (rawDiagonal > 0) onRawDiagonalComputed?.(rawDiagonal)
@@ -296,7 +357,9 @@ const SceneModel = memo((props: ModelProps) => {
 		const isFirstMount = !mountedRef.current
 		mountedRef.current = true
 		if (isFirstMount && !normalizationOptions?.enabled) return
-		bounds.refresh(object).clip().fit()
+		// Framing only — near/far are handled dynamically by the useFrame above, so
+		// rescaling/normalization no longer leaves stale clipping planes behind.
+		bounds.refresh(object).fit()
 	}, [bounds, normalizationOptions?.enabled, object])
 
 	useEffect(() => {
@@ -308,7 +371,12 @@ const SceneModel = memo((props: ModelProps) => {
 	}, [captureScreenshot, onScreenshotCaptureReady])
 
 	return (
-		<group name="focus-target" scale={normalizedScale} dispose={null}>
+		<group
+			ref={focusGroupRef}
+			name="focus-target"
+			scale={normalizedScale}
+			dispose={null}
+		>
 			<primitive object={object} />
 		</group>
 	)


### PR DESCRIPTION
Replace drei's one-shot `.clip()` (which set near/far tight to the bounding box at fit distance, clipping the model when zooming closer and leaving stale planes behind after model-size normalization rescaled the model) with a per-frame recompute of near/far from the model's world-space bounding sphere and the live camera distance. Planes stay tight for depth precision yet always contain the model, and are never persisted. The sphere is read from the rendered group's world bounds (the model sits inside <Center>, so a local-bounds approximation would mis-place the center) and cached until the model or scale changes. drei <Bounds clip> is disabled so near/far have a single source of truth.

Camera settings now persist exclusively through the "Set camera to current view" button. Preview mode ("Lock editing and review saved cameras") no longer writes the freely-orbited viewport onto the current camera when switching cameras, and adding a camera no longer overwrites the current camera with the live view (the new camera still adopts the current view as its initial pose). Also fix the capture button's captured-state styling (missing class separators) and switch it to the shared cn() util.
