### PR TITLE
fix(ui): stop the viewer overwriting the host's corner radii

### DIFF
--- a/packages/viewer/src/components/info-popover.tsx
+++ b/packages/viewer/src/components/info-popover.tsx
@@ -26,7 +26,7 @@ const popoverClasses = {
 	triggerButton:
 		'z-10 flex h-full w-full cursor-pointer items-center justify-center rounded-full border-0 bg-[var(--vctrl-bg)] p-1 leading-none appearance-none hover:bg-[var(--vctrl-hover-bg)] active:bg-[var(--vctrl-active-bg)]',
 	modalBase:
-		'vctrl-viewer-info-popover-modal absolute bottom-0 left-0 flex w-64 flex-col overflow-hidden rounded-lg bg-[var(--vctrl-bg)] text-[var(--vctrl-text)] transition-all duration-300 ease-out',
+		'vctrl-viewer-info-popover-modal absolute bottom-0 left-0 flex w-64 flex-col overflow-hidden rounded-[0.5rem] bg-[var(--vctrl-bg)] text-[var(--vctrl-text)] transition-all duration-300 ease-out',
 	modalOpen: 'visible translate-x-0 translate-y-0 opacity-100',
 	modalClosed: 'invisible -translate-x-2 translate-y-2 opacity-0',
 	textContainer: 'grow p-4 mr-4 [&_p]:text-sm [&_p]:text-[var(--vctrl-text)]',

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -1,6 +1,24 @@
 @import 'tailwindcss/theme';
 @import 'tailwindcss/utilities';
 
+/*
+  The corner-radius scale belongs to whoever is embedding the viewer.
+
+  `tailwindcss/theme` emits the full default theme into `:root, :host`, which
+  includes Tailwind's own `--radius-sm` … `--radius-2xl`. This stylesheet is
+  loaded by a dynamic `import('@vctrl/viewer')`, so in a host app it arrives
+  *after* hydration and its `:root` block then overwrote that app's radius
+  tokens — corners visibly sharpened mid-session once the viewer mounted.
+
+  Clearing the namespace keeps every other default (colours, spacing, type
+  scale) intact for standalone consumers while leaving the host's radii alone.
+  Nothing here needs the scale: the viewer uses `rounded-full`, which takes no
+  token, and one explicit radius in `info-popover.tsx`.
+*/
+@theme {
+	--radius-*: initial;
+}
+
 .viewer {
 	--vctrl-bg: #f3f4f6;
 	--vctrl-hover-bg: #e5e7eb;

--- a/shared/components/src/styles/globals.css
+++ b/shared/components/src/styles/globals.css
@@ -58,19 +58,21 @@
 	--chart-4: oklch(0.627 0.265 303.9);
 	--chart-5: oklch(0.645 0.246 16.439);
 
-	/* Corner radii - confidently rounded, never tight */
-	--radius: 1.25rem;
-	--radius-sm: 0.875rem;
-	--radius-md: 1rem;
-	--radius-xl: 1.5rem;
-	--radius-2xl: 2rem;
+	/*
+	  Corner radii - confidently rounded, never tight.
 
-	/* Motion tokens */
-	--duration-instant: 80ms;
-	--duration-fast: 150ms;
-	--duration-base: 250ms;
-	--duration-slow: 400ms;
-	--duration-cinematic: 700ms;
+	  One knob. The rest of the scale is derived in `@theme` below, so the steps
+	  cannot drift apart. Do not re-declare `--radius-sm`/`-md`/`-xl`/`-2xl`
+	  here: those names are also Tailwind theme keys, and declaring them in both
+	  places is what previously made them self-referential.
+	*/
+	--radius: 1.25rem;
+
+	/*
+	  Motion tokens. The durations live in `@theme` below for the same reason the
+	  radius scale does: `--duration-*` is a Tailwind theme namespace, so
+	  declaring the names here too made them self-referential.
+	*/
 
 	--ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 	--ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
@@ -219,18 +221,27 @@
 	--color-surface-border-light: var(--surface-border-light);
 	--color-surface-glow-light: var(--surface-glow-light);
 
-	/* Motion duration utilities */
-	--duration-instant: var(--duration-instant);
-	--duration-fast: var(--duration-fast);
-	--duration-base: var(--duration-base);
-	--duration-slow: var(--duration-slow);
-	--duration-cinematic: var(--duration-cinematic);
+	/* Motion duration utilities: `duration-fast`, `duration-cinematic`, etc. */
+	--duration-instant: 80ms;
+	--duration-fast: 150ms;
+	--duration-base: 250ms;
+	--duration-slow: 400ms;
+	--duration-cinematic: 700ms;
 
-	--radius-sm: var(--radius-sm);
-	--radius-md: var(--radius-md);
+	/*
+	  Derived from the single `--radius` above rather than restating it. These
+	  used to read `--radius-sm: var(--radius-sm)`, which resolved against the
+	  identically named `:root` declaration and made the property cyclic. A
+	  cyclic custom property is invalid at computed-value time, so every
+	  `rounded-sm`/`-md`/`-xl`/`-2xl` collapsed to a square corner once the
+	  stylesheet finished applying. `rounded-lg` escaped only because
+	  `--radius-lg` reads `--radius`, a different name.
+	*/
+	--radius-sm: calc(var(--radius) - 6px);
+	--radius-md: calc(var(--radius) - 4px);
 	--radius-lg: var(--radius);
-	--radius-xl: var(--radius-xl);
-	--radius-2xl: var(--radius-2xl);
+	--radius-xl: calc(var(--radius) + 4px);
+	--radius-2xl: calc(var(--radius) + 12px);
 	--color-sidebar: var(--sidebar);
 	--color-sidebar-foreground: var(--sidebar-foreground);
 	--color-sidebar-primary: var(--sidebar-primary);


### PR DESCRIPTION
Corners were correct on load and visibly sharpened once the page finished
loading, worst on the publisher route. Two separate defects, both token
plumbing.

## 1. The viewer was overwriting the app's radius scale

`packages/viewer/src/styles.css` imports `tailwindcss/theme`, which emits the
**entire default theme** into `:root, :host` — including Tailwind's own
`--radius-sm` … `--radius-2xl`.

That stylesheet arrives via a dynamic `import('@vctrl/viewer')` inside
`ClientVectrealViewer`, so in the app it loads **after hydration**. Its `:root`
block then replaced the design system's radii with Tailwind's much tighter
defaults:

| Token | Design system | Viewer overrode with |
| --- | --- | --- |
| `--radius-sm` | 0.875rem | 0.25rem |
| `--radius-md` | 1rem | 0.375rem |
| `--radius-lg` | 1.25rem | 0.5rem |
| `--radius-xl` | 1.5rem | 0.75rem |
| `--radius-2xl` | 2rem | 1rem |

That is the whole symptom: correct until the viewer mounts, sharp afterwards,
and most obvious on the publisher route where the viewer always loads.

The fix clears just that namespace:

```css
@theme {
  --radius-*: initial;
}
```

Every other default (colours, spacing, type scale) stays intact for standalone
npm consumers — the viewer's utilities reference 135 theme variables and all of
them still resolve. It never needed the radius scale: `rounded-full` takes no
token, and the single `rounded-lg` in `info-popover.tsx` is now an explicit
`rounded-[0.5rem]`.

Verified in the built bundle: `vendor-vectreal-viewer-*.css` went from 6 radius
declarations to **zero**.

## 2. The scale was self-referential

Independently, `@theme inline` declared each key against an identically named
`:root` declaration:

```css
:root        { --radius-sm: 0.875rem; }
@theme inline{ --radius-sm: var(--radius-sm); }   /* cyclic */
```

Both land in `:root`, the second wins, and a cyclic custom property is **invalid
at computed-value time** — so `rounded-sm`/`-md`/`-xl`/`-2xl` resolved to no
radius at all. `rounded-lg` escaped only because `--radius-lg` reads `--radius`,
a different name, which is why it was the one that always looked right.

The scale now derives from a single `--radius`, preserving every value exactly:

| Utility | Now compiles to | Value | Previously intended |
| --- | --- | --- | --- |
| `rounded-sm` | `calc(var(--radius) - 6px)` | 14px | 0.875rem ✓ |
| `rounded-md` | `calc(var(--radius) - 4px)` | 16px | 1rem ✓ |
| `rounded-lg` | `var(--radius)` | 20px | 1.25rem ✓ |
| `rounded-xl` | `calc(var(--radius) + 4px)` | 24px | 1.5rem ✓ |
| `rounded-2xl` | `calc(var(--radius) + 12px)` | 32px | 2rem ✓ |

The motion durations had the same self-referential shape and move into `@theme`
for the same reason. Nothing consumes them yet, so that part is a latent fix.
A scan confirms **0** self-referential declarations remain.

## Verification

| Check | Result |
| --- | --- |
| `nx run-many --target=typecheck,lint` (viewer, shared/components, platform) | pass |
| `npx vitest run --root apps/vectreal-platform` | 221 passed, 31 files |
| `nx build vectreal-platform` | pass |
| `nx e2e vctrl/viewer-e2e` | pass — packaging gate, since this touches the published package |

Worth a browser pass on the publisher route to confirm the corners now hold
steady after the viewer mounts.
