### PR TITLE
refactor(platform): extract SceneEmbedViewer

### DIFF
--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-info-popover.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-info-popover.tsx
@@ -1,0 +1,41 @@
+import {
+	InfoPopover,
+	InfoPopoverCloseButton,
+	InfoPopoverContent,
+	InfoPopoverText,
+	InfoPopoverTrigger,
+	InfoPopoverVectrealFooter
+} from '@vctrl/viewer'
+
+export interface SceneEmbedInfoPopoverProps {
+	title?: string
+	description?: string
+}
+
+/**
+ * The scene's name and description, behind the viewer's own info affordance.
+ * Rendered into `<SceneEmbedViewer popover>` rather than by it, so a surface
+ * that wants no popover simply omits the prop.
+ */
+const SceneEmbedInfoPopover = ({
+	title,
+	description
+}: SceneEmbedInfoPopoverProps) => (
+	<InfoPopover className="z-100">
+		<InfoPopoverTrigger />
+		<InfoPopoverContent>
+			<InfoPopoverCloseButton />
+			<InfoPopoverText>
+				{title ? <p className="mb-3 font-medium">{title}</p> : null}
+				{description ? (
+					<p>{description}</p>
+				) : (
+					<p className="opacity-50">No description provided for this scene.</p>
+				)}
+			</InfoPopoverText>
+			<InfoPopoverVectrealFooter />
+		</InfoPopoverContent>
+	</InfoPopover>
+)
+
+export default SceneEmbedInfoPopover

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-viewer.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-viewer.tsx
@@ -1,0 +1,75 @@
+import { cn } from '@shared/utils'
+import { memo, useMemo } from 'react'
+
+import { resolveBakedShadowSource } from '../../lib/domain/scene/client/baked-shadow-source'
+import CenteredSpinner from '../centered-spinner'
+import { ClientVectrealViewer } from '../viewer/client-vectreal-viewer'
+
+import type { ModelFile, SceneLoadResult } from '@vctrl/hooks/use-load-model'
+import type { VectrealViewerProps, ViewerLoadingThumbnail } from '@vctrl/viewer'
+import type { ReactNode } from 'react'
+
+export interface SceneEmbedViewerProps {
+	file: ModelFile | null
+	sceneData?: SceneLoadResult
+	/** Sizing for the wrapper. The viewer always fills it. */
+	className?: string
+	loadingThumbnail?: ViewerLoadingThumbnail
+	/** Usually `<SceneEmbedInfoPopover>`; omitted where the surface has its own. */
+	popover?: ReactNode
+	onCommandExecutorReady?: VectrealViewerProps['onCommandExecutorReady']
+	onInteractionEvent?: VectrealViewerProps['onInteractionEvent']
+}
+
+/**
+ * A published scene rendered exactly as an embed renders it: no chrome, no
+ * editing affordances, every setting read from the scene's own saved data.
+ *
+ * The dashboard scene page, the internal preview route, and the external embed
+ * route all show the same thing, so they all render this. Anything a surface
+ * puts *on top* is its own business and stays outside this component.
+ */
+const SceneEmbedViewer = memo(
+	({
+		file,
+		sceneData,
+		className,
+		loadingThumbnail,
+		popover,
+		onCommandExecutorReady,
+		onInteractionEvent
+	}: SceneEmbedViewerProps) => {
+		// The persisted bake from the scene's inlined asset data, so a scene renders
+		// its stored shadow alongside the model instead of re-baking on load.
+		const bakedShadow = useMemo(
+			() => resolveBakedShadowSource(sceneData?.shadows, sceneData?.assetData),
+			[sceneData?.shadows, sceneData?.assetData]
+		)
+
+		return (
+			<div className={cn('relative h-full w-full', className)}>
+				<ClientVectrealViewer
+					model={file?.model}
+					boundsOptions={sceneData?.bounds}
+					cameraOptions={sceneData?.camera}
+					controlsOptions={sceneData?.controls}
+					envOptions={sceneData?.environment}
+					normalizationOptions={sceneData?.normalization}
+					shadowsOptions={sceneData?.shadows}
+					staticShadowBake
+					bakedShadow={bakedShadow}
+					loadingThumbnail={loadingThumbnail}
+					popover={popover}
+					onCommandExecutorReady={onCommandExecutorReady}
+					onInteractionEvent={onInteractionEvent}
+					loader={<CenteredSpinner text="Preparing scene..." />}
+					fallback={<CenteredSpinner text="Loading scene..." />}
+				/>
+			</div>
+		)
+	}
+)
+
+SceneEmbedViewer.displayName = 'SceneEmbedViewer'
+
+export default SceneEmbedViewer

--- a/apps/vectreal-platform/app/components/scene-embed/use-scene-embed-scene.ts
+++ b/apps/vectreal-platform/app/components/scene-embed/use-scene-embed-scene.ts
@@ -6,20 +6,20 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
-import { useConsent } from '../../components/consent/consent-context'
 import {
 	buildPreviewSceneRequest,
 	loadSceneFromApi
 } from '../../lib/domain/scene/client/load-scene-from-api.client'
+import { useConsent } from '../consent/consent-context'
 
 import type { SceneLoadResult } from '@vctrl/hooks/use-load-model'
 
-interface UsePreviewSceneParams {
+interface UseSceneEmbedSceneParams {
 	sceneId?: string
 	projectId?: string
 }
 
-interface PreviewSceneError {
+interface SceneEmbedLoadError {
 	message: string
 	code?: StructuredLoadError['code']
 }
@@ -37,7 +37,7 @@ function isStructuredLoadError(error: unknown): error is StructuredLoadError {
 	)
 }
 
-function getPreviewError(error: unknown): PreviewSceneError {
+function toSceneEmbedLoadError(error: unknown): SceneEmbedLoadError {
 	if (isStructuredLoadError(error)) {
 		return {
 			message: error.message,
@@ -56,12 +56,12 @@ function getPreviewError(error: unknown): PreviewSceneError {
 	}
 }
 
-export function usePreviewScene({ sceneId, projectId }: UsePreviewSceneParams) {
+export function useSceneEmbedScene({ sceneId, projectId }: UseSceneEmbedSceneParams) {
 	const [searchParams] = useSearchParams()
 	const { file, loadFromServer } = useLoadModel()
 	const [isLoadingScene, setIsLoadingScene] = useState(false)
 	const [sceneData, setSceneData] = useState<SceneLoadResult>()
-	const [previewError, setPreviewError] = useState<PreviewSceneError | null>(null)
+	const [loadError, setLoadError] = useState<SceneEmbedLoadError | null>(null)
 	const posthog = usePostHog()
 	const { consent } = useConsent()
 	const trackedPreviewKeysRef = useRef(new Set<string>())
@@ -72,7 +72,7 @@ export function usePreviewScene({ sceneId, projectId }: UsePreviewSceneParams) {
 		}
 
 		setIsLoadingScene(true)
-		setPreviewError(null)
+		setLoadError(null)
 		const token = searchParams.get('token')?.trim() || undefined
 		const { endpoint, requestKey } = buildPreviewSceneRequest({
 			sceneId,
@@ -93,7 +93,7 @@ export function usePreviewScene({ sceneId, projectId }: UsePreviewSceneParams) {
 			setSceneData(loadedSceneData)
 		} catch (error) {
 			console.error('Failed to load preview scene:', error)
-			setPreviewError(getPreviewError(error))
+			setLoadError(toSceneEmbedLoadError(error))
 		} finally {
 			setIsLoadingScene(false)
 		}
@@ -126,7 +126,7 @@ export function usePreviewScene({ sceneId, projectId }: UsePreviewSceneParams) {
 		file,
 		isLoadingScene,
 		sceneData,
-		previewError,
+		loadError,
 		retrySceneLoad: getSceneSettings
 	}
 }

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
@@ -21,12 +21,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger
 } from '@shared/components/ui/dropdown-menu'
-import { cn } from '@shared/utils'
-import {
-	ModelFile,
-	SceneLoadResult,
-	useLoadModel
-} from '@vctrl/hooks/use-load-model'
+import { SceneLoadResult, useLoadModel } from '@vctrl/hooks/use-load-model'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useSetAtom } from 'jotai/react'
 import {
@@ -40,7 +35,7 @@ import {
 	Trash2,
 	X
 } from 'lucide-react'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { data, Link, useNavigate } from 'react-router'
 
 import { Route } from './+types/scene'
@@ -52,12 +47,11 @@ import {
 } from '../../../components/dashboard'
 import { EmbedOptionsPanel } from '../../../components/embed/embed-options-panel'
 import { ScenePublishStateControl } from '../../../components/publishing/scene-publish-state-control'
-import { ClientVectrealViewer } from '../../../components/viewer/client-vectreal-viewer'
+import SceneEmbedViewer from '../../../components/scene-embed/scene-embed-viewer'
 import { useDashboardSceneActions } from '../../../hooks/use-dashboard-scene-actions'
 import { loadAuthenticatedSession } from '../../../lib/domain/auth/auth-loader.server'
 import { buildFullscreenPreviewPath } from '../../../lib/domain/embed/embed-snippet'
 import { getProject } from '../../../lib/domain/project/project-repository.server'
-import { resolveBakedShadowSource } from '../../../lib/domain/scene/client/baked-shadow-source'
 import { loadSceneFromApi } from '../../../lib/domain/scene/client/load-scene-from-api.client'
 import { getDashboardSceneLoadErrorMessage } from '../../../lib/domain/scene/scene-load-error-messages'
 import {
@@ -215,44 +209,6 @@ export function HydrateFallback() {
 
 export { DashboardErrorBoundary as ErrorBoundary } from '../../../components/errors'
 
-interface PreviewModelProps {
-	file: ModelFile | null
-	sceneData?: SceneLoadResult
-	thumbnailUrl?: string | null
-}
-
-const PreviewModel = memo(
-	({ file, sceneData, thumbnailUrl }: PreviewModelProps) => {
-		const loadingThumbnail = toViewerLoadingThumbnail(
-			thumbnailUrl,
-			'Scene thumbnail preview'
-		)
-		const bakedShadow = useMemo(
-			() => resolveBakedShadowSource(sceneData?.shadows, sceneData?.assetData),
-			[sceneData?.shadows, sceneData?.assetData]
-		)
-
-		return (
-			<div className={cn('relative h-full')}>
-				<ClientVectrealViewer
-					cameraOptions={sceneData?.camera}
-					model={file?.model}
-					boundsOptions={sceneData?.bounds}
-					envOptions={sceneData?.environment}
-					controlsOptions={sceneData?.controls}
-					normalizationOptions={sceneData?.normalization}
-					shadowsOptions={sceneData?.shadows}
-					staticShadowBake
-					bakedShadow={bakedShadow}
-					loadingThumbnail={loadingThumbnail}
-					loader={<CenteredSpinner text="Preparing scene..." />}
-					fallback={<CenteredSpinner text="Loading scene..." />}
-				/>
-			</div>
-		)
-	}
-)
-
 const ASSETS_COLLAPSED_LIMIT = 6
 
 function DrawerAssetsSection({
@@ -353,6 +309,13 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 	const [sceneData, setSceneData] = useState<SceneLoadResult>()
 	const [sceneLoadError, setSceneLoadError] = useState<string | null>(null)
 	const [sceneState, setSceneState] = useState(scene)
+	// Memoized because the viewer is memoized: a fresh object every render would
+	// re-render it on every keystroke in the metadata fields below.
+	const loadingThumbnail = useMemo(
+		() =>
+			toViewerLoadingThumbnail(sceneState.thumbnailUrl, 'Scene thumbnail preview'),
+		[sceneState.thumbnailUrl]
+	)
 
 	const [sceneNameDraft, setSceneNameDraft] = useState(scene.name)
 	const [sceneDescriptionDraft, setSceneDescriptionDraft] = useState(
@@ -578,10 +541,10 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 						</section>
 					) : null}
 					<section className="relative min-h-64 flex-1 overflow-hidden rounded-2xl bg-black/2">
-						<PreviewModel
+						<SceneEmbedViewer
 							file={file}
 							sceneData={sceneData}
-							thumbnailUrl={sceneState.thumbnailUrl}
+							loadingThumbnail={loadingThumbnail}
 						/>
 					</section>
 					<section className="bg-muted/30 space-y-6 rounded-2xl px-4 py-4 sm:px-5">

--- a/apps/vectreal-platform/app/routes/preview-page/preview-fullscreen.tsx
+++ b/apps/vectreal-platform/app/routes/preview-page/preview-fullscreen.tsx
@@ -1,101 +1,15 @@
 import { Button } from '@shared/components/ui/button'
-import { ModelFile, SceneLoadResult } from '@vctrl/hooks/use-load-model'
-import {
-	InfoPopover,
-	InfoPopoverCloseButton,
-	InfoPopoverContent,
-	InfoPopoverText,
-	InfoPopoverTrigger,
-	InfoPopoverVectrealFooter,
-	type ViewerCommand
-} from '@vctrl/viewer'
-import { memo, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useSearchParams } from 'react-router'
 
 import { Route } from './+types/preview-fullscreen'
-import { usePreviewScene } from './use-preview-scene'
 import CenteredSpinner from '../../components/centered-spinner'
-import { ClientVectrealViewer } from '../../components/viewer/client-vectreal-viewer'
+import SceneEmbedInfoPopover from '../../components/scene-embed/scene-embed-info-popover'
+import SceneEmbedViewer from '../../components/scene-embed/scene-embed-viewer'
+import { useSceneEmbedScene } from '../../components/scene-embed/use-scene-embed-scene'
 import { useHostedPreviewBridge } from '../../lib/domain/embed/hosted-preview-bridge'
-import { resolveBakedShadowSource } from '../../lib/domain/scene/client/baked-shadow-source'
 
-interface PreviewInfoPopoverProps {
-	title?: string
-	description?: string
-}
-
-interface PreviewModelProps extends PreviewInfoPopoverProps {
-	file: ModelFile | null
-	onCommandExecutorReady: ReturnType<
-		typeof useHostedPreviewBridge
-	>['onCommandExecutorReady']
-	onInteractionEvent: ReturnType<
-		typeof useHostedPreviewBridge
-	>['onInteractionEvent']
-	sceneData?: SceneLoadResult
-}
-
-const PreviewInfoPopover = ({
-	title,
-	description
-}: PreviewInfoPopoverProps) => (
-	<InfoPopover className="z-100">
-		<InfoPopoverTrigger />
-		<InfoPopoverContent>
-			<InfoPopoverCloseButton />
-			<InfoPopoverText>
-				{title ? <p className="mb-3 font-medium">{title}</p> : null}
-				{description ? (
-					<p>{description}</p>
-				) : (
-					<p className="opacity-50">No description provided for this scene.</p>
-				)}
-			</InfoPopoverText>
-			<InfoPopoverVectrealFooter />
-		</InfoPopoverContent>
-	</InfoPopover>
-)
-
-const PreviewModel = memo(
-	({
-		file,
-		sceneData,
-		title,
-		description,
-		onInteractionEvent,
-		onCommandExecutorReady
-	}: PreviewModelProps) => {
-		// Persisted shadow bake from the scene's inlined asset data, so embeds render
-		// the stored shadow in parallel with the model instead of re-baking on load.
-		const bakedShadow = useMemo(
-			() => resolveBakedShadowSource(sceneData?.shadows, sceneData?.assetData),
-			[sceneData?.shadows, sceneData?.assetData]
-		)
-		return (
-			<div className="h-screen w-full">
-				<ClientVectrealViewer
-					boundsOptions={sceneData?.bounds}
-					cameraOptions={sceneData?.camera}
-					className="h-full w-full"
-					model={file?.model}
-					envOptions={sceneData?.environment}
-					controlsOptions={sceneData?.controls}
-					onCommandExecutorReady={onCommandExecutorReady}
-					onInteractionEvent={onInteractionEvent}
-					shadowsOptions={sceneData?.shadows}
-					staticShadowBake
-					bakedShadow={bakedShadow}
-					normalizationOptions={sceneData?.normalization}
-					popover={
-						<PreviewInfoPopover title={title} description={description} />
-					}
-					loader={<CenteredSpinner text="Preparing scene..." />}
-					fallback={<CenteredSpinner text="Loading scene..." />}
-				/>
-			</div>
-		)
-	}
-)
+import type { ViewerCommand } from '@vctrl/viewer'
 
 function usePreviewInitialCommands(): ViewerCommand[] {
 	const [searchParams] = useSearchParams()
@@ -128,8 +42,8 @@ function usePreviewInitialCommands(): ViewerCommand[] {
 const PreviewFullscreenPage = ({ params }: Route.ComponentProps) => {
 	const sceneId = params.sceneId
 	const projectId = params.projectId
-	const { file, isLoadingScene, sceneData, previewError, retrySceneLoad } =
-		usePreviewScene({
+	const { file, isLoadingScene, sceneData, loadError, retrySceneLoad } =
+		useSceneEmbedScene({
 			sceneId,
 			projectId
 		})
@@ -147,16 +61,12 @@ const PreviewFullscreenPage = ({ params }: Route.ComponentProps) => {
 		return <CenteredSpinner className="h-screen" text="Loading scene..." />
 	}
 
-	if (previewError && !file?.model) {
+	if (loadError && !file?.model) {
 		return (
 			<div className="bg-background flex h-screen w-full items-center justify-center p-6">
 				<div className="border-border bg-card w-full max-w-lg space-y-4 rounded-2xl border p-6">
-					<h1 className="text-lg font-semibold">
-						Unable to Load Scene Preview
-					</h1>
-					<p className="text-muted-foreground text-sm">
-						{previewError.message}
-					</p>
+					<h1 className="text-lg font-semibold">Unable to Load Scene Preview</h1>
+					<p className="text-muted-foreground text-sm">{loadError.message}</p>
 					<div className="flex gap-2">
 						<Button type="button" onClick={() => void retrySceneLoad()}>
 							Retry
@@ -175,13 +85,18 @@ const PreviewFullscreenPage = ({ params }: Route.ComponentProps) => {
 	}
 
 	return (
-		<PreviewModel
+		<SceneEmbedViewer
+			className="h-screen"
 			file={file}
+			sceneData={sceneData}
 			onCommandExecutorReady={onCommandExecutorReady}
 			onInteractionEvent={onInteractionEvent}
-			sceneData={sceneData}
-			title={sceneData?.meta?.name?.trim() || undefined}
-			description={sceneData?.meta?.description?.trim() || undefined}
+			popover={
+				<SceneEmbedInfoPopover
+					title={sceneData?.meta?.name?.trim() || undefined}
+					description={sceneData?.meta?.description?.trim() || undefined}
+				/>
+			}
 		/>
 	)
 }

--- a/packages/viewer/src/components/scene/scene-shadows.tsx
+++ b/packages/viewer/src/components/scene/scene-shadows.tsx
@@ -4,7 +4,6 @@ import {
 	RandomizedLight
 } from '@react-three/drei'
 import { useThree } from '@react-three/fiber'
-import type { AccumulativeShadowsProps, NormalizationOptions } from '@vctrl/core'
 import {
 	type ComponentRef,
 	memo,
@@ -28,6 +27,7 @@ import {
 import ShadowLightGizmo from './shadow-light-gizmo'
 
 import type { BakedShadow, ShadowBakeCapture } from '../../types/viewer-types'
+import type { AccumulativeShadowsProps, NormalizationOptions } from '@vctrl/core'
 
 // Accumulative shadows: high-quality baked soft shadows for a static subject.
 // The shadow is baked into the receiving plane's UV space from the


### PR DESCRIPTION
Pure refactor. Groundwork for splitting `/embed` from `/preview`.

## Why

The dashboard scene page and the fullscreen preview route each carried their own
`PreviewModel`: same viewer props, same `resolveBakedShadowSource` memo, same
loader and fallback spinners. The route split coming next would have forked that
duplication a third time, so it gets consolidated first.

## What

New `app/components/scene-embed/`:

| File | Content |
| --- | --- |
| `scene-embed-viewer.tsx` | Chrome-less viewer. Owns the baked-shadow memo, `staticShadowBake`, spinners, `loadingThumbnail` wiring. |
| `scene-embed-info-popover.tsx` | The `InfoPopover` previously inlined in `preview-fullscreen.tsx`. |
| `use-scene-embed-scene.ts` | Moved from `routes/preview-page/use-preview-scene.ts`. |

Both local `PreviewModel` copies are deleted. The popover is passed in as a prop
rather than owned by the viewer, so a surface that wants none simply omits it.

The `scene-shadows.tsx` change is an eslint `--fix` import reorder, not a logic
change.

## No behavior change

- `vectreal-viewer.tsx` already defaults its container to `h-full w-full`, so
  dropping that class in `preview-fullscreen` is a no-op.
- The dashboard's `loadingThumbnail` is now memoized on `thumbnailUrl`, because
  the viewer is memoized and a fresh object each render would re-render it on
  every keystroke in the metadata fields below it.
- Routes, auth, and URLs untouched. No schema or migration.

The publisher keeps using `ClientVectrealViewer` directly, correctly: it is a
live editor, not an embed.

## Verification

| Check | Result |
| --- | --- |
| `nx typecheck vectreal-platform` | pass |
| `nx run-many --target=lint` (viewer, platform) | pass |
| `npx vitest run --root apps/vectreal-platform` | 186 passed, 29 files |
| `nx build vectreal-platform` | pass |

Not yet opened in a browser. Both affected surfaces are worth a manual glance,
though the diff is a deletion plus one element at each call site.
