### PR TITLE
feat: enhance @vctrl/core documentation and improve package structure

### DIFF
--- a/.github/workflows/cd-packages-release.yaml
+++ b/.github/workflows/cd-packages-release.yaml
@@ -25,6 +25,7 @@ jobs:
       core_version: ${{ steps.release.outputs['packages/core--version'] }}
       hooks_version: ${{ steps.release.outputs['packages/hooks--version'] }}
       viewer_version: ${{ steps.release.outputs['packages/viewer--version'] }}
+      embed_version: ${{ steps.release.outputs['packages/embed--version'] }}
 
     steps:
       - name: Create GitHub App token
@@ -57,6 +58,7 @@ jobs:
           CORE_VERSION: ${{ steps.release.outputs['packages/core--version'] }}
           HOOKS_VERSION: ${{ steps.release.outputs['packages/hooks--version'] }}
           VIEWER_VERSION: ${{ steps.release.outputs['packages/viewer--version'] }}
+          EMBED_VERSION: ${{ steps.release.outputs['packages/embed--version'] }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
@@ -96,6 +98,9 @@ jobs:
             echo
             echo "### @vctrl/viewer (${VIEWER_VERSION:-unchanged})"
             extract_section "packages/viewer/CHANGELOG.md" "$VIEWER_VERSION"
+            echo
+            echo "### @vctrl/embed (${EMBED_VERSION:-unchanged})"
+            extract_section "packages/embed/CHANGELOG.md" "$EMBED_VERSION"
           } > release-notes.md
 
           gh release edit "$TAG_NAME" --notes-file release-notes.md
@@ -103,7 +108,11 @@ jobs:
   publish:
     name: Publish Released Packages to NPM
     needs: release-please
-    if: ${{ needs.release-please.outputs.root_release_created == 'true' }}
+    # Publish whenever release-please cuts ANY package release, not only when the
+    # root "." component bumps. The linked-versions plugin keeps @vctrl/* in sync,
+    # but a release can bump the packages without a root change — gating on the
+    # root previously skipped publishing entirely (npm stalled at 0.18.0).
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     environment: packages-releasing
     runs-on: ubuntu-22.04
     permissions:
@@ -163,6 +172,44 @@ jobs:
       - name: Print Environment Info
         run: npx nx report
         shell: bash
+
+      - name: Build released packages
+        run: pnpm nx run-many -t build -p vctrl/core vctrl/hooks vctrl/viewer vctrl/embed
+        shell: bash
+
+      - name: Guard - no workspace specifiers in built manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          # release-please's node-workspace plugin must rewrite every `workspace:*`
+          # specifier to a real version before release. If any survive into a built
+          # manifest's consumer-facing fields, the published package is broken
+          # (uninstallable, or pnpm silently drops the dep). Fail loudly here rather
+          # than ship it. devDependencies are exempt: consumers never install them.
+          node -e '
+            const fs = require("fs");
+            const manifests = [
+              "build/packages/vctrl/core/package.json",
+              "build/packages/vctrl/hooks/package.json",
+              "build/packages/vctrl/viewer/package.json",
+              "build/packages/vctrl/embed/package.json"
+            ];
+            const fields = ["dependencies", "peerDependencies", "optionalDependencies"];
+            let bad = false;
+            for (const m of manifests) {
+              const pkg = JSON.parse(fs.readFileSync(m, "utf8"));
+              for (const f of fields) {
+                for (const [name, spec] of Object.entries(pkg[f] || {})) {
+                  if (typeof spec === "string" && spec.startsWith("workspace:")) {
+                    console.error(`LEAK: ${m} ${f}.${name} = ${spec}`);
+                    bad = true;
+                  }
+                }
+              }
+            }
+            if (bad) { console.error("Refusing to publish: unrewritten workspace specifiers."); process.exit(1); }
+            console.log("OK: no workspace specifiers in consumer-facing fields.");
+          '
 
       - name: Diagnostics - npm trusted publishing context
         shell: bash
@@ -255,6 +302,20 @@ jobs:
 
       - name: Publish @vctrl/viewer
         run: npx nx run vctrl/viewer:publish
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Preflight pack @vctrl/embed
+        run: |
+          npx nx run vctrl/embed:copy-md
+          cd build/packages/vctrl/embed
+          npm pack --dry-run
+        shell: bash
+
+      - name: Publish @vctrl/embed
+        run: npx nx run vctrl/embed:publish
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-viewer-e2e.yaml
+++ b/.github/workflows/ci-viewer-e2e.yaml
@@ -1,0 +1,84 @@
+name: CI - Viewer Packaging E2E
+
+# Installs and renders the *published* @vctrl/viewer tarball from a local
+# Verdaccio registry to catch packaging (bad externals, missing deps,
+# unresolved imports) and runtime-crash regressions before they reach an
+# integration site. Heavier than the quality gate, so it runs only when the
+# viewer or its workspace deps change.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'packages/viewer/**'
+      - 'packages/viewer-e2e/**'
+      - 'packages/core/**'
+      - 'packages/hooks/**'
+      - 'shared/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/ci-viewer-e2e.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/viewer/**'
+      - 'packages/viewer-e2e/**'
+      - 'packages/core/**'
+      - 'packages/hooks/**'
+      - 'shared/**'
+      - '.github/workflows/ci-viewer-e2e.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: viewer-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  viewer-e2e:
+    name: Publish + Render @vctrl/viewer
+    runs-on: ubuntu-22.04
+    env:
+      NX_DAEMON: 'false'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Restore Nx local cache
+        uses: actions/cache@v5
+        with:
+          path: .nx/cache
+          key: ${{ runner.os }}-nx-${{ github.ref_name }}-${{ hashFiles('pnpm-lock.yaml', 'nx.json', '**/project.json', 'tsconfig.base.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nx-${{ github.ref_name }}-
+            ${{ runner.os }}-nx-main-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run viewer packaging e2e
+        run: pnpm nx run vctrl/viewer-e2e:e2e:ci
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: viewer-e2e-playwright-report
+          path: packages/viewer-e2e/playwright-report
+          if-no-files-found: ignore
+          retention-days: 7

--- a/apps/vectreal-platform/app/routes/docs/packages/core.mdx
+++ b/apps/vectreal-platform/app/routes/docs/packages/core.mdx
@@ -12,7 +12,7 @@ npm install @vctrl/core
 pnpm add @vctrl/core
 ```
 
-> `@vctrl/core` targets Node.js only. It uses [Sharp](https://sharp.pixelplumbing.com) for server-side texture compression, which requires a native build.
+> `@vctrl/core` runs in Node.js, browsers, and edge runtimes. For server-side texture compression it can use [Sharp](https://sharp.pixelplumbing.com), but Sharp is an optional add-on rather than a hard dependency: install it yourself (`npm install sharp`) to enable the native path. Without it, `compressTextures` falls back to a basic optimization, and browser/edge callers inject their own encoder, so no native build is required for those targets.
 
 ---
 

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -9,6 +9,12 @@ import tseslint from 'typescript-eslint'
 
 export default defineConfig(tseslint.configs.recommended, [
 	{
+		// Throwaway consumer app for the @vctrl/viewer packaging e2e. Its deps
+		// (@vctrl/viewer, vite, react) only exist in the tmp install created at
+		// runtime, so it must not participate in workspace linting.
+		ignores: ['packages/viewer-e2e/src/consumer-template/**']
+	},
+	{
 		files: ['**/*.{js,mjs,cjs,jsx}'],
 		ignores: [
 			'**/node_modules/**',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,11 +55,12 @@
 		}
 	},
 	"peerDependencies": {
-		"@nx/vite": "22.5.0",
-		"vite": "^7.3.1",
-		"vite-plugin-dts": "4.5.3",
-		"@react-three/drei": "^10.0.7",
-		"@react-three/fiber": "^9.4.2"
+		"@react-three/drei": "^10.0.7"
+	},
+	"peerDependenciesMeta": {
+		"@react-three/drei": {
+			"optional": true
+		}
 	},
 	"dependencies": {
 		"@gltf-transform/core": "^4.0.8",
@@ -67,7 +68,11 @@
 		"@gltf-transform/functions": "^4.0.8",
 		"jszip": "^3.10.1",
 		"meshoptimizer": "^0.21.0",
-		"sharp": "^0.34.3",
 		"three": "^0.177.0"
+	},
+	"devDependencies": {
+		"@nx/vite": "22.5.0",
+		"vite": "^7.3.1",
+		"vite-plugin-dts": "4.5.3"
 	}
 }

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -62,7 +62,7 @@
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
-				"command": "npm publish --access public",
+				"command": "pnpm publish --no-git-checks --access public",
 				"cwd": "build/packages/vctrl/core"
 			}
 		},

--- a/packages/embed/project.json
+++ b/packages/embed/project.json
@@ -55,7 +55,7 @@
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
-				"command": "npm publish --access public",
+				"command": "pnpm publish --no-git-checks --access public",
 				"cwd": "build/packages/vctrl/embed"
 			}
 		}

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -36,6 +36,11 @@
 		"access": "public"
 	},
 	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"import": "./index.es.js",
+			"require": "./index.cjs.js"
+		},
 		"./use-load-model": {
 			"types": "./use-load-model/index.d.ts",
 			"import": "./use-load-model.es.js",
@@ -54,15 +59,16 @@
 	},
 	"peerDependencies": {
 		"react": "^18.0.0 || ^19.0.0",
-		"@gltf-transform/core": "^4.0.8",
-		"file-saver": "^2.0.5",
+		"three": "^0.177.0"
+	},
+	"dependencies": {
+		"@vctrl/core": "workspace:*",
+		"file-saver": "^2.0.5"
+	},
+	"devDependencies": {
 		"@nx/vite": "22.5.0",
 		"@vitejs/plugin-react": "^6.0.0",
 		"vite": "^7.3.1",
 		"vite-plugin-dts": "4.5.3"
-	},
-	"dependencies": {
-		"@vctrl/core": "workspace:*",
-		"three": "^0.177.0"
 	}
 }

--- a/packages/hooks/project.json
+++ b/packages/hooks/project.json
@@ -21,7 +21,7 @@
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
-				"command": "npm publish --access public",
+				"command": "pnpm publish --no-git-checks --access public",
 				"cwd": "build/packages/vctrl/hooks"
 			}
 		},

--- a/packages/hooks/vite.config.ts
+++ b/packages/hooks/vite.config.ts
@@ -55,16 +55,17 @@ export default defineConfig({
 
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
+			// @vctrl/core (and its subpaths) is externalized so consumers share a
+			// single published copy instead of bundling it (which also pulled core's
+			// node-only deps like sharp into this browser package).
 			external: [
 				'react',
 				'react-dom',
 				'three',
 				'react/jsx-runtime',
 				'file-saver',
-				'jszip'
-				// '@gltf-transform/core',
-				// '@gltf-transform/functions',
-				// '@gltf-transform/extensions'
+				'jszip',
+				/^@vctrl\/core(\/.*)?$/
 			],
 			output: {
 				globals: {

--- a/packages/viewer-e2e/.gitignore
+++ b/packages/viewer-e2e/.gitignore
@@ -1,0 +1,2 @@
+playwright-report/
+test-results/

--- a/packages/viewer-e2e/README.md
+++ b/packages/viewer-e2e/README.md
@@ -1,0 +1,54 @@
+# @vctrl/viewer packaging e2e
+
+Integration test that installs and renders the **published** `@vctrl/viewer`
+package the same way a third-party site would, to catch two classes of
+regression that unit tests and Storybook miss:
+
+- **Packaging**: bad `external` config, missing runtime deps, broken `exports`
+  map, `workspace:*` specifiers leaking into the published manifest, or
+  unresolved imports in the tarball. These only surface once the package is
+  installed from a registry into a clean project.
+- **Runtime crashes**: the viewer failing to mount in a real browser (e.g. a
+  hard crash from a bundled dependency, a bad WebGL assumption).
+
+## How it works
+
+`src/run-e2e.ts` orchestrates the whole pipeline:
+
+1. Boots an ephemeral [Verdaccio](https://verdaccio.org/) registry that proxies
+   npmjs for transitive deps (`src/registry/config.yaml`).
+2. Builds and publishes `@vctrl/core`, `@vctrl/hooks`, and `@vctrl/viewer` to it
+   via `nx run <pkg>:copy-md` + `npm publish`.
+3. Scaffolds a throwaway Vite + React consumer app from `src/consumer-template`
+   into a temp dir and `npm install`s `@vctrl/viewer` (plus peer deps) **from
+   the local registry** (no monorepo path aliases, the real tarball).
+4. Builds the consumer (fails on any packaging / unresolved-import regression).
+5. Serves the build and runs Playwright (`tests/viewer-render.spec.ts`), which
+   asserts the viewer mounts and reports no render-time crash.
+
+Everything (registry storage, temp consumer) lives under the OS temp dir and is
+wiped on exit. The developer's global npm config and the public registry are
+never touched.
+
+## Running it
+
+```bash
+pnpm nx run vctrl/viewer-e2e:e2e        # local
+pnpm nx run vctrl/viewer-e2e:e2e:ci     # CI (enables retries + HTML report)
+```
+
+Requires the Playwright Chromium browser:
+
+```bash
+pnpm exec playwright install chromium
+```
+
+CI runs this via `.github/workflows/ci-viewer-e2e.yaml` on PRs that touch the
+viewer or its workspace dependencies.
+
+## Adding assertions
+
+Extend `tests/viewer-render.spec.ts`. The consumer app
+(`src/consumer-template/src/App.tsx`) exposes a `window.__VIEWER_E2E__` flag set
+to `mounted` on success or `crashed` (with the error) from both a React error
+boundary and the global error handlers in `main.tsx`.

--- a/packages/viewer-e2e/playwright.config.ts
+++ b/packages/viewer-e2e/playwright.config.ts
@@ -1,0 +1,48 @@
+import { join } from 'node:path'
+
+import { defineConfig, devices } from '@playwright/test'
+
+// Base URL of the consumer preview server is injected by the orchestration
+// script (run-e2e.ts) via E2E_BASE_URL after it builds + serves the throwaway
+// app that installed @vctrl/viewer from the local registry.
+const baseURL = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:4319'
+
+export default defineConfig({
+	testDir: './tests',
+	// Keep Playwright artifacts inside the project (cwd is the workspace root
+	// when invoked by the orchestrator), so the repo root stays clean.
+	outputDir: join(__dirname, 'test-results'),
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: 1,
+	reporter: process.env.CI
+		? [
+				['github'],
+				['list'],
+				['html', { outputFolder: 'playwright-report', open: 'never' }]
+			]
+		: 'list',
+	use: {
+		baseURL,
+		trace: 'on-first-retry'
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: {
+				...devices['Desktop Chrome'],
+				// R3F needs a real WebGL context. Force the SwiftShader software
+				// renderer so the canvas initializes in headless CI without a GPU.
+				launchOptions: {
+					args: [
+						'--use-gl=angle',
+						'--use-angle=swiftshader',
+						'--enable-unsafe-swiftshader',
+						'--ignore-gpu-blocklist'
+					]
+				}
+			}
+		}
+	]
+})

--- a/packages/viewer-e2e/project.json
+++ b/packages/viewer-e2e/project.json
@@ -1,0 +1,34 @@
+{
+	"name": "vctrl/viewer-e2e",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "packages/viewer-e2e/src",
+	"implicitDependencies": ["vctrl/viewer", "vctrl/core", "vctrl/hooks"],
+	"tags": ["scope:e2e"],
+	"targets": {
+		"e2e": {
+			"executor": "nx:run-commands",
+			"cache": false,
+			"options": {
+				"command": "node --import @swc-node/register/esm-register packages/viewer-e2e/src/run-e2e.ts",
+				"cwd": "{workspaceRoot}"
+			},
+			"configurations": {
+				"ci": {
+					"command": "node --import @swc-node/register/esm-register packages/viewer-e2e/src/run-e2e.ts --ci"
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"packages/viewer-e2e/src/*.ts",
+					"packages/viewer-e2e/tests/**/*.ts",
+					"packages/viewer-e2e/*.ts"
+				]
+			}
+		}
+	}
+}

--- a/packages/viewer-e2e/src/consumer-template/index.html
+++ b/packages/viewer-e2e/src/consumer-template/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>@vctrl/viewer consumer e2e</title>
+		<style>
+			html,
+			body,
+			#root {
+				margin: 0;
+				height: 100%;
+				background: #111;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
+</html>

--- a/packages/viewer-e2e/src/consumer-template/package.json
+++ b/packages/viewer-e2e/src/consumer-template/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "vctrl-viewer-consumer",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"build": "vite build",
+		"preview": "vite preview"
+	},
+	"dependencies": {
+		"@react-three/drei": "^10.0.7",
+		"@react-three/fiber": "^9.1.2",
+		"@react-three/postprocessing": "^3.0.4",
+		"@vctrl/hooks": "latest",
+		"@vctrl/viewer": "latest",
+		"postprocessing": "^6.37.3",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"three": "^0.177.0"
+	},
+	"devDependencies": {
+		"@vitejs/plugin-react": "^5.0.0",
+		"vite": "^7.0.0"
+	}
+}

--- a/packages/viewer-e2e/src/consumer-template/src/App.tsx
+++ b/packages/viewer-e2e/src/consumer-template/src/App.tsx
@@ -1,0 +1,77 @@
+import { useLoadModel } from '@vctrl/hooks'
+import { VectrealViewer } from '@vctrl/viewer'
+import { Component, useEffect, type ReactNode } from 'react'
+
+// Reusable error boundary: a render-time crash would otherwise be swallowed by
+// React. We mirror it onto a window flag the e2e polls, and swap in a marker node.
+class CrashBoundary extends Component<
+	{ children: ReactNode; testid: string; onCrash: (message: string) => void },
+	{ crashed: boolean }
+> {
+	state = { crashed: false }
+
+	static getDerivedStateFromError() {
+		return { crashed: true }
+	}
+
+	componentDidCatch(error: Error) {
+		this.props.onCrash(error.message)
+	}
+
+	render() {
+		if (this.state.crashed) {
+			return <div data-testid={this.props.testid}>crashed</div>
+		}
+		return this.props.children
+	}
+}
+
+// Exercises the @vctrl/hooks -> @vctrl/core externalized dependency graph at
+// runtime. @vctrl/core is no longer bundled into hooks, so it must resolve as a
+// real installed dependency. useLoadModel instantiates core's ModelLoader
+// internally; calling it with no model just initializes idle loader state.
+// Reaching the effect proves the published hooks + its core dependency resolved.
+function HooksProbe() {
+	useLoadModel()
+	useEffect(() => {
+		window.__HOOKS_E2E__ = { status: 'ok' }
+	}, [])
+	return null
+}
+
+export default function App() {
+	return (
+		<div data-testid="viewer-host" style={{ height: '100vh', width: '100vw' }}>
+			<CrashBoundary
+				testid="hooks-crashed"
+				onCrash={(message) => {
+					window.__HOOKS_E2E__ = { status: 'crashed', error: message }
+				}}
+			>
+				<HooksProbe />
+			</CrashBoundary>
+			<CrashBoundary
+				testid="viewer-crashed"
+				onCrash={(message) => {
+					window.__VIEWER_E2E__ = { status: 'crashed', error: message }
+				}}
+			>
+				<VectrealViewer
+					theme="dark"
+					controlsOptions={{ autoRotate: false }}
+					onCommandExecutorReady={() => {
+						// Viewer scene graph is live and the imperative API is wired up.
+						window.__VIEWER_E2E__ = { status: 'mounted' }
+					}}
+				>
+					<ambientLight intensity={0.8} />
+					<directionalLight position={[3, 4, 2]} intensity={1.4} />
+					<mesh>
+						<boxGeometry args={[1.2, 1.2, 1.2]} />
+						<meshStandardMaterial color="#60a5fa" />
+					</mesh>
+				</VectrealViewer>
+			</CrashBoundary>
+		</div>
+	)
+}

--- a/packages/viewer-e2e/src/consumer-template/src/main.tsx
+++ b/packages/viewer-e2e/src/consumer-template/src/main.tsx
@@ -1,0 +1,35 @@
+import '@vctrl/viewer/css'
+
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import App from './App'
+
+declare global {
+	interface Window {
+		__VIEWER_E2E__?: {
+			status: 'mounted' | 'crashed'
+			error?: string
+		}
+	}
+}
+
+// Surface any uncaught runtime error to the e2e harness via a window flag.
+window.addEventListener('error', (event) => {
+	window.__VIEWER_E2E__ = {
+		status: 'crashed',
+		error: event.message
+	}
+})
+window.addEventListener('unhandledrejection', (event) => {
+	window.__VIEWER_E2E__ = {
+		status: 'crashed',
+		error: String(event.reason)
+	}
+})
+
+createRoot(document.getElementById('root')!).render(
+	<StrictMode>
+		<App />
+	</StrictMode>
+)

--- a/packages/viewer-e2e/src/consumer-template/vite.config.ts
+++ b/packages/viewer-e2e/src/consumer-template/vite.config.ts
@@ -1,0 +1,13 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+// Minimal consumer build config. Mirrors how an integration site would bundle
+// @vctrl/viewer: a plain Vite + React app with no awareness of the monorepo.
+export default defineConfig({
+	plugins: [react()],
+	build: {
+		// Fail loudly on any unresolved import from the published package so
+		// packaging regressions (missing deps, bad externals) surface at build.
+		chunkSizeWarningLimit: 5000
+	}
+})

--- a/packages/viewer-e2e/src/registry/config.yaml
+++ b/packages/viewer-e2e/src/registry/config.yaml
@@ -1,0 +1,45 @@
+# Verdaccio configuration for the @vctrl/viewer packaging e2e.
+# This registry is ephemeral: storage lives under a tmp dir created by the
+# orchestration script and is wiped on every run. It proxies npmjs for any
+# package that is not published locally so transitive deps resolve normally.
+
+storage: ./storage
+max_body_size: 200mb
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    cache: true
+    maxage: 30m
+
+packages:
+  # Publish the workspace packages locally only (never proxy them to npm),
+  # so the e2e always exercises the freshly built artifacts.
+  '@vctrl/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  '@shared/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  '**':
+    access: $all
+    publish: $all
+    proxy: npmjs
+
+# Allow unauthenticated publish/install (the registry is local and ephemeral).
+auth:
+  htpasswd:
+    file: ./htpasswd
+    max_users: -1
+
+log:
+  type: stdout
+  format: pretty
+  level: warn
+
+# Speed up CI: do not check for verdaccio self-updates.
+self_path: ./

--- a/packages/viewer-e2e/src/run-e2e.ts
+++ b/packages/viewer-e2e/src/run-e2e.ts
@@ -1,0 +1,328 @@
+/*
+ * @vctrl/viewer packaging + runtime e2e orchestrator.
+ *
+ * Pipeline:
+ *   1. Boot an ephemeral Verdaccio registry (proxies npmjs for transitive deps).
+ *   2. Build and publish @vctrl/core, @vctrl/hooks, @vctrl/viewer to it.
+ *   3. Scaffold a throwaway Vite + React consumer app in a tmp dir.
+ *   4. npm install @vctrl/viewer from the local registry (the real tarball).
+ *   5. Build the consumer (catches packaging / unresolved-import regressions).
+ *   6. Serve it and run Playwright (catches render-time runtime crashes).
+ *
+ * Everything is torn down on exit. Nothing touches the public npm registry or
+ * the developer's global npm config.
+ */
+import { type ChildProcess, spawn } from 'node:child_process'
+import { once } from 'node:events'
+import {
+	cpSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync
+} from 'node:fs'
+import { createRequire } from 'node:module'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const workspaceRoot = join(here, '..', '..', '..')
+const require = createRequire(import.meta.url)
+
+// Resolve the real verdaccio entry JS (the .bin shim is a pnpm wrapper that
+// node cannot spawn directly), then run it with the current node binary.
+function resolveVerdaccioBin(): string {
+	const pkgJson = require.resolve('verdaccio/package.json')
+	const bin = require('verdaccio/package.json').bin
+	const rel = typeof bin === 'string' ? bin : bin.verdaccio
+	return join(dirname(pkgJson), rel)
+}
+
+// Workspace packages to publish, in dependency order. viewer bundles core/shared
+// at build time, but core + hooks are published too so the registry mirrors a
+// real release and any future external dependency would resolve.
+const PACKAGES = [
+	{ project: 'vctrl/core', dir: 'build/packages/vctrl/core' },
+	{ project: 'vctrl/hooks', dir: 'build/packages/vctrl/hooks' },
+	{ project: 'vctrl/viewer', dir: 'build/packages/vctrl/viewer' }
+]
+
+const cleanups: Array<() => void> = []
+function onCleanup(fn: () => void) {
+	cleanups.push(fn)
+}
+function cleanup() {
+	while (cleanups.length) {
+		try {
+			cleanups.pop()!()
+		} catch (err) {
+			console.error('[e2e] cleanup error:', err)
+		}
+	}
+}
+
+function log(msg: string) {
+	console.log(`\n[e2e] ${msg}`)
+}
+
+async function getFreePort(): Promise<number> {
+	const srv = createServer()
+	srv.listen(0)
+	await once(srv, 'listening')
+	const port = (srv.address() as { port: number }).port
+	await new Promise((res) => srv.close(res))
+	return port
+}
+
+function run(
+	cmd: string,
+	args: string[],
+	opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {}
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(cmd, args, {
+			cwd: opts.cwd ?? workspaceRoot,
+			env: { ...process.env, ...opts.env },
+			stdio: 'inherit',
+			shell: process.platform === 'win32'
+		})
+		child.on('error', reject)
+		child.on('exit', (code) =>
+			code === 0
+				? resolve()
+				: reject(new Error(`${cmd} ${args.join(' ')} exited with ${code}`))
+		)
+	})
+}
+
+// The consumer simulates a standalone third-party project. It must NOT inherit
+// the parent pnpm/nx process's package-manager environment (npm_config_*, PNPM_*,
+// etc.) — those redirect native prebuilt resolution (e.g. sharp's @img binaries)
+// and force a from-source node-gyp build that fails in the nested temp dir.
+// Returning the keys as undefined makes child_process omit them.
+function cleanChildEnvOverrides(): NodeJS.ProcessEnv {
+	const overrides: NodeJS.ProcessEnv = {}
+	for (const key of Object.keys(process.env)) {
+		if (/^(npm_config_|npm_package_|npm_lifecycle|NPM_|PNPM_|NX_)/i.test(key)) {
+			overrides[key] = undefined
+		}
+	}
+	return overrides
+}
+
+async function waitForHttp(url: string, timeoutMs = 60000) {
+	const deadline = Date.now() + timeoutMs
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(url)
+			if (res.ok || res.status === 404) return
+		} catch {
+			/* not up yet */
+		}
+		await new Promise((r) => setTimeout(r, 500))
+	}
+	throw new Error(`Timed out waiting for ${url}`)
+}
+
+async function startVerdaccio(storageDir: string): Promise<string> {
+	const port = await getFreePort()
+	const configPath = join(here, 'registry', 'config.yaml')
+	const verdaccioBin = resolveVerdaccioBin()
+	// verdaccio writes its storage relative to cwd, so the dir must exist first.
+	mkdirSync(storageDir, { recursive: true })
+
+	log(`starting Verdaccio on :${port} (storage ${storageDir})`)
+	const proc = spawn(
+		process.execPath,
+		[
+			verdaccioBin,
+			'--config',
+			configPath,
+			'--listen',
+			`http://127.0.0.1:${port}`
+		],
+		{
+			cwd: storageDir,
+			env: { ...process.env, VERDACCIO_STORAGE_PATH: storageDir },
+			stdio: ['ignore', 'inherit', 'inherit'],
+			shell: process.platform === 'win32'
+		}
+	)
+	onCleanup(() => proc.kill('SIGKILL'))
+
+	const registry = `http://127.0.0.1:${port}/`
+	await waitForHttp(registry)
+	return registry
+}
+
+// Rewrite `workspace:*` specifiers in a built package.json to the package's own
+// version, faithfully simulating what release-please's `node-workspace` plugin
+// produces at release time (all @vctrl/* packages share one linked version).
+// This makes the e2e publish the REAL released shape — so a stray `workspace:*`
+// in a consumer-facing field (dependencies / peerDependencies) that points at an
+// unpublished package surfaces as an install failure instead of being masked.
+// `devDependencies` are intentionally left untouched: consumers never install
+// them, and unpublished internal libs (@shared/*) legitimately live there.
+function rewriteWorkspaceSpecifiers(pkgPath: string) {
+	const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as Record<
+		string,
+		unknown
+	> & { version?: string }
+	const linkedVersion = pkg.version ?? '0.0.0'
+	let changed = false
+	for (const field of [
+		'dependencies',
+		'peerDependencies',
+		'optionalDependencies',
+		// devDependencies hold bundled internal libs (@vctrl/core types, @shared/*).
+		// Consumers never install them, but rewrite here too so pnpm publish from the
+		// detached build dir doesn't trip on an unresolved workspace: specifier.
+		'devDependencies'
+	]) {
+		const deps = pkg[field] as Record<string, string> | undefined
+		if (!deps) continue
+		for (const [name, spec] of Object.entries(deps)) {
+			if (typeof spec === 'string' && spec.startsWith('workspace:')) {
+				deps[name] = `^${linkedVersion}`
+				changed = true
+			}
+		}
+	}
+	if (changed) writeFileSync(pkgPath, JSON.stringify(pkg, null, '\t') + '\n')
+}
+
+// Publish a built package to the local registry using a throwaway userconfig so
+// the developer's ~/.npmrc is never touched.
+async function publishPackage(
+	project: string,
+	dir: string,
+	registry: string,
+	npmrc: string
+) {
+	log(`building + publishing ${project}`)
+	// copy-md depends on build, so this builds the package and stages README/LICENSE.
+	// Workspace tasks and publishing run through pnpm (repo convention / pnpm-only
+	// pipeline); only the consumer install below uses npm, to prove the published
+	// package is installable for a plain third-party npm consumer.
+	await run('pnpm', ['nx', 'run', `${project}:copy-md`])
+
+	// Match the released manifest: rewrite `workspace:*` to the linked version
+	// exactly as release-please's node-workspace plugin does on the release PR.
+	rewriteWorkspaceSpecifiers(join(workspaceRoot, dir, 'package.json'))
+
+	const token = Buffer.from('e2e:e2e').toString('base64')
+	writeFileSync(
+		npmrc,
+		[
+			`registry=${registry}`,
+			`//${registry.replace(/^https?:\/\//, '')}:_authToken="${token}"`,
+			`//${registry.replace(/^https?:\/\//, '')}:always-auth=true`,
+			''
+		].join('\n')
+	)
+
+	await run('pnpm', ['publish', '--registry', registry, '--no-git-checks'], {
+		cwd: join(workspaceRoot, dir),
+		env: { NPM_CONFIG_USERCONFIG: npmrc, npm_config_userconfig: npmrc }
+	})
+}
+
+async function main() {
+	const ci = process.argv.includes('--ci')
+	const tmpRoot = mkdtempSync(join(tmpdir(), 'vctrl-viewer-e2e-'))
+	onCleanup(() => rmSync(tmpRoot, { recursive: true, force: true }))
+
+	const storageDir = join(tmpRoot, 'verdaccio-storage')
+	const npmrc = join(tmpRoot, '.npmrc')
+	const consumerDir = join(tmpRoot, 'consumer')
+
+	const registry = await startVerdaccio(storageDir)
+
+	for (const { project, dir } of PACKAGES) {
+		await publishPackage(project, dir, registry, npmrc)
+	}
+
+	// Scaffold the consumer app from the template and pin it to the registry.
+	log(`scaffolding consumer app in ${consumerDir}`)
+	cpSync(join(here, 'consumer-template'), consumerDir, { recursive: true })
+	// legacy-peer-deps mirrors how integration sites install the React Three
+	// Fiber stack: drei declares optional react-native/expo peers that npm's
+	// strict resolver would otherwise reject. The dependency set itself is
+	// declared in the consumer package.json so resolution is deterministic.
+	writeFileSync(
+		join(consumerDir, '.npmrc'),
+		[`registry=${registry}`, 'legacy-peer-deps=true', ''].join('\n')
+	)
+
+	log('installing @vctrl/viewer + @vctrl/hooks + peer deps from local registry')
+	const consumerEnv = cleanChildEnvOverrides()
+	// --ignore-scripts: the @vctrl/core -> @gltf-transform/functions -> ndarray-pixels
+	// chain pulls `sharp` (a native Node binary) as a transitive dependency. A
+	// browser consumer never executes it (ndarray-pixels resolves its sharp-free
+	// browser export), but Verdaccio can't serve sharp's @img prebuilt binaries, so
+	// its install would otherwise source-build via node-gyp and fail. Skipping
+	// install scripts avoids that native build; esbuild still resolves its platform
+	// binary package, so the Vite build below is unaffected.
+	await run('npm', ['install', '--no-audit', '--no-fund', '--ignore-scripts'], {
+		cwd: consumerDir,
+		env: consumerEnv
+	})
+
+	log('building consumer app (packaging regression gate)')
+	await run('npx', ['vite', 'build'], { cwd: consumerDir, env: consumerEnv })
+
+	const previewPort = await getFreePort()
+	const baseURL = `http://127.0.0.1:${previewPort}`
+	log(`serving consumer preview at ${baseURL}`)
+	const preview: ChildProcess = spawn(
+		'npx',
+		[
+			'vite',
+			'preview',
+			'--port',
+			String(previewPort),
+			'--strictPort',
+			'--host',
+			'127.0.0.1'
+		],
+		{
+			cwd: consumerDir,
+			env: { ...process.env, ...consumerEnv },
+			stdio: 'inherit',
+			shell: process.platform === 'win32'
+		}
+	)
+	onCleanup(() => preview.kill('SIGKILL'))
+	await waitForHttp(baseURL)
+
+	log('running Playwright against the published-package render')
+	// Playwright + browsers live in the workspace root install, so run it there.
+	await run(
+		'pnpm',
+		['exec', 'playwright', 'test', '--config', join(here, '..', 'playwright.config.ts')],
+		{ env: { E2E_BASE_URL: baseURL, ...(ci ? { CI: 'true' } : {}) } }
+	)
+
+	log(
+		'e2e passed: @vctrl/viewer + @vctrl/hooks install, bundle, and render cleanly ✓'
+	)
+}
+
+process.on('SIGINT', () => {
+	cleanup()
+	process.exit(130)
+})
+
+main()
+	.then(() => {
+		cleanup()
+		process.exit(0)
+	})
+	.catch((err) => {
+		console.error('\n[e2e] FAILED:', err.message)
+		cleanup()
+		process.exit(1)
+	})

--- a/packages/viewer-e2e/tests/viewer-render.spec.ts
+++ b/packages/viewer-e2e/tests/viewer-render.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+
+// These assertions run against a throwaway Vite app that installed
+// @vctrl/viewer from the local Verdaccio registry (i.e. the real published
+// tarball, not the workspace source). A green run proves the package can be
+// installed, bundled, and rendered on a clean integration site.
+
+test('viewer mounts without a runtime crash', async ({ page }) => {
+	const consoleErrors: string[] = []
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') consoleErrors.push(msg.text())
+	})
+	const pageErrors: string[] = []
+	page.on('pageerror', (err) => pageErrors.push(err.message))
+
+	await page.goto('/')
+
+	// The host element renders synchronously; its presence proves the bundle
+	// loaded and the module graph resolved.
+	await expect(page.getByTestId('viewer-host')).toBeVisible()
+
+	// The error boundary swaps in this node on a render-time crash.
+	await expect(page.getByTestId('viewer-crashed')).toHaveCount(0)
+
+	// Wait for the viewer to report a successful mount via the imperative API.
+	await page.waitForFunction(
+		() => window.__VIEWER_E2E__?.status === 'mounted',
+		undefined,
+		{ timeout: 15000 }
+	)
+
+	const flag = await page.evaluate(() => window.__VIEWER_E2E__)
+	expect(flag?.status, flag?.error).toBe('mounted')
+
+	// @vctrl/hooks probe: proves the published hooks package resolves its
+	// externalized @vctrl/core dependency at runtime (and that the root export
+	// works), not just that viewer renders.
+	await expect(page.getByTestId('hooks-crashed')).toHaveCount(0)
+	await page.waitForFunction(
+		() => window.__HOOKS_E2E__?.status === 'ok',
+		undefined,
+		{ timeout: 15000 }
+	)
+	const hooksFlag = await page.evaluate(() => window.__HOOKS_E2E__)
+	expect(hooksFlag?.status, hooksFlag?.error).toBe('ok')
+
+	expect(pageErrors, pageErrors.join('\n')).toEqual([])
+})
+
+declare global {
+	interface Window {
+		__VIEWER_E2E__?: { status: 'mounted' | 'crashed'; error?: string }
+		__HOOKS_E2E__?: { status: 'ok' | 'crashed'; error?: string }
+	}
+}

--- a/packages/viewer-e2e/tsconfig.json
+++ b/packages/viewer-e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"target": "es2022",
+		"lib": ["es2022", "dom", "dom.iterable"],
+		"types": ["node"],
+		"strict": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/run-e2e.ts", "tests/**/*.ts", "playwright.config.ts"],
+	"exclude": ["node_modules", "src/consumer-template"]
+}

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -28,7 +28,7 @@
 	},
 	"license": "AGPL-3.0-only",
 	"main": "./index.js",
-	"module": "./index.mjs",
+	"module": "./index.js",
 	"types": "./index.d.ts",
 	"type": "module",
 	"publishConfig": {
@@ -51,13 +51,15 @@
 		"@react-three/drei": "^10.0.7",
 		"@react-three/fiber": "^9.1.2",
 		"@react-three/postprocessing": "^3.0.4",
-		"postprocessing": "^6.37.3",
-		"@vctrl/core": "workspace:*",
-		"@shared/components": "workspace:*",
-		"@shared/utils": "workspace:*"
+		"postprocessing": "^6.37.3"
 	},
 	"peerDependencies": {
 		"three": "^0.177.0",
 		"react": "^18.0.0 || ^19.0.0"
+	},
+	"devDependencies": {
+		"@vctrl/core": "workspace:*",
+		"@shared/components": "workspace:*",
+		"@shared/utils": "workspace:*"
 	}
 }

--- a/packages/viewer/project.json
+++ b/packages/viewer/project.json
@@ -30,7 +30,7 @@
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
-				"command": "npm publish --access public",
+				"command": "pnpm publish --no-git-checks --access public",
 				"cwd": "build/packages/vctrl/viewer"
 			}
 		},

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -45,5 +45,10 @@
 			"@vctrl/embed": ["./packages/embed/src/index.ts"]
 		}
 	},
-	"exclude": ["node_modules", "tmp", "**/public/**/*"]
+	"exclude": [
+		"node_modules",
+		"tmp",
+		"**/public/**/*",
+		"packages/viewer-e2e/src/consumer-template"
+	]
 }


### PR DESCRIPTION
- Updated documentation for @vctrl/core to clarify its compatibility with Node.js, browsers, and edge runtimes, and made Sharp an optional dependency.
- Modified ESLint configuration to ignore specific paths for the viewer-e2e consumer app.
- Adjusted peer dependencies in core package.json, marking @react-three/drei as optional.
- Changed publish command in project.json files from npm to pnpm for core, embed, hooks, and viewer packages.
- Updated hooks package.json to include exports for types and module formats.
- Added a new GitHub Actions workflow for end-to-end testing of the @vctrl/viewer packaging.
- Created a new viewer-e2e package with tests to validate the installation and rendering of the @vctrl/viewer package.
- Implemented a run-e2e script to orchestrate the end-to-end testing process using a local Verdaccio registry.
- Added Playwright tests to ensure the viewer mounts without runtime crashes and that hooks resolve correctly.
