### PR TITLE
fix(platform): reject malformed scene route ids before querying

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/scene/scene-route-params.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-route-params.ts
@@ -1,0 +1,42 @@
+import { UUID_REGEX } from '../../../constants/utility-constants'
+
+export interface SceneRouteParams {
+	projectId: string
+	sceneId: string
+}
+
+export type SceneRouteParamsResult =
+	| { ok: true; value: SceneRouteParams }
+	| { ok: false; reason: 'missing' | 'malformed' }
+
+/**
+ * Validate the `:projectId` / `:sceneId` pair shared by the `/embed` and
+ * `/preview` routes.
+ *
+ * Both ids reach Postgres as uuid-typed query parameters, so a malformed value
+ * raises a driver error (`invalid input syntax for type uuid`) instead of
+ * returning no rows. That surfaces as a 500 on input anyone can send, so the
+ * shape is checked before any query runs.
+ */
+export function parseSceneRouteParams(params: {
+	projectId?: string
+	sceneId?: string
+}): SceneRouteParamsResult {
+	const projectId = params.projectId?.trim()
+	const sceneId = params.sceneId?.trim()
+
+	if (!projectId || !sceneId) {
+		return { ok: false, reason: 'missing' }
+	}
+
+	if (!UUID_REGEX.test(projectId) || !UUID_REGEX.test(sceneId)) {
+		return { ok: false, reason: 'malformed' }
+	}
+
+	return { ok: true, value: { projectId, sceneId } }
+}
+
+export const SCENE_ROUTE_PARAM_ERRORS = {
+	missing: 'Project ID and Scene ID are required',
+	malformed: 'Project ID and Scene ID must be valid UUIDs'
+} as const

--- a/apps/vectreal-platform/app/routes/layouts/embed-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/embed-layout.tsx
@@ -3,6 +3,10 @@ import { data, Outlet, type MetaFunction } from 'react-router'
 
 import { Route } from './+types/embed-layout'
 import { validatePreviewApiKeyForProject } from '../../lib/domain/auth/preview-api-key-auth.server'
+import {
+	parseSceneRouteParams,
+	SCENE_ROUTE_PARAM_ERRORS
+} from '../../lib/domain/scene/scene-route-params'
 import { getPublishedScenePreview } from '../../lib/domain/scene/server/scene-preview-repository.server'
 import { buildMeta } from '../../lib/seo'
 
@@ -33,15 +37,14 @@ function withNoStoreHeaders(response: Response): Response {
  * visitor sees. The internal, session-authenticated view lives at `/preview`.
  */
 export async function loader({ request, params }: Route.LoaderArgs) {
-	const projectId = params.projectId?.trim()
-	const sceneId = params.sceneId?.trim()
-
-	if (!projectId || !sceneId) {
+	const parsedParams = parseSceneRouteParams(params)
+	if (!parsedParams.ok) {
 		return withNoStoreHeaders(
-			ApiResponse.badRequest('Project ID and Scene ID are required')
+			ApiResponse.badRequest(SCENE_ROUTE_PARAM_ERRORS[parsedParams.reason])
 		)
 	}
 
+	const { projectId, sceneId } = parsedParams.value
 	const url = new URL(request.url)
 	const tokenFromQuery = url.searchParams.get('token')?.trim() || null
 	const hasTokenCredential =

--- a/apps/vectreal-platform/app/routes/layouts/preview-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/preview-layout.tsx
@@ -4,6 +4,10 @@ import { data, Outlet, redirect, type MetaFunction } from 'react-router'
 import { Route } from './+types/preview-layout'
 import { buildEmbedPath } from '../../lib/domain/embed/embed-snippet'
 import { getProject } from '../../lib/domain/project/project-repository.server'
+import {
+	parseSceneRouteParams,
+	SCENE_ROUTE_PARAM_ERRORS
+} from '../../lib/domain/scene/scene-route-params'
 import { getScene } from '../../lib/domain/scene/server/scene-folder-repository.server'
 import { getAuthUser } from '../../lib/http/auth.server'
 import { buildMeta } from '../../lib/seo'
@@ -36,15 +40,14 @@ function withNoStoreHeaders(response: Response): Response {
  * surface that renders dashboard chrome.
  */
 export async function loader({ request, params }: Route.LoaderArgs) {
-	const projectId = params.projectId?.trim()
-	const sceneId = params.sceneId?.trim()
-
-	if (!projectId || !sceneId) {
+	const parsedParams = parseSceneRouteParams(params)
+	if (!parsedParams.ok) {
 		return withNoStoreHeaders(
-			ApiResponse.badRequest('Project ID and Scene ID are required')
+			ApiResponse.badRequest(SCENE_ROUTE_PARAM_ERRORS[parsedParams.reason])
 		)
 	}
 
+	const { projectId, sceneId } = parsedParams.value
 	const url = new URL(request.url)
 	const hasTokenCredential =
 		Boolean(url.searchParams.get('token')?.trim()) ||

--- a/apps/vectreal-platform/tests/embed-route-split.spec.ts
+++ b/apps/vectreal-platform/tests/embed-route-split.spec.ts
@@ -5,6 +5,7 @@ import {
 	buildEmbedPath,
 	buildInternalPreviewPath
 } from '../app/lib/domain/embed/embed-snippet'
+import { parseSceneRouteParams } from '../app/lib/domain/scene/scene-route-params'
 
 const PROJECT_ID = 'proj-1'
 const SCENE_ID = 'scene-1'
@@ -76,5 +77,63 @@ describe('legacy embed redirect', () => {
 		expect(runLegacyLoader('?token=a%2Bb%2Fc%3D').headers.get('Location')).toBe(
 			'/embed/proj-1/scene-1?token=a%2Bb%2Fc%3D'
 		)
+	})
+})
+
+// Both ids reach Postgres as uuid-typed parameters, so a malformed value raises
+// a driver error rather than returning no rows. Unguarded, that is a 500 on
+// input anyone can send to the public /embed route.
+describe('parseSceneRouteParams', () => {
+	const VALID_PROJECT = '395a09f0-9340-42f2-ac98-03339cf27c9c'
+	const VALID_SCENE = '488bd4a1-46d3-4ee1-8497-25f68a5d6fa2'
+
+	it('accepts a well-formed pair', () => {
+		expect(
+			parseSceneRouteParams({
+				projectId: VALID_PROJECT,
+				sceneId: VALID_SCENE
+			})
+		).toEqual({
+			ok: true,
+			value: { projectId: VALID_PROJECT, sceneId: VALID_SCENE }
+		})
+	})
+
+	it('trims surrounding whitespace', () => {
+		expect(
+			parseSceneRouteParams({
+				projectId: ` ${VALID_PROJECT} `,
+				sceneId: `\t${VALID_SCENE}\n`
+			})
+		).toEqual({
+			ok: true,
+			value: { projectId: VALID_PROJECT, sceneId: VALID_SCENE }
+		})
+	})
+
+	it.each([
+		['both absent', undefined, undefined],
+		['project absent', undefined, VALID_SCENE],
+		['scene absent', VALID_PROJECT, undefined],
+		['whitespace only', '   ', VALID_SCENE]
+	])('reports %s as missing', (_label, projectId, sceneId) => {
+		expect(parseSceneRouteParams({ projectId, sceneId })).toEqual({
+			ok: false,
+			reason: 'missing'
+		})
+	})
+
+	it.each([
+		['non-uuid project id', 'P1', VALID_SCENE],
+		['non-uuid scene id', VALID_PROJECT, 'S1'],
+		['both malformed', 'P1', 'S1'],
+		['uuid missing a section', '395a09f0-9340-42f2-03339cf27c9c', VALID_SCENE],
+		['uuid with a trailing segment', `${VALID_PROJECT}-extra`, VALID_SCENE],
+		['sql-ish input', "' OR 1=1--", VALID_SCENE]
+	])('reports %s as malformed', (_label, projectId, sceneId) => {
+		expect(parseSceneRouteParams({ projectId, sceneId })).toEqual({
+			ok: false,
+			reason: 'malformed'
+		})
 	})
 })


### PR DESCRIPTION
Follow-up to #662, fixing the pre-existing issue noted in that PR's description.

## The bug

`:projectId` and `:sceneId` reach Postgres as uuid-typed query parameters, so a
malformed value raises a driver error instead of returning no rows:

```
PostgresError: invalid input syntax for type uuid: "P1"
  code: '22P02', routine: 'string_to_uuid'
```

That surfaces as **500** rather than a clean rejection. It predates the route
split (the old preview layout called the same validator), but the split made it
more visible: `/embed` is reachable without a session, so the only thing in
front of the query is the token check.

Reproduced before the fix:

```
GET /embed/P1/S1?token=bogus   ->  500
```

## The fix

Validate the pair before any query runs and return `400`. The regex is the
existing `UUID_REGEX` from `constants/utility-constants`, already used this way
in `scene-settings.parser.server.ts`.

Both layouts already duplicated the same trim-and-require step, so the whole
check moved into `lib/domain/scene/scene-route-params.ts`:

```ts
parseSceneRouteParams(params)
// -> { ok: true, value: { projectId, sceneId } }
// -> { ok: false, reason: 'missing' | 'malformed' }
```

It is a separate pure module rather than an inline guard for a concrete reason:
importing either layout in a test pulls in the database client and fails with
`Missing DATABASE_URL`, so an inline check could not be covered. This is also
why no existing test imports a route module with server dependencies.

## Behavior

| Request | Before | After |
| --- | --- | --- |
| `/embed/P1/S1?token=...` | `500` | `400` |
| `/preview/P1/S1` | `500` | `400` |
| `/embed/<uuid>/<uuid>` no token | `404` | `404` |
| `/preview/<uuid>/<uuid>` no session | `404` | `404` |
| `/preview/fullscreen/...` | `301` | `301` |

Valid ids are unaffected, and the `no-store` header on rejections is preserved.

## Verification

| Check | Result |
| --- | --- |
| `nx typecheck vectreal-platform` | pass |
| `nx lint vectreal-platform` | pass |
| `npx vitest run --root apps/vectreal-platform` | 205 passed, 30 files (+12) |
| `nx build vectreal-platform` | pass |

The 12 new cases cover the accepted pair, whitespace trimming, the four missing
permutations, and six malformed shapes including a truncated uuid, a uuid with a
trailing segment, and sql-ish input.

I verified the original 500 against a running dev server while writing #662, but
did not re-run the server to confirm the 400 after this change; that path is
covered by unit tests plus a two-line wiring change in each layout.
