### PR TITLE
fix(ui): separate the brand colour from the hover token

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/billing/billing-settings-section.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/billing/billing-settings-section.tsx
@@ -135,7 +135,7 @@ function StatTile({
 				className={cn(
 					'text-2xl font-semibold tracking-tight tabular-nums',
 					isCritical && 'text-destructive',
-					isWarning && !isCritical && 'text-accent!'
+					isWarning && !isCritical && 'text-orange!'
 				)}
 			>
 				{current.toLocaleString()}
@@ -149,7 +149,7 @@ function StatTile({
 					className={cn(
 						'h-1',
 						isCritical && '[&>div]:bg-destructive',
-						isWarning && !isCritical && '[&>div]:bg-accent!'
+						isWarning && !isCritical && '[&>div]:bg-orange!'
 					)}
 				/>
 			)}
@@ -189,7 +189,7 @@ function MeterRow({
 					className={cn(
 						'text-xs font-medium tabular-nums',
 						isCritical && 'text-destructive',
-						isWarning && !isCritical && 'text-accent!'
+						isWarning && !isCritical && 'text-orange!'
 					)}
 				>
 					{current.toLocaleString()}
@@ -202,7 +202,7 @@ function MeterRow({
 					className={cn(
 						'h-1',
 						isCritical && '[&>div]:bg-destructive',
-						isWarning && !isCritical && '[&>div]:bg-accent!'
+						isWarning && !isCritical && '[&>div]:bg-orange!'
 					)}
 				/>
 			)}

--- a/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
@@ -32,7 +32,7 @@ function KpiTile({
 }) {
 	return (
 		<div className="bg-muted/30 hover:bg-muted/40 flex items-end gap-3 rounded-2xl p-5 pb-4 transition-colors duration-200">
-			<p className="text-accent! mb-1 min-w-6 text-right text-3xl leading-6! font-semibold">
+			<p className="text-orange! mb-1 min-w-6 text-right text-3xl leading-6! font-semibold">
 				{value}
 			</p>
 			<div className="flex items-baseline gap-3">
@@ -74,7 +74,7 @@ export function DashboardOverview({ kpis }: DashboardOverviewProps) {
 				</div>
 				<div className="border-muted/50 group relative h-50 w-full overflow-hidden rounded-2xl border md:h-full">
 					<div className="h-full opacity-75 blur-[50px]">
-						<div className="bg-accent absolute top-1/2 left-1/2 h-80 w-80 -translate-x-1/2 -translate-y-1/2" />
+						<div className="bg-orange absolute top-1/2 left-1/2 h-80 w-80 -translate-x-1/2 -translate-y-1/2" />
 						<div className="absolute top-1/2 left-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 bg-white" />
 					</div>
 					<div className="from-background/75 absolute inset-0 bottom-0 h-full rounded-xl bg-linear-to-t to-transparent opacity-100 transition-opacity duration-500 group-hover:opacity-25" />

--- a/apps/vectreal-platform/app/components/dashboard/inline-editable-metadata-field.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/inline-editable-metadata-field.tsx
@@ -54,9 +54,9 @@ export function InlineEditableMetadataField({
 	}, [isEditing, multiline])
 
 	const indicatorClass = isSaving
-		? 'bg-accent animate-pulse'
+		? 'bg-orange animate-pulse'
 		: isUnsaved
-			? 'bg-accent'
+			? 'bg-orange'
 			: isSaved
 				? 'opacity-0'
 				: 'bg-muted-foreground/35'

--- a/apps/vectreal-platform/app/components/dashboard/logo-sidebar.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/logo-sidebar.tsx
@@ -54,7 +54,7 @@ const LogoSidebar = ({ children, ...sidebarProps }: LogoSidebarProps) => {
 							<Link to="/dashboard" viewTransition>
 								{smallLogo || !open ? (
 									<div className="flex aspect-square size-8 items-center">
-										<VectrealLogoSmall className="text-accent fill-accent size-4" />
+										<VectrealLogoSmall className="text-orange fill-accent size-4" />
 									</div>
 								) : (
 									<div className="flex items-center pl-2">

--- a/apps/vectreal-platform/app/components/global-navigation-loader.tsx
+++ b/apps/vectreal-platform/app/components/global-navigation-loader.tsx
@@ -24,13 +24,13 @@ export function GlobalNavigationLoader() {
 		<div className="pointer-events-none fixed top-0 left-0 z-50 w-full">
 			<div
 				className={cn(
-					'bg-accent h-1 w-full origin-left transition-all duration-300',
+					'bg-orange h-1 w-full origin-left transition-all duration-300',
 					isNavigating
 						? 'animate-loading-bar opacity-100'
 						: 'scale-x-100 opacity-0'
 				)}
 			>
-				<div className="bg-accent/50 animate-loading-shimmer h-full w-full" />
+				<div className="bg-orange/50 animate-loading-shimmer h-full w-full" />
 			</div>
 		</div>
 	)

--- a/apps/vectreal-platform/app/components/home/bento-card.tsx
+++ b/apps/vectreal-platform/app/components/home/bento-card.tsx
@@ -85,7 +85,7 @@ export function BentoCard({
 				className={cn(
 					'relative h-full overflow-hidden rounded-2xl border p-5 transition-colors duration-300',
 					'bg-surface-1 border-surface-border',
-					glow && 'hover:border-accent/30',
+					glow && 'hover:border-orange/30',
 					'flex flex-col gap-3.5'
 				)}
 			>

--- a/apps/vectreal-platform/app/components/home/cinematic-hero.tsx
+++ b/apps/vectreal-platform/app/components/home/cinematic-hero.tsx
@@ -62,7 +62,7 @@ export function CinematicHero() {
 							className="bg-surface-1/70 border-surface-border inline-flex items-center gap-2 rounded-full border px-3 py-1.5 backdrop-blur-sm"
 						>
 							<span
-								className="bg-accent h-1.5 w-1.5 animate-pulse rounded-full"
+								className="bg-orange h-1.5 w-1.5 animate-pulse rounded-full"
 								aria-hidden="true"
 							/>
 							<span className="text-eyebrow text-muted-foreground">
@@ -76,7 +76,7 @@ export function CinematicHero() {
 						>
 							<span>Upload.</span>
 							<span>Prepare.</span>
-							<span className="text-accent">Publish.</span>
+							<span className="text-orange">Publish.</span>
 						</motion.h1>
 
 						<motion.p
@@ -95,7 +95,7 @@ export function CinematicHero() {
 							<Button
 								asChild
 								size="lg"
-								className="group bg-accent hover:bg-accent/90 text-white shadow-[0_8px_30px_-8px_var(--surface-glow)]"
+								className="group bg-orange hover:bg-orange/90 text-white shadow-[0_8px_30px_-8px_var(--surface-glow)]"
 							>
 								<Link to="/publisher">
 									Publish Your First Model
@@ -150,7 +150,7 @@ export function CinematicHero() {
 						<div className="border-surface-border/50 absolute aspect-square w-full max-w-[680px] rounded-full border" />
 						<div className="border-surface-border/75 absolute aspect-square w-1/2 max-w-[360px] rounded-full border" />
 						<div className="animate-spin-slow absolute aspect-square w-3/4 max-w-[540px]">
-							<span className="bg-accent absolute top-0 left-1/2 size-2 -translate-y-1/2 rounded-full shadow-[0_0_12px_2px_var(--accent)]" />
+							<span className="bg-orange absolute top-0 left-1/2 size-2 -translate-y-1/2 rounded-full shadow-[0_0_12px_2px_var(--orange)]" />
 						</div>
 					</div>
 

--- a/apps/vectreal-platform/app/components/home/gradient-cta-block.tsx
+++ b/apps/vectreal-platform/app/components/home/gradient-cta-block.tsx
@@ -83,7 +83,7 @@ export function GradientCtaBlock({
 					<Button
 						asChild
 						size="lg"
-						className="bg-accent hover:bg-accent/90 rounded-xl px-8 text-white"
+						className="bg-orange hover:bg-orange/90 rounded-xl px-8 text-white"
 					>
 						<Link to={primaryCta.to}>{primaryCta.label}</Link>
 					</Button>

--- a/apps/vectreal-platform/app/components/home/grid-bg.tsx
+++ b/apps/vectreal-platform/app/components/home/grid-bg.tsx
@@ -8,7 +8,7 @@ const GridBg = ({ isMobile }: GridBgProps) => {
 	return (
 		<div className="bg-background absolute inset-0 z-0 h-full w-full">
 			{/* Radial background behind grid items  */}
-			<div className="from-accent/35 absolute inset-0 bg-radial-[ellipse_at_center] to-transparent transform-3d" />
+			<div className="from-orange/35 absolute inset-0 bg-radial-[ellipse_at_center] to-transparent transform-3d" />
 			{/* Grid items */}
 			<div className="absolute inset-0 grid grid-cols-16 grid-rows-4 gap-[1px] max-md:grid-cols-8">
 				{Array.from({ length: isMobile ? 32 : 64 }).map((_, index) => (
@@ -18,7 +18,7 @@ const GridBg = ({ isMobile }: GridBgProps) => {
 
 			{/* Overlay to create glow effect */}
 			<div className="absolute inset-0 mix-blend-color-dodge blur-xl">
-				<div className="from-accent/50 absolute inset-0 bg-radial-[ellipse_at_center] to-transparent transform-3d" />
+				<div className="from-orange/50 absolute inset-0 bg-radial-[ellipse_at_center] to-transparent transform-3d" />
 				<div className="absolute inset-0 grid grid-cols-16 grid-rows-4 gap-[1px] max-md:grid-cols-8 max-md:grid-rows-4">
 					{Array.from({ length: isMobile ? 32 : 64 }).map((_, index) => (
 						<div key={index} className={cn('bg-background rounded-sm')} />

--- a/apps/vectreal-platform/app/components/home/how-it-works-showcase.tsx
+++ b/apps/vectreal-platform/app/components/home/how-it-works-showcase.tsx
@@ -97,7 +97,7 @@ function UploadGraphic() {
 					transition={{ type: 'spring', stiffness: 220, damping: 16 }}
 					className="bg-surface-2 border-surface-border flex size-20 items-center justify-center rounded-2xl border shadow-2xl"
 				>
-					<FileBox className="text-accent size-9" />
+					<FileBox className="text-orange size-9" />
 				</motion.div>
 			</div>
 			<div className="w-full max-w-md">
@@ -107,14 +107,14 @@ function UploadGraphic() {
 						initial={{ opacity: 0 }}
 						animate={{ opacity: 1 }}
 						transition={{ delay: 1.6 }}
-						className="text-accent"
+						className="text-orange"
 					>
 						uploaded
 					</motion.span>
 				</div>
 				<div className="bg-surface-2 h-2 w-full overflow-hidden rounded-full">
 					<motion.div
-						className="bg-accent h-full rounded-full"
+						className="bg-orange h-full rounded-full"
 						initial={{ width: '0%' }}
 						animate={{ width: '100%' }}
 						transition={{ duration: 1.4, ease: easeOut, delay: 0.3 }}
@@ -139,7 +139,7 @@ function OptimizeGraphic() {
 				>
 					<span className="text-foreground text-sm">{task}</span>
 					<motion.span
-						className="bg-accent flex size-6 items-center justify-center rounded-full text-white"
+						className="bg-orange flex size-6 items-center justify-center rounded-full text-white"
 						initial={{ scale: 0 }}
 						animate={{ scale: 1 }}
 						transition={{
@@ -162,7 +162,7 @@ function OptimizeGraphic() {
 				<span className="text-muted-foreground text-sm line-through">
 					124 MB
 				</span>
-				<span className="text-accent text-lg font-medium">→ 3.2 MB</span>
+				<span className="text-orange text-lg font-medium">→ 3.2 MB</span>
 			</motion.div>
 		</div>
 	)
@@ -178,7 +178,7 @@ function ManageGraphic() {
 				animate={{ opacity: 1, y: 0 }}
 				transition={stageTransition}
 			>
-				<Cloud className="text-accent size-4" />
+				<Cloud className="text-orange size-4" />
 				<span className="text-muted-foreground text-xs">Synced to cloud</span>
 			</motion.div>
 			<div className="flex w-full max-w-sm flex-col gap-2">
@@ -187,7 +187,7 @@ function ManageGraphic() {
 						key={v}
 						className={cn(
 							'border-surface-border flex items-center justify-between rounded-xl border px-4 py-3',
-							i === 0 ? 'border-accent/30' : 'bg-surface-2/40'
+							i === 0 ? 'border-orange/30' : 'bg-surface-2/40'
 						)}
 						initial={{ opacity: 0, y: 14, scale: 0.96 }}
 						animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -201,7 +201,7 @@ function ManageGraphic() {
 						>
 							{v}
 						</span>
-						{i === 0 && <span className="bg-accent size-1.5 rounded-full" />}
+						{i === 0 && <span className="bg-orange size-1.5 rounded-full" />}
 					</motion.div>
 				))}
 			</div>
@@ -224,19 +224,19 @@ function PublishGraphic() {
 					transition={{ duration: 1.3, ease: 'linear', delay: 0.3 }}
 				>
 					<span className="text-foreground">{'<iframe src='}</span>
-					<span className="text-accent">{'"vectreal.com/…"'}</span>
+					<span className="text-orange">{'"vectreal.com/…"'}</span>
 					<span className="text-foreground">{' />'}</span>
 				</motion.div>
 			</div>
 			<motion.div
-				className="border-accent/30 inline-flex items-center gap-2 rounded-full border px-3 py-1.5"
+				className="border-orange/30 inline-flex items-center gap-2 rounded-full border px-3 py-1.5"
 				initial={{ opacity: 0, scale: 0.9 }}
 				animate={{ opacity: 1, scale: 1 }}
 				transition={{ delay: 1.7, type: 'spring', stiffness: 300, damping: 18 }}
 			>
 				<span className="relative flex size-2">
-					<span className="bg-accent absolute inline-flex size-full animate-ping rounded-full opacity-60" />
-					<span className="bg-accent relative inline-flex size-2 rounded-full" />
+					<span className="bg-orange absolute inline-flex size-full animate-ping rounded-full opacity-60" />
+					<span className="bg-orange relative inline-flex size-2 rounded-full" />
 				</span>
 				<span className="text-xs font-medium text-white">Live</span>
 			</motion.div>
@@ -332,7 +332,7 @@ export function HowItWorksShowcase({ className }: { className?: string }) {
 								className={cn(
 									'group relative flex w-full items-start gap-4 overflow-hidden rounded-2xl border p-4 text-left transition-colors duration-300',
 									isActive
-										? 'border-accent/30 bg-surface-2'
+										? 'border-orange/30 bg-surface-2'
 										: 'border-surface-border bg-surface-1 hover:bg-surface-1/80'
 								)}
 							>
@@ -340,7 +340,7 @@ export function HowItWorksShowcase({ className }: { className?: string }) {
 								{isActive && !prefersReducedMotion && (
 									<span
 										ref={progressBarRef}
-										className="bg-accent/70 absolute bottom-0 left-0 h-0.5"
+										className="bg-orange/70 absolute bottom-0 left-0 h-0.5"
 										style={{ width: '0%' }}
 									/>
 								)}
@@ -348,7 +348,7 @@ export function HowItWorksShowcase({ className }: { className?: string }) {
 									className={cn(
 										'flex size-10 shrink-0 items-center justify-center rounded-xl border transition-colors duration-300',
 										isActive
-											? 'border-accent/40 bg-accent bg-opacity-10'
+											? 'border-orange/40 bg-orange bg-opacity-10'
 											: 'border-surface-border bg-surface-0/60'
 									)}
 								>
@@ -399,7 +399,7 @@ export function HowItWorksShowcase({ className }: { className?: string }) {
 												<step.icon
 													className={cn(
 														'size-5 transition-colors duration-300',
-														isActive ? 'text-accent' : 'text-muted-foreground'
+														isActive ? 'text-orange' : 'text-muted-foreground'
 													)}
 												/>
 											</motion.span>
@@ -411,7 +411,7 @@ export function HowItWorksShowcase({ className }: { className?: string }) {
 										<span
 											className={cn(
 												'text-xs font-medium tabular-nums transition-colors',
-												isActive ? 'text-accent' : 'text-muted-foreground/50'
+												isActive ? 'text-orange' : 'text-muted-foreground/50'
 											)}
 										>
 											0{String(step.index + 1)}

--- a/apps/vectreal-platform/app/components/home/optimization-grid-bg.tsx
+++ b/apps/vectreal-platform/app/components/home/optimization-grid-bg.tsx
@@ -80,7 +80,7 @@ export function OptimizationGridBg({ className }: OptimizationGridBgProps) {
 
 				{/* Funnel: dense on the left, merged and simplified on the right */}
 				<g
-					stroke="var(--accent)"
+					stroke="var(--orange)"
 					strokeWidth={1.5}
 					strokeLinecap="round"
 					opacity={0.16}

--- a/apps/vectreal-platform/app/components/home/optimization-visual.tsx
+++ b/apps/vectreal-platform/app/components/home/optimization-visual.tsx
@@ -91,13 +91,13 @@ export function OptimizationVisual({ className }: { className?: string }) {
 							<span className="text-foreground text-sm font-medium">
 								Vectreal optimized
 							</span>
-							<motion.span className="text-accent font-medium tabular-nums">
+							<motion.span className="text-orange font-medium tabular-nums">
 								{optMbStr}
 							</motion.span>
 						</div>
 						<div className="bg-surface-0 border-surface-border relative h-4 w-full overflow-hidden rounded-full border">
 							<motion.div
-								className="bg-accent absolute right-0 h-full rounded-full"
+								className="bg-orange absolute right-0 h-full rounded-full"
 								style={{ width: optWidthStr }}
 							/>
 						</div>
@@ -106,17 +106,17 @@ export function OptimizationVisual({ className }: { className?: string }) {
 
 				{/* Reduction badge */}
 				<div className="flex flex-col items-start gap-3 lg:items-center lg:text-center">
-					<div className="border-accent/20 inline-flex items-center gap-2 rounded-full border px-3 py-1">
-						<TrendingDown className="text-accent size-3.5" aria-hidden="true" />
-						<span className="text-eyebrow text-accent/80">Smaller payload</span>
+					<div className="border-orange/20 inline-flex items-center gap-2 rounded-full border px-3 py-1">
+						<TrendingDown className="text-orange size-3.5" aria-hidden="true" />
+						<span className="text-eyebrow text-orange/80">Smaller payload</span>
 					</div>
 					<div className="text-stat text-foreground flex items-center">
 						<ArrowDown
-							className="text-accent mr-1 size-8 md:size-10"
+							className="text-orange mr-1 size-8 md:size-10"
 							aria-hidden="true"
 						/>
 						<motion.span>{reductionStr}</motion.span>
-						<span className="text-accent">%</span>
+						<span className="text-orange">%</span>
 					</div>
 					<p className="text-muted-foreground max-w-[28ch] text-sm leading-relaxed">
 						Automatic mesh decimation, texture compression, and Draco encoding —

--- a/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-chapter-rail.tsx
+++ b/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-chapter-rail.tsx
@@ -57,7 +57,7 @@ export function ChapterRail({
 			<motion.span
 				aria-hidden
 				style={{ x: indicatorX, width: '25%', willChange: 'transform' }}
-				className="bg-accent absolute bottom-0 left-0 h-px rounded-full"
+				className="bg-orange absolute bottom-0 left-0 h-px rounded-full"
 			/>
 			{CHAPTERS.map((c, i) => (
 				<button

--- a/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-embed-client.tsx
+++ b/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-embed-client.tsx
@@ -294,7 +294,7 @@ export default function MockShopEmbedClient({
 
 			<div className="absolute top-3 left-3 z-10">
 				<div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/30 px-3 py-1.5 backdrop-blur-sm">
-					<span className="bg-accent h-1.5 w-1.5 rounded-full" />
+					<span className="bg-orange h-1.5 w-1.5 rounded-full" />
 					<span className="text-xs font-medium tracking-wide text-white/55">
 						Powered by Vectreal
 					</span>

--- a/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-filmstrip.tsx
+++ b/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-filmstrip.tsx
@@ -13,7 +13,7 @@ import {
 function ChapterContent({ chapter }: { chapter: Chapter }) {
 	return (
 		<>
-			<p className="text-accent/80 text-[10px] font-semibold tracking-[0.22em] uppercase">
+			<p className="text-orange/80 text-[10px] font-semibold tracking-[0.22em] uppercase">
 				{chapter.label}
 			</p>
 
@@ -36,7 +36,7 @@ function ChapterContent({ chapter }: { chapter: Chapter }) {
 						<p className="text-foreground/25 text-[10px] tracking-[0.18em] uppercase">
 							Coupe · 4.0L Flat-6 · 510 HP · Jet Black Metallic
 						</p>
-						<p className="text-accent mt-1 text-2xl font-bold tracking-tight">
+						<p className="text-orange mt-1 text-2xl font-bold tracking-tight">
 							$182,900
 						</p>
 					</div>

--- a/apps/vectreal-platform/app/components/home/scroll-interaction-section/scroll-interaction-section.tsx
+++ b/apps/vectreal-platform/app/components/home/scroll-interaction-section/scroll-interaction-section.tsx
@@ -51,8 +51,8 @@ function ScrollInteractionSection({
 			{/* Section heading */}
 			<div className="from-background to-background/0 relative z-10 bg-linear-to-b px-4 py-16">
 				<div className="mx-auto max-w-7xl">
-					<div className="border-accent/20 bg-accent/5 text-accent/70 mb-4 inline-flex w-fit items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium tracking-widest uppercase">
-						<span className="bg-accent/60 h-1.5 w-1.5 rounded-full" />
+					<div className="border-orange/20 bg-orange/5 text-orange/70 mb-4 inline-flex w-fit items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium tracking-widest uppercase">
+						<span className="bg-orange/60 h-1.5 w-1.5 rounded-full" />
 						Live Embed
 					</div>
 					<h2

--- a/apps/vectreal-platform/app/components/home/section/section-label.tsx
+++ b/apps/vectreal-platform/app/components/home/section/section-label.tsx
@@ -8,12 +8,12 @@ interface SectionLabelProps {
 const SectionLabel = ({ children, className }: SectionLabelProps) => (
 	<div
 		className={cn(
-			'border-accent/20 bg-accent bg-opacity-5 text-accent/70 text-eyebrow -ml-1 inline-flex w-fit items-center gap-1.5 self-start rounded-full border px-3 py-1.5',
+			'border-orange/20 bg-orange bg-opacity-5 text-orange/70 text-eyebrow -ml-1 inline-flex w-fit items-center gap-1.5 self-start rounded-full border px-3 py-1.5',
 			className
 		)}
 	>
 		<span
-			className="bg-accent/60 h-1.5 w-1.5 rounded-full"
+			className="bg-orange/60 h-1.5 w-1.5 rounded-full"
 			aria-hidden="true"
 		/>
 		{children}

--- a/apps/vectreal-platform/app/components/home/social-proof-bar.tsx
+++ b/apps/vectreal-platform/app/components/home/social-proof-bar.tsx
@@ -29,7 +29,7 @@ export function SocialProofBar({ items, className }: SocialProofBarProps) {
 					className="text-muted-foreground inline-flex items-center gap-2 text-xs font-medium tracking-widest uppercase"
 				>
 					<span
-						className="bg-accent/60 inline-block h-1 w-1 rounded-full"
+						className="bg-orange/60 inline-block h-1 w-1 rounded-full"
 						aria-hidden="true"
 					/>
 					{item.text}

--- a/apps/vectreal-platform/app/components/home/stat-ring.tsx
+++ b/apps/vectreal-platform/app/components/home/stat-ring.tsx
@@ -74,7 +74,7 @@ export function StatRing({
 			ref={ref}
 			className={cn(
 				'bg-surface-1 border-surface-border group flex flex-col items-center gap-4 rounded-2xl border p-6 text-center transition-[transform,border-color] duration-300',
-				'hover:border-accent/30 hover:-translate-y-1',
+				'hover:border-orange/30 hover:-translate-y-1',
 				className
 			)}
 		>
@@ -104,7 +104,7 @@ export function StatRing({
 						cy={SIZE / 2}
 						r={RADIUS}
 						fill="none"
-						stroke="var(--accent)"
+						stroke="var(--orange)"
 						strokeWidth={STROKE}
 						strokeLinecap="round"
 						strokeDasharray={CIRCUMFERENCE}
@@ -117,7 +117,7 @@ export function StatRing({
 						style={{ fontSize: '2.25rem', letterSpacing: '-0.03em' }}
 					>
 						<motion.span>{rounded}</motion.span>
-						<span className="text-accent">{suffix}</span>
+						<span className="text-orange">{suffix}</span>
 					</span>
 				</div>
 			</div>

--- a/apps/vectreal-platform/app/components/layout-components/basic-card.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/basic-card.tsx
@@ -33,13 +33,13 @@ const BasicCard = ({
 		>
 			<div
 				className={cn(
-					'bg-accent/60 absolute top-0 left-0 z-0 m-3 mt-0! h-2 animate-pulse rounded-full blur-xl transition-all md:m-6',
+					'bg-orange/60 absolute top-0 left-0 z-0 m-3 mt-0! h-2 animate-pulse rounded-full blur-xl transition-all md:m-6',
 					highlightClasses
 				)}
 			/>
 			<div
 				className={cn(
-					'bg-accent absolute top-0 left-0 z-10 m-3 mt-0! h-1 w-8 rounded-b-full transition-all md:m-6',
+					'bg-orange absolute top-0 left-0 z-10 m-3 mt-0! h-1 w-8 rounded-b-full transition-all md:m-6',
 					highlightClasses
 				)}
 			/>

--- a/apps/vectreal-platform/app/components/layout-components/page-hero.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/page-hero.tsx
@@ -25,14 +25,14 @@ const PageHero = ({
 	return (
 		<div
 			className={cn(
-				'from-accent/10 relative isolate overflow-hidden bg-linear-to-b via-transparent to-transparent',
+				'from-orange/10 relative isolate overflow-hidden bg-linear-to-b via-transparent to-transparent',
 				className
 			)}
 		>
 			{/* Decorative radial accent gradients - purely visual, pointer-events off */}
 			<div
 				aria-hidden="true"
-				className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_15%_25%,hsl(var(--accent)/0.14),transparent_42%),radial-gradient(circle_at_82%_12%,hsl(var(--accent)/0.09),transparent_45%)]"
+				className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_15%_25%,hsl(var(--orange)/0.14),transparent_42%),radial-gradient(circle_at_82%_12%,hsl(var(--orange)/0.09),transparent_45%)]"
 			/>
 
 			<div className="mx-auto max-w-7xl px-6 pt-24 pb-16">

--- a/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
+++ b/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
@@ -183,7 +183,7 @@ function MobileNav({
 										className={cn(
 											'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors',
 											isActive
-												? 'bg-accent bg-opacity-10 text-accent'
+												? 'bg-orange bg-opacity-10 text-orange'
 												: 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
 										)}
 									>
@@ -191,7 +191,7 @@ function MobileNav({
 										{item.label}
 										{isActive && (
 											<motion.div
-												className="bg-accent ml-auto h-1.5 w-1.5 rounded-full"
+												className="bg-orange ml-auto h-1.5 w-1.5 rounded-full"
 												layoutId="mobile-active-dot"
 											/>
 										)}

--- a/apps/vectreal-platform/app/components/publisher/optimization/panels/fields/mesh-reduction-field.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/panels/fields/mesh-reduction-field.tsx
@@ -87,7 +87,7 @@ export const MeshReductionField: FC = () => {
 							<p className="text-sm font-semibold">Target</p>
 							<InfoTooltip content="The share of the mesh to keep. Lower keeps fewer triangles and reduces detail further." />
 						</div>
-						<span className="text-accent text-xs font-medium">
+						<span className="text-orange text-xs font-medium">
 							Keep {Math.round(getClosestValue(KEEP_PRESETS, ratio) * 100)}%
 						</span>
 					</div>
@@ -104,7 +104,7 @@ export const MeshReductionField: FC = () => {
 							<p className="text-sm font-semibold">Deviation limit</p>
 							<InfoTooltip content="The maximum shape deviation allowed. The simplifier stops as soon as further collapses would exceed this, even if the target has not been reached." />
 						</div>
-						<span className="text-accent text-xs font-medium">
+						<span className="text-orange text-xs font-medium">
 							{getClosestValue(DEVIATION_PRESETS, error).toFixed(3)}
 						</span>
 					</div>

--- a/apps/vectreal-platform/app/components/publisher/optimization/panels/fields/texture-field.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/panels/fields/texture-field.tsx
@@ -98,7 +98,7 @@ export const TextureField: FC = () => {
 				<div className="space-y-2">
 					<div className="flex items-center justify-between gap-3">
 						<Label className="text-sm font-semibold">Compression profile</Label>
-						<span className="text-accent text-xs font-medium">
+						<span className="text-orange text-xs font-medium">
 							{getClosestQuality(quality)}%
 						</span>
 					</div>

--- a/apps/vectreal-platform/app/components/publisher/optimization/panels/preset-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/panels/preset-panel.tsx
@@ -75,7 +75,7 @@ export const PresetPanel: FC = () => {
 						className={cn(
 							'publisher-shell-focus group w-full rounded-xl border p-4 text-left transition-all duration-200',
 							isSelected
-								? 'border-accent/35 bg-shell-surface'
+								? 'border-orange/35 bg-shell-surface'
 								: 'border-shell-border-soft bg-shell-surface-soft hover:border-shell-border-strong hover:bg-shell-surface'
 						)}
 					>
@@ -84,7 +84,7 @@ export const PresetPanel: FC = () => {
 								className={cn(
 									'flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200',
 									isSelected
-										? 'border-accent bg-accent'
+										? 'border-orange bg-orange'
 										: 'border-muted-foreground/30 group-hover:border-muted-foreground/60'
 								)}
 							>
@@ -97,7 +97,7 @@ export const PresetPanel: FC = () => {
 								className={cn(
 									'flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-colors duration-200',
 									isSelected
-										? 'bg-accent/15 text-accent'
+										? 'bg-orange/15 text-orange'
 										: 'bg-shell-surface text-muted-foreground group-hover:text-foreground'
 								)}
 							>
@@ -146,7 +146,7 @@ export const PresetPanel: FC = () => {
 										<div className="flex flex-col gap-1.5">
 											{techniques.map((technique) => (
 												<div key={technique} className="flex items-center gap-2">
-													<Check className="text-accent h-3 w-3 shrink-0" />
+													<Check className="text-orange h-3 w-3 shrink-0" />
 													<span className="text-foreground/75 text-xs">
 														{technique}
 													</span>
@@ -169,9 +169,9 @@ export const PresetPanel: FC = () => {
 				<motion.div
 					initial={{ opacity: 0, y: -4 }}
 					animate={{ opacity: 1, y: 0 }}
-					className="border-accent/35 bg-shell-surface flex items-center gap-3 rounded-xl border p-4"
+					className="border-orange/35 bg-shell-surface flex items-center gap-3 rounded-xl border p-4"
 				>
-					<div className="bg-accent/15 text-accent flex h-7 w-7 shrink-0 items-center justify-center rounded-lg">
+					<div className="bg-orange/15 text-orange flex h-7 w-7 shrink-0 items-center justify-center rounded-lg">
 						<SlidersHorizontal className="h-4 w-4" />
 					</div>
 					<div className="min-w-0">

--- a/apps/vectreal-platform/app/components/publisher/preview-camera-controls.tsx
+++ b/apps/vectreal-platform/app/components/publisher/preview-camera-controls.tsx
@@ -62,7 +62,7 @@ const PreviewCameraControls: React.FC = () => {
 							type="button"
 							onClick={handleExitPreviewMode}
 							aria-label="Exit preview mode"
-							className="bg-accent text-accent-foreground border-border/70 hover:text-foreground absolute -top-8 left-1/2 z-0 h-10 -translate-x-1/2 rounded-t-xl border border-b-0 px-3 pt-2 pb-3 text-xs shadow-lg"
+							className="bg-orange text-white border-border/70 hover:text-foreground absolute -top-8 left-1/2 z-0 h-10 -translate-x-1/2 rounded-t-xl border border-b-0 px-3 pt-2 pb-3 text-xs shadow-lg"
 							whileHover={{ y: -2 }}
 							whileTap={{ y: 0 }}
 						>

--- a/apps/vectreal-platform/app/components/publisher/scene-name-and-location.tsx
+++ b/apps/vectreal-platform/app/components/publisher/scene-name-and-location.tsx
@@ -130,7 +130,7 @@ const SceneNameField = () => {
 						aria-label="Scene name"
 					/>
 					<span
-						className="bg-accent absolute top-1/2 right-2 h-1.5 w-1.5 -translate-y-1/2 animate-pulse rounded-full"
+						className="bg-orange absolute top-1/2 right-2 h-1.5 w-1.5 -translate-y-1/2 animate-pulse rounded-full"
 						aria-hidden="true"
 					/>
 				</div>
@@ -321,7 +321,7 @@ const LocationRow = ({ open, authenticated, onToggle }: LocationRowProps) => {
 			</span>
 			{hasUnsavedLocationChange && locationLabel && (
 				<span
-					className="bg-accent h-1.5 w-1.5 shrink-0 rounded-full"
+					className="bg-orange h-1.5 w-1.5 shrink-0 rounded-full"
 					aria-hidden="true"
 				/>
 			)}

--- a/apps/vectreal-platform/app/components/publisher/settings-components/enhanced-setting-slider.tsx
+++ b/apps/vectreal-platform/app/components/publisher/settings-components/enhanced-setting-slider.tsx
@@ -142,11 +142,11 @@ const EnhancedSettingSlider = ({
 						onFocus={handleInputFocus}
 						onBlur={handleInputBlur}
 						onKeyDown={handleInputKeyDown}
-						className="text-accent h-7 w-20 text-right text-sm font-medium"
+						className="text-orange h-7 w-20 text-right text-sm font-medium"
 						aria-label={`${label} value input`}
 					/>
 				) : (
-					<span className="text-accent text-sm font-medium">
+					<span className="text-orange text-sm font-medium">
 						{formatValue(value)}
 					</span>
 				)}

--- a/apps/vectreal-platform/app/components/publisher/settings-components/preset-button.tsx
+++ b/apps/vectreal-platform/app/components/publisher/settings-components/preset-button.tsx
@@ -25,7 +25,7 @@ export const PresetButton = ({
 		className={cn(
 			'publisher-shell-focus rounded-xl px-3 py-2 text-xs font-semibold transition-all',
 			isActive
-				? 'border border-accent/55 bg-shell-surface ring-1 ring-accent/20 shadow-sm'
+				? 'border border-orange/55 bg-shell-surface ring-1 ring-orange/20 shadow-sm'
 				: 'bg-shell-surface-soft hover:bg-shell-surface',
 			className
 		)}

--- a/apps/vectreal-platform/app/components/publisher/settings-components/range-setting-slider.tsx
+++ b/apps/vectreal-platform/app/components/publisher/settings-components/range-setting-slider.tsx
@@ -210,11 +210,11 @@ const RangeSettingSlider = ({
 							onFocus={handleMinInputFocus}
 							onBlur={handleMinInputBlur}
 							onKeyDown={(e) => handleKeyDown(e, minValue, true)}
-							className="text-accent h-8 text-sm font-medium"
+							className="text-orange h-8 text-sm font-medium"
 							aria-label={`${label} ${rangeLabels.min} value`}
 						/>
 					) : (
-						<div className="text-accent flex h-8 items-center rounded-md border px-3 text-sm font-medium">
+						<div className="text-orange flex h-8 items-center rounded-md border px-3 text-sm font-medium">
 							{formatValue(minValue)}
 						</div>
 					)}
@@ -237,11 +237,11 @@ const RangeSettingSlider = ({
 							onFocus={handleMaxInputFocus}
 							onBlur={handleMaxInputBlur}
 							onKeyDown={(e) => handleKeyDown(e, maxValue, false)}
-							className="text-accent h-8 text-sm font-medium"
+							className="text-orange h-8 text-sm font-medium"
 							aria-label={`${label} ${rangeLabels.max} value`}
 						/>
 					) : (
-						<div className="text-accent flex h-8 items-center rounded-md border px-3 text-sm font-medium">
+						<div className="text-orange flex h-8 items-center rounded-md border px-3 text-sm font-medium">
 							{formatValue(maxValue)}
 						</div>
 					)}

--- a/apps/vectreal-platform/app/components/publisher/settings-components/setting-slider.tsx
+++ b/apps/vectreal-platform/app/components/publisher/settings-components/setting-slider.tsx
@@ -46,7 +46,7 @@ const SettingSlider = ({
 				<Label htmlFor={id}>{label}</Label>
 				{tooltip && <InfoTooltip content={tooltip} />}
 			</div>
-			<span className="text-accent text-sm font-medium">
+			<span className="text-orange text-sm font-medium">
 				{formatValue(value)}
 			</span>
 		</div>

--- a/apps/vectreal-platform/app/components/publisher/shell/publisher-header.tsx
+++ b/apps/vectreal-platform/app/components/publisher/shell/publisher-header.tsx
@@ -79,7 +79,7 @@ export const PublisherHeader: FC<PublisherHeaderProps> = ({
 					<>
 						<span className="hidden items-center gap-3 px-3 sm:flex">
 							<span
-								className="bg-accent h-1.5 w-1.5 rounded-full"
+								className="bg-orange h-1.5 w-1.5 rounded-full"
 								aria-hidden="true"
 							/>
 							<p className="text-muted-foreground text-xs font-medium tracking-wide">

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -167,8 +167,8 @@ const HotspotsSettingsPanel = memo(() => {
 									key={hotspot.id}
 									className={`flex cursor-pointer items-center gap-3 rounded-md px-3 py-2 transition-colors ${
 										selectedId === hotspot.id
-											? 'bg-accent/80'
-											: 'hover:bg-accent/40'
+											? 'bg-orange/80'
+											: 'hover:bg-orange/40'
 									}`}
 									onClick={() =>
 										setSelectedId((prev) =>

--- a/apps/vectreal-platform/app/components/publisher/sidebars/file-size-comparison.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/file-size-comparison.tsx
@@ -43,7 +43,7 @@ export const FileSizeComparison: FC<FileSizeComparisonProps> = ({
 					animate={{ opacity: 1, y: 0 }}
 					transition={{ duration: 0.5 }}
 				>
-					<div className="text-accent text-3xl font-medium tracking-tight">
+					<div className="text-orange text-3xl font-medium tracking-tight">
 						{formatValue(initialFileSize)}
 					</div>
 					<div className="text-muted-foreground text-sm">Before</div>

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/delivery-summary.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/delivery-summary.tsx
@@ -89,7 +89,7 @@ export const DeliverySummary: FC<DeliverySummaryProps> = ({
 					)}
 				>
 					<span className="flex items-center gap-2">
-						<Sparkles className="text-accent h-4 w-4 shrink-0" />
+						<Sparkles className="text-orange h-4 w-4 shrink-0" />
 						<span className="text-sm font-medium">Optimize scene</span>
 					</span>
 					<span className="text-muted-foreground mt-1 block text-xs leading-relaxed">

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/optimization-options.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/optimization-options.tsx
@@ -73,7 +73,7 @@ export const OptimizationOptions: FC = () => {
 						const detail = describeSetting(key, optimizations)
 						return (
 							<div key={key} className="flex items-center gap-2 text-xs">
-								<Check className="text-accent h-3 w-3 shrink-0" />
+								<Check className="text-orange h-3 w-3 shrink-0" />
 								<span className="text-foreground/75">
 									{getOptimizationDefinition(key).title}
 								</span>

--- a/apps/vectreal-platform/app/components/radio-accordion/radio-item.tsx
+++ b/apps/vectreal-platform/app/components/radio-accordion/radio-item.tsx
@@ -42,8 +42,8 @@ const RadioAccordionItem = <T extends string>(
 				'group relative w-full rounded-xl border border-transparent p-2 text-left',
 				'select-none',
 				!isSelected &&
-					'hover:bg-accent/5 focus-visible:bg-accent/10 bg-muted/25 focus:outline-none',
-				isSelected && 'bg-accent/10 border-accent/50'
+					'hover:bg-orange/5 focus-visible:bg-orange/10 bg-muted/25 focus:outline-none',
+				isSelected && 'bg-orange/10 border-orange/50'
 			)}
 		>
 			<div className="flex items-center gap-2">
@@ -51,8 +51,8 @@ const RadioAccordionItem = <T extends string>(
 					className={cn(
 						'flex h-6 w-6 items-center justify-center rounded-md transition-all duration-500',
 						isSelected
-							? 'bg-accent text-primary-foreground fill-primary-foreground'
-							: 'bg-muted text-muted-foreground fill-muted-foreground group-hover:bg-accent/20 group-hover:text-accent'
+							? 'bg-orange text-primary-foreground fill-primary-foreground'
+							: 'bg-muted text-muted-foreground fill-muted-foreground group-hover:bg-orange/20 group-hover:text-orange'
 					)}
 				>
 					{option.icon}

--- a/apps/vectreal-platform/app/routes/contact-page.tsx
+++ b/apps/vectreal-platform/app/routes/contact-page.tsx
@@ -267,7 +267,7 @@ export default function ContactPage({ actionData }: Route.ComponentProps) {
 					</BasicCard>
 
 					<div className="space-y-6">
-						<Card className="border-accent/20 rounded-3xl shadow-none">
+						<Card className="border-orange/20 rounded-3xl shadow-none">
 							<CardHeader>
 								<CardTitle className="text-lg">
 									Routes to the right team
@@ -275,7 +275,7 @@ export default function ContactPage({ actionData }: Route.ComponentProps) {
 							</CardHeader>
 							<CardContent className="space-y-4 text-sm">
 								<div className="flex items-start gap-3">
-									<LifeBuoy className="text-accent mt-0.5 h-4 w-4" />
+									<LifeBuoy className="text-orange mt-0.5 h-4 w-4" />
 									<div>
 										<p className="font-medium">Support</p>
 										<p className="text-muted-foreground">
@@ -284,7 +284,7 @@ export default function ContactPage({ actionData }: Route.ComponentProps) {
 									</div>
 								</div>
 								<div className="flex items-start gap-3">
-									<Sparkles className="text-accent mt-0.5 h-4 w-4" />
+									<Sparkles className="text-orange mt-0.5 h-4 w-4" />
 									<div>
 										<p className="font-medium">Sales</p>
 										<p className="text-muted-foreground">
@@ -294,7 +294,7 @@ export default function ContactPage({ actionData }: Route.ComponentProps) {
 									</div>
 								</div>
 								<div className="flex items-start gap-3">
-									<Users className="text-accent mt-0.5 h-4 w-4" />
+									<Users className="text-orange mt-0.5 h-4 w-4" />
 									<div>
 										<p className="font-medium">Partnerships</p>
 										<p className="text-muted-foreground">
@@ -306,19 +306,19 @@ export default function ContactPage({ actionData }: Route.ComponentProps) {
 							</CardContent>
 						</Card>
 
-						<Card className="border-accent/20 rounded-3xl shadow-none">
+						<Card className="border-orange/20 rounded-3xl shadow-none">
 							<CardHeader>
 								<CardTitle className="text-lg">Quick links</CardTitle>
 							</CardHeader>
 							<CardContent className="space-y-3 text-sm">
-								<Link className="text-accent block underline" to="/pricing">
+								<Link className="text-orange block underline" to="/pricing">
 									View pricing and plans
 								</Link>
-								<Link className="text-accent block underline" to="/docs">
+								<Link className="text-orange block underline" to="/docs">
 									Read integration docs
 								</Link>
 								<a
-									className="text-accent block underline"
+									className="text-orange block underline"
 									href="mailto:info@vectreal.com"
 								>
 									Email the team directly

--- a/apps/vectreal-platform/app/routes/docs/index.tsx
+++ b/apps/vectreal-platform/app/routes/docs/index.tsx
@@ -74,8 +74,8 @@ export default function DocsIndexPage() {
 						<Link key={href} to={href} className="group outline-none">
 							<BasicCard className="h-full" highlight>
 								<CardHeader className="pb-2">
-									<div className="bg-accent/10 mb-3 flex h-9 w-9 items-center justify-center rounded-xl">
-										<Icon className="text-accent h-4.5 w-4.5" />
+									<div className="bg-orange/10 mb-3 flex h-9 w-9 items-center justify-center rounded-xl">
+										<Icon className="text-orange h-4.5 w-4.5" />
 									</div>
 									<CardTitle className="text-base font-medium">
 										{title}

--- a/apps/vectreal-platform/app/routes/home-page/home-page.tsx
+++ b/apps/vectreal-platform/app/routes/home-page/home-page.tsx
@@ -244,9 +244,9 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 								glow={feature.glow}
 								className="w-[78%] shrink-0 snap-center sm:w-auto sm:shrink"
 							>
-								<div className="border-surface-border bg-surface-0/60 group-hover:border-accent/40 group-hover:bg-accent/5 flex size-11 items-center justify-center rounded-xl border transition-colors duration-300">
+								<div className="border-surface-border bg-surface-0/60 group-hover:border-orange/40 group-hover:bg-orange/5 flex size-11 items-center justify-center rounded-xl border transition-colors duration-300">
 									<feature.icon
-										className="text-accent size-5 transition-transform duration-300 group-hover:scale-110"
+										className="text-orange size-5 transition-transform duration-300 group-hover:scale-110"
 										aria-hidden="true"
 									/>
 								</div>
@@ -291,7 +291,7 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 								<li key={item.text} className="flex items-center gap-3">
 									<span className="border-surface-border bg-surface-1 flex size-9 shrink-0 items-center justify-center rounded-lg border">
 										<item.icon
-											className="text-accent size-4"
+											className="text-orange size-4"
 											aria-hidden="true"
 										/>
 									</span>
@@ -344,7 +344,7 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 									{'# Install the viewer\n'}
 								</span>
 								<span className="text-foreground">{'pnpm add '}</span>
-								<span className="text-accent">{'@vctrl/viewer\n\n'}</span>
+								<span className="text-orange">{'@vctrl/viewer\n\n'}</span>
 								<span className="text-muted-foreground/50">
 									{'// Drop a model into any React app\n'}
 								</span>
@@ -353,12 +353,12 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 									{' { VectrealViewer } '}
 								</span>
 								<span className="text-[#7aa2f7]">{'from'}</span>
-								<span className="text-accent">{" '@vctrl/viewer'\n\n"}</span>
+								<span className="text-orange">{" '@vctrl/viewer'\n\n"}</span>
 								<span className="text-foreground">{'<'}</span>
 								<span className="text-[#e0af68]">{'VectrealViewer'}</span>
 								<span className="text-[#9ece6a]">{' src'}</span>
 								<span className="text-foreground">{'='}</span>
-								<span className="text-accent">{'{modelUrl}'}</span>
+								<span className="text-orange">{'{modelUrl}'}</span>
 								<span className="text-foreground">{' />'}</span>
 							</code>
 						</pre>
@@ -388,7 +388,7 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 							<div className="mt-1 flex flex-wrap gap-3">
 								<Link
 									to="/contact"
-									className="text-accent hover:text-accent/80 text-sm font-medium underline-offset-4 hover:underline"
+									className="text-orange hover:text-orange/80 text-sm font-medium underline-offset-4 hover:underline"
 								>
 									Contact us
 								</Link>
@@ -399,7 +399,7 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 									to="https://discord.gg/A9a3nPkZw7"
 									target="_blank"
 									rel="noreferrer"
-									className="text-accent hover:text-accent/80 text-sm font-medium underline-offset-4 hover:underline"
+									className="text-orange hover:text-orange/80 text-sm font-medium underline-offset-4 hover:underline"
 								>
 									Ask on Discord
 								</Link>

--- a/apps/vectreal-platform/app/routes/publisher-page/drop-zone.tsx
+++ b/apps/vectreal-platform/app/routes/publisher-page/drop-zone.tsx
@@ -129,7 +129,7 @@ export const DropZone = ({ isMobile }: Props) => {
 												<div
 													className={cn(
 														'bg-muted/50 mb-6 flex h-20 w-20 items-center justify-center rounded-full transition-all duration-300',
-														isDragActive ? 'bg-accent' : ''
+														isDragActive ? 'bg-orange' : ''
 													)}
 												>
 													<FolderUp
@@ -170,7 +170,7 @@ export const DropZone = ({ isMobile }: Props) => {
 								<Button
 									variant="ghost"
 									asChild
-									className="hover:bg-accent/50 flex h-auto w-full grow items-center justify-start gap-3 rounded-xl p-3"
+									className="hover:bg-orange/50 flex h-auto w-full grow items-center justify-start gap-3 rounded-xl p-3"
 								>
 									<Link to="/docs/getting-started/first-model" viewTransition>
 										<div className="bg-muted flex h-8 w-8 items-center justify-center rounded-md">
@@ -188,7 +188,7 @@ export const DropZone = ({ isMobile }: Props) => {
 								<Button
 									variant="ghost"
 									asChild
-									className="hover:bg-accent/50 flex h-auto w-full grow items-center justify-start gap-3 rounded-xl p-3"
+									className="hover:bg-orange/50 flex h-auto w-full grow items-center justify-start gap-3 rounded-xl p-3"
 								>
 									<Link to="/docs/guides/upload" viewTransition>
 										<div className="bg-muted flex h-8 w-8 items-center justify-center rounded-md">
@@ -206,7 +206,7 @@ export const DropZone = ({ isMobile }: Props) => {
 								<Button
 									variant="ghost"
 									asChild
-									className="hover:bg-accent/50 flex h-auto w-full grow items-center justify-start gap-3 rounded-xl p-3"
+									className="hover:bg-orange/50 flex h-auto w-full grow items-center justify-start gap-3 rounded-xl p-3"
 								>
 									<Link to="/docs" viewTransition>
 										<div className="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-md">

--- a/apps/vectreal-platform/app/styles/mdx.module.css
+++ b/apps/vectreal-platform/app/styles/mdx.module.css
@@ -40,7 +40,7 @@
 
 	h2 {
 		@apply text-xl font-light tracking-wide capitalize;
-		border-left: 2px solid var(--color-accent);
+		border-left: 2px solid var(--color-orange);
 		padding-left: 1rem;
 		margin-top: 4rem !important;
 		scroll-margin-top: 6.5rem;
@@ -96,7 +96,7 @@
 	}
 
 	a {
-		color: var(--color-accent);
+		color: var(--color-orange);
 		text-underline-offset: 4px;
 		opacity: 0.85;
 		transition: opacity 0.15s ease;
@@ -127,7 +127,7 @@
 
 	blockquote {
 		border-left: 2px solid
-			color-mix(in oklch, var(--color-accent) 50%, transparent);
+			color-mix(in oklch, var(--color-orange) 50%, transparent);
 		padding-left: 1rem;
 		font-style: italic;
 		opacity: 0.75;
@@ -136,7 +136,7 @@
 	:not(pre) > code {
 		@apply rounded font-mono text-sm;
 		background: var(--color-muted);
-		color: var(--color-accent);
+		color: var(--color-orange);
 		padding: 0.125rem 0.375rem;
 	}
 
@@ -148,7 +148,7 @@
 
 	pre code {
 		background: transparent;
-		color: var(--color-accent);
+		color: var(--color-orange);
 		padding: 0;
 	}
 

--- a/shared/components/src/assets/icons/vectreal-logo-animated.tsx
+++ b/shared/components/src/assets/icons/vectreal-logo-animated.tsx
@@ -51,7 +51,7 @@ export const VectrealLogoAnimated = ({
 					fill="currentColor"
 					className={cn(
 						'transition-colors duration-500',
-						colored && 'text-accent'
+						colored && 'text-orange'
 					)}
 					d="M100.18,82.41l-26.13.08a15.19,15.19,0,0,1,26.13-.08ZM87.14,105a15.16,15.16,0,0,0,11-4.68l10.8,10.42V97.53H74.05A15.14,15.14,0,0,0,87.14,105Zm9.91-93.25A40.56,40.56,0,0,0,68.41,0H0V60H18.41L31.69,95.7,46,60H63.39l-25.34,60H87.14a30,30,0,1,1,21.78-50.79v-29A39.81,39.81,0,0,0,97.05,11.75Z"
 				/>

--- a/shared/components/src/styles/globals.css
+++ b/shared/components/src/styles/globals.css
@@ -28,7 +28,13 @@
 	--secondary-foreground: oklch(0.205 0 0);
 	--muted: oklch(0.97 0 0);
 	--muted-foreground: oklch(0.556 0 0);
-	--accent: var(--orange);
+	/*
+	  The hover/focus background for menus, options, and ghost controls, not a
+	  brand colour. It used to point at --orange, which made every dropdown item
+	  and ghost hover a solid brand block. Reach for --orange (or bg-orange /
+	  text-orange) when you want the brand.
+	*/
+	--accent: oklch(0.97 0 0);
 	--accent-foreground: oklch(0.205 0 0);
 	--destructive: oklch(0.637 0.237 25.331);
 	--destructive-foreground: oklch(0.985 0 0);
@@ -131,8 +137,9 @@
 	--secondary-foreground: oklch(0.985 0 0);
 	--muted: oklch(0.269 0 0);
 	--muted-foreground: oklch(0.708 0 0);
-	--accent: var(--orange);
-	--accent-foreground: oklch(0.269 0 0);
+	/* Neutral hover/focus surface, matching --muted. See the light block above. */
+	--accent: oklch(0.269 0 0);
+	--accent-foreground: oklch(0.985 0 0);
 	--destructive: oklch(0.637 0.237 25.331);
 	--destructive-foreground: oklch(0.985 0 0);
 	--border: oklch(0.269 0 0);


### PR DESCRIPTION
The solid orange block on every menu hover comes from one line:

```css
/* globals.css */
--accent: var(--orange);
```

In shadcn's system `--accent` is the hover/focus background for menus, options
and ghost controls. Pointing it at the brand made every dropdown item, select
option, command entry, context menu and ghost hover paint a brand-coloured
block. That is what the camera list, the publisher user menu and the dashboard
sidebar user menu were all showing.

## Why the token could not just be flipped

The codebase had also adopted `bg-accent` as its way of saying "brand orange".
**43 files** use it that way: hero CTAs, progress bars, section eyebrows, the
publisher's unsaved dot, preset highlights. Flipping the token alone would have
greyed out the marketing site.

So both roles are separated:

| Role | Before | After |
| --- | --- | --- |
| Brand orange | `bg-accent`, `text-accent`, `border-accent` | `bg-orange`, `text-orange`, `border-orange` |
| Hover / focus surface | `--accent: var(--orange)` | `--accent: oklch(0.97 0 0)` light, `oklch(0.269 0 0)` dark |

The `--color-orange` mapping already existed at `globals.css:214` and was
completely unused, so the brand utilities needed no new plumbing.

Dark mode's `--accent-foreground` also flips from `oklch(0.269 0 0)` to
`oklch(0.985 0 0)`. It was dark because it sat on orange; on a dark neutral it
has to be light or menu text disappears on hover.

## Shared UI needed no changes

Every `accent` reference in `shared/components/src/ui` is a `hover:`, `focus:`,
`data-[selected]`, `data-[state=open]` or `aria-selected` state, so all of them
inherit the neutral automatically. I checked each of the 11 files.

The single brand usage in shared was the animated logo's `colored` variant,
which now uses `text-orange`.

## Verification

| Check | Result |
| --- | --- |
| `nx typecheck vectreal-platform` | pass |
| `nx lint` (shared/components, vectreal-platform) | pass |
| `npx vitest run --root apps/vectreal-platform` | 221 passed, 31 files |
| `nx build vectreal-platform` | pass |

Automated checks cannot see colour, so this wants a visual pass: the home page
(hero CTA, how-it-works, section eyebrows, stat rings), the publisher (preset
panel, unsaved dots, sliders), and any menu to confirm hovers are now quiet.

## Found while auditing, not fixed here

`@theme inline` declares four self-referential radius keys
(`--radius-sm: var(--radius-sm)` and the md/xl/2xl equivalents). They collide
with Tailwind v4's built-in keys of the same name, which is the likely cause of
corners going sharper after full load. Separate PR.
