### PR TITLE
feat(ui): stop BasicCard overriding the design system, extract StatTile

### DIFF
--- a/apps/vectreal-platform/app/components/layout-components/basic-card.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/basic-card.tsx
@@ -13,9 +13,19 @@ const getHighlightClasses = (highlight: boolean | undefined) => {
 	if (typeof highlight === 'boolean') {
 		return highlight ? 'h-1 group-hover:w-16' : 'hidden'
 	}
-	return 'h-[1px] w-8'
+	return 'h-px w-8'
 }
 
+/**
+ * A `Card` with the brand highlight bar across its top edge.
+ *
+ * The card body is deliberately left to `Card`, which already carries
+ * `ds-raised`. This wrapper used to override it with `bg-muted/75`,
+ * `rounded-3xl` and `border-t-accent/25 border-l-accent/25` - a raw surface, a
+ * radius outside the scale, and a drawn bevel - which re-introduced all three
+ * anti-patterns on every card across newsroom and docs. The bevel had also
+ * quietly turned grey when `--accent` became the neutral hover token.
+ */
 const BasicCard = ({
 	children,
 	className,
@@ -28,7 +38,7 @@ const BasicCard = ({
 
 	return (
 		<Component
-			className={cn('group relative overflow-hidden rounded-3xl', className)}
+			className={cn('group relative overflow-hidden rounded-2xl', className)}
 			{...props}
 		>
 			<div
@@ -43,12 +53,7 @@ const BasicCard = ({
 					highlightClasses
 				)}
 			/>
-			<Card
-				className={cn(
-					'bg-muted/75 border-t-accent/25 border-l-accent/25 relative h-full rounded-3xl backdrop-blur-2xl',
-					cardClassName
-				)}
-			>
+			<Card className={cn('relative h-full rounded-2xl', cardClassName)}>
 				{children}
 			</Card>
 		</Component>

--- a/apps/vectreal-platform/app/components/layout-components/index.ts
+++ b/apps/vectreal-platform/app/components/layout-components/index.ts
@@ -1,2 +1,3 @@
 export { default as BasicCard } from './basic-card'
 export { default as PageHero } from './page-hero'
+export { StatGrid, StatTile } from './stat-tile'

--- a/apps/vectreal-platform/app/components/layout-components/stat-tile.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/stat-tile.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@shared/utils'
+
+import type { ReactNode } from 'react'
+
+/**
+ * A labelled value on a sunken well.
+ *
+ * This shape existed eight times in the scene detail route alone - four in the
+ * sidebar and four in the drawer that shows the same data on narrow screens -
+ * and the two sets had drifted apart: the sidebar used `bg-background/70`, an
+ * uppercase `text-[11px]` label and `mt-1` between label and value, the drawer
+ * used `ds-overlay`, a sentence-case `text-xs` label and no gap. Same data,
+ * same component, two typographies.
+ */
+
+interface StatTileProps {
+	label: ReactNode
+	value: ReactNode
+	className?: string
+	style?: React.CSSProperties
+}
+
+export function StatTile({ label, value, className, style }: StatTileProps) {
+	return (
+		<div className={cn('ds-sunken rounded-xl p-3', className)} style={style}>
+			<p className="text-muted-foreground text-eyebrow">{label}</p>
+			<p className="mt-1 font-medium">{value}</p>
+		</div>
+	)
+}
+
+interface StatGridProps {
+	children: ReactNode
+	className?: string
+}
+
+/** Two-column grid for `StatTile`. Wide tiles span it with `col-span-2`. */
+export function StatGrid({ children, className }: StatGridProps) {
+	return (
+		<div className={cn('grid grid-cols-2 gap-2 text-sm', className)}>
+			{children}
+		</div>
+	)
+}

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
@@ -39,6 +39,7 @@ import {
 	SceneAssetListItem
 } from '../../../components/dashboard'
 import { EmbedOptionsPanel } from '../../../components/embed/embed-options-panel'
+import { StatGrid, StatTile } from '../../../components/layout-components'
 import { ScenePublishStateControl } from '../../../components/publishing/scene-publish-state-control'
 import SceneEmbedViewer from '../../../components/scene-embed/scene-embed-viewer'
 import { useDashboardSceneActions } from '../../../hooks/use-dashboard-scene-actions'
@@ -538,7 +539,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 							</div>
 						</section>
 					) : null}
-					<section className="relative min-h-64 flex-1 overflow-hidden rounded-2xl bg-black/2">
+					<section className="relative min-h-64 flex-1 overflow-hidden rounded-2xl ds-sunken">
 						<SceneEmbedViewer
 							file={file}
 							sceneData={sceneData}
@@ -615,7 +616,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 						>
 							<Info className="text-muted-foreground absolute top-3 right-3 h-4 w-4 opacity-25 transition-opacity duration-300 group-hover:opacity-100" />
 							<div className="space-y-2">
-								<p className="text-muted-foreground text-[11px] tracking-[0.22em] uppercase">
+								<p className="text-muted-foreground text-eyebrow">
 									Scene Workspace
 								</p>
 
@@ -661,57 +662,42 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 				<aside className="ds-raised hidden min-h-0 flex-col gap-3 overflow-hidden rounded-2xl p-4 xl:flex">
 					<section className="space-y-3">
 						<div>
-							<p className="text-muted-foreground text-[11px] tracking-[0.2em] uppercase">
+							<p className="text-muted-foreground text-eyebrow">
 								At a Glance
 							</p>
 							<h2 className="mt-1 text-base leading-tight font-medium tracking-tight">
 								Scene Metrics
 							</h2>
 						</div>
-						<div className="grid grid-cols-2 gap-2 text-sm">
-							<div className="bg-background/70 rounded-xl p-3">
-								<p className="text-muted-foreground text-[11px] uppercase">
-									Size
-								</p>
-								<p className="mt-1 font-medium">
-									{formatBytes(sceneDetails.fileSizeBytes)}
-								</p>
-							</div>
-							<div className="bg-background/70 rounded-xl p-3">
-								<p className="text-muted-foreground text-[11px] uppercase">
-									Assets
-								</p>
-								<p className="mt-1 font-medium">{sceneDetails.assetCount}</p>
-							</div>
-							<div className="bg-background/70 rounded-xl p-3">
-								<p className="text-muted-foreground text-[11px] uppercase">
-									Texture Size
-								</p>
-								<p className="mt-1 font-medium">
-									{sceneDetails.textureBytes != null
+						<StatGrid>
+							<StatTile
+								label="Size"
+								value={formatBytes(sceneDetails.fileSizeBytes)}
+							/>
+							<StatTile label="Assets" value={sceneDetails.assetCount} />
+							<StatTile
+								label="Texture Size"
+								value={
+									sceneDetails.textureBytes != null
 										? formatBytes(sceneDetails.textureBytes)
 										: sceneDetails.textureCount != null
 											? `${sceneDetails.textureCount} textures`
-											: '-'}
-								</p>
-							</div>
-							<div className="bg-background/70 rounded-xl p-3">
-								<p className="text-muted-foreground text-[11px] uppercase">
-									Meshes
-								</p>
-								<p className="mt-1 font-medium">
-									{sceneDetails.meshesCount ?? '-'}
-								</p>
-							</div>
-						</div>
+											: '-'
+								}
+							/>
+							<StatTile
+								label="Meshes"
+								value={sceneDetails.meshesCount ?? '-'}
+							/>
+						</StatGrid>
 					</section>
 
 					<section className="space-y-2 overflow-y-auto">
-						<p className="text-muted-foreground text-[11px] tracking-[0.2em] uppercase">
+						<p className="text-muted-foreground text-eyebrow">
 							Assets Preview
 						</p>
 						{sceneDetails.assets.length === 0 ? (
-							<p className="text-muted-foreground bg-background/70 rounded-xl p-3 text-sm">
+							<p className="text-muted-foreground ds-sunken rounded-xl p-3 text-sm">
 								No linked assets.
 							</p>
 						) : (
@@ -720,7 +706,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 									<SceneAssetListItem
 										key={asset.id}
 										{...buildAssetListItemProps(asset, sceneData?.assetData)}
-										className="bg-background/70"
+										className="ds-sunken"
 									/>
 								))}
 								{sceneDetails.assets.length > 4 && (
@@ -739,7 +725,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 						)}
 					</section>
 
-					<section className="bg-background/70 rounded-xl p-3">
+					<section className="ds-sunken rounded-xl p-3">
 						<div className="flex items-center gap-2">
 							<Avatar className="h-8 w-8">
 								<AvatarImage
@@ -806,37 +792,27 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 							<h3 className="text-sm font-semibold tracking-tight">
 								Scene Stats
 							</h3>
-							<div className="grid grid-cols-2 gap-3 text-sm">
-								<div className="ds-overlay rounded-xl p-3">
-									<p className="text-muted-foreground text-xs">Current Size</p>
-									<p className="font-medium">
-										{formatBytes(sceneDetails.fileSizeBytes)}
-									</p>
-								</div>
-								<div className="ds-overlay rounded-xl p-3">
-									<p className="text-muted-foreground text-xs">Assets</p>
-									<p className="font-medium">{sceneDetails.assetCount}</p>
-								</div>
-								<div className="ds-overlay rounded-xl p-3">
-									<p className="text-muted-foreground text-xs">Texture Size</p>
-									<p className="font-medium">
-										{sceneDetails.textureBytes != null
+							<StatGrid>
+								<StatTile
+									label="Current Size"
+									value={formatBytes(sceneDetails.fileSizeBytes)}
+								/>
+								<StatTile label="Assets" value={sceneDetails.assetCount} />
+								<StatTile
+									label="Texture Size"
+									value={
+										sceneDetails.textureBytes != null
 											? formatBytes(sceneDetails.textureBytes)
 											: sceneDetails.textureCount != null
 												? `${sceneDetails.textureCount} textures`
-												: '-'}
-									</p>
-								</div>
-								<div className="ds-overlay rounded-xl p-3">
-									<p className="text-muted-foreground text-xs">
-										Meshes / Vertices
-									</p>
-									<p className="font-medium">
-										{sceneDetails.meshesCount ?? '-'} /{' '}
-										{sceneDetails.verticesCount ?? '-'}
-									</p>
-								</div>
-							</div>
+												: '-'
+									}
+								/>
+								<StatTile
+									label="Meshes / Vertices"
+									value={`${sceneDetails.meshesCount ?? '-'} / ${sceneDetails.verticesCount ?? '-'}`}
+								/>
+							</StatGrid>
 						</section>
 
 						<DrawerAssetsSection


### PR DESCRIPTION
**Phase 1** of the token consolidation plan. Needs a visual pass — see below.

## BasicCard was undoing the design system

It wrapped the shared `Card` and then overrode everything `Card` provides:

| Override | What it replaced |
| --- | --- |
| `bg-muted/75` | `ds-raised` |
| `rounded-3xl` | the radius scale — 1.5rem fixed, does not track `--radius` |
| `border-t-accent/25 border-l-accent/25` | nothing; a drawn bevel |

A raw surface, an off-scale radius and a drawn border — all three anti-patterns —
on **every card across newsroom and docs**, 17 call sites. It is the single root
cause for most of both routes.

The bevels were also no longer what anyone intended: they had quietly turned grey
when #666 made `--accent` the neutral hover token, so they had been silently
wrong since that merged.

It now contributes only the orange highlight bar and lets `Card` be the surface.
`backdrop-blur-2xl` goes too — it was blurring behind a translucent background,
and `ds-raised` resolves to an opaque colour, so it had nothing to do.

## StatTile / StatGrid

The shape existed **eight times** in the scene detail route — four in the sidebar,
four in the drawer that shows the same data on narrow screens — and the two sets
had drifted apart:

| | Sidebar | Drawer |
| --- | --- | --- |
| surface | `bg-background/70` | `ds-overlay` |
| label | uppercase `text-[11px]` | sentence-case `text-xs` |
| label/value gap | `mt-1` | none |
| grid gap | `gap-2` | `gap-3` |

Same data, same component, two typographies. Both now render the same tile.

## Scene route cleanup

With the tiles shared, the rest of the file follows: remaining `bg-background/70`
wells become `ds-sunken`, and the hand-rolled eyebrows (`text-[11px]` at
`tracking-[0.2em]` *and* `tracking-[0.22em]` — two arbitrary values in one file)
adopt the existing `.text-eyebrow`. The file now has **zero** raw surface classes,
arbitrary text sizes or arbitrary tracking.

## Two deliberate narrowings of the plan

**The other primitives are deferred.** `ArticleCard`, `ArticleMeta`, `CtaPanel`,
`TocRail`, `AdjacentPager` and `AuthorChip` serve only newsroom and docs. Landing
them here means shipping components with no consumers; they belong in Phases 4–5
alongside the call sites that adopt them.

**Storybook coverage needs its own PR.** Storybook is scoped to
`packages/viewer/src/**` — all 9 stories are viewer stories, and Chromatic is
wired to that project. Giving the visual gate anything real to diff means
standing up a second Storybook for `shared/components` and wiring it to
Chromatic. That is infrastructure work, not a bolt-on, and doing it badly is
worse than not doing it.

## Verification

`typecheck`, `lint`, `test` (221 passing), `build` all green.

**This one genuinely changes how things look, and CI cannot see any of it.**
Please check:

- **Newsroom and docs cards** — corners go `rounded-3xl` → `rounded-2xl`, and the
  surface goes from `bg-muted/75` to `ds-raised`. This is the intended
  correction, but it is 17 cards and it should be looked at in both themes.
- **Scene detail sidebar and its drawer** — the drawer's tiles change more than
  the sidebar's: labels become uppercase eyebrows and the grid gap tightens from
  `gap-3` to `gap-2`. Both tile sets are now `ds-sunken`; worth confirming the
  drawer's tiles still separate from the drawer surface underneath them.
