### PR TITLE
refactor(ui): move the last overlay primitives onto the surface ladder

### DIFF
--- a/apps/vectreal-platform/app/components/consent/consent-banner.tsx
+++ b/apps/vectreal-platform/app/components/consent/consent-banner.tsx
@@ -26,7 +26,7 @@ export function ConsentBanner() {
 					animate={{ y: 0, opacity: 1 }}
 					exit={{ y: 80, opacity: 0 }}
 					transition={{ duration: 0.25, ease: 'easeOut' }}
-					className="bg-card/95 fixed right-0 bottom-0 left-0 z-50 border-t px-4 py-4 shadow-lg backdrop-blur-sm sm:px-6"
+					className="ds-overlay fixed right-0 bottom-0 left-0 z-50 border-t px-4 py-4 shadow-lg backdrop-blur-sm sm:px-6"
 					role="dialog"
 					aria-modal="false"
 					aria-label="Cookie consent"

--- a/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
@@ -151,7 +151,7 @@ const SigninLayout = ({ loaderData }: Route.ComponentProps) => {
 		<main className="h-full min-h-screen w-full overflow-hidden">
 			<section className="flex min-h-screen w-full flex-col overflow-hidden">
 				<div className="grid grow overflow-hidden md:grid-cols-[1fr_1fr]">
-					<div className="bg-card relative flex flex-col justify-center border-r p-8 shadow-2xl">
+					<div className="ds-raised relative flex flex-col justify-center p-8 shadow-2xl">
 						<div className="mx-auto flex max-w-md flex-col gap-8 py-16">
 							<div className="flex grow flex-col justify-end">
 								<h1 className="mb-6 text-2xl leading-tight font-medium sm:text-3xl md:text-4xl lg:text-5xl">
@@ -231,7 +231,7 @@ const SigninLayout = ({ loaderData }: Route.ComponentProps) => {
 							</AnimatePresence>
 							<span className="relative">
 								<Separator />
-								<p className="bg-card text-muted-foreground absolute left-1/2 -translate-x-1/2 -translate-y-3 px-2">
+								<p className="ds-raised text-muted-foreground absolute left-1/2 -translate-x-1/2 -translate-y-3 px-2">
 									or
 								</p>
 							</span>

--- a/shared/components/src/ui/alert.tsx
+++ b/shared/components/src/ui/alert.tsx
@@ -3,13 +3,13 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 
 const alertVariants = cva(
-	'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+	'relative w-full rounded-xl px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
 	{
 		variants: {
 			variant: {
-				default: 'bg-card text-card-foreground',
+				default: 'ds-raised text-card-foreground',
 				destructive:
-					'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90'
+					'text-destructive ds-raised [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90'
 			}
 		},
 		defaultVariants: {

--- a/shared/components/src/ui/calendar.tsx
+++ b/shared/components/src/ui/calendar.tsx
@@ -33,7 +33,7 @@ function Calendar({
 					'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
 				row: 'flex w-full mt-2',
 				cell: cn(
-					'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md',
+					'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-primary/12 [&:has([aria-selected].day-range-end)]:rounded-r-md',
 					props.mode === 'range'
 						? '[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md'
 						: '[&:has([aria-selected])]:rounded-md'
@@ -48,12 +48,12 @@ function Calendar({
 					'day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground',
 				day_selected:
 					'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
-				day_today: 'bg-accent text-accent-foreground',
+				day_today: 'ds-overlay text-foreground font-medium',
 				day_outside:
 					'day-outside text-muted-foreground aria-selected:text-muted-foreground',
 				day_disabled: 'text-muted-foreground opacity-50',
 				day_range_middle:
-					'aria-selected:bg-accent aria-selected:text-accent-foreground',
+					'aria-selected:bg-primary/12 aria-selected:text-foreground',
 				day_hidden: 'invisible',
 				...classNames
 			}}

--- a/shared/components/src/ui/command.tsx
+++ b/shared/components/src/ui/command.tsx
@@ -21,7 +21,7 @@ function Command({
 		<CommandPrimitive
 			data-slot="command"
 			className={cn(
-				'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+				'ds-overlay text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-xl',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/hover-card.tsx
+++ b/shared/components/src/ui/hover-card.tsx
@@ -20,10 +20,23 @@ function HoverCardContent({
 	className,
 	align = 'center',
 	sideOffset = 4,
+	container,
 	...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+}: React.ComponentProps<typeof HoverCardPrimitive.Content> & {
+	/**
+	 * Portal target. The content mounts on `document.body` by default, which
+	 * puts it outside any themed subtree - so a hover card opened inside a
+	 * `.dark` container renders with light tokens. Pass the themed element to
+	 * keep it in scope. Storybook's side-by-side themes need this; so does any
+	 * app region that themes a subtree rather than the document.
+	 */
+	container?: HTMLElement | null
+}) {
 	return (
-		<HoverCardPrimitive.Portal data-slot="hover-card-portal">
+		<HoverCardPrimitive.Portal
+			data-slot="hover-card-portal"
+			container={container}
+		>
 			<HoverCardPrimitive.Content
 				data-slot="hover-card-content"
 				align={align}

--- a/shared/components/src/ui/hover-card.tsx
+++ b/shared/components/src/ui/hover-card.tsx
@@ -29,7 +29,7 @@ function HoverCardContent({
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(
-					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-xl! border p-4 shadow-md outline-hidden',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-xl! p-4 shadow-md outline-hidden',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/navigation-menu.tsx
+++ b/shared/components/src/ui/navigation-menu.tsx
@@ -90,7 +90,7 @@ function NavigationMenuContent({
 			data-slot="navigation-menu-content"
 			className={cn(
 				'data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto',
-				'group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none',
+				'group-data-[viewport=false]/navigation-menu:bg-[color-mix(in_oklch,var(--foreground)_8%,var(--background))] group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-xl group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none',
 				className
 			)}
 			{...props}
@@ -111,7 +111,7 @@ function NavigationMenuViewport({
 			<NavigationMenuPrimitive.Viewport
 				data-slot="navigation-menu-viewport"
 				className={cn(
-					'origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]',
+					'origin-top-center ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-xl shadow md:w-[var(--radix-navigation-menu-viewport-width)]',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/overlay-surfaces.stories.tsx
+++ b/shared/components/src/ui/overlay-surfaces.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { Alert, AlertDescription, AlertTitle } from './alert'
 import { Button } from './button'
 import {
@@ -9,6 +11,7 @@ import {
 	CommandList
 } from './command'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from './hover-card'
+
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
@@ -67,18 +70,28 @@ export const CommandPalette: Story = {
 	)
 }
 
+/**
+ * The hover card portals to `document.body` by default, which lands it outside
+ * the decorator's themed wrapper - so it rendered light in the dark column and
+ * the story could not show the thing it exists to show. It is pinned to the
+ * panel here via `container`.
+ */
 export const HoverCardOnPanel: Story = {
-	render: () => (
-		<div className="ds-raised rounded-2xl p-6">
-			<HoverCard open>
-				<HoverCardTrigger asChild>
-					<Button variant="ghost">Author</Button>
-				</HoverCardTrigger>
-				<HoverCardContent align="start">
-					An overlay opening over a raised panel. It has to step up from the
-					panel, not match it.
-				</HoverCardContent>
-			</HoverCard>
-		</div>
-	)
+	render: function HoverCardStory() {
+		const [panel, setPanel] = useState<HTMLDivElement | null>(null)
+
+		return (
+			<div ref={setPanel} className="ds-raised relative rounded-2xl p-6">
+				<HoverCard open>
+					<HoverCardTrigger asChild>
+						<Button variant="ghost">Author</Button>
+					</HoverCardTrigger>
+					<HoverCardContent align="start" container={panel}>
+						An overlay opening over a raised panel. It has to step up from the
+						panel, not match it.
+					</HoverCardContent>
+				</HoverCard>
+			</div>
+		)
+	}
 }

--- a/shared/components/src/ui/overlay-surfaces.stories.tsx
+++ b/shared/components/src/ui/overlay-surfaces.stories.tsx
@@ -1,0 +1,84 @@
+import { Alert, AlertDescription, AlertTitle } from './alert'
+import { Button } from './button'
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList
+} from './command'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from './hover-card'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+/**
+ * The overlay primitives that #668 missed.
+ *
+ * `alert`, `command`, `hover-card` and `navigation-menu` were still painting
+ * with `bg-card` / `bg-popover` plus a drawn border while dropdown, popover,
+ * select and context-menu had already moved to the surface ladder - so two
+ * menus opening over the same page did not agree on what an overlay looks like.
+ *
+ * Rendered on a `ds-raised` panel rather than the page: an overlay that only
+ * separates from the flat background is the failure mode worth catching, and it
+ * is the one the elevation ladder was built to fix.
+ */
+const meta = {
+	title: 'Components/Overlay surfaces',
+	parameters: { layout: 'padded' }
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Alerts: Story = {
+	render: () => (
+		<div className="ds-raised space-y-4 rounded-2xl p-6">
+			<Alert>
+				<AlertTitle>Scene published</AlertTitle>
+				<AlertDescription>
+					It is live at your embed URL. Borders removed; the surface separates
+					on its own.
+				</AlertDescription>
+			</Alert>
+			<Alert variant="destructive">
+				<AlertTitle>Upload failed</AlertTitle>
+				<AlertDescription>The file exceeded your plan limit.</AlertDescription>
+			</Alert>
+		</div>
+	)
+}
+
+export const CommandPalette: Story = {
+	render: () => (
+		<div className="ds-raised rounded-2xl p-6">
+			<Command className="max-w-md">
+				<CommandInput placeholder="Search scenes..." />
+				<CommandList>
+					<CommandEmpty>No results.</CommandEmpty>
+					<CommandGroup heading="Scenes">
+						<CommandItem>Living room</CommandItem>
+						<CommandItem>Product hero</CommandItem>
+					</CommandGroup>
+				</CommandList>
+			</Command>
+		</div>
+	)
+}
+
+export const HoverCardOnPanel: Story = {
+	render: () => (
+		<div className="ds-raised rounded-2xl p-6">
+			<HoverCard open>
+				<HoverCardTrigger asChild>
+					<Button variant="ghost">Author</Button>
+				</HoverCardTrigger>
+				<HoverCardContent align="start">
+					An overlay opening over a raised panel. It has to step up from the
+					panel, not match it.
+				</HoverCardContent>
+			</HoverCard>
+		</div>
+	)
+}


### PR DESCRIPTION
Phase 7 of the design-token consolidation. Follows #670, #671, #672, #673, #675, #676.

### The gap #668 left

#668 moved `dropdown-menu`, `popover`, `select`, `context-menu` and `menubar` to `ds-overlay`, and left `alert`, `command`, `hover-card` and `navigation-menu` painting with `bg-card` / `bg-popover` plus a drawn border. Two menus opening over the same page did not agree on what an overlay looks like.

### The calendar was a different bug

`--accent` became the **neutral hover token** in #666, but the calendar still used it as the **selected-day fill**. So a hovered day and a selected day were the same colour, and a selected range read as merely hovered — only its `bg-primary` endpoints looked chosen. Selection is now a primary tint, and "today" is a surface step rather than a colour.

### Two things that could not be written the obvious way

Both for the same reason — `ds-*` classes live in `@layer components` and are **not registered utilities**:

- `group-data-[viewport=false]/navigation-menu:ds-overlay` generates **nothing**. A variant has no utility to attach to. Written as an arbitrary-value utility instead, and confirmed present in the built CSS:
  ```
  navigation-menu\:bg-\[color-mix…\]:is(…[data-viewport=false] *){background-color:color-mix(in oklch,var(--foreground) 8%,var(--background))}
  ```
- `ds-divider-b` does not exist — I wrote it, the build did not complain, and it would have silently dropped the separator. The command palette's search divider is genuine, so it keeps a plain `border-b`.

That is the fourth and fifth instance of this family across #672, #674, #675 and here. Phase 8's lint rule should catch it directly.

### App-side surfaces

The consent banner and the sign-in panel. The banner **keeps** its top border — a real edge against arbitrary page content scrolling beneath it. The "or" divider label keeps matching its panel exactly, since its entire job is to punch a hole in the rule behind it.

### Storybook

Adds coverage for the three primitives that had none, rendered **on a `ds-raised` panel rather than the page**. An overlay that separates from a flat background but not from a panel is the failure mode worth catching, and it is the one the nesting ladder in #672 was built to fix. Chromatic will diff these.

### Verification

- `nx run-many --target=lint,typecheck --projects=shared/components,storybook` ✅
- `nx typecheck vectreal-platform` ✅
- `nx test vectreal-platform` ✅ (221 passed)
- `nx build vectreal-platform` ✅ · `nx build-storybook storybook` ✅
- Built CSS inspected; no `bg-card` / `bg-popover` left in `shared/components/src/ui`.