### PR TITLE
fix(core): keep sharp out of browser bundles

### DIFF
--- a/packages/core/src/model-optimizer/texture-compression.ts
+++ b/packages/core/src/model-optimizer/texture-compression.ts
@@ -35,6 +35,23 @@ type ProgressEmitter = (operation: string, progress: number) => void
 type TransformRunner = (transforms: Transform[], name: string) => Promise<void>
 
 /**
+ * Do not inline this into the `import()` below.
+ *
+ * sharp is an optional Node-only native module. A literal `import('sharp')`
+ * survives this package's build as a literal specifier, so every downstream
+ * bundler statically resolves it and pulls sharp's Node builtins into browser
+ * bundles. Since sharp 0.35 ships ESM, that is a hard build error rather than
+ * an externalization warning:
+ *
+ *   "spawnSync" is not exported by "__vite-browser-external"
+ *
+ * Reading the specifier from a binding keeps the import opaque to static
+ * analysis while Node still resolves it at runtime. Browser and edge callers
+ * pass `options.encoder` and never reach this branch.
+ */
+const SHARP_SPECIFIER = 'sharp'
+
+/**
  * Run texture compression on a loaded document.
  * Returns the list of applied optimization labels to append.
  */
@@ -53,7 +70,7 @@ export async function runTextureCompression(
 		encoder = options.encoder as TextureCompressionEncoder
 	} else {
 		try {
-			const sharpModule = await import(/* @vite-ignore */ 'sharp')
+			const sharpModule = await import(/* @vite-ignore */ SHARP_SPECIFIER)
 			encoder = sharpModule.default || sharpModule
 
 			if (typeof encoder !== 'function') {


### PR DESCRIPTION
Unblocks #659 and #660, which are both red on `CI - Viewer Packaging E2E` for a
reason neither PR caused.

## What broke

`@vctrl/core` loads `sharp` (optional, Node-only, native) through a dynamic
import. sharp is marked `external` in this package's vite config, so the emitted
chunk kept a **literal** specifier:

```js
// build/packages/vctrl/core/model-optimizer-*.js
let e = await import(/* @vite-ignore */ "sharp");
```

`@vite-ignore` suppresses the analysis warning but does not stop a downstream
bundler from resolving a string literal. So every consumer that bundles
`@vctrl/core` for the browser pulled sharp in.

That stayed invisible for two reasons. In this repo, core resolves to **source**
via tsconfig paths, so only a real npm consumer hits the built artifact, which
is exactly what the packaging e2e simulates. And while sharp shipped CommonJS,
Vite externalized its Node builtins with warnings rather than failing.

## What detonated it

`ndarray-pixels@5.2.0` was published at **21:55:57Z** and bumped sharp from
`^0.34.0` to `^0.35.0`. `main`'s last green run of this job was 21:49:02Z, six
minutes earlier. Every branch built after that picked up sharp 0.35.

sharp changed module format in 0.35:

| sharp | File | Import style | Vite result |
| --- | --- | --- | --- |
| 0.34.4 | `lib/libvips.js` | `const { spawnSync } = require('node:child_process')` | externalized, warning only |
| 0.35.3 | `dist/libvips.mjs` | `import { spawnSync } from 'node:child_process'` | hard error |

Line 6 of `dist/libvips.mjs` is that ESM import, matching the CI error exactly:

```
node_modules/sharp/dist/libvips.mjs (6:9): "spawnSync" is not exported
by "__vite-browser-external"
```

## The fix

Read the specifier from a module-scope binding so it stays opaque to static
analysis while Node still resolves it at runtime. Verified in the built output
that rollup does not fold it back into the import position.

This is our bug, not ndarray-pixels'. Pinning that dependency would only hide a
regression that also affects anyone bundling `@vctrl/core` from npm.

## Behavior

Unchanged. The import already sits inside a `try/catch` that falls back to
`runBasicTextureOptimization`, and browser and edge callers pass
`options.encoder` rather than reaching this branch.

## Verification

Before and after, same machine, `nx e2e vctrl/viewer-e2e`:

| | Modules transformed | Result |
| --- | --- | --- |
| `main` | 726 | `✗ Build failed` |
| this branch | 655 | `✓ 1 passed` |

The 71-module drop is sharp and its dependency tree leaving the browser bundle.
All sharp, libvips, and detect-libc externalization warnings are gone.

| Check | Result |
| --- | --- |
| `nx run-many --target=typecheck` (core, hooks, viewer, platform) | pass |
| `nx run-many --target=lint` (core, hooks, viewer, platform) | pass |
| `npx vitest run --root apps/vectreal-platform` | 186 passed, 29 files |
| `nx build vectreal-platform` | pass |
| `nx e2e vctrl/viewer-e2e` | pass |

Merge this first, then #659 and #660 should go green on re-run.
