### PR TITLE
feat(platform): split /embed from /preview

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
@@ -287,7 +287,7 @@ const SceneActionsCell = memo(({ row }: { row: SceneRow }) => {
 						</DropdownMenuItem>
 						<DropdownMenuItem asChild>
 							<Link
-								to={`/preview/fullscreen/${row.projectId}/${row.id}/`}
+								to={`/preview/${row.projectId}/${row.id}`}
 								state={{
 									name: row.name,
 									description: row.description || undefined,

--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
@@ -14,7 +14,7 @@ import { toast } from 'sonner'
 
 import {
 	addPreviewTokenPlaceholder,
-	buildFullscreenPreviewPath,
+	buildEmbedPath,
 	buildResponsiveEmbedSnippet,
 	buildSdkEmbedSnippet,
 	EMBED_COPY,
@@ -42,7 +42,7 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 	const canEmbed = Boolean(sceneId && projectId)
 
 	const previewPath = canEmbed
-		? buildFullscreenPreviewPath({
+		? buildEmbedPath({
 				projectId: projectId as string,
 				sceneId: sceneId as string
 			})

--- a/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-chapters.ts
+++ b/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-chapters.ts
@@ -5,7 +5,7 @@ export const DEMO_SCENE_URL =
 	typeof import.meta !== 'undefined' &&
 	(import.meta.env.VITE_PUBLIC_DEMO_SCENE_URL as string | undefined)
 		? (import.meta.env.VITE_PUBLIC_DEMO_SCENE_URL as string)
-		: `https://vectreal.com/preview/fullscreen/395a09f0-9340-42f2-ac98-03339cf27c9c/488bd4a1-46d3-4ee1-8497-25f68a5d6fa2?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}`
+		: `https://vectreal.com/embed/395a09f0-9340-42f2-ac98-03339cf27c9c/488bd4a1-46d3-4ee1-8497-25f68a5d6fa2?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}`
 
 export const CHAPTERS = [
 	{

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
@@ -2,16 +2,21 @@ import { Button } from '@shared/components/ui/button'
 import { useMemo } from 'react'
 import { useSearchParams } from 'react-router'
 
-import { Route } from './+types/preview-fullscreen'
-import CenteredSpinner from '../../components/centered-spinner'
-import SceneEmbedInfoPopover from '../../components/scene-embed/scene-embed-info-popover'
-import SceneEmbedViewer from '../../components/scene-embed/scene-embed-viewer'
-import { useSceneEmbedScene } from '../../components/scene-embed/use-scene-embed-scene'
+import SceneEmbedInfoPopover from './scene-embed-info-popover'
+import SceneEmbedViewer from './scene-embed-viewer'
+import { useSceneEmbedScene } from './use-scene-embed-scene'
 import { useHostedPreviewBridge } from '../../lib/domain/embed/hosted-preview-bridge'
+import CenteredSpinner from '../centered-spinner'
 
 import type { ViewerCommand } from '@vctrl/viewer'
 
-function usePreviewInitialCommands(): ViewerCommand[] {
+export interface SceneEmbedPageProps {
+	projectId?: string
+	sceneId?: string
+}
+
+/** Opening viewer state driven by the embed URL's query parameters. */
+function useInitialCommands(): ViewerCommand[] {
 	const [searchParams] = useSearchParams()
 	return useMemo(() => {
 		const commands: ViewerCommand[] = []
@@ -39,15 +44,20 @@ function usePreviewInitialCommands(): ViewerCommand[] {
 	}, [searchParams])
 }
 
-const PreviewFullscreenPage = ({ params }: Route.ComponentProps) => {
-	const sceneId = params.sceneId
-	const projectId = params.projectId
+/**
+ * The full-viewport scene page shared by `/embed` and `/preview`.
+ *
+ * Both routes render exactly the same thing; they differ only in how their
+ * layout authenticates the request. Anything a surface adds on top (the
+ * internal preview's chrome) wraps this rather than being switched on inside.
+ */
+const SceneEmbedPage = ({ projectId, sceneId }: SceneEmbedPageProps) => {
 	const { file, isLoadingScene, sceneData, loadError, retrySceneLoad } =
 		useSceneEmbedScene({
 			sceneId,
 			projectId
 		})
-	const initialCommands = usePreviewInitialCommands()
+	const initialCommands = useInitialCommands()
 	const { onCommandExecutorReady, onInteractionEvent } = useHostedPreviewBridge(
 		{
 			sceneId,
@@ -101,4 +111,4 @@ const PreviewFullscreenPage = ({ params }: Route.ComponentProps) => {
 	)
 }
 
-export default PreviewFullscreenPage
+export default SceneEmbedPage

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
@@ -45,11 +45,20 @@ type EmbedSnippetOptions = {
 const DEFAULT_WIDTH = '100%'
 const DEFAULT_HEIGHT = '400px'
 
-export function buildFullscreenPreviewPath(params: {
+/** External embed target. Token-authenticated, never renders internal chrome. */
+export function buildEmbedPath(params: {
 	projectId: string
 	sceneId: string
 }): string {
-	return `/preview/fullscreen/${params.projectId}/${params.sceneId}`
+	return `/embed/${params.projectId}/${params.sceneId}`
+}
+
+/** Internal preview target. Session-authenticated, reachable from the dashboard. */
+export function buildInternalPreviewPath(params: {
+	projectId: string
+	sceneId: string
+}): string {
+	return `/preview/${params.projectId}/${params.sceneId}`
 }
 
 export function addPreviewTokenPlaceholder(previewPath: string): string {

--- a/apps/vectreal-platform/app/lib/http/cdn-cache-policy.server.ts
+++ b/apps/vectreal-platform/app/lib/http/cdn-cache-policy.server.ts
@@ -27,6 +27,7 @@ export const CDN_PROTECTED_PREFIXES = [
 	'/dashboard',
 	'/publisher',
 	'/preview',
+	'/embed',
 	'/onboarding',
 	'/api',
 	'/auth'

--- a/apps/vectreal-platform/app/routes.tsx
+++ b/apps/vectreal-platform/app/routes.tsx
@@ -148,13 +148,21 @@ export default [
 		)
 	]),
 
-	// Preview page for scenes
-	layout('./routes/layouts/preview-layout.tsx', [
-		route(
-			'preview/fullscreen/:projectId/:sceneId/',
-			'./routes/preview-page/preview-fullscreen.tsx'
-		)
+	// External embeds: preview API key only, never internal chrome
+	layout('./routes/layouts/embed-layout.tsx', [
+		route('embed/:projectId/:sceneId', './routes/embed-page/embed-scene.tsx')
 	]),
+
+	// Internal preview: session only, reachable from the dashboard
+	layout('./routes/layouts/preview-layout.tsx', [
+		route('preview/:projectId/:sceneId', './routes/preview-page/preview-scene.tsx')
+	]),
+
+	// Embeds published before the /embed split still point here
+	route(
+		'preview/fullscreen/:projectId/:sceneId/',
+		'./routes/embed-page/legacy-embed-redirect.ts'
+	),
 
 	// Dashboard - each route handles its own data loading
 	...prefix('dashboard', [

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
@@ -6,7 +6,6 @@ import {
 } from '@shared/components/ui/avatar'
 import { Badge } from '@shared/components/ui/badge'
 import { Button } from '@shared/components/ui/button'
-import { ButtonGroup } from '@shared/components/ui/button-group'
 import {
 	Drawer,
 	DrawerClose,
@@ -15,12 +14,6 @@ import {
 	DrawerHeader,
 	DrawerTitle
 } from '@shared/components/ui/drawer'
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger
-} from '@shared/components/ui/dropdown-menu'
 import { SceneLoadResult, useLoadModel } from '@vctrl/hooks/use-load-model'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useSetAtom } from 'jotai/react'
@@ -29,7 +22,6 @@ import {
 	ChevronRight,
 	Cloud,
 	Info,
-	LayoutDashboard,
 	Radio,
 	Rocket,
 	Trash2,
@@ -50,7 +42,7 @@ import { ScenePublishStateControl } from '../../../components/publishing/scene-p
 import SceneEmbedViewer from '../../../components/scene-embed/scene-embed-viewer'
 import { useDashboardSceneActions } from '../../../hooks/use-dashboard-scene-actions'
 import { loadAuthenticatedSession } from '../../../lib/domain/auth/auth-loader.server'
-import { buildFullscreenPreviewPath } from '../../../lib/domain/embed/embed-snippet'
+import { buildInternalPreviewPath } from '../../../lib/domain/embed/embed-snippet'
 import { getProject } from '../../../lib/domain/project/project-repository.server'
 import { loadSceneFromApi } from '../../../lib/domain/scene/client/load-scene-from-api.client'
 import { getDashboardSceneLoadErrorMessage } from '../../../lib/domain/scene/scene-load-error-messages'
@@ -330,7 +322,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 
 	const metadataResetTimerRef = useRef<number | null>(null)
 
-	const fullscreenPreviewPath = buildFullscreenPreviewPath({
+	const previewPath = buildInternalPreviewPath({
 		projectId: project.id,
 		sceneId: sceneState.id
 	})
@@ -582,29 +574,11 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 								/>
 							</div>
 							<div className="flex shrink-0 flex-col gap-3 max-md:w-full xl:justify-end">
-								<ButtonGroup className="w-full">
-									<Button asChild className="w-full">
-										<Link viewTransition to={fullscreenPreviewPath}>
-											Preview
-										</Link>
-									</Button>
-
-									<DropdownMenu>
-										<DropdownMenuTrigger asChild>
-											<Button size="icon">
-												<ChevronDown className="h-4 w-4" />
-											</Button>
-										</DropdownMenuTrigger>
-										<DropdownMenuContent>
-											<DropdownMenuItem asChild>
-												<Link viewTransition to={fullscreenPreviewPath}>
-													<LayoutDashboard className="mr-2 h-4 w-4" />
-													Fullscreen Preview
-												</Link>
-											</DropdownMenuItem>
-										</DropdownMenuContent>
-									</DropdownMenu>
-								</ButtonGroup>
+								<Button asChild className="w-full">
+									<Link viewTransition to={previewPath}>
+										Preview
+									</Link>
+								</Button>
 
 								<Button variant="secondary" asChild>
 									<Link viewTransition to={`/publisher/${sceneState.id}`}>

--- a/apps/vectreal-platform/app/routes/docs/getting-started/first-model.mdx
+++ b/apps/vectreal-platform/app/routes/docs/getting-started/first-model.mdx
@@ -81,7 +81,7 @@ The snippet looks like:
 ```html
 <div style="position:relative;padding-top:56.25%;width:100%">
   <iframe
-    src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
     style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
     allow="autoplay"
     loading="lazy"

--- a/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
@@ -38,7 +38,7 @@ Or include the CDN script before your page code:
 <div style="width: 100%; height: 400px;">
   <iframe
     id="vectreal-scene"
-    src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
     style="width: 100%; height: 100%; border: 0;"
     allow="autoplay; xr-spatial-tracking"
     allowfullscreen
@@ -85,7 +85,7 @@ For zero-JavaScript initial configuration, add parameters to the iframe `src`:
 ```html
 <!-- Opens on a specific camera with auto-rotate off -->
 <iframe
-  src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=KEY&camera=hero&autoRotate=0"
+  src="https://vectreal.com/embed/<projectId>/<sceneId>?token=KEY&camera=hero&autoRotate=0"
   ...
 ></iframe>
 ```
@@ -206,7 +206,7 @@ If you prefer zero dependencies, you can implement the protocol directly. Both s
 
 ```html
 <iframe id="vectreal-preview"
-  src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=KEY"
+  src="https://vectreal.com/embed/<projectId>/<sceneId>?token=KEY"
   ...
 ></iframe>
 

--- a/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
@@ -34,7 +34,7 @@ External iframe embeds require a **preview API key** scoped to the project that 
 Pass the key as the `token` query parameter in the embed URL:
 
 ```
-/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY
+/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY
 ```
 
 Or as a `Bearer` token in the `Authorization` header for API requests:
@@ -76,7 +76,7 @@ The hosted preview iframe can also be controlled from the parent page over `post
 ```html
 <div style="position:relative;padding-top:56.25%;width:100%">
   <iframe
-    src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
     style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
     allow="autoplay"
     loading="lazy"
@@ -88,7 +88,7 @@ The hosted preview iframe can also be controlled from the parent page over `post
 
 ```html
 <iframe
-  src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+  src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
   width="800"
   height="450"
   style="border:0"
@@ -134,7 +134,7 @@ Hosted preview iframes support a small `postMessage` protocol layered on top of 
 <div style="position:relative;padding-top:56.25%;width:100%">
   <iframe
     id="vectreal-preview"
-    src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
     style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
     allow="autoplay; xr-spatial-tracking"
     loading="lazy"
@@ -189,7 +189,7 @@ Hosted preview iframes support a small `postMessage` protocol layered on top of 
 
 ### Behavior notes
 
-- This protocol is only available on hosted preview routes such as `/preview/fullscreen/:projectId/:sceneId`.
+- This protocol is only available on hosted embed routes such as `/embed/:projectId/:sceneId`.
 - Preview API keys and allowed embed domains still gate access before the iframe loads.
 - `set_controls_enabled` only affects runtime interactivity in the current viewer session. It does not rewrite persisted `controlsOptions` defaults.
 - `host_scroll_progress` should be normalized to the `[0, 1]` range. The hosted preview bridge only re-fires range-based interactions when progress re-enters a configured range.
@@ -197,13 +197,19 @@ Hosted preview iframes support a small `postMessage` protocol layered on top of 
 
 ---
 
-## Preview mode
+## Embed route
 
-| Mode | URL | Description |
+| Route | URL | Description |
 |---|---|---|
-| **Fullscreen** | `/preview/fullscreen/:projectId/:sceneId` | Full viewport, immersive experience |
+| **Embed** | `/embed/:projectId/:sceneId` | Full viewport, immersive experience |
 
-Supports the `token` query param and `Authorization: Bearer` authentication.
+Supports the `token` query param and `Authorization: Bearer` authentication. A
+request without either receives `404`, whether or not the caller is signed in.
+
+Embeds published before this route existed used
+`/preview/fullscreen/:projectId/:sceneId`. That URL still works: it issues a
+permanent redirect to `/embed/...` and preserves the full query string, so
+existing embeds keep their token and camera parameters.
 
 ---
 
@@ -212,6 +218,8 @@ Supports the `token` query param and `Authorization: Bearer` authentication.
 | Scenario | Status |
 |---|---|
 | Missing `projectId` or `sceneId` | `400 Bad Request` |
+| No `token` or `Authorization` header | `404 Not Found` |
+| Legacy `/preview/fullscreen/...` URL | `301 Moved Permanently` |
 | Rate limited token validation | `429 Too Many Requests` |
 | Disallowed embed domain | `403 Forbidden` |
 | Draft or non-existent scene (external access) | `404 Not Found` |

--- a/apps/vectreal-platform/app/routes/embed-page/embed-scene.tsx
+++ b/apps/vectreal-platform/app/routes/embed-page/embed-scene.tsx
@@ -1,0 +1,12 @@
+import { Route } from './+types/embed-scene'
+import SceneEmbedPage from '../../components/scene-embed/scene-embed-page'
+
+/**
+ * The external embed target. Authenticated by preview API key in
+ * `embed-layout.tsx`, so this route structurally cannot render internal chrome.
+ */
+const EmbedScenePage = ({ params }: Route.ComponentProps) => (
+	<SceneEmbedPage projectId={params.projectId} sceneId={params.sceneId} />
+)
+
+export default EmbedScenePage

--- a/apps/vectreal-platform/app/routes/embed-page/legacy-embed-redirect.ts
+++ b/apps/vectreal-platform/app/routes/embed-page/legacy-embed-redirect.ts
@@ -1,0 +1,18 @@
+import { redirect } from 'react-router'
+
+import { Route } from './+types/legacy-embed-redirect'
+import { buildEmbedPath } from '../../lib/domain/embed/embed-snippet'
+
+/**
+ * `/preview/fullscreen/:projectId/:sceneId` was the embed URL before external
+ * embeds moved to `/embed`. Every live embed carries `?token=`, and the docs
+ * also pass `camera`, `autoRotate`, and `transition`, so the query string has to
+ * survive the redirect or existing embeds break.
+ */
+export function loader({ params, request }: Route.LoaderArgs) {
+	const { search } = new URL(request.url)
+	const projectId = params.projectId ?? ''
+	const sceneId = params.sceneId ?? ''
+
+	return redirect(`${buildEmbedPath({ projectId, sceneId })}${search}`, 301)
+}

--- a/apps/vectreal-platform/app/routes/layouts/embed-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/embed-layout.tsx
@@ -1,0 +1,87 @@
+import { ApiResponse } from '@shared/utils'
+import { data, Outlet, type MetaFunction } from 'react-router'
+
+import { Route } from './+types/embed-layout'
+import { validatePreviewApiKeyForProject } from '../../lib/domain/auth/preview-api-key-auth.server'
+import { getPublishedScenePreview } from '../../lib/domain/scene/server/scene-preview-repository.server'
+import { buildMeta } from '../../lib/seo'
+
+export const meta: MetaFunction = () =>
+	buildMeta(
+		[
+			{ title: 'Embed - Vectreal' },
+			{ property: 'og:title', content: 'Embed - Vectreal' }
+		],
+		undefined,
+		{ private: true }
+	)
+
+function withNoStoreHeaders(response: Response): Response {
+	const headers = new Headers(response.headers)
+	headers.set('Cache-Control', 'no-store')
+	return new Response(response.body, {
+		status: response.status,
+		headers
+	})
+}
+
+/**
+ * External embeds authenticate by preview API key and nothing else.
+ *
+ * A request without a token gets 404 rather than falling back to session auth,
+ * so a signed-in user opening an embed URL sees exactly what an anonymous
+ * visitor sees. The internal, session-authenticated view lives at `/preview`.
+ */
+export async function loader({ request, params }: Route.LoaderArgs) {
+	const projectId = params.projectId?.trim()
+	const sceneId = params.sceneId?.trim()
+
+	if (!projectId || !sceneId) {
+		return withNoStoreHeaders(
+			ApiResponse.badRequest('Project ID and Scene ID are required')
+		)
+	}
+
+	const url = new URL(request.url)
+	const tokenFromQuery = url.searchParams.get('token')?.trim() || null
+	const hasTokenCredential =
+		Boolean(tokenFromQuery) || Boolean(request.headers.get('authorization')?.trim())
+
+	if (!hasTokenCredential) {
+		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
+	}
+
+	const authResult = await validatePreviewApiKeyForProject({
+		request,
+		projectId
+	})
+
+	if (!authResult.ok) {
+		if (authResult.error === 'rate_limited') {
+			return withNoStoreHeaders(ApiResponse.error('Too many requests', 429))
+		}
+		if (authResult.error === 'domain_not_allowed') {
+			return withNoStoreHeaders(ApiResponse.forbidden('Forbidden'))
+		}
+
+		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
+	}
+
+	const previewScene = await getPublishedScenePreview(projectId, sceneId)
+	if (!previewScene) {
+		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
+	}
+
+	return data({
+		projectId,
+		sceneId,
+		tokenFromQuery,
+		authenticatedByApiKeyId: authResult.apiKeyId
+	})
+}
+
+const EmbedLayout = () => {
+	return <Outlet />
+}
+
+export default EmbedLayout

--- a/apps/vectreal-platform/app/routes/layouts/preview-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/preview-layout.tsx
@@ -1,11 +1,10 @@
 import { ApiResponse } from '@shared/utils'
-import { data, Outlet, type MetaFunction } from 'react-router'
+import { data, Outlet, redirect, type MetaFunction } from 'react-router'
 
 import { Route } from './+types/preview-layout'
-import { validatePreviewApiKeyForProject } from '../../lib/domain/auth/preview-api-key-auth.server'
+import { buildEmbedPath } from '../../lib/domain/embed/embed-snippet'
 import { getProject } from '../../lib/domain/project/project-repository.server'
 import { getScene } from '../../lib/domain/scene/server/scene-folder-repository.server'
-import { getPublishedScenePreview } from '../../lib/domain/scene/server/scene-preview-repository.server'
 import { getAuthUser } from '../../lib/http/auth.server'
 import { buildMeta } from '../../lib/seo'
 
@@ -28,6 +27,14 @@ function withNoStoreHeaders(response: Response): Response {
 	})
 }
 
+/**
+ * The internal preview authenticates by session and nothing else.
+ *
+ * A request arriving here with a token is meant for an external embed, so it is
+ * redirected to the `/embed` equivalent rather than handled. Keeping exactly one
+ * credential type per route is what stops the external URL from ever reaching a
+ * surface that renders dashboard chrome.
+ */
 export async function loader({ request, params }: Route.LoaderArgs) {
 	const projectId = params.projectId?.trim()
 	const sceneId = params.sceneId?.trim()
@@ -38,79 +45,35 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		)
 	}
 
+	const url = new URL(request.url)
 	const hasTokenCredential =
-		Boolean(new URL(request.url).searchParams.get('token')?.trim()) ||
+		Boolean(url.searchParams.get('token')?.trim()) ||
 		Boolean(request.headers.get('authorization')?.trim())
 
-	let authMode: 'apiKey' | 'session' | null = null
-	let authenticatedByApiKeyId: string | null = null
-	let sessionUserId: string | null = null
-	let sessionHeaders: HeadersInit = {}
-
 	if (hasTokenCredential) {
-		const authResult = await validatePreviewApiKeyForProject({
-			request,
-			projectId
-		})
-
-		if (!authResult.ok) {
-			if (authResult.error === 'rate_limited') {
-				return withNoStoreHeaders(ApiResponse.error('Too many requests', 429))
-			}
-			if (authResult.error === 'domain_not_allowed') {
-				return withNoStoreHeaders(ApiResponse.forbidden('Forbidden'))
-			}
-
-			return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
-		}
-
-		authMode = 'apiKey'
-		authenticatedByApiKeyId = authResult.apiKeyId
-	} else {
-		const sessionAuth = await getAuthUser(request)
-		if (sessionAuth instanceof Response) {
-			return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
-		}
-
-		sessionHeaders = sessionAuth.headers ?? {}
-
-		const project = await getProject(projectId, sessionAuth.user.id)
-		if (!project) {
-			return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
-		}
-
-		authMode = 'session'
-		sessionUserId = sessionAuth.user.id
+		return redirect(
+			`${buildEmbedPath({ projectId, sceneId })}${url.search}`
+		)
 	}
 
-	if (authMode === 'apiKey') {
-		const previewScene = await getPublishedScenePreview(projectId, sceneId)
-		if (!previewScene) {
-			return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
-		}
-	} else {
-		if (!sessionUserId) {
-			return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
-		}
-
-		const scene = await getScene(sceneId, sessionUserId)
-		if (!scene || scene.projectId !== projectId) {
-			return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
-		}
+	const sessionAuth = await getAuthUser(request)
+	if (sessionAuth instanceof Response) {
+		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
 	}
 
-	const url = new URL(request.url)
-	const tokenFromQuery = url.searchParams.get('token')?.trim() || null
+	const project = await getProject(projectId, sessionAuth.user.id)
+	if (!project) {
+		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
+	}
+
+	const scene = await getScene(sceneId, sessionAuth.user.id)
+	if (!scene || scene.projectId !== projectId) {
+		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
+	}
 
 	return data(
-		{
-			projectId,
-			sceneId,
-			authMode,
-			tokenFromQuery,
-			authenticatedByApiKeyId
-		},
-		{ headers: authMode === 'session' ? sessionHeaders : undefined }
+		{ projectId, sceneId },
+		{ headers: sessionAuth.headers ?? {} }
 	)
 }
 

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/02_the-vectreal-publisher-walkthrough.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/02_the-vectreal-publisher-walkthrough.mdx
@@ -191,7 +191,7 @@ Copy the embed snippet from the **Embed** section in the publish sidebar or from
 ```html
 <div style="position:relative;padding-top:56.25%;width:100%">
   <iframe
-    src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
     style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
     allow="autoplay"
     loading="lazy"
@@ -203,7 +203,7 @@ Copy the embed snippet from the **Embed** section in the publish sidebar or from
 
 ```html
 <iframe
-  src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+  src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
   width="800"
   height="450"
   style="border:0"
@@ -214,14 +214,13 @@ Copy the embed snippet from the **Embed** section in the publish sidebar or from
 
 Paste either snippet into any HTML page. The embedded viewer loads your published scene.
 
-**Two preview layout variants are available:**
+**Embeds are served from a single route:**
 
 | Mode | URL pattern | Best for |
 |---|---|---|
-| Fullscreen | `/preview/fullscreen/:projectId/:sceneId` | Full viewport, immersive presentation |
-| Product detail | `/preview/product-detail/:projectId/:sceneId` | Compact viewer for e-commerce product pages |
+| Embed | `/embed/:projectId/:sceneId` | Full viewport, immersive presentation |
 
-Both modes support the `token` query parameter and `Authorization: Bearer` authentication.
+It supports the `token` query parameter and `Authorization: Bearer` authentication.
 
 ---
 

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/05_camera-presets-and-transitions.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/05_camera-presets-and-transitions.mdx
@@ -132,7 +132,7 @@ If you only had time to set up one extra camera, **set up Hero**. The first fram
 ### Camera Settings - Field of View Is Doing More Work Than You Think
 
 <EmbedShowcase
-  src={`https://vectreal.com/preview/fullscreen/395a09f0-9340-42f2-ac98-03339cf27c9c/bae36111-22da-46a4-85c5-2d9bfdbb8f4f?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}&transition=linear`}
+  src={`https://vectreal.com/embed/395a09f0-9340-42f2-ac98-03339cf27c9c/bae36111-22da-46a4-85c5-2d9bfdbb8f4f?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}&transition=linear`}
   label="Live embed · drag to orbit · scroll to zoom"
   caption="Default camera at FOV 50°. Drag the model to feel the natural perspective. The camera system described in this article drives every Vectreal embed."
   height={440}
@@ -186,13 +186,13 @@ When the visitor (or your app code) switches from one camera to another, three b
 
 <div className="my-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
   <EmbedShowcase
-    src={`https://vectreal.com/preview/fullscreen/395a09f0-9340-42f2-ac98-03339cf27c9c/bae36111-22da-46a4-85c5-2d9bfdbb8f4f?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}&transition=none`}
+    src={`https://vectreal.com/embed/395a09f0-9340-42f2-ac98-03339cf27c9c/bae36111-22da-46a4-85c5-2d9bfdbb8f4f?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}&transition=none`}
     label="Transition: Instant"
     caption="Camera teleports immediately - no animation."
     height={320}
   />
   <EmbedShowcase
-    src={`https://vectreal.com/preview/fullscreen/395a09f0-9340-42f2-ac98-03339cf27c9c/bae36111-22da-46a4-85c5-2d9bfdbb8f4f?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}&transition=linear`}
+    src={`https://vectreal.com/embed/395a09f0-9340-42f2-ac98-03339cf27c9c/bae36111-22da-46a4-85c5-2d9bfdbb8f4f?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}&transition=linear`}
     label="Transition: Linear · ease in-out · 1000 ms"
     caption="Camera lerps smoothly to the saved position."
     height={320}
@@ -299,7 +299,7 @@ This is the layout that turns a 3D embed into a slide deck. Combined with a few 
 ---
 
 <EmbedShowcase
-  src={`https://vectreal.com/preview/fullscreen/395a09f0-9340-42f2-ac98-03339cf27c9c/bae36111-22da-46a4-85c5-2d9bfdbb8f4f?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}&transition=object_avoidance&autoRotate=0`}
+  src={`https://vectreal.com/embed/395a09f0-9340-42f2-ac98-03339cf27c9c/bae36111-22da-46a4-85c5-2d9bfdbb8f4f?token=${import.meta.env.VITE_PUBLIC_VECTREAL_API_KEY_PROD}&transition=object_avoidance&autoRotate=0`}
   label="Smart transition · object avoidance · controls off"
   caption="E-commerce preset: auto-rotate off, zoom on, vertical limit 90°. Switch cameras using the viewer's built-in camera selector - the Smart transition arcs around geometry between views."
   height={480}

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/embed-showcase.tsx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/embed-showcase.tsx
@@ -6,7 +6,7 @@
  * Usage in MDX:
  *   import EmbedShowcase from './embed-showcase'
  *   <EmbedShowcase
- *     src="https://vectreal.com/preview/fullscreen/…?token=…"
+ *     src="https://vectreal.com/embed/…?token=…"
  *     label="Linear transition · Ease in-out · 1000 ms"
  *     caption="Switch cameras to see the linear transition in action."
  *     height={420}

--- a/apps/vectreal-platform/app/routes/preview-page/preview-scene.tsx
+++ b/apps/vectreal-platform/app/routes/preview-page/preview-scene.tsx
@@ -1,0 +1,12 @@
+import { Route } from './+types/preview-scene'
+import SceneEmbedPage from '../../components/scene-embed/scene-embed-page'
+
+/**
+ * The internal preview target. Session-authenticated in `preview-layout.tsx`
+ * and reachable only from the dashboard.
+ */
+const PreviewScenePage = ({ params }: Route.ComponentProps) => (
+	<SceneEmbedPage projectId={params.projectId} sceneId={params.sceneId} />
+)
+
+export default PreviewScenePage

--- a/apps/vectreal-platform/tests/cacheable-public-paths.server.test.ts
+++ b/apps/vectreal-platform/tests/cacheable-public-paths.server.test.ts
@@ -110,10 +110,20 @@ describe('isAnonymousCacheableRequest', () => {
 		).toBe(false)
 	})
 
-	it('does NOT cache publisher and preview pages', () => {
+	it('does NOT cache publisher, preview, and embed pages', () => {
 		expect(
 			isAnonymousCacheableRequest(req('https://x.test/publisher/scene-123'))
 		).toBe(false)
+		expect(isAnonymousCacheableRequest(req('https://x.test/preview/p/s'))).toBe(
+			false
+		)
+		expect(isAnonymousCacheableRequest(req('https://x.test/embed/p/s'))).toBe(
+			false
+		)
+		expect(
+			isAnonymousCacheableRequest(req('https://x.test/embed/p/s.data'))
+		).toBe(false)
+		// The legacy embed URL redirects, but must stay fail-closed on the way.
 		expect(
 			isAnonymousCacheableRequest(req('https://x.test/preview/fullscreen/p/s'))
 		).toBe(false)

--- a/apps/vectreal-platform/tests/embed-route-split.spec.ts
+++ b/apps/vectreal-platform/tests/embed-route-split.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import { loader as legacyEmbedRedirectLoader } from '../app/routes/embed-page/legacy-embed-redirect'
+import {
+	buildEmbedPath,
+	buildInternalPreviewPath
+} from '../app/lib/domain/embed/embed-snippet'
+
+const PROJECT_ID = 'proj-1'
+const SCENE_ID = 'scene-1'
+
+function legacyRequest(search = ''): Request {
+	return new Request(
+		`https://vectreal.com/preview/fullscreen/${PROJECT_ID}/${SCENE_ID}/${search}`
+	)
+}
+
+function runLegacyLoader(search = ''): Response {
+	return legacyEmbedRedirectLoader({
+		request: legacyRequest(search),
+		params: { projectId: PROJECT_ID, sceneId: SCENE_ID },
+		context: {} as never
+	} as never) as Response
+}
+
+describe('embed and preview path builders', () => {
+	it('builds the external embed path', () => {
+		expect(buildEmbedPath({ projectId: PROJECT_ID, sceneId: SCENE_ID })).toBe(
+			'/embed/proj-1/scene-1'
+		)
+	})
+
+	it('builds the internal preview path', () => {
+		expect(
+			buildInternalPreviewPath({ projectId: PROJECT_ID, sceneId: SCENE_ID })
+		).toBe('/preview/proj-1/scene-1')
+	})
+
+	it('keeps the two surfaces on distinct prefixes', () => {
+		const embed = buildEmbedPath({ projectId: PROJECT_ID, sceneId: SCENE_ID })
+		const preview = buildInternalPreviewPath({
+			projectId: PROJECT_ID,
+			sceneId: SCENE_ID
+		})
+
+		expect(embed.startsWith('/embed/')).toBe(true)
+		expect(preview.startsWith('/preview/')).toBe(true)
+		expect(embed).not.toBe(preview)
+	})
+})
+
+describe('legacy embed redirect', () => {
+	it('redirects permanently so search engines and caches follow', () => {
+		expect(runLegacyLoader().status).toBe(301)
+	})
+
+	it('points at the new embed path', () => {
+		expect(runLegacyLoader().headers.get('Location')).toBe(
+			'/embed/proj-1/scene-1'
+		)
+	})
+
+	// Every embed in the wild carries ?token=; the docs also pass camera,
+	// autoRotate, and transition. Dropping the query would break all of them.
+	it('preserves the full query string', () => {
+		const location = runLegacyLoader(
+			'?token=abc123&camera=hero&autoRotate=0&transition=linear'
+		).headers.get('Location')
+
+		expect(location).toBe(
+			'/embed/proj-1/scene-1?token=abc123&camera=hero&autoRotate=0&transition=linear'
+		)
+	})
+
+	it('preserves a token containing url-encoded characters', () => {
+		expect(runLegacyLoader('?token=a%2Bb%2Fc%3D').headers.get('Location')).toBe(
+			'/embed/proj-1/scene-1?token=a%2Bb%2Fc%3D'
+		)
+	})
+})

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -23,7 +23,7 @@ npm install @vctrl/embed
 <div style="width: 100%; height: 400px;">
 	<iframe
 		id="vectreal-scene"
-		src="https://vectreal.com/preview/fullscreen/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+		src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
 		style="width: 100%; height: 100%; border: 0;"
 		allow="autoplay; xr-spatial-tracking"
 		allowfullscreen


### PR DESCRIPTION
PR 11 of the preview/embed stack. No schema change, no migration.

## Why

`/preview/fullscreen/...` served two audiences from one URL, branching on which
credential the request carried: a preview API key for external embeds, or a
session for the dashboard view. One route with two auth modes means the URL you
hand to a customer can reach a surface meant for signed-in users.

## What

Each surface gets one route and exactly one credential type.

| Route | Auth | No credential |
| --- | --- | --- |
| `/embed/:projectId/:sceneId` | preview API key only | `404` |
| `/preview/:projectId/:sceneId` | session only | `404` |
| `/preview/fullscreen/:projectId/:sceneId` | n/a | `301` → `/embed/...` |

- **`embed-layout.tsx`** is lifted from the old `hasTokenCredential` branch:
  same 429 / 403 / 404 responses, same `no-store`. A request with no token gets
  404 instead of falling back to session auth, so a signed-in user opening an
  embed URL sees what an anonymous visitor sees.
- **`preview-layout.tsx`** is lifted from the `else` branch. A request arriving
  *with* a token is redirected to the `/embed` equivalent rather than handled,
  which is what structurally keeps the external URL off this surface.
- **`legacy-embed-redirect.ts`** preserves the full query string. Every embed in
  the wild carries `?token=`, and the docs also pass `camera`, `autoRotate`, and
  `transition`, so dropping it would break all of them.

`/embed` is added to `CDN_PROTECTED_PREFIXES`, so the new prefix is fail-closed
from its first commit rather than after someone notices.

## Shared page body

Both routes render the same thing (chrome for the internal preview lands
separately), so the page body moved to `components/scene-embed/scene-embed-page.tsx`
rather than being copied into two route files. Git tracked it as a rename of
`preview-fullscreen.tsx`. The route modules are 12 lines each.

## Also in here

- The scene detail page's preview **dropdown is removed**. Its only item pointed
  at the same path as the button next to it, left over from when a second
  preview layout existed. `ButtonGroup`, the `DropdownMenu*` imports and
  `LayoutDashboard` go with it.
- The publisher walkthrough article still documented
  `/preview/product-detail/:projectId/:sceneId`, a route deleted earlier in this
  stack. That row is gone.
- `buildFullscreenPreviewPath` → `buildEmbedPath`, plus `buildInternalPreviewPath`
  for dashboard links. 20 URL rewrites across docs, news-room articles, the home
  page mock-shop (a live production URL), and `packages/embed/README.md`.

## Verification

Runtime, against the dev server:

| Request | Expected | Actual |
| --- | --- | --- |
| `/preview/fullscreen/P/S/?token=abc&camera=hero` | 301 + query kept | `301` → `/embed/P/S?token=abc&camera=hero` |
| `/preview/fullscreen/P/S/` | 301, bare path | `301` → `/embed/P/S` |
| `/embed/P/S` (no token) | 404 | `404` |
| `/embed/P/S?token=bogus` | 404 | `404` |
| `/preview/P/S` (no session) | 404 | `404` |
| `/preview/P/S?token=abc` | redirect to embed | `302` → `/embed/P/S?token=abc` |

| Check | Result |
| --- | --- |
| `nx typecheck vectreal-platform` | pass |
| `nx lint vectreal-platform` | pass |
| `npx vitest run --root apps/vectreal-platform` | 193 passed, 30 files (+7) |
| `nx build vectreal-platform` | pass |

New `tests/embed-route-split.spec.ts` covers the path builders and the redirect:
301 status, target, full query preservation, and a url-encoded token.

## Not verified

The rendered `/preview` and `/embed` pages themselves need a signed-in pass with
a real scene; I only exercised the auth and redirect layers. Unrelated
pre-existing rough edge found while testing: a non-UUID `projectId` reaches
Postgres and 500s on the uuid cast instead of 404ing. It predates this PR (the
old layout called the same validator) so I left it alone.
