### PR TITLE
fix(viewer): shadows ignore model normalization

### DIFF
--- a/packages/viewer/src/components/scene/scene-shadows.tsx
+++ b/packages/viewer/src/components/scene/scene-shadows.tsx
@@ -4,7 +4,7 @@ import {
 	RandomizedLight
 } from '@react-three/drei'
 import { useThree } from '@react-three/fiber'
-import { AccumulativeShadowsProps } from '@vctrl/core'
+import { AccumulativeShadowsProps, NormalizationOptions } from '@vctrl/core'
 import {
 	type ComponentRef,
 	memo,
@@ -136,6 +136,14 @@ type SceneShadowsProps = Partial<AccumulativeShadowsProps> & {
 	 */
 	model?: Object3D
 	/**
+	 * Model normalization, which rescales the model via an ancestor group.
+	 *
+	 * Read only to know when to re-measure: the scale lives on a group above the
+	 * model, so toggling it changes the model's world size without changing the
+	 * `model` object itself, and nothing else here would notice.
+	 */
+	normalizationOptions?: NormalizationOptions
+	/**
 	 * Set while the loaded model's geometry is actively animating. Camera
 	 * auto-rotate keeps the model static and must NOT set this. When true the
 	 * viewer renders cheaper contact shadows that track the moving geometry.
@@ -202,8 +210,15 @@ const DEFAULT_METRICS: ModelMetrics = {
  * makes the shadow read too small under tall models and too large under flat
  * ones. Returns unit metrics until measured.
  */
-const useModelMetrics = (model?: Object3D): ModelMetrics => {
+const useModelMetrics = (
+	model?: Object3D,
+	normalizationOptions?: NormalizationOptions
+): ModelMetrics => {
 	const [metrics, setMetrics] = useState<ModelMetrics>(DEFAULT_METRICS)
+
+	const normalizationEnabled = normalizationOptions?.enabled ?? false
+	const normalizationMinSize = normalizationOptions?.minSize
+	const normalizationMaxSize = normalizationOptions?.maxSize
 
 	useEffect(() => {
 		if (!model) return
@@ -222,7 +237,11 @@ const useModelMetrics = (model?: Object3D): ModelMetrics => {
 				measured: true
 			})
 		}
-	}, [model])
+		// Normalization is a dependency because it rescales the model from an
+		// ancestor group: the object identity is unchanged, but every figure
+		// derived here (plane size, light distance, shadow-camera extent, and the
+		// bake signature built from them) is in model-size units and goes stale.
+	}, [model, normalizationEnabled, normalizationMinSize, normalizationMaxSize])
 
 	return metrics
 }
@@ -307,6 +326,7 @@ const ShadowBakeCapture = ({
 const SceneShadows = memo(
 	({
 		model,
+		normalizationOptions,
 		isModelAnimating = false,
 		lightEditable = false,
 		onLightChange,
@@ -316,7 +336,7 @@ const SceneShadows = memo(
 		...props
 	}: SceneShadowsProps) => {
 		const { footprint, radius, height, vertexCount, measured } =
-			useModelMetrics(model)
+			useModelMetrics(model, normalizationOptions)
 		const apiRef = useRef<React.ComponentRef<typeof AccumulativeShadows> | null>(
 			null
 		)

--- a/packages/viewer/src/components/scene/scene-shadows.tsx
+++ b/packages/viewer/src/components/scene/scene-shadows.tsx
@@ -4,7 +4,7 @@ import {
 	RandomizedLight
 } from '@react-three/drei'
 import { useThree } from '@react-three/fiber'
-import { AccumulativeShadowsProps, NormalizationOptions } from '@vctrl/core'
+import type { AccumulativeShadowsProps, NormalizationOptions } from '@vctrl/core'
 import {
 	type ComponentRef,
 	memo,

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -478,6 +478,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 								</Center>
 								<SceneShadows
 									model={model}
+									normalizationOptions={normalizationOptions}
 									{...(shadowsOptions as Partial<AccumulativeShadowsProps>)}
 									lightEditable={shadowLightEditable}
 									onLightChange={onShadowLightChange}


### PR DESCRIPTION
Toggling "normalize size" breaks shadows: the light handle lands inside the model, the shadow stops rendering even when the light is moved, the ground shadow disappears, and toggling back off leaves an oversized shadow behind.

One cause. `useModelMetrics` measures the model's world bounds and re-runs only when the `model` object changes. Normalization applies its scale on an ancestor group, so the object identity never changes and the metrics go stale.

Everything the shadow rig sizes is in model-size units derived from those metrics — plane scale and ground shadow (× footprint), light distance and penumbra, and the shadow camera's extent and near/far (× radius). A stale radius puts the light inside the model and shrinks the ortho shadow camera until it no longer contains the subject, which is why nothing renders. The bake signature is built from the same figures, so a stale bake also survives a change that should have invalidated it.

Normalization is now a dependency of the measurement. The bake signature then invalidates on its own, since it already includes footprint and radius.

Pre-existing on `main`; not introduced by the publisher work. Independent of the other open PRs.