### PR TITLE
feat(platform): internal preview chrome

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/preview-camera-controls.tsx
+++ b/apps/vectreal-platform/app/components/publisher/preview-camera-controls.tsx
@@ -1,17 +1,7 @@
-import {
-	SelectItem,
-	SelectContent,
-	SelectTrigger,
-	SelectValue,
-	Select,
-	Button
-} from '@shared/components'
 import { cn } from '@shared/utils'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useSetAtom, useAtom, useAtomValue } from 'jotai'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
-
 
 import { PUBLISHER_LAYER } from './shell/shell-layout'
 import { isSceneCamera } from '../../lib/domain/scene/scene-camera'
@@ -23,6 +13,7 @@ import {
 	cameraAtom,
 	selectedCameraIdAtom
 } from '../../lib/stores/scene-settings-store'
+import CameraSwitcherPill from '../scene-embed/preview-chrome/camera-switcher-pill'
 
 const PreviewCameraControls: React.FC = () => {
 	const [isPreviewMode, setIsPreviewMode] = useAtom(isPreviewModeAtom)
@@ -35,40 +26,11 @@ const PreviewCameraControls: React.FC = () => {
 		[cameras]
 	)
 
-	const activePreviewCameraIndex = useMemo(() => {
-		if (!sceneCameras.length) return -1
-		const selectedIndex = sceneCameras.findIndex(
-			(cameraEntry) => cameraEntry.cameraId === selectedCameraId
-		)
-		return selectedIndex >= 0 ? selectedIndex : 0
-	}, [sceneCameras, selectedCameraId])
-
-	const activePreviewCamera =
-		activePreviewCameraIndex >= 0
-			? sceneCameras[activePreviewCameraIndex]
-			: null
-
 	const handleSelectPreviewCamera = useCallback(
 		(nextCameraId: string) => {
 			setSelectedCameraId(nextCameraId)
 		},
 		[setSelectedCameraId]
-	)
-
-	const handleCyclePreviewCamera = useCallback(
-		(direction: -1 | 1) => {
-			if (!sceneCameras.length) {
-				return
-			}
-
-			const currentIndex =
-				activePreviewCameraIndex >= 0 ? activePreviewCameraIndex : 0
-			const nextIndex =
-				(currentIndex + direction + sceneCameras.length) % sceneCameras.length
-
-			setSelectedCameraId(sceneCameras[nextIndex].cameraId)
-		},
-		[activePreviewCameraIndex, sceneCameras, setSelectedCameraId]
 	)
 
 	const handleExitPreviewMode = useCallback(() => {
@@ -107,46 +69,12 @@ const PreviewCameraControls: React.FC = () => {
 							<span className="flex items-center gap-1.5">Exit Preview</span>
 						</motion.button>
 
-						<div className="bg-muted/92 border-border/70 relative z-10 flex items-center gap-2 rounded-2xl border px-2 py-1.5 shadow-2xl backdrop-blur-2xl">
-							<Button
-								variant="ghost"
-								size="icon"
-								className="h-8 w-8 rounded-xl"
-								onClick={() => handleCyclePreviewCamera(-1)}
-								aria-label="Previous camera"
-							>
-								<ChevronLeft className="h-4 w-4" />
-							</Button>
-
-							<Select
-								value={activePreviewCamera?.cameraId ?? ''}
-								onValueChange={handleSelectPreviewCamera}
-							>
-								<SelectTrigger className="h-8 min-w-44 rounded-xl text-xs">
-									<SelectValue placeholder="Select camera" />
-								</SelectTrigger>
-								<SelectContent>
-									{sceneCameras.map((cameraEntry) => (
-										<SelectItem
-											key={cameraEntry.cameraId}
-											value={cameraEntry.cameraId}
-										>
-											{cameraEntry.name || 'Unnamed Camera'}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-
-							<Button
-								variant="ghost"
-								size="icon"
-								className="h-8 w-8 rounded-xl"
-								onClick={() => handleCyclePreviewCamera(1)}
-								aria-label="Next camera"
-							>
-								<ChevronRight className="h-4 w-4" />
-							</Button>
-						</div>
+						<CameraSwitcherPill
+							className="relative z-10"
+							cameras={sceneCameras}
+							activeCameraId={selectedCameraId ?? null}
+							onSelect={handleSelectPreviewCamera}
+						/>
 					</div>
 				</motion.div>
 			) : null}

--- a/apps/vectreal-platform/app/components/scene-embed/preview-chrome/camera-switcher-pill.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/preview-chrome/camera-switcher-pill.tsx
@@ -1,0 +1,110 @@
+import {
+	Button,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@shared/components'
+import { cn } from '@shared/utils'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useCallback, useMemo } from 'react'
+
+export interface CameraSwitcherOption {
+	cameraId: string
+	name?: null | string
+}
+
+export interface CameraSwitcherPillProps {
+	cameras: CameraSwitcherOption[]
+	activeCameraId: null | string
+	onSelect: (cameraId: string) => void
+	className?: string
+}
+
+/**
+ * `‹ Camera name ›` in a floating pill.
+ *
+ * Presentational on purpose: the publisher drives it from jotai atoms and the
+ * internal preview drives it from the viewer's own `camera_changed` events. Two
+ * data sources, one visual, so switching cameras looks identical in both.
+ */
+const CameraSwitcherPill = ({
+	cameras,
+	activeCameraId,
+	onSelect,
+	className
+}: CameraSwitcherPillProps) => {
+	// Falling back to the first camera keeps the control labelled before the
+	// viewer has reported which camera it opened on.
+	const activeIndex = useMemo(() => {
+		if (!cameras.length) return -1
+		const index = cameras.findIndex(
+			(camera) => camera.cameraId === activeCameraId
+		)
+		return index >= 0 ? index : 0
+	}, [cameras, activeCameraId])
+
+	const activeCamera = activeIndex >= 0 ? cameras[activeIndex] : null
+
+	const cycle = useCallback(
+		(direction: -1 | 1) => {
+			if (!cameras.length) return
+
+			const currentIndex = activeIndex >= 0 ? activeIndex : 0
+			const nextIndex =
+				(currentIndex + direction + cameras.length) % cameras.length
+
+			onSelect(cameras[nextIndex].cameraId)
+		},
+		[activeIndex, cameras, onSelect]
+	)
+
+	const isCyclable = cameras.length > 1
+
+	return (
+		<div
+			className={cn(
+				'bg-muted/92 border-border/70 flex items-center gap-2 rounded-2xl border px-2 py-1.5 shadow-2xl backdrop-blur-2xl',
+				className
+			)}
+		>
+			<Button
+				variant="ghost"
+				size="icon"
+				className="h-8 w-8 rounded-xl"
+				onClick={() => cycle(-1)}
+				disabled={!isCyclable}
+				aria-label="Previous camera"
+			>
+				<ChevronLeft className="h-4 w-4" />
+			</Button>
+
+			<Select value={activeCamera?.cameraId ?? ''} onValueChange={onSelect}>
+				<SelectTrigger className="h-8 min-w-44 rounded-xl text-xs">
+					<SelectValue placeholder="Select camera" />
+				</SelectTrigger>
+				<SelectContent>
+					{cameras.map((camera) => (
+						<SelectItem key={camera.cameraId} value={camera.cameraId}>
+							{camera.name || 'Unnamed Camera'}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+
+			<Button
+				variant="ghost"
+				size="icon"
+				className="h-8 w-8 rounded-xl"
+				onClick={() => cycle(1)}
+				disabled={!isCyclable}
+				aria-label="Next camera"
+			>
+				<ChevronRight className="h-4 w-4" />
+			</Button>
+		</div>
+	)
+}
+
+export default CameraSwitcherPill

--- a/apps/vectreal-platform/app/components/scene-embed/preview-chrome/preview-chrome.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/preview-chrome/preview-chrome.tsx
@@ -1,0 +1,153 @@
+import { Button } from '@shared/components'
+import { cn } from '@shared/utils'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+import { ArrowLeft, Eye, EyeOff } from 'lucide-react'
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router'
+
+import CameraSwitcherPill, {
+	type CameraSwitcherOption
+} from './camera-switcher-pill'
+import { useChromeVisibility } from './use-chrome-visibility'
+
+export interface PreviewChromeProps {
+	/** Where Back and Escape land. Always the scene's dashboard page. */
+	backTo: string
+	cameras: CameraSwitcherOption[]
+	activeCameraId: null | string
+	onSelectCamera: (cameraId: string) => void
+}
+
+const PILL_SURFACE =
+	'bg-muted/92 border-border/70 rounded-2xl border shadow-2xl backdrop-blur-2xl'
+
+/**
+ * The internal preview's overlay: leave, switch camera, get out of the way.
+ *
+ * Only `/preview` renders this. `/embed` cannot, because it is a different
+ * route with a different layout, which is the point of the split.
+ *
+ * Placement keeps the viewer's own info popover (bottom-right) clear: leaving
+ * and hiding sit on the top edge, cameras along the bottom-center.
+ */
+const PreviewChrome = ({
+	backTo,
+	cameras,
+	activeCameraId,
+	onSelectCamera
+}: PreviewChromeProps) => {
+	const navigate = useNavigate()
+	const prefersReducedMotion = useReducedMotion()
+
+	const handleExit = useCallback(() => {
+		// Deliberately not history.back(): a preview link pasted into Slack has no
+		// history to return to, and should still land on the scene it previews.
+		void navigate(backTo)
+	}, [backTo, navigate])
+
+	const { isVisible, show, toggle } = useChromeVisibility({
+		onExit: handleExit
+	})
+
+	const fade = prefersReducedMotion
+		? { duration: 0 }
+		: { duration: 0.18, ease: 'easeOut' as const }
+
+	const offset = prefersReducedMotion ? 0 : 8
+
+	return (
+		<div className="pointer-events-none absolute inset-0 z-50">
+			<AnimatePresence initial={false}>
+				{isVisible ? (
+					<motion.div
+						key="chrome"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={fade}
+					>
+						<motion.div
+							className="pointer-events-auto absolute top-3 left-3"
+							initial={{ y: -offset }}
+							animate={{ y: 0 }}
+							exit={{ y: -offset }}
+							transition={fade}
+						>
+							<Button
+								variant="ghost"
+								onClick={handleExit}
+								className={cn(PILL_SURFACE, 'h-10 gap-2 px-3 text-xs')}
+							>
+								<ArrowLeft className="h-4 w-4" />
+								Back
+							</Button>
+						</motion.div>
+
+						<motion.div
+							className="pointer-events-auto absolute top-3 right-3"
+							initial={{ y: -offset }}
+							animate={{ y: 0 }}
+							exit={{ y: -offset }}
+							transition={fade}
+						>
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={toggle}
+								aria-label="Hide preview controls (H)"
+								title="Hide controls (H)"
+								className={cn(PILL_SURFACE, 'h-10 w-10')}
+							>
+								<EyeOff className="h-4 w-4" />
+							</Button>
+						</motion.div>
+
+						{cameras.length > 0 ? (
+							<motion.div
+								className="pointer-events-auto absolute inset-x-0 bottom-3 flex justify-center px-3"
+								initial={{ y: offset }}
+								animate={{ y: 0 }}
+								exit={{ y: offset }}
+								transition={fade}
+							>
+								<CameraSwitcherPill
+									cameras={cameras}
+									activeCameraId={activeCameraId}
+									onSelect={onSelectCamera}
+								/>
+							</motion.div>
+						) : null}
+					</motion.div>
+				) : (
+					// Hiding the chrome must not strand anyone. This stays on screen at
+					// low contrast and resolves into a real control on hover or focus.
+					<motion.div
+						key="restore"
+						className="pointer-events-auto absolute top-3 right-3"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={fade}
+					>
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={show}
+							aria-label="Show preview controls (H)"
+							title="Show controls (H)"
+							className={cn(
+								PILL_SURFACE,
+								'h-10 w-10 opacity-25 transition-opacity duration-200',
+								'hover:opacity-100 focus-visible:opacity-100'
+							)}
+						>
+							<Eye className="h-4 w-4" />
+						</Button>
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</div>
+	)
+}
+
+export default PreviewChrome

--- a/apps/vectreal-platform/app/components/scene-embed/preview-chrome/use-chrome-visibility.ts
+++ b/apps/vectreal-platform/app/components/scene-embed/preview-chrome/use-chrome-visibility.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export interface UseChromeVisibilityParams {
+	/** Invoked on Escape. The chrome's Back control calls the same thing. */
+	onExit: () => void
+}
+
+export interface ChromeVisibility {
+	isVisible: boolean
+	show: () => void
+	hide: () => void
+	toggle: () => void
+}
+
+/**
+ * Typing an `h` into a field should not blank the screen, and a keystroke aimed
+ * at an open camera dropdown belongs to that dropdown.
+ */
+export function isEditableEventTarget(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) {
+		return false
+	}
+
+	if (target.isContentEditable) {
+		return true
+	}
+
+	const tagName = target.tagName
+	if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+		return true
+	}
+
+	// Radix Select renders a button with listbox semantics rather than a <select>.
+	return Boolean(target.closest('[role="listbox"], [role="combobox"]'))
+}
+
+/**
+ * What a keydown means to the chrome, separated from the listener so the
+ * decision can be tested without a DOM.
+ */
+export function resolveChromeKeyAction(
+	event: Pick<KeyboardEvent, 'key' | 'altKey' | 'ctrlKey' | 'metaKey'>
+): 'exit' | 'toggle' | null {
+	if (event.altKey || event.ctrlKey || event.metaKey) {
+		return null
+	}
+
+	if (event.key === 'Escape') {
+		return 'exit'
+	}
+
+	return event.key === 'h' || event.key === 'H' ? 'toggle' : null
+}
+
+/**
+ * Chrome starts visible and only hides when asked.
+ *
+ * No auto-hide-on-idle: the scene is the point, but a control that vanishes on
+ * its own leaves people hunting for it. `H` toggles, `Esc` leaves. Hidden state
+ * still leaves a restore affordance on screen, so this is never a dead end.
+ */
+export function useChromeVisibility({
+	onExit
+}: UseChromeVisibilityParams): ChromeVisibility {
+	const [isVisible, setIsVisible] = useState(true)
+
+	const show = useCallback(() => setIsVisible(true), [])
+	const hide = useCallback(() => setIsVisible(false), [])
+	const toggle = useCallback(() => setIsVisible((current) => !current), [])
+
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (isEditableEventTarget(event.target)) {
+				return
+			}
+
+			const action = resolveChromeKeyAction(event)
+			if (!action) {
+				return
+			}
+
+			event.preventDefault()
+			if (action === 'exit') {
+				onExit()
+				return
+			}
+
+			toggle()
+		}
+
+		window.addEventListener('keydown', handleKeyDown)
+		return () => window.removeEventListener('keydown', handleKeyDown)
+	}, [onExit, toggle])
+
+	return { isVisible, show, hide, toggle }
+}

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
@@ -1,18 +1,37 @@
 import { Button } from '@shared/components/ui/button'
-import { useMemo } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
 import SceneEmbedInfoPopover from './scene-embed-info-popover'
 import SceneEmbedViewer from './scene-embed-viewer'
 import { useSceneEmbedScene } from './use-scene-embed-scene'
 import { useHostedPreviewBridge } from '../../lib/domain/embed/hosted-preview-bridge'
+import { isSceneCamera } from '../../lib/domain/scene/scene-camera'
 import CenteredSpinner from '../centered-spinner'
 
-import type { ViewerCommand } from '@vctrl/viewer'
+import type {
+	ViewerCommand,
+	ViewerCommandExecutor,
+	ViewerInteractionEvent
+} from '@vctrl/viewer'
+import type { ReactNode } from 'react'
+
+/** What an overlay needs from the running viewer. */
+export interface SceneEmbedViewerControl {
+	/** Scene cameras only; hotspots and the like are navigational. */
+	cameras: { cameraId: string; name?: null | string }[]
+	activeCameraId: null | string
+	activateCamera: (cameraId: string) => void
+}
 
 export interface SceneEmbedPageProps {
 	projectId?: string
 	sceneId?: string
+	/**
+	 * Rendered over the viewer. A function because chrome needs the live control
+	 * surface, which only exists once the viewer has registered its executor.
+	 */
+	chrome?: (control: SceneEmbedViewerControl) => ReactNode
 }
 
 /** Opening viewer state driven by the embed URL's query parameters. */
@@ -51,20 +70,62 @@ function useInitialCommands(): ViewerCommand[] {
  * layout authenticates the request. Anything a surface adds on top (the
  * internal preview's chrome) wraps this rather than being switched on inside.
  */
-const SceneEmbedPage = ({ projectId, sceneId }: SceneEmbedPageProps) => {
+const SceneEmbedPage = ({
+	projectId,
+	sceneId,
+	chrome
+}: SceneEmbedPageProps) => {
 	const { file, isLoadingScene, sceneData, loadError, retrySceneLoad } =
 		useSceneEmbedScene({
 			sceneId,
 			projectId
 		})
 	const initialCommands = useInitialCommands()
-	const { onCommandExecutorReady, onInteractionEvent } = useHostedPreviewBridge(
-		{
-			sceneId,
-			interactions: sceneData?.interactions,
-			cameras: sceneData?.camera?.cameras,
-			initialCommands
+	const bridge = useHostedPreviewBridge({
+		sceneId,
+		interactions: sceneData?.interactions,
+		cameras: sceneData?.camera?.cameras,
+		initialCommands
+	})
+
+	const executorRef = useRef<null | ViewerCommandExecutor>(null)
+	const [activeCameraId, setActiveCameraId] = useState<null | string>(null)
+
+	// `useHostedPreviewBridge` returns a fresh object each render, and the viewer
+	// re-runs its executor-registration effect whenever these props change
+	// identity — unregistering with `null` on the way through. Reading the bridge
+	// from a ref keeps the callbacks below referentially stable, so tracking the
+	// active camera in state cannot tear down the executor that switching needs.
+	const bridgeRef = useRef(bridge)
+	bridgeRef.current = bridge
+
+	// The embed SDK bridge and the chrome both need these, so they chain rather
+	// than compete for the viewer's single callback slot.
+	const onCommandExecutorReady = useCallback(
+		(executor: null | ViewerCommandExecutor) => {
+			executorRef.current = executor
+			bridgeRef.current.onCommandExecutorReady?.(executor)
+		},
+		[]
+	)
+
+	const onInteractionEvent = useCallback((event: ViewerInteractionEvent) => {
+		if (event.type === 'camera_changed') {
+			setActiveCameraId(event.cameraId)
+		} else if (event.type === 'initial_framing_completed' && event.cameraId) {
+			setActiveCameraId(event.cameraId)
 		}
+
+		bridgeRef.current.onInteractionEvent?.(event)
+	}, [])
+
+	const activateCamera = useCallback((cameraId: string) => {
+		executorRef.current?.execute({ type: 'activate_camera', cameraId })
+	}, [])
+
+	const sceneCameras = useMemo(
+		() => (sceneData?.camera?.cameras ?? []).filter(isSceneCamera),
+		[sceneData?.camera?.cameras]
 	)
 
 	if (isLoadingScene && !file?.model) {
@@ -95,19 +156,25 @@ const SceneEmbedPage = ({ projectId, sceneId }: SceneEmbedPageProps) => {
 	}
 
 	return (
-		<SceneEmbedViewer
-			className="h-screen"
-			file={file}
-			sceneData={sceneData}
-			onCommandExecutorReady={onCommandExecutorReady}
-			onInteractionEvent={onInteractionEvent}
-			popover={
-				<SceneEmbedInfoPopover
-					title={sceneData?.meta?.name?.trim() || undefined}
-					description={sceneData?.meta?.description?.trim() || undefined}
-				/>
-			}
-		/>
+		<div className="relative h-screen w-full">
+			<SceneEmbedViewer
+				file={file}
+				sceneData={sceneData}
+				onCommandExecutorReady={onCommandExecutorReady}
+				onInteractionEvent={onInteractionEvent}
+				popover={
+					<SceneEmbedInfoPopover
+						title={sceneData?.meta?.name?.trim() || undefined}
+						description={sceneData?.meta?.description?.trim() || undefined}
+					/>
+				}
+			/>
+			{chrome?.({
+				cameras: sceneCameras,
+				activeCameraId,
+				activateCamera
+			})}
+		</div>
 	)
 }
 

--- a/apps/vectreal-platform/app/routes/preview-page/preview-scene.tsx
+++ b/apps/vectreal-platform/app/routes/preview-page/preview-scene.tsx
@@ -1,12 +1,25 @@
 import { Route } from './+types/preview-scene'
+import PreviewChrome from '../../components/scene-embed/preview-chrome/preview-chrome'
 import SceneEmbedPage from '../../components/scene-embed/scene-embed-page'
 
 /**
  * The internal preview target. Session-authenticated in `preview-layout.tsx`
- * and reachable only from the dashboard.
+ * and reachable only from the dashboard, which is why it is the surface allowed
+ * to carry chrome.
  */
 const PreviewScenePage = ({ params }: Route.ComponentProps) => (
-	<SceneEmbedPage projectId={params.projectId} sceneId={params.sceneId} />
+	<SceneEmbedPage
+		projectId={params.projectId}
+		sceneId={params.sceneId}
+		chrome={({ cameras, activeCameraId, activateCamera }) => (
+			<PreviewChrome
+				backTo={`/dashboard/projects/${params.projectId}/${params.sceneId}`}
+				cameras={cameras}
+				activeCameraId={activeCameraId}
+				onSelectCamera={activateCamera}
+			/>
+		)}
+	/>
 )
 
 export default PreviewScenePage

--- a/apps/vectreal-platform/tests/preview-chrome-visibility.spec.ts
+++ b/apps/vectreal-platform/tests/preview-chrome-visibility.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	isEditableEventTarget,
+	resolveChromeKeyAction
+} from '../app/components/scene-embed/preview-chrome/use-chrome-visibility'
+
+function key(
+	overrides: Partial<Pick<KeyboardEvent, 'key' | 'altKey' | 'ctrlKey' | 'metaKey'>>
+) {
+	return {
+		key: 'a',
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		...overrides
+	}
+}
+
+describe('resolveChromeKeyAction', () => {
+	it.each(['h', 'H'])('treats %s as a visibility toggle', (pressed) => {
+		expect(resolveChromeKeyAction(key({ key: pressed }))).toBe('toggle')
+	})
+
+	it('treats Escape as leaving the preview', () => {
+		expect(resolveChromeKeyAction(key({ key: 'Escape' }))).toBe('exit')
+	})
+
+	it('ignores unrelated keys', () => {
+		expect(resolveChromeKeyAction(key({ key: 'k' }))).toBeNull()
+	})
+
+	// Cmd+H hides the window on macOS and Ctrl+H is a browser shortcut; the
+	// chrome must not swallow either.
+	it.each([
+		['meta', { key: 'h', metaKey: true }],
+		['ctrl', { key: 'h', ctrlKey: true }],
+		['alt', { key: 'h', altKey: true }]
+	])('ignores %s-modified h', (_label, overrides) => {
+		expect(resolveChromeKeyAction(key(overrides))).toBeNull()
+	})
+
+	it('ignores modified Escape', () => {
+		expect(resolveChromeKeyAction(key({ key: 'Escape', metaKey: true }))).toBeNull()
+	})
+})
+
+describe('isEditableEventTarget', () => {
+	it('returns false for a plain element', () => {
+		expect(isEditableEventTarget(document.createElement('div'))).toBe(false)
+	})
+
+	it('returns false when there is no target', () => {
+		expect(isEditableEventTarget(null)).toBe(false)
+	})
+
+	it.each(['input', 'textarea', 'select'])(
+		'treats <%s> as editable so typing is never hijacked',
+		(tagName) => {
+			expect(isEditableEventTarget(document.createElement(tagName))).toBe(true)
+		}
+	)
+
+	it('treats contenteditable as editable', () => {
+		const element = document.createElement('div')
+		element.contentEditable = 'true'
+		// jsdom does not derive isContentEditable from the attribute.
+		Object.defineProperty(element, 'isContentEditable', { value: true })
+
+		expect(isEditableEventTarget(element)).toBe(true)
+	})
+
+	// Radix Select renders a button with listbox semantics, not a <select>, so
+	// arrow and letter keys aimed at an open camera dropdown belong to it.
+	it.each(['listbox', 'combobox'])(
+		'treats a %s descendant as editable',
+		(role) => {
+			const wrapper = document.createElement('div')
+			wrapper.setAttribute('role', role)
+			const child = document.createElement('span')
+			wrapper.appendChild(child)
+
+			expect(isEditableEventTarget(child)).toBe(true)
+		}
+	)
+})


### PR DESCRIPTION
PR 12 of the preview/embed stack. Builds on the `scene-embed-page.tsx` seam from
#662.

`/preview` gets controls. `/embed` structurally cannot: it is a different route
behind a different layout, which was the whole point of the split.

## Behavior

| Control | Placement | Notes |
| --- | --- | --- |
| Back | top-left | Always the scene's dashboard page |
| Hide | top-right | `H` toggles; no auto-hide |
| Cameras | bottom-center | Only when the scene has cameras |

- **Back and Escape** land on `/dashboard/projects/:projectId/:sceneId`
  unconditionally. Deliberately not `history.back()`: a preview link pasted into
  Slack has no history to return to and should still reach the scene it
  previews.
- **Hiding is never a dead end.** The hidden state keeps a low-contrast control
  on screen that resolves to full opacity on hover or focus. There is no
  auto-hide on idle, because a control that vanishes on its own leaves people
  hunting for it.
- **Keystrokes are not hijacked.** `H` and `Escape` are ignored when the target
  is an input, textarea, select, or contenteditable, or sits inside a
  `listbox`/`combobox` (Radix Select renders a button with listbox semantics,
  not a `<select>`). Modified `Cmd/Ctrl/Alt+H` is left to the browser and OS.
- Placement keeps the viewer's own info popover (bottom-right) clear.
- Motion is opacity plus an 8px offset at 180ms, collapsed to zero under
  `useReducedMotion`.

## Shared pill

The `‹ camera ›` control moves to `camera-switcher-pill.tsx`, and the publisher
renders it instead of its own copy. Two data sources, one visual: the publisher
drives it from jotai atoms, the preview from the viewer's `camera_changed`
events. Cycling and index resolution move into the pill, so
`preview-camera-controls.tsx` sheds that logic and drops to a thin wrapper
(-86 lines).

## The one subtle bit

Chrome reaches the viewer through a `chrome` render prop on `SceneEmbedPage`
that hands over the live control surface (cameras, active id, activate).

The bridge is read through a ref rather than a `useCallback` dependency.
`useHostedPreviewBridge` returns a fresh object literal every render, and
`scene-camera.tsx:494-503` re-runs its registration effect whenever those props
change identity, unregistering with `null` on the way through:

```js
useEffect(() => {
  onCommandExecutorReady?.({ execute: executeViewerCommand })
  onInteractionEvent?.({ type: 'viewer_ready' })
  return () => { onCommandExecutorReady?.(null) }
}, [executeViewerCommand, onCommandExecutorReady, onInteractionEvent])
```

Without the ref, tracking the active camera in state re-rendered on every
`camera_changed`, which tore down the executor that switching depends on and
re-fired `viewer_ready`. Camera switching was dead until this was stabilized.

## Verification

Camera switching confirmed working in the browser on a real scene, via both the
arrows and the select.

| Check | Result |
| --- | --- |
| `nx typecheck vectreal-platform` | pass |
| `nx lint vectreal-platform` | pass |
| `npx vitest run --root apps/vectreal-platform` | 209 passed, 31 files (+16) |

The 16 new cases cover the key-action decision (`h`/`H`/`Escape`, unrelated
keys, modifier combinations) and the editable-target guard, both split out of
the hook so they test without a DOM.

## Not verified

Reduced-motion rendering and the hidden-state restore affordance were not
exercised in a browser; the rest of the chrome was.
