### PR TITLE
feat(viewer): make the loading thumbnail stylable

### DIFF
--- a/packages/viewer/src/components/loading-thumbnail-backdrop.tsx
+++ b/packages/viewer/src/components/loading-thumbnail-backdrop.tsx
@@ -8,6 +8,16 @@ interface LoadingThumbnailBackdropProps {
 	isLoaded: boolean
 }
 
+/**
+ * `true` keeps the default blur, `false` drops it, a string replaces it. Kept
+ * separate so the two falsy-ish cases stay distinguishable.
+ */
+const resolveBlurClass = (blur: ViewerLoadingThumbnail['blur']) => {
+	if (blur === false) return null
+	if (typeof blur === 'string') return blur
+	return 'blur-sm'
+}
+
 const LoadingThumbnailBackdrop = ({
 	thumbnail,
 	isLoaded
@@ -35,12 +45,20 @@ const LoadingThumbnailBackdrop = ({
 				src={thumbnail.src}
 				alt={thumbnail.alt || 'Viewer loading thumbnail'}
 				className={cn(
-					'h-full w-full object-cover blur-sm transition-transform duration-700 ease-out',
-					isLoaded ? 'scale-100' : isEntered ? 'scale-105' : 'scale-110'
+					'h-full w-full transition-transform duration-700 ease-out',
+					thumbnail.objectFit === 'contain' ? 'object-contain' : 'object-cover',
+					resolveBlurClass(thumbnail.blur),
+					isLoaded ? 'scale-100' : isEntered ? 'scale-105' : 'scale-110',
+					// Last so a consumer's class wins any conflict through twMerge.
+					thumbnail.className
 				)}
 			/>
-			<div className="bg-background/35 absolute inset-0" />
-			<div className="from-background/60 via-background/15 absolute inset-0 bg-gradient-to-b to-transparent" />
+			{thumbnail.scrim !== false && (
+				<>
+					<div className="bg-background/35 absolute inset-0" />
+					<div className="from-background/60 via-background/15 absolute inset-0 bg-gradient-to-b to-transparent" />
+				</>
+			)}
 		</div>
 	)
 }

--- a/packages/viewer/src/components/overlay.stories.tsx
+++ b/packages/viewer/src/components/overlay.stories.tsx
@@ -55,12 +55,45 @@ export const Loaded: Story = {
 	}
 }
 
+const THUMBNAIL_SRC =
+	'https://images.unsplash.com/photo-1673951284213-2a3550681b7d?ixlib=rb-4.1.0&q=85&fm=jpg&cs=srgb&w=1920&h=1080&fit=crop'
+
 export const LoadingWithThumbnail: Story = {
 	args: {
 		hasContent: false,
 		loadingThumbnail: {
-			src: 'https://images.unsplash.com/photo-1673951284213-2a3550681b7d?ixlib=rb-4.1.0&q=85&fm=jpg&cs=srgb&w=1920&h=1080&fit=crop',
+			src: THUMBNAIL_SRC,
 			alt: 'Preview thumbnail backdrop'
+		}
+	}
+}
+
+/**
+ * The presentation is the consuming app's call. Turning off the blur and the
+ * scrims shows the thumbnail as-is, which suits a shot already styled to match
+ * the surrounding page.
+ */
+export const LoadingWithUnstyledThumbnail: Story = {
+	args: {
+		hasContent: false,
+		loadingThumbnail: {
+			src: THUMBNAIL_SRC,
+			alt: 'Preview thumbnail backdrop',
+			blur: false,
+			scrim: false
+		}
+	}
+}
+
+/** `contain` fits the whole image in rather than cropping it to fill. */
+export const LoadingWithContainedThumbnail: Story = {
+	args: {
+		hasContent: false,
+		loadingThumbnail: {
+			src: THUMBNAIL_SRC,
+			alt: 'Preview thumbnail backdrop',
+			blur: 'blur-xl',
+			objectFit: 'contain'
 		}
 	}
 }

--- a/packages/viewer/src/components/scene/scene-shadows.tsx
+++ b/packages/viewer/src/components/scene/scene-shadows.tsx
@@ -4,7 +4,6 @@ import {
 	RandomizedLight
 } from '@react-three/drei'
 import { useThree } from '@react-three/fiber'
-import type { AccumulativeShadowsProps, NormalizationOptions } from '@vctrl/core'
 import {
 	type ComponentRef,
 	memo,
@@ -28,6 +27,7 @@ import {
 import ShadowLightGizmo from './shadow-light-gizmo'
 
 import type { BakedShadow, ShadowBakeCapture } from '../../types/viewer-types'
+import type { AccumulativeShadowsProps, NormalizationOptions } from '@vctrl/core'
 
 // Accumulative shadows: high-quality baked soft shadows for a static subject.
 // The shadow is baked into the receiving plane's UV space from the

--- a/packages/viewer/src/types/viewer-types.ts
+++ b/packages/viewer/src/types/viewer-types.ts
@@ -57,9 +57,40 @@ export interface BakedShadow {
  */
 export type ShadowBakeCapture = () => Promise<null | ShadowBakeResult>
 
+/**
+ * The still image shown behind the canvas until the model is ready.
+ *
+ * Only `src` is required. Everything else describes how it is presented, and
+ * every default reproduces the viewer's built-in look, so a consuming app opts
+ * into changes rather than having to restate the defaults.
+ */
 export interface ViewerLoadingThumbnail {
 	src: string
 	alt?: string
+	/**
+	 * `false` renders the image sharp. A string replaces the default blur with
+	 * your own class, e.g. `'blur-xl'`.
+	 * @default true
+	 */
+	blur?: boolean | string
+	/**
+	 * The two scrims that tint the image towards the background color. `false`
+	 * shows the thumbnail unmodified, which suits a shot that already matches
+	 * the surrounding page.
+	 * @default true
+	 */
+	scrim?: boolean
+	/**
+	 * `'contain'` fits the whole thumbnail into the canvas instead of filling it,
+	 * so nothing is cropped.
+	 * @default 'cover'
+	 */
+	objectFit?: 'contain' | 'cover'
+	/**
+	 * Applied to the image. Class conflicts resolve in favor of this value, so it
+	 * can override any of the options above.
+	 */
+	className?: string
 }
 
 export type {


### PR DESCRIPTION
The loading thumbnail hard-coded `blur-sm`, two scrims, and `object-cover`. A consuming app that wanted a sharp thumbnail, no scrim, or `contain` had no way to ask for it.

`ViewerLoadingThumbnail` gains four optional fields:

| Field | Default | Effect |
| --- | --- | --- |
| `blur` | `true` | `false` renders sharp; a string replaces the class |
| `scrim` | `true` | `false` drops both background scrims |
| `objectFit` | `'cover'` | `'contain'` fits instead of cropping |
| `className` | — | applied to the image; wins conflicts via tailwind-merge |

Every default reproduces the current render, so no consumer changes appearance.

Two stories added covering the unstyled and contained variants.

Also included: a two-line import-order autofix in `scene-shadows.tsx` that `nx lint --fix` applies to current `main`. No behavior change.