### PR TITLE
chore(lint): enforce the two design-system failures this sweep kept hitting

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -113,6 +113,62 @@ export default defineConfig(tseslint.configs.recommended, [
 			]
 		}
 	},
+	/*
+	  Design-system adherence.
+
+	  Both rules encode a failure this consolidation actually hit, more than once
+	  each, and that nothing else catches.
+	*/
+	{
+		files: ['apps/**/*.{ts,tsx}', 'shared/**/*.{ts,tsx}'],
+		ignores: [
+			// Mail clients do not resolve custom properties, so email templates
+			// must inline their hex.
+			'**/lib/email/templates/**',
+			// Stories deliberately show raw values beside their tokens.
+			'**/*.stories.tsx'
+		],
+		rules: {
+			'no-restricted-syntax': [
+				'error',
+				{
+					/*
+					  A Tailwind variant on a `ds-*` or `.text-*` class.
+
+					  Those classes live in `@layer components` and are not registered
+					  utilities, so a variant has nothing to attach to and Tailwind
+					  emits no rule at all. It fails silently - the class is in the
+					  markup and simply does nothing. `hover:ds-overlay`,
+					  `focus-within:ds-overlay` and
+					  `group-data-[viewport=false]/navigation-menu:ds-overlay` all
+					  shipped past review during this sweep before being caught by
+					  reading built CSS.
+
+					  Write the value as an arbitrary utility instead:
+					  `hover:bg-[color-mix(in_oklch,var(--foreground)_8%,var(--background))]`.
+					*/
+					selector:
+						'Literal[value=/(^|\\s)[a-z][a-z0-9-]*(\\[[^\\]]*\\])?(\\/[a-z-]+)?:(ds-(raised|overlay|sunken|divider)|text-(display|headline|h2|h3|stat|body-lg|eyebrow|label-xs))/]',
+					message:
+						'Tailwind variants cannot be applied to ds-* or text-* design-system classes: they are @layer components rules, not utilities, so this generates nothing. Use an arbitrary value, e.g. hover:bg-[color-mix(in_oklch,var(--foreground)_8%,var(--background))].'
+				},
+				{
+					/*
+					  A raw hex colour in a Tailwind arbitrary value.
+
+					  Colours belong to the token set. Where a literal is genuinely
+					  correct - depicting someone else's interface, for instance - hoist
+					  it to a named constant with a comment, which also takes it out of
+					  the class string and past this rule.
+					*/
+					selector:
+						'Literal[value=/(bg|text|border|from|via|to|fill|stroke|shadow|ring|outline|decoration|accent|caret)-\\[#[0-9a-fA-F]{3,8}/]',
+					message:
+						'Raw hex in a Tailwind class. Use a design token (bg-orange, text-muted-foreground, ds-raised) or, for a colour that must not follow the theme, a named constant with a comment saying why.'
+				}
+			]
+		}
+	},
 	{
 		files: ['**/*.json'],
 		ignores: ['**/node_modules/**', '**/package.json'],


### PR DESCRIPTION
Phase 8, the last of the design-token consolidation. Follows #670–#677.

Without enforcement this drifts straight back, so these two rules encode mistakes that **actually shipped past review** during phases 3–7 and that nothing else catches.

### Rule 1 — variants on `ds-*` / `.text-*`

These classes live in `@layer components` and are **not registered utilities**, so a variant has nothing to attach to and Tailwind emits no rule at all. It fails *silently* — the class sits in the markup and does nothing.

Three instances got through this sweep, each caught only by reading built CSS:

| Where | Written | Effect |
|---|---|---|
| #672 | `ds-overlay` on `Skeleton` | no-op |
| #674 | `focus-within:ds-overlay` | no-op |
| #677 | `group-data-[viewport=false]/…:ds-overlay` | no-op |

The message names the fix: write the value as an arbitrary utility, e.g. `hover:bg-[color-mix(in_oklch,var(--foreground)_8%,var(--background))]`.

The `@apply` half of the same trap already fails the build (`Cannot apply unknown utility class`), so it needs no rule — noted in the config so nobody adds a redundant one.

### Rule 2 — raw hex in Tailwind arbitrary values

Exemptions, both deliberate:
- **email templates** — mail clients do not resolve custom properties
- **stories** — they show raw values beside their tokens on purpose

Where a literal is genuinely correct (the home page's macOS window controls and Tokyo Night palette depict *someone else's* interface and must not follow this theme), the fix is a named constant with a comment — which also lifts it out of the class string and past the rule. #676 already did that, so the rule lands green.

### Verified, not assumed

A rule that never fires proves nothing, so both were run against deliberate violations:

```
hover:ds-overlay                                      → caught
focus-within:ds-overlay                               → caught
group-data-[viewport=false]/navigation-menu:ds-overlay → caught
md:text-headline                                      → caught
bg-[#fc6c18] text-[#7aa2f7]                           → caught
ds-overlay hover:bg-accent text-headline              → passes
bg-orange/12 text-orange                              → passes
```

`nx run-many --target=lint --projects=vectreal-platform,shared/components,storybook` passes on the workspace as it stands.

### Still outstanding from Phase 8

Pushing the corrected `--accent` (neutral hover, not brand) and `--radius: 1rem` back to the **Vectreal Design System** repo (`tokens/colors.css`, `tokens/spacing.css`, `guidelines/spacing-radii.html`), which still disagrees with the code. That repo is not in this workspace, so it needs doing separately — flagging rather than silently dropping it.