### PR TITLE
style(ui): align shared surface treatments

### DIFF
--- a/shared/components/src/ui/accordion.tsx
+++ b/shared/components/src/ui/accordion.tsx
@@ -33,7 +33,7 @@ function AccordionTrigger({
 				suppressHydrationWarning
 				data-slot="accordion-trigger"
 				className={cn(
-					'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+					'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/alert-dialog.tsx
+++ b/shared/components/src/ui/alert-dialog.tsx
@@ -54,7 +54,7 @@ function AlertDialogContent({
 			<AlertDialogPrimitive.Content
 				data-slot="alert-dialog-content"
 				className={cn(
-					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-lg duration-200 sm:max-w-lg',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/sonner.tsx
+++ b/shared/components/src/ui/sonner.tsx
@@ -4,6 +4,13 @@ const Toaster = ({ ...props }: ToasterProps) => {
 	return (
 		<Sonner
 			theme="dark"
+			// Centered horizontally so notifications read the same regardless of
+			// which side of the screen the current surface occupies, and inset by
+			// the same 12px the publisher's floating surfaces use so a toast lines
+			// up with whatever it appears beside. Overridable per call site.
+			position="bottom-center"
+			offset={12}
+			mobileOffset={12}
 			className="toaster group"
 			style={
 				{


### PR DESCRIPTION
Three small shared-component tweaks:

- Toasts move to bottom-center with a 12px offset, matching the inset used by floating surfaces.
- Alert dialog radius goes from `rounded-lg` to `rounded-2xl`, matching other surfaces.
- Accordion triggers no longer underline on hover.