### PR TITLE
fix(contact): stop static-prerendering the contact page

### DIFF
--- a/apps/vectreal-platform/react-router.config.ts
+++ b/apps/vectreal-platform/react-router.config.ts
@@ -14,7 +14,6 @@ const STATIC_PRERENDER_PATHS = [
 	'/',
 	'/about',
 	'/changelog',
-	'/contact',
 	'/code-of-conduct',
 	'/privacy-policy',
 	'/terms-of-service',


### PR DESCRIPTION
## Summary
- Production contact-form submissions are fully CSRF-blocked. `/contact` was included in `STATIC_PRERENDER_PATHS` (`react-router.config.ts`) alongside purely static marketing pages, but its loader mints a per-visitor CSRF token and its action validates it.
- Prerendering bakes one build-time CSRF token into a static `contact.data` / `contact/index.html`. `react-router-serve` serves that static file for any request matching the exact `/contact` path before SSR runs — confirmed live in prod (`content-type: application/octet-stream`, identical `etag`/body across requests, `"csrf"` value frozen and `"turnstileSiteKey":""` from a missing build-time secret).
- Every client-side nav to Contact fetches `/contact.data` (single-fetch, canonical no-trailing-slash path) and gets this frozen token, which never matches the visitor's own freshly-minted `csrf` cookie, so `ensureValidCsrfFormData` rejects every submission.
- Fix: remove `/contact` from `STATIC_PRERENDER_PATHS` so it's SSR-only like other stateful/auth-aware routes. Verified locally that the build no longer emits `contact.data`/`contact/index.html` static artifacts.

## Test plan
- [x] `pnpm nx build vectreal-platform` — confirmed no static `contact.data`/`contact/index.html` in build output
- [x] `pnpm nx typecheck vectreal-platform`
- [x] `pnpm nx lint vectreal-platform`
- [ ] After deploy: submit the contact form in production and confirm no CSRF error