### PR TITLE
refactor(onboarding,home): put the brand colour behind tokens

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
@@ -107,7 +107,7 @@ const HotspotDot: FC<HotspotDotProps> = memo(
 			isSelected && isHotspotToolActive
 				? '#f97316'
 				: isLinkedCameraActive
-					? '#22c55e'
+					? 'var(--success)'
 					: hotspot.visible
 						? '#3b82f6'
 						: '#6b7280'

--- a/apps/vectreal-platform/app/routes/confirm-pending.tsx
+++ b/apps/vectreal-platform/app/routes/confirm-pending.tsx
@@ -202,11 +202,11 @@ export default function ConfirmPending() {
 						<div
 							className="flex h-16 w-16 items-center justify-center rounded-2xl"
 							style={{
-								background: 'rgba(252,108,24,0.1)',
-								border: '1px solid rgba(252,108,24,0.2)'
+								background: 'rgb(var(--orange-rgb) / 0.1)',
+								border: '1px solid rgb(var(--orange-rgb) / 0.2)'
 							}}
 						>
-							<Mail className="h-7 w-7" style={{ color: '#fc6c18' }} />
+							<Mail className="h-7 w-7" style={{ color: 'var(--orange)' }} />
 						</div>
 					</motion.div>
 

--- a/apps/vectreal-platform/app/routes/home-page/home-page.tsx
+++ b/apps/vectreal-platform/app/routes/home-page/home-page.tsx
@@ -33,6 +33,26 @@ import {
 } from '../../lib/seo-registry'
 import { identifyMobileRequest } from '../../lib/utils/identify-mobile-request'
 
+/*
+  Literal colours, deliberately outside the token system.
+
+  The panel below is a picture of someone else's interface: macOS window
+  controls and a Tokyo Night editor. They have to stay put when this site's
+  theme changes, so tokenising them would be the bug, not the fix. Naming them
+  says so, and gives a lint rule something to allowlist.
+*/
+const WINDOW_CONTROLS = {
+	close: '#ff5f57',
+	minimize: '#febc2e',
+	zoom: '#28c840'
+} as const
+
+const SYNTAX = {
+	keyword: '#7aa2f7',
+	component: '#e0af68',
+	attribute: '#9ece6a'
+} as const
+
 export async function loader({ request }: Route.LoaderArgs) {
 	const isMobile = identifyMobileRequest(request)
 	return { isMobile }
@@ -331,9 +351,24 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 					{/* Right: real install + usage code visual */}
 					<div className="bg-surface-1 border-surface-border overflow-hidden rounded-2xl border shadow-xl">
 						<div className="border-surface-border flex items-center gap-2 border-b px-4 py-3">
-							<span className="size-3 rounded-full bg-[#ff5f57]" />
-							<span className="size-3 rounded-full bg-[#febc2e]" />
-							<span className="size-3 rounded-full bg-[#28c840]" />
+							{/*
+							  Deliberately literal, not tokens. These depict macOS window
+							  controls and a Tokyo Night editor - they are a picture of
+							  someone else's UI, so they must not follow this site's theme.
+							  See WINDOW_CONTROLS and SYNTAX above.
+							*/}
+							<span
+								className="size-3 rounded-full"
+								style={{ background: WINDOW_CONTROLS.close }}
+							/>
+							<span
+								className="size-3 rounded-full"
+								style={{ background: WINDOW_CONTROLS.minimize }}
+							/>
+							<span
+								className="size-3 rounded-full"
+								style={{ background: WINDOW_CONTROLS.zoom }}
+							/>
 							<span className="text-muted-foreground/60 ml-2 text-xs">
 								your-app.tsx
 							</span>
@@ -348,15 +383,15 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 								<span className="text-muted-foreground/50">
 									{'// Drop a model into any React app\n'}
 								</span>
-								<span className="text-[#7aa2f7]">{'import'}</span>
+								<span style={{ color: SYNTAX.keyword }}>{'import'}</span>
 								<span className="text-foreground">
 									{' { VectrealViewer } '}
 								</span>
-								<span className="text-[#7aa2f7]">{'from'}</span>
+								<span style={{ color: SYNTAX.keyword }}>{'from'}</span>
 								<span className="text-orange">{" '@vctrl/viewer'\n\n"}</span>
 								<span className="text-foreground">{'<'}</span>
-								<span className="text-[#e0af68]">{'VectrealViewer'}</span>
-								<span className="text-[#9ece6a]">{' src'}</span>
+								<span style={{ color: SYNTAX.component }}>{'VectrealViewer'}</span>
+								<span style={{ color: SYNTAX.attribute }}>{' src'}</span>
 								<span className="text-foreground">{'='}</span>
 								<span className="text-orange">{'{modelUrl}'}</span>
 								<span className="text-foreground">{' />'}</span>

--- a/apps/vectreal-platform/app/routes/onboarding-page/onboarding-page.tsx
+++ b/apps/vectreal-platform/app/routes/onboarding-page/onboarding-page.tsx
@@ -88,7 +88,7 @@ const PillGroup = ({
 					className={cn(
 						'rounded-full border px-4 py-1.5 text-sm font-medium transition-all duration-150',
 						active
-							? 'border-[rgba(252,108,24,0.6)] bg-[rgba(252,108,24,0.12)] text-[#fc6c18]'
+							? 'border-[rgb(var(--orange-rgb)/0.6)] bg-[rgb(var(--orange-rgb)/0.12)] text-orange'
 							: 'text-primary/55 hover:border-primary/25 hover:text-primary/80 border-primary/12 bg-primary/4'
 					)}
 				>
@@ -126,9 +126,9 @@ const StepDot = ({
 				width: active ? 28 : 8,
 				height: 8,
 				backgroundColor: active
-					? '#fc6c18'
+					? 'var(--orange)'
 					: completed
-						? 'rgba(252,108,24,0.55)'
+						? 'rgb(var(--orange-rgb) / 0.55)'
 						: 'var(--primary)'
 			}}
 			transition={{ type: 'spring', stiffness: 500, damping: 35 }}

--- a/apps/vectreal-platform/app/routes/onboarding-page/onboarding-visuals.tsx
+++ b/apps/vectreal-platform/app/routes/onboarding-page/onboarding-visuals.tsx
@@ -15,12 +15,28 @@ import {
 
 const OnboardingWelcomeScene = lazy(() => import('./onboarding-welcome-client'))
 
+/*
+  These panels are always dark - they sit on the onboarding backdrop, not on the
+  page surface - so they tint with white rather than with `--foreground`, and
+  the `ds-*` ladder does not apply. Naming the steps is still worth doing: there
+  were six distinct white alphas here and nothing said which was a hairline,
+  which was a resting surface and which was a raised one.
+*/
+const TINT = {
+	hairline: 'rgb(255 255 255 / 0.12)',
+	edge: 'rgb(255 255 255 / 0.16)',
+	surface: 'rgb(255 255 255 / 0.04)',
+	surfaceRaised: 'rgb(255 255 255 / 0.06)',
+	dots: 'rgb(255 255 255 / 0.35)',
+	mutedText: 'rgb(255 255 255 / 0.4)'
+} as const
+
 const GridBackground = () => (
 	<div
 		className="absolute inset-0 opacity-25"
 		style={{
 			backgroundImage:
-				'radial-gradient(circle, rgba(255,255,255,0.35) 1px, transparent 1px)',
+				`radial-gradient(circle, ${TINT.dots} 1px, transparent 1px)`,
 			backgroundSize: '24px 24px'
 		}}
 	/>
@@ -45,12 +61,12 @@ const SceneStatusBadge = ({ published }: SceneStatusBadgeProps) => (
 		animate={
 			published
 				? {
-						backgroundColor: 'rgba(252,108,24,0.15)',
-						color: '#fc6c18'
+						backgroundColor: 'rgb(var(--orange-rgb) / 0.15)',
+						color: 'var(--orange)'
 					}
 				: {
-						backgroundColor: 'rgba(255,255,255,0.06)',
-						color: 'rgba(255,255,255,0.4)'
+						backgroundColor: TINT.surfaceRaised,
+						color: TINT.mutedText
 					}
 		}
 		transition={{ duration: 0.3 }}
@@ -93,7 +109,7 @@ export const WelcomeVisual: ComponentType = () => {
 					className="absolute top-6 -right-24 h-64 w-64 rounded-full"
 					style={{
 						background:
-							'radial-gradient(circle, rgba(252,108,24,0.22), transparent 70%)',
+							'radial-gradient(circle, rgb(var(--orange-rgb) / 0.22), transparent 70%)',
 						filter: 'blur(42px)'
 					}}
 				/>
@@ -101,7 +117,7 @@ export const WelcomeVisual: ComponentType = () => {
 					className="absolute bottom-8 -left-16 h-48 w-48 rounded-full"
 					style={{
 						background:
-							'radial-gradient(circle, rgba(255,255,255,0.12), transparent 70%)',
+							`radial-gradient(circle, ${TINT.hairline}, transparent 70%)`,
 						filter: 'blur(36px)'
 					}}
 				/>
@@ -126,7 +142,7 @@ export const UploadVisual: ComponentType = () => {
 				className="pointer-events-none absolute inset-0"
 				style={{
 					background:
-						'radial-gradient(circle at 55% 45%, rgba(252,108,24,0.12) 0%, transparent 62%)'
+						'radial-gradient(circle at 55% 45%, rgb(var(--orange-rgb) / 0.12) 0%, transparent 62%)'
 				}}
 			/>
 
@@ -138,9 +154,9 @@ export const UploadVisual: ComponentType = () => {
 						className="relative z-10 flex w-[74%] max-w-[460px] flex-col items-center gap-4 rounded-2xl border-2 border-dashed border-white/20 py-12"
 						animate={{
 							borderColor: [
-								'rgba(255,255,255,0.16)',
-								'rgba(252,108,24,0.55)',
-								'rgba(255,255,255,0.16)'
+								TINT.edge,
+								'rgb(var(--orange-rgb) / 0.55)',
+								TINT.edge
 							]
 						}}
 						transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
@@ -159,7 +175,7 @@ export const UploadVisual: ComponentType = () => {
 								className="pointer-events-none absolute inset-0 -z-10 rounded-2xl"
 								style={{
 									background:
-										'radial-gradient(circle, rgba(252,108,24,0.35) 0%, transparent 70%)',
+										'radial-gradient(circle, rgb(var(--orange-rgb) / 0.35) 0%, transparent 70%)',
 									filter: 'blur(18px)'
 								}}
 							/>
@@ -226,7 +242,7 @@ export const PublishVisual: ComponentType = () => {
 				className="pointer-events-none absolute inset-0"
 				style={{
 					background:
-						'radial-gradient(circle at 72% 56%, rgba(252,108,24,0.14) 0%, transparent 60%)'
+						'radial-gradient(circle at 72% 56%, rgb(var(--orange-rgb) / 0.14) 0%, transparent 60%)'
 				}}
 			/>
 
@@ -238,7 +254,7 @@ export const PublishVisual: ComponentType = () => {
 							className="relative z-10 size-28 rounded-3xl"
 							style={{
 								background:
-									'linear-gradient(135deg, rgba(252,108,24,0.75), rgba(252,108,24,0.38))'
+									'linear-gradient(135deg, rgb(var(--orange-rgb) / 0.75), rgb(var(--orange-rgb) / 0.38))'
 							}}
 							animate={{ rotate: 360 }}
 							transition={{ duration: 11, repeat: Infinity, ease: 'linear' }}
@@ -258,7 +274,7 @@ export const PublishVisual: ComponentType = () => {
 						<div className="h-1 w-full overflow-hidden rounded-full bg-white/10">
 							<motion.div
 								className="h-full rounded-full"
-								animate={{ width: `${quality}%`, backgroundColor: '#fc6c18' }}
+								animate={{ width: `${quality}%`, backgroundColor: 'var(--orange)' }}
 								transition={{ type: 'spring', stiffness: 80, damping: 20 }}
 							/>
 						</div>
@@ -277,7 +293,7 @@ export const PublishVisual: ComponentType = () => {
 										animate={{ opacity: 1, y: 0 }}
 										exit={{ opacity: 0, y: -4 }}
 										className="flex items-center justify-center gap-1 rounded-lg py-1.5 text-[10px] font-semibold text-white"
-										style={{ background: '#fc6c18' }}
+										style={{ background: 'var(--orange)' }}
 									>
 										<Zap className="size-2.5" />
 										Publish
@@ -293,16 +309,16 @@ export const PublishVisual: ComponentType = () => {
 										<div className="flex items-center gap-1 text-[10px] text-white/60">
 											<CheckCircle2
 												className="size-3 shrink-0"
-												style={{ color: '#fc6c18' }}
+												style={{ color: 'var(--orange)' }}
 											/>
 											Live on CDN
 										</div>
 										<div
 											className="truncate rounded-md px-2 py-1 text-[8px]"
 											style={{
-												background: 'rgba(252,108,24,0.08)',
-												color: '#fc6c18',
-												border: '1px solid rgba(252,108,24,0.2)'
+												background: 'rgb(var(--orange-rgb) / 0.08)',
+												color: 'var(--orange)',
+												border: '1px solid rgb(var(--orange-rgb) / 0.2)'
 											}}
 										>
 											cdn.vectreal.com/...
@@ -335,7 +351,7 @@ export const DashboardVisual: ComponentType = () => {
 				className="pointer-events-none absolute inset-0"
 				style={{
 					background:
-						'radial-gradient(ellipse at 64% 0%, rgba(252,108,24,0.1) 0%, transparent 56%)'
+						'radial-gradient(ellipse at 64% 0%, rgb(var(--orange-rgb) / 0.1) 0%, transparent 56%)'
 				}}
 			/>
 
@@ -354,8 +370,8 @@ export const DashboardVisual: ComponentType = () => {
 									className="h-14 rounded-md"
 									style={{
 										background: scene.published
-											? 'linear-gradient(135deg, rgba(252,108,24,0.26), rgba(252,108,24,0.1))'
-											: 'rgba(255,255,255,0.04)'
+											? 'linear-gradient(135deg, rgb(var(--orange-rgb) / 0.26), rgb(var(--orange-rgb) / 0.1))'
+											: TINT.surface
 									}}
 								/>
 								<p className="truncate text-[9px] font-medium text-white/60">

--- a/apps/vectreal-platform/app/routes/signup-page/signup-page.tsx
+++ b/apps/vectreal-platform/app/routes/signup-page/signup-page.tsx
@@ -299,9 +299,10 @@ function getPasswordStrength(password: string): {
 	if (/[A-Z]/.test(password)) score++
 	if (/[0-9]/.test(password)) score++
 	if (/[^a-zA-Z0-9]/.test(password)) score++
-	if (score <= 2) return { score: 1, label: 'Weak', color: '#ef4444' }
-	if (score <= 4) return { score: 2, label: 'Fair', color: '#f59e0b' }
-	return { score: 3, label: 'Strong', color: '#22c55e' }
+	if (score <= 2)
+		return { score: 1, label: 'Weak', color: 'var(--destructive)' }
+	if (score <= 4) return { score: 2, label: 'Fair', color: 'var(--warning)' }
+	return { score: 3, label: 'Strong', color: 'var(--success)' }
 }
 
 // ─── Motion config ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Phase 6 of the design-token consolidation. Follows #670, #671, #672, #673, #675; independent of #674.

### Brand orange

Every hand-typed `#fc6c18` in UI code is gone — `onboarding-visuals`, `onboarding-page`, `confirm-pending`. The thirteen `rgba(252,108,24,α)` values in the onboarding visuals become `rgb(var(--orange-rgb) / α)`, which is the spelling `--orange-rgb` was added for: `--orange` is a hex, so an alpha cannot be applied to it inline any other way.

**Deliberately not `bg-orange/12`.** Tailwind resolves an alpha on a hex with `color-mix`, and lightningcss emits a no-alpha fallback beside it — so a 12% wash degrades to a *solid brand block*. Verified in the built CSS:

```css
/* bg-orange/12 — two declarations, fallback is solid orange */
.bg-orange\/12{background-color:var(--orange)}
.bg-orange\/12{background-color:color-mix(in oklab, var(--orange) 12%, transparent)}

/* the channel token — one declaration, no fallback */
background-color:rgb(var(--orange-rgb)/.12)
```

This is the hazard the `--orange-rgb` comment in `globals.css` already warned about; this PR is the first place it would have bitten.

**Left literal on purpose:** the email templates (mail clients need inline hex) and the shields.io badge URLs in the docs, which are query parameters to someone else's service.

### Semantic colours

- `signup-page` scored password strength with `#ef4444` / `#f59e0b` / `#22c55e` — destructive / warning / success, spelled out.
- `publisher-editor-scene` had one more `#22c55e`.

### Two judgment calls, both toward *not* tokenising

**The onboarding white tints are named, not tokenised.** Those panels are always dark and sit on the onboarding backdrop rather than the page surface, so they tint with white and the `ds-*` ladder genuinely does not apply. But six distinct alphas with nothing saying which was a hairline, which a resting surface and which a raised one is still drift — so they are now `TINT.hairline`, `TINT.edge`, `TINT.surface`, and so on.

**The home page's seven hex values stay literal.** They depict macOS window controls and a Tokyo Night editor — a picture of someone else's interface, which has to stay put when this site's theme changes. Tokenising them would be the bug rather than the fix. They are named constants now (`WINDOW_CONTROLS`, `SYNTAX`) with a comment saying why, which also gives the lint rule in Phase 8 something to allowlist rather than fight.

### Verification

- `nx typecheck vectreal-platform` ✅
- `nx lint vectreal-platform` ✅
- `nx test vectreal-platform` ✅ (221 passed)
- `nx build vectreal-platform` ✅
- Built CSS and JS inspected: no raw brand rgba left in the client bundle, and the token form emits without a fallback.