### PR TITLE
refactor(publisher): move the publish sidebar onto the surface ladder

### DIFF
--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
@@ -22,6 +22,7 @@ import {
 	toAbsoluteEmbedUrl
 } from '../../lib/domain/embed/embed-snippet'
 import { InfoTooltip } from '../info-tooltip'
+import { InlineNotice } from '../layout-components'
 
 interface EmbedOptionsPanelProps {
 	sceneId?: string
@@ -162,20 +163,18 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 	return (
 		<div className={cn('space-y-3', className)}>
 			{!canEmbed && (
-				<div className="border-warning/40 bg-warning/10 text-warning-muted-foreground rounded-2xl border px-3 py-2 text-xs">
-					{EMBED_COPY.unavailableUntilSaved}
-				</div>
+				<InlineNotice>{EMBED_COPY.unavailableUntilSaved}</InlineNotice>
 			)}
 			{canEmbed && (
-				<div className="border-warning/40 bg-warning/10 text-warning-muted-foreground rounded-2xl border px-3 py-2 text-xs">
+				<InlineNotice>
 					{EMBED_COPY.draftWarningPrefix}
 					<code className="mx-1">{PREVIEW_API_KEY_PLACEHOLDER}</code>
 					{EMBED_COPY.draftWarningSuffix}
-					<div className="text-warning-foreground/90 mt-1 text-[11px]">
+					<div className="text-label-xs mt-1 opacity-80">
 						Tip: create separate keys per environment and restrict keys to only
 						the projects each embed needs.
 					</div>
-				</div>
+				</InlineNotice>
 			)}
 
 			<div className="grid grid-cols-2 gap-4">

--- a/apps/vectreal-platform/app/components/layout-components/index.ts
+++ b/apps/vectreal-platform/app/components/layout-components/index.ts
@@ -1,3 +1,4 @@
 export { default as BasicCard } from './basic-card'
+export { InlineNotice } from './inline-notice'
 export { default as PageHero } from './page-hero'
 export { StatGrid, StatTile } from './stat-tile'

--- a/apps/vectreal-platform/app/components/layout-components/inline-notice.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/inline-notice.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@shared/utils'
+
+import type { ReactNode } from 'react'
+
+const TONE_CLASSES = {
+	warning: 'bg-warning-bg text-warning-foreground',
+	error: 'bg-error-bg text-error-foreground',
+	neutral: 'publisher-shell-nested text-muted-foreground'
+} as const
+
+interface InlineNoticeProps {
+	tone?: keyof typeof TONE_CLASSES
+	children: ReactNode
+	className?: string
+}
+
+/**
+ * A short caveat sitting under the control it qualifies.
+ *
+ * Four of these existed across the publish and embed panels, and no two agreed:
+ * two radii (`rounded-md` and `rounded-2xl`) and two foregrounds
+ * (`text-warning-foreground` and `text-warning-muted-foreground`) for the same
+ * kind of message. Each also drew a border, which the surface ladder replaces
+ * with a value step.
+ */
+export function InlineNotice({
+	tone = 'warning',
+	children,
+	className
+}: InlineNoticeProps) {
+	return (
+		<div
+			className={cn(
+				'rounded-xl px-3 py-2 text-xs',
+				TONE_CLASSES[tone],
+				className
+			)}
+		>
+			{children}
+		</div>
+	)
+}

--- a/apps/vectreal-platform/app/components/publisher/optimization/results/optimization-results.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/results/optimization-results.tsx
@@ -54,9 +54,9 @@ export const OptimizationResults: FC<OptimizationResultsProps> = ({
 			animate={{ opacity: 1, y: 0 }}
 			exit={{ opacity: 0, y: -8 }}
 			transition={{ duration: 0.3 }}
-			className="publisher-shell-nested space-y-1 px-4 pt-3 pb-1"
+			className="publisher-shell-nested space-y-1 rounded-xl px-4 pt-3 pb-1"
 		>
-			<p className="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
+			<p className="text-muted-foreground text-eyebrow">
 				Optimization result
 			</p>
 

--- a/apps/vectreal-platform/app/components/publisher/optimization/scene-normalization-notice.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/scene-normalization-notice.tsx
@@ -37,7 +37,7 @@ export const SceneNormalizationNotice: FC = () => {
 			initial={{ opacity: 0, y: 6 }}
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.2, delay: 0.01 }}
-			className="publisher-shell-nested flex items-center justify-between gap-3 px-4 py-3"
+			className="publisher-shell-nested flex items-center justify-between gap-3 rounded-xl px-4 py-3"
 		>
 			{normalization.enabled ? (
 				<>

--- a/apps/vectreal-platform/app/components/publisher/sidebars/accordion-components.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/accordion-components.tsx
@@ -16,7 +16,7 @@ export const AccordionItem = ({ className, ...props }: AccordionItemProps) => {
 	return (
 		<BaseAccordionItem
 			{...props}
-			className={cn('publisher-shell-nested px-4', className)}
+			className={cn('publisher-shell-nested rounded-2xl px-4', className)}
 		/>
 	)
 }
@@ -30,7 +30,14 @@ export const AccordionTrigger = ({
 			{...props}
 			className={cn('py-3 hover:no-underline', className)}
 		>
-			<span className="flex items-center gap-3">{props.children}</span>
+			{/*
+			  The section icon is sized here rather than per call site, which had
+			  drifted across four values — some of them numeric `size` props that
+			  bypass the class entirely and so could not be corrected in one place.
+			*/}
+			<span className="flex items-center gap-3 [&_svg]:size-4 [&_svg]:shrink-0">
+				{props.children}
+			</span>
 		</BaseAccordionTrigger>
 	)
 }

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/publish-sidebar-content.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/publish-sidebar-content.tsx
@@ -94,7 +94,7 @@ const PublishSidebarContent: FC<PublishSidebarContentProps> = ({
 			>
 				{!hideHeader && (
 					<>
-						<CardHeader className="py-6">
+						<CardHeader className="px-4 py-4">
 							<CardTitle>Publish Your Scene</CardTitle>
 							<CardDescription>
 								Save, publish, and share your 3D scene with the world
@@ -105,123 +105,132 @@ const PublishSidebarContent: FC<PublishSidebarContentProps> = ({
 					</>
 				)}
 
-				{showSceneInfo && (
-					<DeliverySummary
-						sceneBytes={currentSceneBytes}
-						sizeReductionPercent={sizeReductionPercent}
-						sizeDeltaLabel={sizeDeltaLabel}
-						onOpenOptimization={onOpenOptimizationDrawer}
-					/>
-				)}
-
-				{canAccessPublishFeatures && <ScenePreview />}
-
-				<Accordion type="single" collapsible className="space-y-2 p-4">
-					{/*
-					  First in the list because it comes first in the workflow: what
-					  ships is decided here, before anything below it matters.
-					*/}
-					<AccordionItem value="optimize">
-						<AccordionTrigger>
-							<Sparkles className="inline" size={14} />
-							Optimization
-						</AccordionTrigger>
-						<AccordionContent>
-							<OptimizationOptions />
-						</AccordionContent>
-					</AccordionItem>
-
-					<AccordionItem value="save">
-						<AccordionTrigger>
-							<Save className="inline" size={14} />
-							Download
-						</AccordionTrigger>
-						<AccordionContent>
-							<SaveOptions />
-						</AccordionContent>
-					</AccordionItem>
-
-					{!isAuthenticated && (
-						<div className="px-4 pb-3">
-							<p className="text-muted-foreground mb-2 text-xs">
-								Sign up and save this scene once to unlock Publish and Embed.
-							</p>
-							<Button
-								type="button"
-								size="sm"
-								className="w-full"
-								onClick={() => void onRequireAuth?.()}
-							>
-								Sign In or Sign Up to Save
-							</Button>
-						</div>
+				{/*
+				  One column owns the sidebar's gutter and rhythm. The sections used
+				  to each carry their own padding, which had drifted to six different
+				  vertical values and two different left edges, so the top half of the
+				  sidebar did not line up with the accordion below it.
+				*/}
+				<div className="flex flex-col gap-3 p-4">
+					{showSceneInfo && (
+						<DeliverySummary
+							sceneBytes={currentSceneBytes}
+							sizeReductionPercent={sizeReductionPercent}
+							sizeDeltaLabel={sizeDeltaLabel}
+							onOpenOptimization={onOpenOptimizationDrawer}
+						/>
 					)}
 
-					{!hasSavedScene && isAuthenticated && (
-						<div className="my-4 pb-2">
-							<p className="text-muted-foreground mb-2 text-xs">
-								Save this scene once to unlock Publish and Embed.
-							</p>
-							<Button
-								type="button"
-								size="sm"
-								className="w-full"
-								disabled={isSaveDisabled}
-								onClick={() => void handleSaveScene()}
-							>
-								{isSaving ? (
-									<>
-										<LoadingSpinner />
-										Saving...
-									</>
-								) : (
-									'Save Scene'
-								)}
-							</Button>
-						</div>
-					)}
+					{canAccessPublishFeatures && <ScenePreview />}
 
-					{isSaveDisabled &&
-						saveAvailability?.reason === 'requires-size-reduction' && (
-							<div className="my-4 pb-2">
+					<Accordion
+						type="single"
+						collapsible
+						className="flex flex-col gap-3"
+					>
+						{/*
+						  First in the list because it comes first in the workflow: what
+						  ships is decided here, before anything below it matters.
+						*/}
+						<AccordionItem value="optimize">
+							<AccordionTrigger>
+								<Sparkles />
+								Optimization
+							</AccordionTrigger>
+							<AccordionContent>
+								<OptimizationOptions />
+							</AccordionContent>
+						</AccordionItem>
+
+						<AccordionItem value="save">
+							<AccordionTrigger>
+								<Save />
+								Download
+							</AccordionTrigger>
+							<AccordionContent>
+								<SaveOptions />
+							</AccordionContent>
+						</AccordionItem>
+
+						{!isAuthenticated && (
+							<div>
 								<p className="text-muted-foreground mb-2 text-xs">
-									This scene is over your plan's max scene size. Optimize to
-									reduce it below the limit to enable saving and publishing.
+									Sign up and save this scene once to unlock Publish and Embed.
 								</p>
+								<Button
+									type="button"
+									size="sm"
+									className="w-full"
+									onClick={() => void onRequireAuth?.()}
+								>
+									Sign In or Sign Up to Save
+								</Button>
 							</div>
 						)}
 
-					{canAccessPublishFeatures && (
-						<>
-							<AccordionItem value="publish">
-								<AccordionTrigger>
-									<Globe className="inline" size={14} />
-									Publish
-								</AccordionTrigger>
-								<AccordionContent>
-									<PublishOptions
-										sceneId={sceneId}
-										publishState={publishState}
-										saveSceneSettings={saveSceneSettings}
-									/>
-								</AccordionContent>
-							</AccordionItem>
+						{!hasSavedScene && isAuthenticated && (
+							<div>
+								<p className="text-muted-foreground mb-2 text-xs">
+									Save this scene once to unlock Publish and Embed.
+								</p>
+								<Button
+									type="button"
+									size="sm"
+									className="w-full"
+									disabled={isSaveDisabled}
+									onClick={() => void handleSaveScene()}
+								>
+									{isSaving ? (
+										<>
+											<LoadingSpinner />
+											Saving...
+										</>
+									) : (
+										'Save Scene'
+									)}
+								</Button>
+							</div>
+						)}
 
-							{publishState.status === 'published' && (
-								<AccordionItem value="embed">
+						{isSaveDisabled &&
+							saveAvailability?.reason === 'requires-size-reduction' && (
+								<p className="text-muted-foreground text-xs">
+									This scene is over your plan's max scene size. Optimize to
+									reduce it below the limit to enable saving and publishing.
+								</p>
+							)}
+
+						{canAccessPublishFeatures && (
+							<>
+								<AccordionItem value="publish">
 									<AccordionTrigger>
-										<Code className="inline" size={14} />
-										Embed
+										<Globe />
+										Publish
 									</AccordionTrigger>
 									<AccordionContent>
-										<EmbedOptions sceneId={sceneId} projectId={projectId} />
+										<PublishOptions
+											sceneId={sceneId}
+											publishState={publishState}
+											saveSceneSettings={saveSceneSettings}
+										/>
 									</AccordionContent>
 								</AccordionItem>
-							)}
-						</>
-					)}
-				</Accordion>
 
+								{publishState.status === 'published' && (
+									<AccordionItem value="embed">
+										<AccordionTrigger>
+											<Code />
+											Embed
+										</AccordionTrigger>
+										<AccordionContent>
+											<EmbedOptions sceneId={sceneId} projectId={projectId} />
+										</AccordionContent>
+									</AccordionItem>
+								)}
+							</>
+						)}
+					</Accordion>
+				</div>
 			</motion.div>
 		</div>
 	)

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/delivery-summary.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/delivery-summary.tsx
@@ -1,5 +1,5 @@
-import { cn, formatFileSize } from '@shared/utils'
-import { Sparkles } from 'lucide-react'
+import { formatFileSize } from '@shared/utils'
+import { Sparkles, TriangleAlert } from 'lucide-react'
 
 import {
 	DELIVERY_ESTIMATE_EXPLANATION,
@@ -44,13 +44,11 @@ export const DeliverySummary: FC<DeliverySummaryProps> = ({
 	const hasOptimized = sizeReductionPercent !== null
 
 	return (
-		<div className="space-y-3 px-4 pt-4 pb-2">
+		<div className="space-y-3">
 			<div className="flex items-center justify-between gap-2">
-				<p className="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
-					Delivery
-				</p>
+				<p className="text-muted-foreground text-eyebrow">Delivery</p>
 				{estimate ? (
-					<span className="text-muted-foreground flex items-center gap-1 text-[11px]">
+					<span className="text-muted-foreground text-label-xs flex items-center gap-1">
 						{estimate.label} on {DELIVERY_REFERENCE_LABEL}
 						<InfoTooltip content={DELIVERY_ESTIMATE_EXPLANATION} />
 					</span>
@@ -83,13 +81,20 @@ export const DeliverySummary: FC<DeliverySummaryProps> = ({
 				<button
 					type="button"
 					onClick={onOpenOptimization}
-					className={cn(
-						'publisher-shell-focus border-shell-border-soft hover:border-shell-border-strong hover:bg-shell-surface-soft w-full rounded-xl border p-3 text-left transition-colors',
-						estimate?.isSlow && 'border-amber-500/40 bg-amber-500/5'
-					)}
+					className="publisher-shell-focus publisher-shell-nested-interactive w-full rounded-xl p-3 text-left"
 				>
+					{/*
+					  A slow scene changes the urgency of this control, not its identity.
+					  It used to swap the whole surface to an amber tint, which read as a
+					  different kind of element and also cost it its hover state, since
+					  the tint and the surface class set the same property.
+					*/}
 					<span className="flex items-center gap-2">
-						<Sparkles className="text-orange h-4 w-4 shrink-0" />
+						{estimate?.isSlow ? (
+							<TriangleAlert className="text-warning h-4 w-4 shrink-0" />
+						) : (
+							<Sparkles className="text-orange h-4 w-4 shrink-0" />
+						)}
 						<span className="text-sm font-medium">Optimize scene</span>
 					</span>
 					<span className="text-muted-foreground mt-1 block text-xs leading-relaxed">

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/embed-options.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/embed-options.tsx
@@ -12,7 +12,7 @@ interface EmbedOptionsProps {
 
 export const EmbedOptions: FC<EmbedOptionsProps> = ({ sceneId, projectId }) => {
 	return (
-		<motion.div variants={itemVariants} className="space-y-4 px-2 py-2">
+		<motion.div variants={itemVariants} className="space-y-3 pb-4">
 			<EmbedOptionsPanel sceneId={sceneId} projectId={projectId} />
 		</motion.div>
 	)

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/optimization-options.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/optimization-options.tsx
@@ -57,12 +57,10 @@ export const OptimizationOptions: FC = () => {
 	const enabledKeys = listEnabledKeys(optimizations)
 
 	return (
-		<div className="space-y-3 pb-3">
+		<div className="space-y-3 pb-4">
 			<div className="flex items-center justify-between gap-2">
-				<p className="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
-					Preset
-				</p>
-				<span className="bg-shell-surface text-foreground rounded-lg px-2 py-0.5 text-xs font-medium">
+				<p className="text-muted-foreground text-eyebrow">Preset</p>
+				<span className="publisher-shell-nested text-foreground rounded-full px-2 py-0.5 text-xs font-medium">
 					{PRESET_LABELS[optimizationPreset] ?? optimizationPreset}
 				</span>
 			</div>

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/publish-options.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/publish-options.tsx
@@ -21,6 +21,7 @@ import {
 	buildUpgradeModalState,
 	upgradeModalAtom
 } from '../../../../../lib/stores/upgrade-modal-store'
+import { InlineNotice } from '../../../../layout-components'
 import { ScenePublishStateControl } from '../../../../publishing/scene-publish-state-control'
 import { itemVariants } from '../../animation'
 
@@ -203,20 +204,18 @@ export const PublishOptions: FC<PublishOptionsProps> = ({
 						: 'Scene is ready to publish.'
 
 	return (
-		<motion.div variants={itemVariants} className="space-y-4 px-2 py-2">
+		<motion.div variants={itemVariants} className="space-y-3 pb-4">
 			<div className="text-muted-foreground text-sm">
 				Publish your current optimized scene. This saves first only when there
 				are unsaved changes.
 			</div>
 			{!sceneId && (
-				<div className="border-warning/40 bg-warning/10 text-warning-foreground rounded-md border px-3 py-2 text-xs">
+				<InlineNotice>
 					First publish will save and assign a scene ID automatically.
-				</div>
+				</InlineNotice>
 			)}
 
-			<div className="border-border/60 bg-muted/30 text-muted-foreground rounded-md border px-3 py-2 text-xs">
-				{statusText}
-			</div>
+			<InlineNotice tone="neutral">{statusText}</InlineNotice>
 
 			<ScenePublishStateControl
 				publishState={publishState}

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/save-options.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/save-options.tsx
@@ -116,18 +116,16 @@ export const SaveOptions: FC = () => {
 	}
 
 	return (
-		<motion.div
-			variants={itemVariants}
-			className="flex flex-col gap-4 px-2 py-2"
-		>
-			{/* Export Section */}
+		<motion.div variants={itemVariants} className="flex flex-col gap-3 pb-4">
 			<div className="space-y-3">
-				<div>
-					<h4 className="text-sm font-medium">Download Model</h4>
-					<p className="text-muted-foreground text-xs">
-						Export your optimized 3D model for use in other applications
-					</p>
-				</div>
+				{/*
+				  No heading of its own: the accordion trigger above already says
+				  "Download", and a second title inside it was a third section-header
+				  shape competing with the two the sidebar actually uses.
+				*/}
+				<p className="text-muted-foreground text-xs">
+					Export your optimized 3D model for use in other applications
+				</p>
 
 				<RadioAccordion
 					label="Export Format"

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/scene-preview.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/sections/scene-preview.tsx
@@ -27,9 +27,9 @@ export const ScenePreview: FC = () => {
 			initial={{ opacity: 0, y: 10 }}
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.4 }}
-			className="space-y-2 px-4 pb-2"
+			className="space-y-3"
 		>
-			<div className="border-shell-border-soft bg-shell-surface-soft relative aspect-video w-full overflow-hidden rounded-xl border">
+			<div className="publisher-shell-nested relative aspect-video w-full overflow-hidden rounded-xl">
 				{thumbnailUrl ? (
 					<img
 						src={thumbnailUrl}

--- a/shared/components/src/styles/globals.css
+++ b/shared/components/src/styles/globals.css
@@ -581,8 +581,35 @@
 		@apply bg-shell-surface border-shell-border-soft rounded-xl border shadow-xl backdrop-blur-xl;
 	}
 
+	/*
+	  A block nested inside a publisher shell panel.
+
+	  Deliberately not `ds-raised`. The `ds-*` ladder mixes against `--background`
+	  because it describes surfaces sitting on the page; a shell panel does not —
+	  it floats over the 3D canvas at its own opacity, and in dark mode it is
+	  lighter than the page background. Mixing against `--background` there put a
+	  nested block *below* the panel it sits on.
+
+	  So it uses the ladder's mechanism (a value tint, never a border) against a
+	  transparent base, which separates from whatever the panel resolves to in
+	  either theme. It also stacks: a block nested inside a nested block reaches
+	  the next step up on its own, the same way the `ds-*` ladder self-corrects.
+
+	  Radius is left to the caller. Panels take `rounded-2xl` and inner blocks
+	  `rounded-xl`, and baking one in meant call sites had to override it with
+	  another utility from the same layer — a precedence coin-flip.
+	*/
 	.publisher-shell-nested {
-		@apply bg-shell-surface-soft rounded-xl shadow-sm;
+		background-color: color-mix(in oklch, var(--foreground) 5%, transparent);
+	}
+
+	/* Same surface, for blocks that are themselves the control. */
+	.publisher-shell-nested-interactive {
+		background-color: color-mix(in oklch, var(--foreground) 5%, transparent);
+		transition: background-color var(--duration-fast) var(--ease-out);
+	}
+	.publisher-shell-nested-interactive:hover {
+		background-color: color-mix(in oklch, var(--foreground) 9%, transparent);
 	}
 
 	.publisher-shell-focus {


### PR DESCRIPTION
Phase 3 of the design-token consolidation. Follows #670, #671, #672.

The publish sidebar painted with `--shell-*` and drew a border around every panel — the pattern the design system replaces with value steps. Its spacing lived in the sections rather than the container, where it had drifted to six vertical values and two different left edges, so the top half of the sidebar did not line up with the accordion below it.

### The surface change

`.publisher-shell-nested` is re-based off a value tint instead of `--shell-surface-soft` + `shadow-sm`.

It deliberately does **not** use `ds-raised`. The `ds-*` ladder mixes against `--background` because it describes surfaces sitting on the page; a shell panel does not — it floats over the 3D canvas at its own opacity, and in dark mode it is *lighter* than the page background. Mixing against `--background` there put a nested block below the panel it sits on. Tinting against a transparent base separates from whatever the panel resolves to in either theme, and stacks: a block nested inside a nested block reaches the next step on its own, the same way the `ds-*` ladder self-corrects.

Radius moves out of the class and to the caller — panels `rounded-2xl`, inner blocks `rounded-xl`. Baking one in meant call sites had to override it with another utility from the same cascade layer, which is a precedence coin-flip (the same trap that made `ds-overlay` on `Skeleton` a no-op in #672).

### Also here

- One column owns the gutter and rhythm: `p-4`, `gap-3` throughout, replacing `pt-4 pb-2` / `pb-2` / `pb-3` / `py-2` / `py-6` and the `px-4`-vs-`px-2` split between the top sections and the accordion bodies.
- Section icons sized by the trigger rather than per call site — four values, some of them numeric `size={14}` props that bypass the class and so could not be corrected in one place.
- `InlineNotice` replaces four hand-rolled caveats that agreed on neither radius (`rounded-md` vs `rounded-2xl`) nor foreground (`text-warning-foreground` vs `text-warning-muted-foreground`).
- The slow-scene state now changes the optimize control's *urgency*, not its identity. Swapping the whole surface to amber also silently cost it its hover state, since the tint and the surface class set the same property from the same layer.
- The Download panel loses its inner heading — the accordion trigger above it already says Download.
- `text-[11px]` eyebrows → `.text-eyebrow` / `.text-label-xs`.

### Scope

The publisher's canvas chrome (header, tool sidebar, optimization drawer and panels, publish card) keeps `--shell-*` by design: it sits over the viewport and needs the opaque backdrop-blur those tokens carry. This PR only moves what is inside the publish sidebar.

### Verification

- `nx typecheck vectreal-platform` ✅
- `nx run-many --target=lint --projects=vectreal-platform,shared/components` ✅
- `nx test vectreal-platform` ✅
- `nx build vectreal-platform` ✅
- Built CSS inspected: the new utilities emit correctly, and no publish-sidebar rule references `--shell-*` any more.

Needs a browser pass in light and dark before merge — the surface maths is the part worth looking at.