### PR TITLE
feat(ui): align tokens with the design system and layer surfaces by value

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/data-table.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/data-table.tsx
@@ -46,7 +46,6 @@ export interface DataTableSelectionAction<TData> {
 interface DataTableProps<TData, TValue> {
 	columns: ColumnDef<TData, TValue>[]
 	data: TData[]
-	appearance?: 'default' | 'minimal'
 	searchKey?: string
 	searchPlaceholder?: string
 	searchValue: string
@@ -69,7 +68,6 @@ interface DataTableProps<TData, TValue> {
 export function DataTable<TData, TValue>({
 	columns,
 	data,
-	appearance = 'default',
 	searchKey,
 	searchPlaceholder = 'Search...',
 	searchValue,
@@ -122,7 +120,6 @@ export function DataTable<TData, TValue>({
 		.getFilteredSelectedRowModel()
 		.rows.map((row) => row.original)
 	const hasSelection = selectedRows.length > 0
-	const isMinimal = appearance === 'minimal'
 
 	const getCellTitle = (value: unknown): string | undefined => {
 		if (
@@ -156,11 +153,7 @@ export function DataTable<TData, TValue>({
 							placeholder={searchPlaceholder}
 							value={searchValue}
 							onChange={(event) => onSearchValueChange(event.target.value)}
-							className={
-								isMinimal
-									? 'bg-muted/30 h-10 rounded-xl border-0 pl-9 shadow-none focus-visible:ring-2'
-									: 'pl-9'
-							}
+							className="ds-sunken h-10 rounded-xl border-0 pl-9 shadow-none focus-visible:ring-2"
 						/>
 					</div>
 				)}
@@ -207,30 +200,23 @@ export function DataTable<TData, TValue>({
 				)}
 			</div>
 
-			<div
-				className={
-					isMinimal
-						? 'bg-muted/20 rounded-2xl p-2'
-						: 'bg-card/50 rounded-xl border backdrop-blur-sm'
-				}
-			>
-				<Table>
-					<TableHeader className={isMinimal ? '[&_tr]:border-0' : undefined}>
+			{/*
+			  One table treatment everywhere. The container is a raised surface
+			  rather than a bordered box, and rows separate from it by value on
+			  hover, so nothing here draws an outline.
+			*/}
+			<div className="ds-raised rounded-2xl p-2">
+				<Table className="border-separate border-spacing-0">
+					<TableHeader className="[&_tr]:border-0">
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow
 								key={headerGroup.id}
-								className={
-									isMinimal ? 'border-0 hover:bg-transparent' : undefined
-								}
+								className="border-0 hover:bg-transparent"
 							>
 								{headerGroup.headers.map((header) => (
 									<TableHead
 										key={header.id}
-										className={
-											isMinimal
-												? 'text-muted-foreground h-11 px-3 text-xs font-medium tracking-wide'
-												: undefined
-										}
+										className="text-muted-foreground h-11 px-3 text-xs font-medium tracking-wide"
 									>
 										{header.isPlaceholder
 											? null
@@ -249,21 +235,13 @@ export function DataTable<TData, TValue>({
 								<TableRow
 									key={row.id}
 									data-state={row.getIsSelected() && 'selected'}
-									className={
-										isMinimal
-											? 'hover:bg-muted/45 data-[state=selected]:bg-muted/50 rounded-xl border-0 transition-colors duration-150'
-											: undefined
-									}
+									className="group border-0"
 								>
 									{row.getVisibleCells().map((cell) => (
 										<TableCell
 											key={cell.id}
 											title={getCellTitle(cell.getValue())}
-											className={
-												isMinimal
-													? 'px-3 py-3 [&>a,&>span]:max-w-sm [&>a,&>span]:truncate!'
-													: '[&>a,&>span]:max-w-sm [&>a,&>span]:truncate!'
-											}
+											className="group-hover:bg-foreground/6 group-data-[state=selected]:bg-foreground/8 border-0 px-3 py-3 transition-colors duration-150 first:rounded-l-xl last:rounded-r-xl [&>a,&>span]:max-w-sm [&>a,&>span]:truncate!"
 										>
 											{flexRender(
 												cell.column.columnDef.cell,
@@ -274,14 +252,10 @@ export function DataTable<TData, TValue>({
 								</TableRow>
 							))
 						) : (
-							<TableRow className={isMinimal ? 'border-0' : undefined}>
+							<TableRow className="border-0">
 								<TableCell
 									colSpan={columns.length}
-									className={
-										isMinimal
-											? 'text-muted-foreground h-24 text-center'
-											: 'h-24 text-center'
-									}
+									className="text-muted-foreground h-24 text-center"
 								>
 									No results found.
 								</TableCell>

--- a/apps/vectreal-platform/app/components/home/how-it-works-showcase.tsx
+++ b/apps/vectreal-platform/app/components/home/how-it-works-showcase.tsx
@@ -348,7 +348,7 @@ export function HowItWorksShowcase({ className }: { className?: string }) {
 									className={cn(
 										'flex size-10 shrink-0 items-center justify-center rounded-xl border transition-colors duration-300',
 										isActive
-											? 'border-orange/40 bg-orange bg-opacity-10'
+											? 'border-orange/40 bg-orange/10'
 											: 'border-surface-border bg-surface-0/60'
 									)}
 								>

--- a/apps/vectreal-platform/app/components/home/section/section-label.tsx
+++ b/apps/vectreal-platform/app/components/home/section/section-label.tsx
@@ -8,7 +8,7 @@ interface SectionLabelProps {
 const SectionLabel = ({ children, className }: SectionLabelProps) => (
 	<div
 		className={cn(
-			'border-orange/20 bg-orange bg-opacity-5 text-orange/70 text-eyebrow -ml-1 inline-flex w-fit items-center gap-1.5 self-start rounded-full border px-3 py-1.5',
+			'border-orange/20 bg-orange/5 text-orange/70 text-eyebrow -ml-1 inline-flex w-fit items-center gap-1.5 self-start rounded-full border px-3 py-1.5',
 			className
 		)}
 	>

--- a/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
+++ b/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
@@ -164,7 +164,7 @@ function MobileNav({
 					)}
 
 					{/* Nav links */}
-					<div className="flex flex-1 flex-col gap-1 py-4">
+					<div className="flex flex-1 flex-col gap-1 px-4 py-4">
 						{allDrawerItems.map((item, i) => {
 							const isActive =
 								item.to === '/'
@@ -183,18 +183,12 @@ function MobileNav({
 										className={cn(
 											'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors',
 											isActive
-												? 'bg-orange bg-opacity-10 text-orange'
+												? 'bg-orange/10 text-orange'
 												: 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
 										)}
 									>
 										{item.icon}
 										{item.label}
-										{isActive && (
-											<motion.div
-												className="bg-orange ml-auto h-1.5 w-1.5 rounded-full"
-												layoutId="mobile-active-dot"
-											/>
-										)}
 									</Link>
 								</motion.div>
 							)

--- a/apps/vectreal-platform/app/routes/contact-page.tsx
+++ b/apps/vectreal-platform/app/routes/contact-page.tsx
@@ -267,7 +267,7 @@ export default function ContactPage({ actionData }: Route.ComponentProps) {
 					</BasicCard>
 
 					<div className="space-y-6">
-						<Card className="border-orange/20 rounded-3xl shadow-none">
+						<Card className="rounded-2xl">
 							<CardHeader>
 								<CardTitle className="text-lg">
 									Routes to the right team
@@ -306,7 +306,7 @@ export default function ContactPage({ actionData }: Route.ComponentProps) {
 							</CardContent>
 						</Card>
 
-						<Card className="border-orange/20 rounded-3xl shadow-none">
+						<Card className="rounded-2xl">
 							<CardHeader>
 								<CardTitle className="text-lg">Quick links</CardTitle>
 							</CardHeader>

--- a/apps/vectreal-platform/app/routes/dashboard-page/dashboard-page.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/dashboard-page.tsx
@@ -148,7 +148,6 @@ const DashboardPage = ({ loaderData }: Route.ComponentProps) => {
 								}))
 							})
 						}}
-						appearance="minimal"
 					/>
 				</section>
 			) : (

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
@@ -236,7 +236,7 @@ function DrawerAssetsSection({
 					{initial.map((asset) => (
 						<SceneAssetListItem
 							key={asset.id}
-							className="bg-muted/40"
+							className="ds-raised"
 							{...(assetPropsById.get(asset.id) ||
 								buildAssetListItemProps(asset, assetData))}
 						/>
@@ -255,7 +255,7 @@ function DrawerAssetsSection({
 								{extra.map((asset) => (
 									<SceneAssetListItem
 										key={asset.id}
-										className="bg-muted/40"
+										className="ds-raised"
 										{...(assetPropsById.get(asset.id) ||
 											buildAssetListItemProps(asset, assetData))}
 									/>
@@ -516,7 +516,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 			<div className="grid h-full min-h-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_20rem]">
 				<main className="flex min-h-0 flex-col gap-4">
 					{sceneLoadError && !file?.model ? (
-						<section className="bg-muted/30 border-border space-y-3 rounded-2xl border p-5">
+						<section className="ds-raised space-y-3 rounded-2xl p-5">
 							<h2 className="text-base font-semibold">Unable to Load Scene</h2>
 							<p className="text-muted-foreground text-sm">{sceneLoadError}</p>
 							<div className="flex flex-wrap gap-2">
@@ -540,7 +540,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 							loadingThumbnail={loadingThumbnail}
 						/>
 					</section>
-					<section className="bg-muted/30 space-y-6 rounded-2xl px-4 py-4 sm:px-5">
+					<section className="ds-raised space-y-6 rounded-2xl px-4 py-4 sm:px-5">
 						<header className="flex flex-col items-start gap-6 md:flex-row">
 							{/*
 						  `min-w-0` is what stops a long scene name from pushing the
@@ -606,7 +606,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 							onClick={() => setDrawerOpen(true)}
 							title="Open details panel"
 							aria-label="Open details panel"
-							className="bg-muted/25 hover:bg-muted/50 group relative flex w-full flex-col gap-6 rounded-2xl p-4 text-left transition-colors duration-300"
+							className="ds-raised hover:bg-foreground/8 group relative flex w-full flex-col gap-6 rounded-2xl p-4 text-left transition-colors duration-300"
 						>
 							<Info className="text-muted-foreground absolute top-3 right-3 h-4 w-4 opacity-25 transition-opacity duration-300 group-hover:opacity-100" />
 							<div className="space-y-2">
@@ -653,7 +653,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 					</section>
 				</main>
 
-				<aside className="bg-muted/30 hidden min-h-0 flex-col gap-3 overflow-hidden rounded-2xl p-4 xl:flex">
+				<aside className="ds-raised hidden min-h-0 flex-col gap-3 overflow-hidden rounded-2xl p-4 xl:flex">
 					<section className="space-y-3">
 						<div>
 							<p className="text-muted-foreground text-[11px] tracking-[0.2em] uppercase">
@@ -722,7 +722,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 									<button
 										type="button"
 										onClick={() => setDrawerOpen(true)}
-										className="hover:bg-muted/50 bg-background/70 flex w-full items-center justify-between gap-3 rounded-xl p-3 text-left transition-colors duration-300"
+										className="ds-overlay hover:bg-foreground/12 flex w-full items-center justify-between gap-3 rounded-xl p-3 text-left transition-colors duration-300"
 									>
 										<p className="text-muted-foreground text-sm">
 											…and {sceneDetails.assets.length - 4} more.
@@ -802,17 +802,17 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 								Scene Stats
 							</h3>
 							<div className="grid grid-cols-2 gap-3 text-sm">
-								<div className="bg-muted/50 rounded-xl p-3">
+								<div className="ds-overlay rounded-xl p-3">
 									<p className="text-muted-foreground text-xs">Current Size</p>
 									<p className="font-medium">
 										{formatBytes(sceneDetails.fileSizeBytes)}
 									</p>
 								</div>
-								<div className="bg-muted/50 rounded-xl p-3">
+								<div className="ds-overlay rounded-xl p-3">
 									<p className="text-muted-foreground text-xs">Assets</p>
 									<p className="font-medium">{sceneDetails.assetCount}</p>
 								</div>
-								<div className="bg-muted/50 rounded-xl p-3">
+								<div className="ds-overlay rounded-xl p-3">
 									<p className="text-muted-foreground text-xs">Texture Size</p>
 									<p className="font-medium">
 										{sceneDetails.textureBytes != null
@@ -822,7 +822,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 												: '-'}
 									</p>
 								</div>
-								<div className="bg-muted/50 rounded-xl p-3">
+								<div className="ds-overlay rounded-xl p-3">
 									<p className="text-muted-foreground text-xs">
 										Meshes / Vertices
 									</p>

--- a/shared/components/src/styles/globals.css
+++ b/shared/components/src/styles/globals.css
@@ -72,7 +72,7 @@
 	  here: those names are also Tailwind theme keys, and declaring them in both
 	  places is what previously made them self-referential.
 	*/
-	--radius: 1.25rem;
+	--radius: 1rem;
 
 	/*
 	  Motion tokens. The durations live in `@theme` below for the same reason the
@@ -98,12 +98,43 @@
 	--surface-border-light: oklch(0.88 0 0 / 0.7);
 	--surface-glow-light: oklch(0.75 0.14 40 / 0.14);
 
-	/* Display typography scale */
-	--text-display: clamp(3.5rem, 8vw, 7rem);
+	/*
+	  Typography scale, mirroring `tokens/typography.css` in the Vectreal Design
+	  System. The `.text-*` classes further down consume these rather than
+	  restating the numbers.
+
+	  Deliberately plain custom properties and NOT `@theme` keys: `--text-*`,
+	  `--tracking-*`, `--font-*`, `--space-*` and `--container-*` are all Tailwind
+	  theme namespaces, and declaring a name in both places makes it
+	  self-referential. See the radius note above.
+	*/
+	--text-display: clamp(2.75rem, 6.4vw, 5.5rem);
 	--text-headline: clamp(2rem, 4vw, 3.5rem);
+	--text-h2: clamp(1.75rem, 2.8vw, 2.5rem);
+	--text-h3: clamp(1.35rem, 2vw, 1.75rem);
+	--text-stat: clamp(3rem, 5.5vw, 4.25rem);
+	--text-body-lg: 1.125rem;
 	--text-label-xs: 0.6875rem;
-	--tracking-display: -0.04em;
+	--tracking-display: -0.038em;
 	--tracking-headline: -0.025em;
+	--tracking-h2: -0.025em;
+	--tracking-h3: -0.02em;
+	--tracking-eyebrow: 0.14em;
+
+	/* Spacing scale and page measure, from `tokens/spacing.css`. */
+	--space-1: 0.25rem;
+	--space-2: 0.5rem;
+	--space-3: 0.75rem;
+	--space-4: 1rem;
+	--space-5: 1.25rem;
+	--space-6: 1.5rem;
+	--space-8: 2rem;
+	--space-10: 2.5rem;
+	--space-12: 3rem;
+	--space-16: 4rem;
+	--space-24: 6rem;
+	--space-36: 9rem;
+	--container-max: 80rem;
 
 	/* Sidebar tokens */
 	--sidebar: oklch(0.985 0 0);
@@ -228,6 +259,12 @@
 	--color-surface-border-light: var(--surface-border-light);
 	--color-surface-glow-light: var(--surface-glow-light);
 
+	/*
+	  `--font-sans` is a Tailwind namespace, so it is set here rather than in
+	  `:root`, where it would have collided with Tailwind's own default stack.
+	*/
+	--font-sans: 'DM Sans Variable', sans-serif;
+
 	/* Motion duration utilities: `duration-fast`, `duration-cinematic`, etc. */
 	--duration-instant: 80ms;
 	--duration-fast: 150ms;
@@ -281,7 +318,7 @@
 	}
 
 	html {
-		font-family: 'DM Sans Variable', sans-serif;
+		font-family: var(--font-sans);
 		font-optical-sizing: auto;
 	}
 
@@ -297,43 +334,72 @@
 }
 
 @layer components {
+	/* ---- Surface elevation ----
+	  Vectreal separates surfaces by value, not by outlines: "matte flat
+	  surfaces, no hard borders". A 1px border at app-chrome contrast reads as a
+	  drawn box; a few percent of foreground mixed into the background reads as
+	  depth.
+
+	  These are theme-aware by construction, unlike the `--surface-0/1/2` tokens,
+	  which are fixed dark values for the always-dark marketing sections. Mixing
+	  against `--foreground` means the same class lifts in dark mode and settles
+	  in light mode without a second definition.
+
+	  raised  - cards, table containers, anything sitting on the page
+	  overlay - popovers, menus, and rows hovered on top of `raised`
+	  sunken  - wells and inputs that should recede instead of lift
+	*/
+	.ds-raised {
+		background-color: color-mix(in oklch, var(--foreground) 4%, var(--background));
+	}
+	.ds-overlay {
+		background-color: color-mix(in oklch, var(--foreground) 8%, var(--background));
+	}
+	.ds-sunken {
+		background-color: color-mix(in oklch, var(--foreground) 2.5%, var(--background));
+	}
+	/* Only where a divider genuinely carries meaning. Never to draw a box. */
+	.ds-divider {
+		background-color: color-mix(in oklch, var(--foreground) 10%, transparent);
+	}
+
 	/* ---- Type scale (single source of truth) ---- */
 	.text-eyebrow {
-		font-size: 0.6875rem;
+		font-size: var(--text-label-xs);
 		font-weight: 500;
 		line-height: 1;
-		letter-spacing: 0.14em;
+		letter-spacing: var(--tracking-eyebrow);
 		text-transform: uppercase;
 	}
 	.text-display {
-		font-size: clamp(2.75rem, 6.4vw, 5.5rem);
+		font-size: var(--text-display);
 		font-weight: 500;
 		line-height: 1.02;
-		letter-spacing: -0.038em;
+		letter-spacing: var(--tracking-display);
 		text-wrap: balance;
 	}
 	.text-h2 {
-		font-size: clamp(1.75rem, 2.8vw, 2.5rem);
+		font-size: var(--text-h2);
 		font-weight: 500;
 		line-height: 1.1;
-		letter-spacing: -0.025em;
+		letter-spacing: var(--tracking-h2);
 		text-wrap: balance;
 	}
 	.text-h3 {
-		font-size: clamp(1.35rem, 2vw, 1.75rem);
+		font-size: var(--text-h3);
 		font-weight: 500;
 		line-height: 1.18;
-		letter-spacing: -0.02em;
+		letter-spacing: var(--tracking-h3);
 	}
 	.text-stat {
-		font-size: clamp(3rem, 5.5vw, 4.25rem);
+		font-size: var(--text-stat);
 		font-weight: 500;
 		line-height: 1;
 		letter-spacing: -0.04em;
 		font-variant-numeric: tabular-nums;
 	}
 	.text-body-lg {
-		font-size: 1.125rem;
+		font-size: var(--text-body-lg);
 		line-height: 1.6;
 		text-wrap: pretty;
 	}

--- a/shared/components/src/ui/card.tsx
+++ b/shared/components/src/ui/card.tsx
@@ -6,7 +6,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
 		<div
 			data-slot="card"
 			className={cn(
-				'bg-card text-card-foreground flex flex-col gap-6 rounded-xl py-6 shadow-sm',
+				'ds-raised text-card-foreground flex flex-col gap-6 rounded-xl py-6',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/context-menu.tsx
+++ b/shared/components/src/ui/context-menu.tsx
@@ -84,7 +84,7 @@ function ContextMenuSubContent({
 		<ContextMenuPrimitive.SubContent
 			data-slot="context-menu-sub-content"
 			className={cn(
-				'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
 				className
 			)}
 			{...props}
@@ -101,7 +101,7 @@ function ContextMenuContent({
 			<ContextMenuPrimitive.Content
 				data-slot="context-menu-content"
 				className={cn(
-					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md p-1 shadow-md',
 					className
 				)}
 				{...props}
@@ -210,7 +210,7 @@ function ContextMenuSeparator({
 	return (
 		<ContextMenuPrimitive.Separator
 			data-slot="context-menu-separator"
-			className={cn('bg-border -mx-1 my-1 h-px', className)}
+			className={cn('ds-divider -mx-1 my-1 h-px', className)}
 			{...props}
 		/>
 	)

--- a/shared/components/src/ui/dropdown-menu.tsx
+++ b/shared/components/src/ui/dropdown-menu.tsx
@@ -41,7 +41,7 @@ function DropdownMenuContent({
 				data-slot="dropdown-menu-content"
 				sideOffset={sideOffset}
 				className={cn(
-					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl! border p-1 shadow-md',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl! p-1 shadow-md',
 					className
 				)}
 				{...props}
@@ -169,7 +169,7 @@ function DropdownMenuSeparator({
 	return (
 		<DropdownMenuPrimitive.Separator
 			data-slot="dropdown-menu-separator"
-			className={cn('bg-border -mx-1 my-1 h-px', className)}
+			className={cn('ds-divider -mx-1 my-1 h-px', className)}
 			{...props}
 		/>
 	)
@@ -229,7 +229,7 @@ function DropdownMenuSubContent({
 		<DropdownMenuPrimitive.SubContent
 			data-slot="dropdown-menu-sub-content"
 			className={cn(
-				'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/menubar.tsx
+++ b/shared/components/src/ui/menubar.tsx
@@ -11,7 +11,7 @@ function Menubar({
 		<MenubarPrimitive.Root
 			data-slot="menubar"
 			className={cn(
-				'bg-background flex h-9 items-center gap-1 rounded-md border p-1 shadow-xs',
+				'bg-background flex h-9 items-center gap-1 rounded-md p-1 shadow-xs',
 				className
 			)}
 			{...props}
@@ -76,7 +76,7 @@ function MenubarContent({
 				alignOffset={alignOffset}
 				sideOffset={sideOffset}
 				className={cn(
-					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md p-1 shadow-md',
 					className
 				)}
 				{...props}
@@ -185,7 +185,7 @@ function MenubarSeparator({
 	return (
 		<MenubarPrimitive.Separator
 			data-slot="menubar-separator"
-			className={cn('bg-border -mx-1 my-1 h-px', className)}
+			className={cn('ds-divider -mx-1 my-1 h-px', className)}
 			{...props}
 		/>
 	)
@@ -245,7 +245,7 @@ function MenubarSubContent({
 		<MenubarPrimitive.SubContent
 			data-slot="menubar-sub-content"
 			className={cn(
-				'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/popover.tsx
+++ b/shared/components/src/ui/popover.tsx
@@ -29,7 +29,7 @@ function PopoverContent({
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(
-					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-xl! border p-4 shadow-md outline-hidden',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-xl! p-4 shadow-md outline-hidden',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/select.tsx
+++ b/shared/components/src/ui/select.tsx
@@ -58,7 +58,7 @@ function SelectContent({
 			<SelectPrimitive.Content
 				data-slot="select-content"
 				className={cn(
-					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-[120] max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border shadow-md',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-[120] max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border shadow-md',
 					position === 'popper' &&
 						'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
 					className

--- a/shared/components/src/ui/sheet.tsx
+++ b/shared/components/src/ui/sheet.tsx
@@ -69,7 +69,12 @@ function SheetContent({
 				{...props}
 			>
 				{children}
-				<SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+				{/*
+				  A 16px icon was the whole hit target, on a `rounded-xs` corner that
+				  matched nothing else in the system. Now a proper 36px round target
+				  that grows a surface on hover.
+				*/}
+				<SheetPrimitive.Close className="ring-offset-background focus-visible:ring-ring hover:bg-foreground/8 absolute top-4 right-4 flex size-9 items-center justify-center rounded-full opacity-70 transition-[opacity,background-color] hover:opacity-100 focus-visible:ring-2 focus-visible:outline-hidden disabled:pointer-events-none">
 					<XIcon className="size-4" />
 					<span className="sr-only">Close</span>
 				</SheetPrimitive.Close>


### PR DESCRIPTION
> Rebuilt on current `main` now that #666 and #667 have merged. One commit,
> 15 files — the diff is exactly the design-alignment work.

Brings the repo in line with the Vectreal Design System (read via
`claude.ai/design`) and replaces drawn boxes with elevation, per its stated rule:
*"matte flat surfaces, no hard borders"*.

## Tokens

Adds the scales the design system defines and the repo lacked: `--space-1` …
`--space-36`, `--container-max`, `--text-h2/h3/stat/body-lg`,
`--tracking-eyebrow/h2/h3`. The `.text-*` classes consume them instead of
restating the numbers.

Two **stale** tokens corrected — they disagreed with the rule that actually
rendered:

| Token | Was | Now |
| --- | --- | --- |
| `--text-display` | `clamp(3.5rem, 8vw, 7rem)` | `clamp(2.75rem, 6.4vw, 5.5rem)` |
| `--tracking-display` | `-0.04em` | `-0.038em` |

`--radius` drops to `1rem`, which is a one-line change thanks to #667.

These are plain `:root` properties, **not** `@theme` keys, on purpose:
`--text-*`, `--tracking-*`, `--space-*` and `--container-*` are Tailwind theme
namespaces, and declaring a name in both places makes it self-referential — the
bug #667 exists to fix. `--font-sans` is the one exception and lives in
`@theme`, because Tailwind already fills that namespace. I hit that collision
while writing this and caught it in the build output.

## Surfaces

New `ds-raised` / `ds-overlay` / `ds-sunken` / `ds-divider`, mixing foreground
into background so a single class reads correctly in both themes. (The existing
`--surface-0/1/2` tokens are fixed dark values for the always-dark marketing
sections, so they can't serve the app.)

Dropdown, popover, select, context-menu and menubar panels now lift by value
rather than drawing a 1px box; their separators become a seam. This is why
removing borders needed elevation first: in dark mode `--popover` **equals**
`--background`, so the border was doing all the separating.

**`Card` moves to `ds-raised`** — the broadest change here. Its `bg-card` also
equals `--background` in dark mode, so a bare `Card` was invisible and every
call site invented its own separation. That is the root cause of the
inconsistent surface treatment across the app. The contact page needed only a
radius afterwards; its `border-orange/20` and off-scale `rounded-3xl` are gone.

## Data grid

One treatment everywhere. The `appearance` prop had a `minimal` variant used
**solely** by the dashboard landing page and a bordered `default` used by the
other four pages; the fork is deleted in favour of `minimal`.

Row corners now actually round. `border-radius` does not apply to `<tr>`, so
that `rounded-xl` was always dead CSS and hover painted a hard rectangle. The
radius moves to the first and last cells, and the table switches to
`border-separate` — without which collapsed borders suppress cell radii anyway.

## Bugs found along the way

`bg-opacity-*` is a Tailwind **v3** utility removed in v4, leaving three call
sites as dead CSS. The mobile nav was the visible casualty: its active item
rendered **solid orange under orange text**. Also there: the redundant active
dot is removed, and the item list picks up the `px-4` the header and CTA
already used. The sheet close button was a 16px icon with no padding on a
`rounded-xs` corner, matching nothing else; it becomes a 36px round target.

## Verification

| Check | Result |
| --- | --- |
| `nx typecheck vectreal-platform` | pass |
| `nx lint` (shared/components, platform) | pass |
| `npx vitest run --root apps/vectreal-platform` | 221 passed, 31 files |
| `nx build vectreal-platform` | pass |

Token output was checked in the built CSS rather than inferred from source,
which is how the `--font-sans` collision surfaced.

## Wants a visual pass

Automated checks cannot see any of this. The **`Card` default** is the one to
look at hardest, since it touches billing, pricing and every other card
surface. Then the data-grid row hover, the scene detail sidebar, and the mobile
nav active state.

## Not included

Breadcrumbs grid layout and the skeleton loaders, both still outstanding.

