### PR TITLE
feat(publisher): show preview mode instead of explaining it

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
+++ b/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
@@ -9,6 +9,7 @@ import { DynamicSidebar, ToolSidebar } from '.'
 import OptimizationDrawer from './optimization/optimization-drawer'
 import PreviewCameraControls from './preview-camera-controls'
 import { usePublisherViewerCapture } from './publisher-viewer-capture-context'
+import { PreviewModeBadge } from './shell/preview-mode-badge'
 import { PublishCard } from './shell/publish-card'
 import { PublisherHeader } from './shell/publisher-header'
 import { PUBLISHER_LAYER } from './shell/shell-layout'
@@ -344,6 +345,8 @@ const OverlayControls = ({
 					dashboardHref={sceneDetailsHref ?? '/dashboard'}
 					isMobile={isMobileRequest}
 				/>
+
+				<PreviewModeBadge />
 
 				<PreviewCameraControls />
 			</div>

--- a/apps/vectreal-platform/app/components/publisher/preview-camera-controls.tsx
+++ b/apps/vectreal-platform/app/components/publisher/preview-camera-controls.tsx
@@ -1,14 +1,11 @@
 import { cn } from '@shared/utils'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useSetAtom, useAtom, useAtomValue } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { useCallback, useMemo } from 'react'
 
 import { PUBLISHER_LAYER } from './shell/shell-layout'
 import { isSceneCamera } from '../../lib/domain/scene/scene-camera'
-import {
-	isPreviewModeAtom,
-	processAtom
-} from '../../lib/stores/publisher-config-store'
+import { isPreviewModeAtom } from '../../lib/stores/publisher-config-store'
 import {
 	cameraAtom,
 	selectedCameraIdAtom
@@ -16,8 +13,7 @@ import {
 import CameraSwitcherPill from '../scene-embed/preview-chrome/camera-switcher-pill'
 
 const PreviewCameraControls: React.FC = () => {
-	const [isPreviewMode, setIsPreviewMode] = useAtom(isPreviewModeAtom)
-	const setProcessState = useSetAtom(processAtom)
+	const isPreviewMode = useAtomValue(isPreviewModeAtom)
 	const { cameras } = useAtomValue(cameraAtom)
 	const [selectedCameraId, setSelectedCameraId] = useAtom(selectedCameraIdAtom)
 
@@ -33,17 +29,6 @@ const PreviewCameraControls: React.FC = () => {
 		[setSelectedCameraId]
 	)
 
-	const handleExitPreviewMode = useCallback(() => {
-		setIsPreviewMode(false)
-		setProcessState((prev) => ({
-			...prev,
-			mode: 'compose',
-			activeComposeTool: 'camera-controls',
-			showSidebar: true,
-			showPublishPanel: false
-		}))
-	}, [setIsPreviewMode, setProcessState])
-
 	return (
 		<AnimatePresence>
 			{isPreviewMode && sceneCameras.length > 0 ? (
@@ -57,25 +42,17 @@ const PreviewCameraControls: React.FC = () => {
 						PUBLISHER_LAYER.previewControls
 					)}
 				>
-					<div className="pointer-events-auto relative">
-						<motion.button
-							type="button"
-							onClick={handleExitPreviewMode}
-							aria-label="Exit preview mode"
-							className="bg-accent text-accent-foreground border-border/70 hover:text-foreground absolute -top-8 left-1/2 z-0 h-10 -translate-x-1/2 rounded-t-xl border border-b-0 px-3 pt-2 pb-3 text-xs shadow-lg"
-							whileHover={{ y: -2 }}
-							whileTap={{ y: 0 }}
-						>
-							<span className="flex items-center gap-1.5">Exit Preview</span>
-						</motion.button>
-
-						<CameraSwitcherPill
-							className="relative z-10"
-							cameras={sceneCameras}
-							activeCameraId={selectedCameraId ?? null}
-							onSelect={handleSelectPreviewCamera}
-						/>
-					</div>
+					{/*
+					  Exiting lives on the preview frame now, not here. It has to be
+					  reachable even when a scene has no cameras, and this component
+					  renders nothing in that case.
+					*/}
+					<CameraSwitcherPill
+						className="pointer-events-auto"
+						cameras={sceneCameras}
+						activeCameraId={selectedCameraId ?? null}
+						onSelect={handleSelectPreviewCamera}
+					/>
 				</motion.div>
 			) : null}
 		</AnimatePresence>

--- a/apps/vectreal-platform/app/components/publisher/shell/preview-mode-badge.tsx
+++ b/apps/vectreal-platform/app/components/publisher/shell/preview-mode-badge.tsx
@@ -1,0 +1,74 @@
+import { cn } from '@shared/utils'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+import { useAtom, useSetAtom } from 'jotai/react'
+import { useCallback } from 'react'
+
+import { PUBLISHER_EDGE_INSET, PUBLISHER_LAYER } from './shell-layout'
+import {
+	isPreviewModeAtom,
+	processAtom
+} from '../../../lib/stores/publisher-config-store'
+import PreviewExitBadge from '../../scene-embed/preview-chrome/preview-exit-badge'
+
+/**
+ * Preview mode, shown rather than explained.
+ *
+ * Entering preview used to be announced by an amber paragraph in a sidebar that
+ * preview mode itself had just closed. The state is now carried by the canvas:
+ * the editing chrome recedes, and one labelled pill says where you are and how
+ * to leave.
+ *
+ * It sits top-left, taking the place the tool rail just vacated. The nav cube
+ * owns bottom-left and the camera controls own bottom-center, so this is the
+ * only edge position that collides with nothing.
+ *
+ * Rendered here rather than beside the camera controls because it has to exist
+ * even when a scene has no cameras — otherwise preview mode has no exit at all
+ * once the sidebar closes.
+ */
+export const PreviewModeBadge = () => {
+	const [isPreviewMode, setIsPreviewMode] = useAtom(isPreviewModeAtom)
+	const setProcessState = useSetAtom(processAtom)
+	const prefersReducedMotion = useReducedMotion()
+
+	const handleExitPreviewMode = useCallback(() => {
+		setIsPreviewMode(false)
+		setProcessState((prev) => ({
+			...prev,
+			mode: 'compose',
+			activeComposeTool: 'camera-controls',
+			showSidebar: true,
+			showPublishPanel: false
+		}))
+	}, [setIsPreviewMode, setProcessState])
+
+	const offset = prefersReducedMotion ? 0 : -8
+	const transition = prefersReducedMotion
+		? { duration: 0 }
+		: { duration: 0.24, ease: [0.4, 0, 0.2, 1] as const }
+
+	return (
+		<AnimatePresence>
+			{isPreviewMode ? (
+				<motion.div
+					initial={{ opacity: 0, y: offset }}
+					animate={{ opacity: 1, y: 0 }}
+					exit={{ opacity: 0, y: offset }}
+					transition={transition}
+					className={cn(
+						'absolute top-0 left-0',
+						PUBLISHER_EDGE_INSET,
+						PUBLISHER_LAYER.previewControls
+					)}
+				>
+					<PreviewExitBadge
+						exitLabel="Exit preview mode"
+						onExit={handleExitPreviewMode}
+					/>
+				</motion.div>
+			) : null}
+		</AnimatePresence>
+	)
+}
+
+export default PreviewModeBadge

--- a/apps/vectreal-platform/app/components/publisher/shell/publish-card.tsx
+++ b/apps/vectreal-platform/app/components/publisher/shell/publish-card.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../lib/domain/scene/scene-delivery-estimate'
 import {
 	hasUnsavedChangesAtom,
+	isPreviewModeAtom,
 	sceneMetaAtom
 } from '../../../lib/stores/publisher-config-store'
 
@@ -53,6 +54,7 @@ export const PublishCard: FC<PublishCardProps> = ({
 }) => {
 	const { thumbnailUrl } = useAtomValue(sceneMetaAtom)
 	const hasUnsavedChanges = useAtomValue(hasUnsavedChangesAtom)
+	const isPreviewMode = useAtomValue(isPreviewModeAtom)
 
 	const estimate = estimateDeliveryTime(sceneBytes)
 	const statusLabel = isPublished
@@ -64,12 +66,19 @@ export const PublishCard: FC<PublishCardProps> = ({
 	return (
 		<motion.div
 			initial={{ opacity: 0, y: 12 }}
-			animate={{ opacity: 1, y: 0 }}
+			// Preview mode is about seeing the scene, so the card leaves rather than
+			// dimming. `animate` (not `exit`) keeps it mounted, so its own publish
+			// state survives the round trip.
+			animate={
+				isPreviewMode ? { opacity: 0, y: 12 } : { opacity: 1, y: 0 }
+			}
 			transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+			aria-hidden={isPreviewMode}
 			className={cn(
 				'publisher-shell-panel absolute right-0 bottom-0 w-60 overflow-hidden p-2',
 				PUBLISHER_EDGE_INSET,
 				PUBLISHER_LAYER.card,
+				isPreviewMode && 'pointer-events-none',
 				disabled && 'pointer-events-none opacity-45 saturate-50'
 			)}
 		>

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/camera-controls-settings/camera-controls-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/camera-controls-settings/camera-controls-settings-panel.tsx
@@ -21,6 +21,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import {
 	Camera,
 	Check,
+	ExternalLink,
 	Eye,
 	EyeOff,
 	Link,
@@ -29,16 +30,20 @@ import {
 	Trash2
 } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useParams } from 'react-router'
 
 import {
 	defaultCameraOptions,
 	defaultControlsOptions,
 	type FieldConfig
 } from './constants'
+import { buildInternalPreviewPath } from '../../../../../lib/domain/embed/embed-snippet'
 import { resolveDefaultSceneCameraId } from '../../../../../lib/domain/scene/scene-camera'
 import {
 	canEditCameraSettingsAtom,
+	currentLocationAtom,
 	isPreviewModeAtom,
+	lastSavedSceneIdAtom,
 	processAtom
 } from '../../../../../lib/stores/publisher-config-store'
 import {
@@ -324,6 +329,16 @@ const CameraControlsSettingsPanel = memo(() => {
 	const canEditCameraSettings = useAtomValue(canEditCameraSettingsAtom)
 	const setIsPreviewMode = useSetAtom(isPreviewModeAtom)
 	const setProcessState = useSetAtom(processAtom)
+	const routeParams = useParams()
+	const { projectId } = useAtomValue(currentLocationAtom)
+	const lastSavedSceneId = useAtomValue(lastSavedSceneIdAtom)
+	// The route param lags a first save, so fall back to the just-saved id.
+	// Without both ids there is no scene on disk to open, hence the disabled state.
+	const savedSceneId = routeParams.sceneId ?? lastSavedSceneId ?? null
+	const fullPreviewHref =
+		projectId && savedSceneId
+			? buildInternalPreviewPath({ projectId, sceneId: savedSceneId })
+			: null
 	const [hotspots, setHotspots] = useAtom(hotspotsAtom)
 	const [cameraNameDraft, setCameraNameDraft] = useState('')
 	const [transitionAdvancedOpen, setTransitionAdvancedOpen] = useState(false)
@@ -792,31 +807,73 @@ const CameraControlsSettingsPanel = memo(() => {
 		<div className="space-y-8">
 			<SidebarSection>
 				<SidebarSectionContent>
-					<div className="border-border/60 bg-muted/40 flex items-center justify-between rounded-xl border p-3">
-						<div>
+					<div className="border-border/60 bg-muted/40 space-y-2 rounded-xl border p-3">
+						<div className="flex items-center justify-between gap-3">
 							<p className="text-sm font-semibold">Preview Mode</p>
-							<p className="text-muted-foreground mt-0.5 text-xs">
-								Lock editing and review saved cameras in sequence.
-							</p>
+							<Button
+								variant={isPreviewMode ? 'secondary' : 'default'}
+								size="sm"
+								disabled={!allCameras.length}
+								onClick={
+									isPreviewMode ? handleExitPreviewMode : handleEnterPreviewMode
+								}
+							>
+								{isPreviewMode ? (
+									<>
+										<EyeOff className="mr-2 h-4 w-4" /> Exit
+									</>
+								) : (
+									<>
+										<Eye className="mr-2 h-4 w-4" /> Enter
+									</>
+								)}
+							</Button>
 						</div>
-						<Button
-							variant={isPreviewMode ? 'secondary' : 'default'}
-							size="sm"
-							disabled={!allCameras.length}
-							onClick={
-								isPreviewMode ? handleExitPreviewMode : handleEnterPreviewMode
-							}
-						>
-							{isPreviewMode ? (
-								<>
-									<EyeOff className="mr-2 h-4 w-4" /> Exit
-								</>
-							) : (
-								<>
-									<Eye className="mr-2 h-4 w-4" /> Enter
-								</>
-							)}
-						</Button>
+
+						{/*
+						  The handoff between the two preview tools. In-canvas preview
+						  reviews cameras while you compose; the full preview is the saved
+						  scene on its own route, opened in a new tab so the publisher and
+						  whatever is unsaved in it stay put. On its own row: sharing the
+						  trigger's axis squashed both.
+						*/}
+						{fullPreviewHref ? (
+							<Button
+								variant="ghost"
+								size="sm"
+								asChild
+								className="h-8 w-full justify-start px-2"
+							>
+								<a
+									href={fullPreviewHref}
+									target="_blank"
+									rel="noreferrer"
+									className="text-muted-foreground hover:text-foreground text-xs"
+								>
+									Open full preview
+									<ExternalLink className="ml-1.5 h-3.5 w-3.5" />
+								</a>
+							</Button>
+						) : (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									{/* A disabled button swallows pointer events, so the
+									    tooltip needs a wrapper to hang off. */}
+									<span tabIndex={0} className="block">
+										<Button
+											variant="ghost"
+											size="sm"
+											disabled
+											className="text-muted-foreground h-8 w-full justify-start px-2 text-xs"
+										>
+											Open full preview
+											<ExternalLink className="ml-1.5 h-3.5 w-3.5" />
+										</Button>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent>Save this scene first.</TooltipContent>
+							</Tooltip>
+						)}
 					</div>
 				</SidebarSectionContent>
 			</SidebarSection>
@@ -824,18 +881,6 @@ const CameraControlsSettingsPanel = memo(() => {
 			{/* Camera Manager */}
 			<SidebarSection>
 				<SidebarSectionContent>
-					{isPreviewMode && (
-						<div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2">
-							<p className="text-xs text-amber-700 dark:text-amber-400">
-								Previewing through{' '}
-								<span className="font-semibold">
-									{selectedCamera?.name ?? 'camera'}
-								</span>
-								. Switch cameras to transition.
-							</p>
-						</div>
-					)}
-
 					{/* Camera Name */}
 					<SettingRow label="Camera Name">
 						<div className="flex w-full flex-col gap-1">

--- a/apps/vectreal-platform/app/components/publisher/sidebars/tool-sidebar.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/tool-sidebar.tsx
@@ -6,6 +6,7 @@ import {
 } from '@shared/components/ui/tooltip'
 import { cn } from '@shared/utils'
 import { User } from '@supabase/supabase-js'
+import { motion } from 'framer-motion'
 import { useAtomValue, useSetAtom } from 'jotai/react'
 import { memo, useCallback } from 'react'
 
@@ -17,6 +18,7 @@ import {
 import { DynamicSidebar } from './dynamic-sidebar'
 import {
 	arePublisherActionsDisabledAtom,
+	isPreviewModeAtom,
 	processAtom,
 	toolSidebarStateAtom
 } from '../../../lib/stores/publisher-config-store'
@@ -39,6 +41,7 @@ export const ToolSidebar = memo(
 		const arePublisherActionsDisabled = useAtomValue(
 			arePublisherActionsDisabledAtom
 		)
+		const isPreviewMode = useAtomValue(isPreviewModeAtom)
 		const setProcessState = useSetAtom(processAtom)
 		const activeToolDefinition = getComposeToolDefinition(activeComposeTool)
 
@@ -76,11 +79,21 @@ export const ToolSidebar = memo(
 		return (
 			<>
 				{/* Anchored to the canvas stage, so the rail starts below the header. */}
-				<div className={cn(
-						"absolute top-0 left-0 hidden flex-col gap-2 md:flex",
+				<motion.div
+					// Editing tools have no meaning in preview mode, so the rail leaves
+					// instead of sitting there disabled.
+					animate={
+						isPreviewMode ? { opacity: 0, x: -8 } : { opacity: 1, x: 0 }
+					}
+					transition={{ duration: 0.24, ease: [0.4, 0, 0.2, 1] }}
+					aria-hidden={isPreviewMode}
+					className={cn(
+						'absolute top-0 left-0 hidden flex-col gap-2 md:flex',
 						PUBLISHER_EDGE_INSET,
-						PUBLISHER_LAYER.toolRail
-					)}>
+						PUBLISHER_LAYER.toolRail,
+						isPreviewMode && 'pointer-events-none'
+					)}
+				>
 					{COMPOSE_TOOL_DEFINITIONS.map(({ value, icon: Icon, shortLabel }) => {
 						const isActive = value === activeComposeTool && showSidebar
 						return (
@@ -111,7 +124,7 @@ export const ToolSidebar = memo(
 							</Tooltip>
 						)
 					})}
-				</div>
+				</motion.div>
 
 				<DynamicSidebar
 					open={showSidebar}

--- a/apps/vectreal-platform/app/components/scene-embed/preview-chrome/camera-switcher-pill.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/preview-chrome/camera-switcher-pill.tsx
@@ -1,14 +1,12 @@
 import {
 	Button,
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue
+	Popover,
+	PopoverContent,
+	PopoverTrigger
 } from '@shared/components'
 import { cn } from '@shared/utils'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { useCallback, useMemo } from 'react'
+import { Check, ChevronLeft, ChevronRight } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
 
 export interface CameraSwitcherOption {
 	cameraId: string
@@ -23,11 +21,23 @@ export interface CameraSwitcherPillProps {
 }
 
 /**
- * `‹ Camera name ›` in a floating pill.
+ * Below this, stepping through is faster than opening a list, so the name is
+ * plain text and a dropdown affordance would be promising something pointless.
+ */
+const LIST_THRESHOLD = 3
+
+/**
+ * `‹ Camera name  2/5 ›` in a floating pill.
  *
  * Presentational on purpose: the publisher drives it from jotai atoms and the
- * internal preview drives it from the viewer's own `camera_changed` events. Two
- * data sources, one visual, so switching cameras looks identical in both.
+ * internal preview from the viewer's own `camera_changed` events. Two data
+ * sources, one visual.
+ *
+ * There is deliberately no select control here. A bordered field sitting on the
+ * pill's matte surface reads as stuck on rather than part of it, and at the same
+ * value as its container the border has to do all the work of separating them.
+ * Arrows are the real action, so they carry the control, the name is quiet text,
+ * and the counter supplies the orientation a dropdown only implied.
  */
 const CameraSwitcherPill = ({
 	cameras,
@@ -35,6 +45,8 @@ const CameraSwitcherPill = ({
 	onSelect,
 	className
 }: CameraSwitcherPillProps) => {
+	const [isListOpen, setIsListOpen] = useState(false)
+
 	// Falling back to the first camera keeps the control labelled before the
 	// viewer has reported which camera it opened on.
 	const activeIndex = useMemo(() => {
@@ -60,19 +72,43 @@ const CameraSwitcherPill = ({
 		[activeIndex, cameras, onSelect]
 	)
 
+	const handleSelect = useCallback(
+		(cameraId: string) => {
+			onSelect(cameraId)
+			setIsListOpen(false)
+		},
+		[onSelect]
+	)
+
 	const isCyclable = cameras.length > 1
+	const hasList = cameras.length > LIST_THRESHOLD
+	const activeName = activeCamera?.name || 'Unnamed Camera'
+
+	const label = (
+		<>
+			{/* Announced on change so the camera is not a purely visual state. */}
+			<span className="truncate" aria-live="polite">
+				{activeName}
+			</span>
+			{isCyclable ? (
+				<span className="text-muted-foreground text-[11px] tabular-nums">
+					{activeIndex + 1}/{cameras.length}
+				</span>
+			) : null}
+		</>
+	)
 
 	return (
 		<div
 			className={cn(
-				'bg-muted/92 border-border/70 flex items-center gap-2 rounded-2xl border px-2 py-1.5 shadow-2xl backdrop-blur-2xl',
+				'bg-muted/92 border-border/70 flex items-center gap-0.5 rounded-2xl border p-1 shadow-2xl backdrop-blur-2xl',
 				className
 			)}
 		>
 			<Button
 				variant="ghost"
 				size="icon"
-				className="h-8 w-8 rounded-xl"
+				className="h-8 w-8 shrink-0 rounded-xl"
 				onClick={() => cycle(-1)}
 				disabled={!isCyclable}
 				aria-label="Previous camera"
@@ -80,23 +116,64 @@ const CameraSwitcherPill = ({
 				<ChevronLeft className="h-4 w-4" />
 			</Button>
 
-			<Select value={activeCamera?.cameraId ?? ''} onValueChange={onSelect}>
-				<SelectTrigger className="h-8 min-w-44 rounded-xl text-xs">
-					<SelectValue placeholder="Select camera" />
-				</SelectTrigger>
-				<SelectContent>
-					{cameras.map((camera) => (
-						<SelectItem key={camera.cameraId} value={camera.cameraId}>
-							{camera.name || 'Unnamed Camera'}
-						</SelectItem>
-					))}
-				</SelectContent>
-			</Select>
+			{hasList ? (
+				<Popover open={isListOpen} onOpenChange={setIsListOpen}>
+					<PopoverTrigger asChild>
+						<Button
+							variant="ghost"
+							className="h-8 min-w-40 justify-center gap-2 rounded-xl px-3 text-xs font-medium"
+							aria-label={`Camera: ${activeName}. Choose a camera`}
+						>
+							{label}
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent
+						align="center"
+						sideOffset={8}
+						className="bg-muted/92 border-border/70 w-56 rounded-2xl border p-1 shadow-2xl backdrop-blur-2xl"
+					>
+						<div role="listbox" aria-label="Cameras">
+							{cameras.map((camera, index) => {
+								const isActive = index === activeIndex
+								return (
+									<button
+										key={camera.cameraId}
+										type="button"
+										role="option"
+										aria-selected={isActive}
+										onClick={() => handleSelect(camera.cameraId)}
+										className={cn(
+											// A neutral tint rather than `bg-accent`: this is a glass
+									// surface floating over the scene, and the row should
+									// separate from it by value alone.
+									'hover:bg-foreground/10 focus-visible:bg-foreground/10 focus-visible:ring-ring flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-xs transition-colors focus-visible:ring-2 focus-visible:outline-none',
+											// The active row is marked, not filled. A solid accent
+											// block here fights the matte surface it sits on.
+											isActive && 'text-primary font-medium'
+										)}
+									>
+										<span className="truncate">
+											{camera.name || 'Unnamed Camera'}
+										</span>
+										{isActive ? (
+											<Check className="ml-auto h-3.5 w-3.5 shrink-0" />
+										) : null}
+									</button>
+								)
+							})}
+						</div>
+					</PopoverContent>
+				</Popover>
+			) : (
+				<div className="flex h-8 min-w-40 items-center justify-center gap-2 px-3 text-xs font-medium">
+					{label}
+				</div>
+			)}
 
 			<Button
 				variant="ghost"
 				size="icon"
-				className="h-8 w-8 rounded-xl"
+				className="h-8 w-8 shrink-0 rounded-xl"
 				onClick={() => cycle(1)}
 				disabled={!isCyclable}
 				aria-label="Next camera"

--- a/apps/vectreal-platform/app/components/scene-embed/preview-chrome/preview-chrome.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/preview-chrome/preview-chrome.tsx
@@ -1,13 +1,14 @@
 import { Button } from '@shared/components'
 import { cn } from '@shared/utils'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
-import { ArrowLeft, Eye, EyeOff } from 'lucide-react'
+import { Eye, EyeOff } from 'lucide-react'
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router'
 
 import CameraSwitcherPill, {
 	type CameraSwitcherOption
 } from './camera-switcher-pill'
+import PreviewExitBadge from './preview-exit-badge'
 import { useChromeVisibility } from './use-chrome-visibility'
 
 export interface PreviewChromeProps {
@@ -73,14 +74,12 @@ const PreviewChrome = ({
 							exit={{ y: -offset }}
 							transition={fade}
 						>
-							<Button
-								variant="ghost"
-								onClick={handleExit}
-								className={cn(PILL_SURFACE, 'h-10 gap-2 px-3 text-xs')}
-							>
-								<ArrowLeft className="h-4 w-4" />
-								Back
-							</Button>
+							{/* Same badge the publisher's in-canvas preview uses, so
+							    leaving a preview looks the same wherever you are. */}
+							<PreviewExitBadge
+								exitLabel="Back to scene"
+								onExit={handleExit}
+							/>
 						</motion.div>
 
 						<motion.div

--- a/apps/vectreal-platform/app/components/scene-embed/preview-chrome/preview-exit-badge.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/preview-chrome/preview-exit-badge.tsx
@@ -1,0 +1,48 @@
+import { Button } from '@shared/components'
+import { cn } from '@shared/utils'
+import { X } from 'lucide-react'
+
+export interface PreviewExitBadgeProps {
+	/** The mode this badge names. */
+	label?: string
+	/** Accessible name for the exit control; also its tooltip. */
+	exitLabel: string
+	onExit: () => void
+	className?: string
+}
+
+/**
+ * "You are previewing, and here is the way out."
+ *
+ * Shared by the publisher's in-canvas preview mode and the standalone `/preview`
+ * route so leaving a preview looks and reads the same in both, the way
+ * `CameraSwitcherPill` already does for switching cameras. Two very different
+ * exits — one clears a jotai flag, the other navigates — behind one affordance.
+ */
+const PreviewExitBadge = ({
+	label = 'Preview',
+	exitLabel,
+	onExit,
+	className
+}: PreviewExitBadgeProps) => (
+	<div
+		className={cn(
+			'bg-muted/92 border-border/70 flex items-center gap-1 rounded-2xl border py-1 pr-1 pl-3 shadow-2xl backdrop-blur-2xl',
+			className
+		)}
+	>
+		<span className="text-xs font-medium">{label}</span>
+		<Button
+			variant="ghost"
+			size="icon"
+			onClick={onExit}
+			aria-label={exitLabel}
+			title={exitLabel}
+			className="h-7 w-7 rounded-xl"
+		>
+			<X className="h-3.5 w-3.5" />
+		</Button>
+	</div>
+)
+
+export default PreviewExitBadge

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
@@ -21,6 +21,7 @@ import {
 	ChevronDown,
 	ChevronRight,
 	Cloud,
+	Eye,
 	Info,
 	Radio,
 	Rocket,
@@ -574,15 +575,26 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 								/>
 							</div>
 							<div className="flex shrink-0 flex-col gap-3 max-md:w-full xl:justify-end">
-								<Button asChild className="w-full">
+								{/*
+								  Stacked actions, so both are left-aligned rather than
+								  centred: centring puts each icon at a different x because
+								  the labels differ in width, and the icons stop reading as a
+								  column.
+								*/}
+								<Button asChild className="w-full justify-start">
 									<Link viewTransition to={previewPath}>
+										<Eye className="mr-2 h-4 w-4 shrink-0" />
 										Preview
 									</Link>
 								</Button>
 
-								<Button variant="secondary" asChild>
+								<Button
+									variant="secondary"
+									asChild
+									className="w-full justify-start"
+								>
 									<Link viewTransition to={`/publisher/${sceneState.id}`}>
-										<Rocket className="mr-2 h-4 w-4" />
+										<Rocket className="mr-2 h-4 w-4 shrink-0" />
 										Open in Publisher
 									</Link>
 								</Button>


### PR DESCRIPTION
PR 13 of the preview/embed stack.

## Show, do not tell

Entering preview was announced by an amber paragraph **in a sidebar that preview
mode itself had just closed**, and the toggle carried a line of prose explaining
what it did. Both deleted. The canvas carries the state now:

- Tool rail and publish card animate out. Editing tools have no meaning in
  preview, so they leave rather than sit there disabled.
- A "Preview" badge sits top-left, in the space the rail just vacated, carrying
  the exit control.

Top-left is the only edge position that collides with nothing: `publisher-view-cube.tsx:26`
puts the nav cube at `bottom-left` and the camera controls own bottom-center.

### A bug this fixes

The badge lives on the shell rather than beside the camera controls, because it
has to exist when a scene has **no cameras**. The old "Exit Preview" tab was
attached to `PreviewCameraControls`, which renders nothing in that case, so a
camera-less scene could enter preview with no way out once the sidebar closed.

## Shared exit badge

`preview-exit-badge.tsx` is shared with the `/preview` route, which drops its own
back button for it. Leaving a preview now looks the same wherever you are: two
very different exits, one clearing a jotai flag and one navigating, behind one
affordance. Same pattern as `CameraSwitcherPill`.

## Camera switcher rework

The select is gone. A bordered field on the pill's matte surface read as stuck
on rather than part of it, and at the same value as its container the border had
to do all the work of separating the two.

```
before   ‹  [ Hero View            ⌄ ]  ›     bordered field on matte pill
after    ‹        Hero View   2/5       ›     one plane, no field
```

Arrows carry the control because they are the real action. The name is quiet
text with a position counter supplying the orientation the dropdown only
implied, and a list appears **only above three cameras**, where stepping through
stops being faster than opening a menu. The list marks the active row with
colour and a check rather than filling it with a solid block.

## Open full preview

The handoff between the two preview tools: in-canvas preview reviews cameras
while composing, the full preview is the saved scene on its own route. Opens in
a new tab so the publisher and any unsaved work stay put, and is disabled with a
tooltip until the scene has both ids. On its own row, since sharing the
trigger's axis squashed both.

## Dashboard scene detail

Both actions are left-aligned now. Centring put each icon at a different x
because the labels differ in width, so the icons stopped reading as a column.
Preview also regains the icon it lost when its dropdown was removed in #662.

## Verification

Placement, the sidebar row, and the switcher were all checked in the browser.

| Check | Result |
| --- | --- |
| `nx typecheck vectreal-platform` | pass |
| `nx lint vectreal-platform` | pass |
| `npx vitest run --root apps/vectreal-platform` | 221 passed, 31 files |
| `nx build vectreal-platform` | pass |

## Follow-up, not in here

The camera list uses a neutral tint rather than `bg-accent`, because
`globals.css:31,134` sets `--accent: var(--orange)`. That makes the shadcn
hover/focus token a solid brand block, which is why the publisher and dashboard
user menus look the way they do. It is referenced by 11 shared UI components and
24 app files, so it is getting its own PR rather than riding along here.
