### PR TITLE
fix(ui): polish mobile nav, docs layout, and dashboard header overflow

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/dynamic-breadcrumb.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dynamic-breadcrumb.tsx
@@ -115,6 +115,7 @@ export const DynamicBreadcrumb = memo(() => {
 		<AnimatePresence mode="wait" initial={false}>
 			<motion.div
 				key={contentKey}
+				className="overflow-hidden"
 				initial={{ opacity: 0, x: -8 }}
 				animate={{ opacity: 1, x: 0 }}
 				exit={{ opacity: 0, x: 8 }}
@@ -140,8 +141,8 @@ export const DynamicBreadcrumb = memo(() => {
 						</BreadcrumbList>
 					</Breadcrumb>
 				) : (
-					<Breadcrumb className="grow">
-						<BreadcrumbList className="text-primary/75">
+					<Breadcrumb className="grow overflow-x-auto">
+						<BreadcrumbList className="text-primary/75 flex-nowrap gap-1 whitespace-nowrap">
 							{renderedBreadcrumbs.map((item, index) => {
 								const isFirst = index === 0
 								const showSeparator = !isFirst

--- a/apps/vectreal-platform/app/components/docs/docs-mobile-navigation.tsx
+++ b/apps/vectreal-platform/app/components/docs/docs-mobile-navigation.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@shared/components/ui/button'
 import { ScrollArea } from '@shared/components/ui/scroll-area'
 import {
 	Sheet,
@@ -8,7 +7,7 @@ import {
 	SheetTitle,
 	SheetTrigger
 } from '@shared/components/ui/sheet'
-import { BookText, Menu } from 'lucide-react'
+import { BookText } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import { DocsPageToc } from './docs-page-toc'
@@ -16,13 +15,14 @@ import { DocsTreeNav } from './docs-tree-nav'
 
 import type { DocHeading } from '../../hooks/use-doc-toc'
 
-interface DocsMobileNavigationProps {
+interface DocsMobileNavigationProps extends React.PropsWithChildren {
 	pathname: string
 	headings: DocHeading[]
 	activeId: string | null
 }
 
 export function DocsMobileNavigation({
+	children,
 	pathname,
 	headings,
 	activeId
@@ -34,14 +34,9 @@ export function DocsMobileNavigation({
 	}, [pathname])
 
 	return (
-		<div className="mb-6 flex items-center justify-between gap-3 lg:hidden">
+		<div className="flex items-center justify-between gap-3 lg:hidden">
 			<Sheet open={open} onOpenChange={setOpen}>
-				<SheetTrigger asChild>
-					<Button variant="secondary" size="sm" className="gap-2">
-						<Menu className="h-4 w-4" aria-hidden="true" />
-						Browse docs
-					</Button>
-				</SheetTrigger>
+				<SheetTrigger asChild>{children}</SheetTrigger>
 				<SheetContent side="left" className="w-[90vw] max-w-sm">
 					<SheetHeader>
 						<SheetTitle className="flex items-center gap-2">

--- a/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
+++ b/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
@@ -1,7 +1,13 @@
 import { VectrealLogoAnimated } from '@shared/components/assets/icons/vectreal-logo-animated'
 import { Button } from '@shared/components/ui/button'
 import { Separator } from '@shared/components/ui/separator'
-import { Sheet, SheetContent } from '@shared/components/ui/sheet'
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle
+} from '@shared/components/ui/sheet'
 import { cn } from '@shared/utils'
 import { User } from '@supabase/supabase-js'
 import { motion } from 'framer-motion'
@@ -77,7 +83,14 @@ function MobileNav({
 				className="fixed top-0 right-0 left-0 z-50 flex items-center justify-between p-2"
 				aria-label="Main navigation"
 			>
-				<div className="from-background absolute inset-0 z-0 h-12 bg-linear-to-b to-transparent backdrop-blur-sm" />
+				<div
+					className={cn(
+						'absolute inset-0 z-0 h-12 backdrop-blur-sm',
+						isHomePage
+							? 'from-background bg-linear-to-b to-transparent'
+							: 'bg-background/80 border-border/40 border-b'
+					)}
+				/>
 				<div className="relative flex w-full items-center justify-between">
 					{/* Logo */}
 					<Link
@@ -124,6 +137,20 @@ function MobileNav({
 					side="right"
 					className="bg-background/80 border-border/40 flex flex-col gap-0 pt-8 backdrop-blur-2xl"
 				>
+					<SheetHeader className="px-4">
+						<SheetTitle className="capitalize">
+							{user
+								? `Hi, ${user.user_metadata?.full_name || 'User'}!`
+								: 'Menu'}
+						</SheetTitle>
+						<SheetDescription className="text-muted-foreground text-sm">
+							{user
+								? 'Navigate your dashboard and account settings.'
+								: 'Explore the platform and sign in to access your dashboard.'}
+						</SheetDescription>
+					</SheetHeader>
+
+					<Separator className="bg-border/50" />
 					{/* Publisher CTA for unauthenticated users */}
 					{!user && (
 						<div className="px-4 pt-4">

--- a/apps/vectreal-platform/app/routes/docs/getting-started/index.mdx
+++ b/apps/vectreal-platform/app/routes/docs/getting-started/index.mdx
@@ -2,8 +2,6 @@
 
 This section walks you through setting up the Vectreal Platform monorepo locally and running the full dev stack for the first time.
 
----
-
 ## Prerequisites
 
 | Tool | Version | Notes |
@@ -12,8 +10,6 @@ This section walks you through setting up the Vectreal Platform monorepo locally
 | pnpm | 9 or later | Used as the workspace package manager |
 | Docker | Latest | Required for the local Supabase stack |
 | Supabase CLI | Latest | `npm i -g supabase` |
-
----
 
 ## Repository structure
 
@@ -29,8 +25,6 @@ vectreal-platform/
 │   └── utils/                # Shared utilities
 └── terraform/                # Infrastructure as code (GCP)
 ```
-
----
 
 ## Next steps
 

--- a/apps/vectreal-platform/app/routes/docs/index.tsx
+++ b/apps/vectreal-platform/app/routes/docs/index.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@shared/components/ui/badge'
 import { Button } from '@shared/components/ui/button'
 import { CardContent, CardHeader, CardTitle } from '@shared/components/ui/card'
 import { ArrowRight, BookOpen, Code2, GitBranch, Rocket } from 'lucide-react'
@@ -64,7 +63,6 @@ export default function DocsIndexPage() {
 								View on GitHub
 							</a>
 						</Button>
-						<Badge variant="secondary">Open source</Badge>
 					</>
 				}
 			/>

--- a/apps/vectreal-platform/app/routes/layouts/dashboard-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/dashboard-layout.tsx
@@ -236,26 +236,30 @@ const DashboardLayout = () => {
 							plan={plan}
 						/>
 					</LogoSidebar>
-					<SidebarInset className="relative overflow-hidden">
+					<SidebarInset className="relative w-dvw overflow-hidden">
 						<DashboardManagementDialogs />
 						<UpgradeModal />
 
-						<div className="z-50 flex items-center gap-4 p-4 px-6 pl-4">
+						<div className="bg-background/80 fixed top-0 z-50 flex w-dvw items-center gap-4 p-4 px-6 pl-4 backdrop-blur-lg">
 							<SidebarTrigger />
-							<div className="flex items-center gap-2">
+							<div className="flex items-center gap-2 overflow-hidden">
 								<DynamicBreadcrumb />
 								{isBackgroundRefreshing && (
-									<Loader2 className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
+									<Loader2 className="text-muted-foreground h-3.5 w-3.5 shrink-0 animate-spin" />
 								)}
 							</div>
 						</div>
-						{!(isSceneDetailRoute && willBePublisherRoute) &&
-							!(isSceneDetailRoute || willBeSceneDetail) && <DashboardHeader />}
-						{isContentNavigationLoading && !willBeOverlayRoute ? (
-							skeleton
-						) : (
-							<Outlet />
-						)}
+						<div className="mt-14">
+							{!(isSceneDetailRoute && willBePublisherRoute) &&
+								!(isSceneDetailRoute || willBeSceneDetail) && (
+									<DashboardHeader />
+								)}
+							{isContentNavigationLoading && !willBeOverlayRoute ? (
+								skeleton
+							) : (
+								<Outlet />
+							)}
+						</div>
 					</SidebarInset>
 				</SidebarProvider>
 			</Provider>

--- a/apps/vectreal-platform/app/routes/layouts/docs-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/docs-layout.tsx
@@ -8,7 +8,8 @@ import {
 } from '@shared/components/ui/breadcrumb'
 import { Button } from '@shared/components/ui/button'
 import { ScrollArea } from '@shared/components/ui/scroll-area'
-import { ChevronLeft, ChevronRight, Pencil } from 'lucide-react'
+import { cn } from '@shared/utils'
+import { ChevronLeft, ChevronRight, Menu, Pencil } from 'lucide-react'
 import { useRef } from 'react'
 import { type MetaFunction, Link, Outlet, useLocation } from 'react-router'
 
@@ -118,9 +119,9 @@ export default function DocsLayout() {
 	const categoryPage = categorySlug ? getDocPage(categorySlug) : undefined
 
 	return (
-		<div className="mx-auto flex w-full max-w-7xl gap-0 px-4 pt-22 pb-16">
+		<div className="mx-auto flex w-full max-w-7xl gap-0 px-4 pb-16">
 			<aside
-				className="sticky top-20 hidden h-[calc(100vh-5rem)] w-64 shrink-0 lg:block"
+				className="sticky top-24 hidden h-[calc(100vh-5rem)] w-64 shrink-0 md:top-28 lg:block"
 				aria-label="Docs navigation"
 			>
 				<ScrollArea className="h-full pr-4 pb-8">
@@ -129,20 +130,26 @@ export default function DocsLayout() {
 			</aside>
 
 			<main className="min-w-0 flex-1 lg:px-8">
-				<DocsMobileNavigation
-					pathname={pathname}
-					headings={headings}
-					activeId={activeId}
-				/>
-
-				<div className="mb-4 flex items-center justify-between gap-3">
+				<div className="bg-muted fixed top-12 left-0 z-20 mb-4 flex w-dvw items-center justify-between gap-3 px-4 py-1 md:top-16">
 					<Breadcrumb aria-label="Docs breadcrumb">
 						<BreadcrumbList>
 							<BreadcrumbItem>
 								<BreadcrumbLink asChild>
-									<Link to="/docs" viewTransition>
-										Docs
-									</Link>
+									<span>
+										<Link className="max-md:hidden" to="/docs" viewTransition>
+											Docs
+										</Link>
+
+										<DocsMobileNavigation
+											pathname={pathname}
+											headings={headings}
+											activeId={activeId}
+										>
+											<span className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm font-medium">
+												<Menu className="h-5 w-5" /> Docs
+											</span>
+										</DocsMobileNavigation>
+									</span>
 								</BreadcrumbLink>
 							</BreadcrumbItem>
 							{categoryLabel && (
@@ -173,12 +180,13 @@ export default function DocsLayout() {
 								)}
 						</BreadcrumbList>
 					</Breadcrumb>
-					<span className="border-border/60 bg-muted/50 text-foreground rounded-full border px-2.5 py-0.5 text-xs font-medium">
-						{page?.version ?? 'latest'}
-					</span>
+					<span className="border-border/60 bg-muted/50 text-foreground rounded-full border px-2.5 py-0.5 text-xs font-medium"></span>
 				</div>
 
-				<article ref={contentRef} className={styles.docsContent}>
+				<article
+					ref={contentRef}
+					className={cn('mt-24 md:mt-28', styles.docsContent)}
+				>
 					<Outlet />
 				</article>
 

--- a/apps/vectreal-platform/app/routes/news-room-page/news-room-article-page.tsx
+++ b/apps/vectreal-platform/app/routes/news-room-page/news-room-article-page.tsx
@@ -273,7 +273,7 @@ export default function NewsRoomArticlePage({
 	}
 
 	return (
-		<div className="mx-auto flex w-full max-w-7xl gap-0 px-4 pt-16 pb-18">
+		<div className="mx-auto flex w-full max-w-7xl gap-0 px-4 py-16">
 			<main className="min-w-0 flex-1 lg:px-8">
 				<Button variant="ghost" asChild className="mb-6 -ml-2">
 					<Link to="/news-room" viewTransition>
@@ -406,7 +406,7 @@ export default function NewsRoomArticlePage({
 					<p className="text-primary text-xs font-semibold tracking-[0.14em] uppercase">
 						Built for makers shipping in 3D
 					</p>
-					<h2 className="max-w-2xl text-2xl leading-tight font-semibold tracking-tight md:text-3xl">
+					<h2 className="max-w-2xl text-2xl leading-tight! font-semibold tracking-tight md:text-3xl">
 						Ready to publish your first interactive scene?
 					</h2>
 

--- a/apps/vectreal-platform/app/styles/mdx.module.css
+++ b/apps/vectreal-platform/app/styles/mdx.module.css
@@ -148,7 +148,7 @@
 
 	pre code {
 		background: transparent;
-		color: inherit;
+		color: var(--color-accent);
 		padding: 0;
 	}
 


### PR DESCRIPTION
## Summary
- Mobile nav drawer now has an accessible `SheetTitle`/`SheetDescription` and picks up a solid background/border on non-home routes instead of always using the transparent home gradient.
- `DocsMobileNavigation` accepts a custom trigger via `children`, so the mobile "Docs" breadcrumb entry now doubles as the drawer trigger instead of a separate "Browse docs" button.
- Dashboard breadcrumb bar and docs breadcrumb bar are now sticky/fixed with proper `overflow-x-auto`/`flex-nowrap` handling so long titles no longer overflow the layout.
- Trimmed redundant `---` dividers in the getting-started doc and dropped unused `Badge`/`Menu` button leftovers.
- Fixed docs code block text color (was `inherit`, now uses `--color-accent`) and normalized news-room article page vertical padding.

## Test plan
- [x] `pnpm nx typecheck vectreal-platform`
- [x] `pnpm nx lint vectreal-platform`
- [ ] Manually verify mobile nav drawer and docs mobile nav in browser