### PR TITLE
feat(dashboard): shared pieces for the dashboard overhaul, and a thumbnail scoping fix

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/billing/billing-settings-section.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/billing/billing-settings-section.tsx
@@ -1,8 +1,6 @@
 import { Badge } from '@shared/components/ui/badge'
 import { Button } from '@shared/components/ui/button'
-import { Progress } from '@shared/components/ui/progress'
 import { Separator } from '@shared/components/ui/separator'
-import { cn } from '@shared/utils'
 import {
 	AlertTriangle,
 	ArrowUpRight,
@@ -17,6 +15,7 @@ import { Link } from 'react-router'
 
 import { DASHBOARD_ROUTES } from '../../../constants/dashboard'
 import { PLAN_DISPLAY_NAMES } from '../../../constants/product-copy'
+import { UsageMeter } from '../usage-meter'
 
 import type { BillingState } from '../../../constants/plan-config'
 import type { BillingSettingsData } from '../../../lib/domain/dashboard/dashboard-types'
@@ -98,117 +97,6 @@ const WARNING_STATES = new Set<BillingState>([
 	'incomplete_expired',
 	'paused'
 ])
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-function StatTile({
-	label,
-	current,
-	limit,
-	monthly
-}: {
-	label: string
-	current: number
-	limit: number | null
-	monthly?: boolean
-}) {
-	const unlimited = limit === null
-	const percent = unlimited
-		? 0
-		: Math.min(Math.round((current / limit) * 100), 100)
-	const isWarning = !unlimited && percent >= 80
-	const isCritical = !unlimited && percent >= 95
-
-	return (
-		<div className="bg-muted/20 space-y-3 rounded-xl p-4">
-			<p className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
-				{label}
-				{monthly && (
-					<span className="text-muted-foreground/60 ml-1 tracking-normal normal-case">
-						/mo
-					</span>
-				)}
-			</p>
-			<p
-				className={cn(
-					'text-2xl font-semibold tracking-tight tabular-nums',
-					isCritical && 'text-destructive',
-					isWarning && !isCritical && 'text-orange!'
-				)}
-			>
-				{current.toLocaleString()}
-				<span className="text-muted-foreground ml-0.5 text-sm font-normal">
-					{!unlimited ? `/ ${limit.toLocaleString()}` : '/ ∞'}
-				</span>
-			</p>
-			{!unlimited && (
-				<Progress
-					value={percent}
-					className={cn(
-						'h-1',
-						isCritical && '[&>div]:bg-destructive',
-						isWarning && !isCritical && '[&>div]:bg-orange!'
-					)}
-				/>
-			)}
-			{unlimited && <div className="bg-muted/40 h-1 rounded-full" />}
-		</div>
-	)
-}
-
-function MeterRow({
-	label,
-	current,
-	limit,
-	monthly
-}: {
-	label: string
-	current: number
-	limit: number | null
-	monthly?: boolean
-}) {
-	const unlimited = limit === null
-	const percent = unlimited
-		? 0
-		: Math.min(Math.round((current / limit) * 100), 100)
-	const isWarning = !unlimited && percent >= 80
-	const isCritical = !unlimited && percent >= 95
-
-	return (
-		<div className="space-y-1.5">
-			<div className="flex items-center justify-between">
-				<span className="text-muted-foreground text-xs">
-					{label}
-					{monthly && (
-						<span className="text-muted-foreground/50 ml-1">/mo</span>
-					)}
-				</span>
-				<span
-					className={cn(
-						'text-xs font-medium tabular-nums',
-						isCritical && 'text-destructive',
-						isWarning && !isCritical && 'text-orange!'
-					)}
-				>
-					{current.toLocaleString()}
-					{!unlimited ? ` / ${limit.toLocaleString()}` : ' / ∞'}
-				</span>
-			</div>
-			{!unlimited && (
-				<Progress
-					value={percent}
-					className={cn(
-						'h-1',
-						isCritical && '[&>div]:bg-destructive',
-						isWarning && !isCritical && '[&>div]:bg-orange!'
-					)}
-				/>
-			)}
-		</div>
-	)
-}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -356,17 +244,17 @@ export function BillingSettingsSection({
 
 			{/* ── KPI stat grid ─────────────────────────────────── */}
 			<section className="grid grid-cols-2 gap-3 md:grid-cols-3">
-				<StatTile
+				<UsageMeter
 					label="Scenes"
 					current={usage.scenesTotal}
 					limit={usage.sceneLimit}
 				/>
-				<StatTile
+				<UsageMeter
 					label="Projects"
 					current={usage.projectsTotal}
 					limit={usage.projectsLimit}
 				/>
-				<StatTile
+				<UsageMeter
 					label="Published"
 					current={usage.publishedScenes}
 					limit={usage.publishedSceneLimit}
@@ -378,21 +266,24 @@ export function BillingSettingsSection({
 			{/* ── Detailed usage meters ────────────────────────── */}
 			<section className="grid gap-8 md:grid-cols-2">
 				<div className="space-y-4">
-					<p className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
+					<p className="text-muted-foreground text-eyebrow">
 						Content
 					</p>
 					<div className="space-y-3">
-						<MeterRow
+						<UsageMeter
+							variant="row"
 							label="Scenes (total)"
 							current={usage.scenesTotal}
 							limit={usage.sceneLimit}
 						/>
-						<MeterRow
+						<UsageMeter
+							variant="row"
 							label="Published scenes"
 							current={usage.publishedScenes}
 							limit={usage.publishedSceneLimit}
 						/>
-						<MeterRow
+						<UsageMeter
+							variant="row"
 							label="Projects"
 							current={usage.projectsTotal}
 							limit={usage.projectsLimit}
@@ -400,11 +291,12 @@ export function BillingSettingsSection({
 					</div>
 				</div>
 				<div className="space-y-4">
-					<p className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
+					<p className="text-muted-foreground text-eyebrow">
 						API &amp; processing
 					</p>
 					<div className="space-y-3">
-						<MeterRow
+						<UsageMeter
+							variant="row"
 							label="API requests"
 							current={usage.apiRequestsMonth}
 							limit={usage.apiRequestsMonthLimit}
@@ -413,11 +305,12 @@ export function BillingSettingsSection({
 					</div>
 				</div>
 				<div className="space-y-4">
-					<p className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
+					<p className="text-muted-foreground text-eyebrow">
 						Storage &amp; bandwidth
 					</p>
 					<div className="space-y-3">
-						<MeterRow
+						<UsageMeter
+							variant="row"
 							label="Storage used (MB)"
 							current={Math.round(usage.storageBytesTotal / (1024 * 1024))}
 							limit={
@@ -426,13 +319,15 @@ export function BillingSettingsSection({
 									: null
 							}
 						/>
-						<MeterRow
+						<UsageMeter
+							variant="row"
 							label="Embed bandwidth (GB)"
 							current={usage.embedBandwidthMonth}
 							limit={usage.embedBandwidthLimit}
 							monthly
 						/>
-						<MeterRow
+						<UsageMeter
+							variant="row"
 							label="Preview loads"
 							current={usage.previewLoadsMonth}
 							limit={usage.previewLoadsMonthLimit}

--- a/apps/vectreal-platform/app/components/dashboard/dashboard-pieces.stories.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dashboard-pieces.stories.tsx
@@ -70,16 +70,15 @@ export const UsageMeters: Story = {
 
 /**
  * A missing thumbnail is the normal case, not the exception - `thumbnailUrl` is
- * only written after a publisher save with a viewport capture. The placeholder
- * tint is derived from the name, so it must stay stable per scene.
+ * only written after a publisher save with a viewport capture. Both a null
+ * source and a 404 resolve to the same neutral well, so there is one state to
+ * diff rather than two.
  */
 export const Thumbnails: Story = {
 	render: () => (
-		<div className="ds-raised grid grid-cols-2 gap-4 rounded-2xl p-6 md:grid-cols-4">
-			<SceneThumbnail src={null} name="Living Room" />
-			<SceneThumbnail src={null} name="Product Hero" />
-			<SceneThumbnail src={null} name="Office Chair" />
-			<SceneThumbnail src="/does-not-exist.png" name="Broken Source" />
+		<div className="ds-raised grid grid-cols-2 gap-4 rounded-2xl p-6">
+			<SceneThumbnail src={null} />
+			<SceneThumbnail src="/does-not-exist.png" />
 		</div>
 	)
 }

--- a/apps/vectreal-platform/app/components/dashboard/dashboard-pieces.stories.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dashboard-pieces.stories.tsx
@@ -1,0 +1,142 @@
+import { MemoryRouter } from 'react-router'
+
+import { ProjectCard } from './project-card'
+import { SceneThumbnail } from './scene-thumbnail'
+import { StatusBreakdown } from './status-breakdown'
+import { UsageMeter, UsageMeterGrid } from './usage-meter'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+/**
+ * The pieces the dashboard landing page and projects browse are built from.
+ *
+ * Rendered on a `ds-raised` panel rather than the page background: these all sit
+ * inside panels in the real layout, and a surface that separates from a flat
+ * background but not from a panel is the failure the elevation ladder exists to
+ * catch.
+ */
+const meta = {
+	title: 'Dashboard/Pieces',
+	parameters: { layout: 'padded' }
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const MB = 1024 * 1024
+
+/**
+ * The states that matter are the ends: unlimited (every paid plan has at least
+ * one), and at/over a limit, which is where the meter has to actually say
+ * something rather than decorate.
+ */
+export const UsageMeters: Story = {
+	render: () => (
+		<div className="ds-raised space-y-6 rounded-2xl p-6">
+			<UsageMeterGrid>
+				<UsageMeter label="Scenes" current={4} limit={10} />
+				<UsageMeter label="Published" current={8} limit={10} />
+				<UsageMeter label="Projects" current={1} limit={1} />
+				<UsageMeter label="Storage" current={12} limit={null} />
+			</UsageMeterGrid>
+
+			<div className="max-w-sm space-y-3">
+				<UsageMeter variant="row" label="Scenes (total)" current={4} limit={10} />
+				<UsageMeter
+					variant="row"
+					label="API requests"
+					current={9_400}
+					limit={10_000}
+					monthly
+				/>
+				<UsageMeter
+					variant="row"
+					label="Storage used"
+					current={480 * MB}
+					limit={500 * MB}
+					format={(value) => `${Math.round(value / MB)} MB`}
+				/>
+				<UsageMeter
+					variant="row"
+					label="Embed bandwidth"
+					current={2}
+					limit={null}
+					monthly
+				/>
+			</div>
+		</div>
+	)
+}
+
+/**
+ * A missing thumbnail is the normal case, not the exception - `thumbnailUrl` is
+ * only written after a publisher save with a viewport capture. The placeholder
+ * tint is derived from the name, so it must stay stable per scene.
+ */
+export const Thumbnails: Story = {
+	render: () => (
+		<div className="ds-raised grid grid-cols-2 gap-4 rounded-2xl p-6 md:grid-cols-4">
+			<SceneThumbnail src={null} name="Living Room" />
+			<SceneThumbnail src={null} name="Product Hero" />
+			<SceneThumbnail src={null} name="Office Chair" />
+			<SceneThumbnail src="/does-not-exist.png" name="Broken Source" />
+		</div>
+	)
+}
+
+export const StatusBreakdowns: Story = {
+	render: () => (
+		<div className="ds-raised space-y-4 rounded-2xl p-6">
+			<StatusBreakdown counts={{ published: 9, draft: 3, archived: 0 }} />
+			<StatusBreakdown counts={{ published: 0, draft: 4, archived: 2 }} />
+			<StatusBreakdown
+				counts={{ published: 2, draft: 1, archived: 0 }}
+				verbose
+			/>
+			<StatusBreakdown counts={{ published: 0, draft: 0, archived: 0 }} />
+		</div>
+	)
+}
+
+/**
+ * The last card has no scenes: it must read "No scenes yet" rather than borrow
+ * today's date, which is what the table did.
+ */
+export const ProjectCards: Story = {
+	render: () => (
+		<MemoryRouter>
+			<div className="ds-raised grid gap-4 rounded-2xl p-6 md:grid-cols-3">
+				<ProjectCard
+					project={{
+						id: '1',
+						name: 'Studio Showcase',
+						organizationName: 'Acme',
+						counts: { published: 9, draft: 3, archived: 0 },
+						thumbnailUrl: null,
+						updatedAt: new Date()
+					}}
+				/>
+				<ProjectCard
+					project={{
+						id: '2',
+						name: 'Retail Configurator',
+						organizationName: 'Acme',
+						counts: { published: 1, draft: 3, archived: 2 },
+						thumbnailUrl: null,
+						updatedAt: new Date(Date.now() - 5 * 86_400_000)
+					}}
+				/>
+				<ProjectCard
+					project={{
+						id: '3',
+						name: 'Archive',
+						organizationName: 'Acme',
+						counts: { published: 0, draft: 0, archived: 0 },
+						thumbnailUrl: null,
+						updatedAt: null
+					}}
+				/>
+			</div>
+		</MemoryRouter>
+	)
+}

--- a/apps/vectreal-platform/app/components/dashboard/project-card.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/project-card.tsx
@@ -60,7 +60,6 @@ export function ProjectCard({ project, className }: ProjectCardProps) {
 			>
 				<SceneThumbnail
 					src={project.thumbnailUrl}
-					name={project.name}
 					className="rounded-none"
 				/>
 

--- a/apps/vectreal-platform/app/components/dashboard/project-card.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/project-card.tsx
@@ -1,0 +1,100 @@
+import { Button } from '@shared/components/ui/button'
+import { cn } from '@shared/utils'
+import { Pencil } from 'lucide-react'
+import { Link } from 'react-router'
+
+import { SceneThumbnail } from './scene-thumbnail'
+import { StatusBreakdown, type SceneStatusCounts } from './status-breakdown'
+
+export interface ProjectCardData {
+	id: string
+	name: string
+	organizationName: string
+	counts: SceneStatusCounts
+	/** From the project's most recently updated scene that has one. */
+	thumbnailUrl?: null | string
+	/**
+	 * Null when the project has no scenes. `projects` has no timestamp column of
+	 * its own, so this is derived from its scenes - and a project without scenes
+	 * genuinely has no date rather than one of today.
+	 */
+	updatedAt: Date | null
+}
+
+interface ProjectCardProps {
+	project: ProjectCardData
+	className?: string
+}
+
+function formatUpdated(updatedAt: Date | null) {
+	if (!updatedAt) {
+		return 'No scenes yet'
+	}
+
+	const days = Math.floor((Date.now() - updatedAt.getTime()) / 86_400_000)
+	if (days < 1) return 'Updated today'
+	if (days === 1) return 'Updated yesterday'
+	if (days < 30) return `Updated ${days} days ago`
+
+	return `Updated ${updatedAt.toLocaleDateString('en-US', {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric'
+	})}`
+}
+
+/**
+ * A project at a glance.
+ *
+ * The card carries what the table could not: a thumbnail borrowed from the
+ * project's most recent scene, and how its scenes divide across draft and
+ * published. Both come from data the loader already had in hand.
+ */
+export function ProjectCard({ project, className }: ProjectCardProps) {
+	return (
+		<div className={cn('group/card relative', className)}>
+			<Link
+				to={`/dashboard/projects/${project.id}`}
+				viewTransition
+				className="ds-raised-interactive block overflow-hidden rounded-2xl"
+			>
+				<SceneThumbnail
+					src={project.thumbnailUrl}
+					name={project.name}
+					className="rounded-none"
+				/>
+
+				<div className="space-y-2 p-4">
+					<div className="min-w-0">
+						<p className="truncate font-medium">{project.name}</p>
+						<p className="text-muted-foreground truncate text-xs">
+							{project.organizationName}
+						</p>
+					</div>
+
+					<StatusBreakdown counts={project.counts} />
+
+					<p className="text-muted-foreground text-label-xs">
+						{formatUpdated(project.updatedAt)}
+					</p>
+				</div>
+			</Link>
+
+			{/*
+			  Outside the card link rather than inside it: nesting an anchor in an
+			  anchor is invalid, and the browser resolves it by dropping one of them.
+			*/}
+			<Button
+				variant="ghost"
+				size="icon"
+				asChild
+				className="absolute top-2 right-2 opacity-0 transition-opacity group-hover/card:opacity-100 focus-visible:opacity-100"
+			>
+				<Link to={`/dashboard/projects/${project.id}/edit`}>
+					<Pencil className="size-4" />
+					<span className="sr-only">Edit {project.name}</span>
+				</Link>
+			</Button>
+		</div>
+	)
+}

--- a/apps/vectreal-platform/app/components/dashboard/scene-thumbnail.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/scene-thumbnail.tsx
@@ -1,0 +1,82 @@
+import { cn } from '@shared/utils'
+import { Box } from 'lucide-react'
+import { useState } from 'react'
+
+interface SceneThumbnailProps {
+	/** `scenes.thumbnailUrl` - an internal API path, and often null. */
+	src?: null | string
+	/** Seeds the placeholder, so the same scene always gets the same tint. */
+	name: string
+	className?: string
+	/** Rendered at card size by default; `sm` suits table rows. */
+	size?: 'sm' | 'md'
+}
+
+/**
+ * Six brand-adjacent hues. Deliberately derived from the scene name rather than
+ * random, so a scene keeps its colour across renders and pages - a placeholder
+ * that changes on every navigation reads as a loading bug.
+ */
+const PLACEHOLDER_HUES = [18, 340, 265, 200, 150, 45]
+
+function hueFor(name: string) {
+	let hash = 0
+	for (let index = 0; index < name.length; index += 1) {
+		hash = (hash * 31 + name.charCodeAt(index)) % 4096
+	}
+	return PLACEHOLDER_HUES[hash % PLACEHOLDER_HUES.length]
+}
+
+/**
+ * A scene's thumbnail, or a stand-in for it.
+ *
+ * A missing thumbnail is the normal case, not the exception: `thumbnailUrl` is
+ * only written when a scene has been saved through the publisher after a
+ * viewport capture, so every scene predating that has none. A load failure is
+ * treated identically - by the time the image 404s the reason no longer matters
+ * to the person looking at it.
+ */
+export function SceneThumbnail({
+	src,
+	name,
+	className,
+	size = 'md'
+}: SceneThumbnailProps) {
+	const [failed, setFailed] = useState(false)
+	const showPlaceholder = !src || failed
+
+	return (
+		<div
+			className={cn(
+				'ds-sunken relative overflow-hidden',
+				size === 'sm' ? 'size-9 rounded-lg' : 'aspect-video w-full rounded-xl',
+				className
+			)}
+		>
+			{showPlaceholder ? (
+				<div
+					className="flex h-full w-full items-center justify-center"
+					style={{
+						background: `linear-gradient(135deg, oklch(0.62 0.16 ${hueFor(name)} / 0.22), transparent 70%)`
+					}}
+					aria-hidden="true"
+				>
+					<Box
+						className={cn(
+							'text-muted-foreground/50',
+							size === 'sm' ? 'size-4' : 'size-7'
+						)}
+					/>
+				</div>
+			) : (
+				<img
+					src={src}
+					alt=""
+					loading="lazy"
+					onError={() => setFailed(true)}
+					className="h-full w-full object-cover object-center"
+				/>
+			)}
+		</div>
+	)
+}

--- a/apps/vectreal-platform/app/components/dashboard/scene-thumbnail.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/scene-thumbnail.tsx
@@ -5,26 +5,9 @@ import { useState } from 'react'
 interface SceneThumbnailProps {
 	/** `scenes.thumbnailUrl` - an internal API path, and often null. */
 	src?: null | string
-	/** Seeds the placeholder, so the same scene always gets the same tint. */
-	name: string
 	className?: string
 	/** Rendered at card size by default; `sm` suits table rows. */
 	size?: 'sm' | 'md'
-}
-
-/**
- * Six brand-adjacent hues. Deliberately derived from the scene name rather than
- * random, so a scene keeps its colour across renders and pages - a placeholder
- * that changes on every navigation reads as a loading bug.
- */
-const PLACEHOLDER_HUES = [18, 340, 265, 200, 150, 45]
-
-function hueFor(name: string) {
-	let hash = 0
-	for (let index = 0; index < name.length; index += 1) {
-		hash = (hash * 31 + name.charCodeAt(index)) % 4096
-	}
-	return PLACEHOLDER_HUES[hash % PLACEHOLDER_HUES.length]
 }
 
 /**
@@ -38,7 +21,6 @@ function hueFor(name: string) {
  */
 export function SceneThumbnail({
 	src,
-	name,
 	className,
 	size = 'md'
 }: SceneThumbnailProps) {
@@ -53,12 +35,18 @@ export function SceneThumbnail({
 				className
 			)}
 		>
+			{/*
+			  A neutral well, not a per-scene colour.
+
+			  This first cycled six hues keyed off the scene name. That colour
+			  encoded nothing - the name sits right next to it - so it was decoration
+			  in six directions, and it put magenta and green into a product whose
+			  palette is one accent over neutrals. The surface ladder already says
+			  "nothing here yet"; it does not need help.
+			*/}
 			{showPlaceholder ? (
 				<div
 					className="flex h-full w-full items-center justify-center"
-					style={{
-						background: `linear-gradient(135deg, oklch(0.62 0.16 ${hueFor(name)} / 0.22), transparent 70%)`
-					}}
 					aria-hidden="true"
 				>
 					<Box

--- a/apps/vectreal-platform/app/components/dashboard/status-breakdown.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/status-breakdown.tsx
@@ -6,12 +6,20 @@ export interface SceneStatusCounts {
 	archived: number
 }
 
-/**
- * Published leads because it is the state that costs a quota slot and the one
- * users check for. Archived is only shown when there is some.
- */
+/*
+  One accent and two weights of neutral - not three colours.
+
+  Published leads because it is the state that costs a quota slot and the one
+  users scan for, so it gets the brand accent. Draft and archived are the same
+  hue at decreasing strength, which is what "less live" should look like.
+
+  Green was wrong here: publishing is a state, not a success, and nothing else
+  in the app says published-is-green - the scene table distinguishes them with
+  `Badge` default vs secondary. A colour that appears in one component and
+  nowhere else is a dialect, not a system.
+*/
 const STATUS_STYLES = [
-	{ key: 'published', label: 'published', dot: 'bg-success' },
+	{ key: 'published', label: 'published', dot: 'bg-orange' },
 	{ key: 'draft', label: 'draft', dot: 'bg-muted-foreground/60' },
 	{ key: 'archived', label: 'archived', dot: 'bg-muted-foreground/30' }
 ] as const

--- a/apps/vectreal-platform/app/components/dashboard/status-breakdown.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/status-breakdown.tsx
@@ -1,0 +1,73 @@
+import { cn } from '@shared/utils'
+
+export interface SceneStatusCounts {
+	published: number
+	draft: number
+	archived: number
+}
+
+/**
+ * Published leads because it is the state that costs a quota slot and the one
+ * users check for. Archived is only shown when there is some.
+ */
+const STATUS_STYLES = [
+	{ key: 'published', label: 'published', dot: 'bg-success' },
+	{ key: 'draft', label: 'draft', dot: 'bg-muted-foreground/60' },
+	{ key: 'archived', label: 'archived', dot: 'bg-muted-foreground/30' }
+] as const
+
+interface StatusBreakdownProps {
+	counts: SceneStatusCounts
+	/** Spells out the status names; otherwise it is dots and numbers only. */
+	verbose?: boolean
+	className?: string
+}
+
+/**
+ * How a project's scenes divide across draft, published and archived.
+ *
+ * The dashboard loader already computes this per project and throws it away,
+ * so a project row could only ever say "12 scenes" - which does not answer the
+ * question people actually have about a project, namely how much of it is live.
+ */
+export function StatusBreakdown({
+	counts,
+	verbose,
+	className
+}: StatusBreakdownProps) {
+	const visible = STATUS_STYLES.filter(
+		// Archived is noise until it exists; draft and published always show, so
+		// an all-draft project still reads as "0 published".
+		(status) => counts[status.key] > 0 || status.key !== 'archived'
+	)
+
+	const total = counts.published + counts.draft + counts.archived
+	if (total === 0) {
+		return (
+			<span className={cn('text-muted-foreground text-xs', className)}>
+				No scenes yet
+			</span>
+		)
+	}
+
+	return (
+		<div
+			className={cn(
+				'text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs',
+				className
+			)}
+		>
+			{visible.map((status) => (
+				<span key={status.key} className="flex items-center gap-1.5">
+					<span
+						className={cn('size-1.5 shrink-0 rounded-full', status.dot)}
+						aria-hidden="true"
+					/>
+					<span className="tabular-nums">{counts[status.key]}</span>
+					{verbose ? <span>{status.label}</span> : null}
+					<span className="sr-only">{status.label}</span>
+				</span>
+			))}
+		</div>
+	)
+}

--- a/apps/vectreal-platform/app/components/dashboard/usage-meter.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/usage-meter.tsx
@@ -47,15 +47,24 @@ export function hasUsagePressure(readings: UsageReading[]) {
 	return readings.some((reading) => reading.level !== 'ok')
 }
 
+/*
+  Warning is `--warning` (amber), not `--orange`.
+
+  The billing page used the brand colour to mean "approaching your limit", which
+  is the same mistake as the newsroom's `text-primary`-as-accent: reaching for a
+  colour that already means something else. Orange is the brand, and it is used
+  below to mark the state a user cares about - it cannot also mean "careful".
+  Only these two semantic tokens appear here, and only for their semantics.
+*/
 const LEVEL_TEXT: Record<UsageLevel, string> = {
 	ok: '',
-	warning: 'text-orange!',
+	warning: 'text-warning',
 	critical: 'text-destructive'
 }
 
 const LEVEL_BAR: Record<UsageLevel, string> = {
 	ok: '',
-	warning: '[&>div]:bg-orange!',
+	warning: '[&>div]:bg-warning',
 	critical: '[&>div]:bg-destructive'
 }
 

--- a/apps/vectreal-platform/app/components/dashboard/usage-meter.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/usage-meter.tsx
@@ -1,0 +1,176 @@
+import { Progress } from '@shared/components/ui/progress'
+import { cn } from '@shared/utils'
+
+import type { ReactNode } from 'react'
+
+/** At or above this share of the limit, the meter warns. */
+const WARNING_AT = 80
+/** At or above this, it is critical - the next action is likely to be refused. */
+const CRITICAL_AT = 95
+
+export type UsageLevel = 'ok' | 'warning' | 'critical'
+
+export interface UsageReading {
+	unlimited: boolean
+	percent: number
+	level: UsageLevel
+}
+
+/**
+ * Where a usage figure sits against its limit.
+ *
+ * `limit === null` means unlimited, which every plan above free uses for at
+ * least one key - so it is a first-class case, not an edge one. An unlimited
+ * meter is never a warning however large the number gets.
+ */
+export function readUsage(current: number, limit: null | number): UsageReading {
+	if (limit === null || limit <= 0) {
+		return { unlimited: true, percent: 0, level: 'ok' }
+	}
+
+	const percent = Math.min(Math.round((current / limit) * 100), 100)
+
+	return {
+		unlimited: false,
+		percent,
+		level:
+			percent >= CRITICAL_AT
+				? 'critical'
+				: percent >= WARNING_AT
+					? 'warning'
+					: 'ok'
+	}
+}
+
+/** True when any reading deserves the user's attention. */
+export function hasUsagePressure(readings: UsageReading[]) {
+	return readings.some((reading) => reading.level !== 'ok')
+}
+
+const LEVEL_TEXT: Record<UsageLevel, string> = {
+	ok: '',
+	warning: 'text-orange!',
+	critical: 'text-destructive'
+}
+
+const LEVEL_BAR: Record<UsageLevel, string> = {
+	ok: '',
+	warning: '[&>div]:bg-orange!',
+	critical: '[&>div]:bg-destructive'
+}
+
+interface UsageMeterProps {
+	label: ReactNode
+	current: number
+	/** `null` for unlimited. */
+	limit: null | number
+	/** Appends "/mo" to the label for per-period limits. */
+	monthly?: boolean
+	/**
+	 * `tile` is a standalone block for a grid; `row` is a compact line for a
+	 * list. They differ only in layout - the reading and its colours are shared.
+	 */
+	variant?: 'tile' | 'row'
+	/** Defaults to `toLocaleString`. Pass one for bytes, requests, and so on. */
+	format?: (value: number) => string
+	className?: string
+}
+
+/**
+ * A usage figure against its plan limit.
+ *
+ * The billing page had two of these - `StatTile` and `MeterRow` - written out
+ * separately in one file, each recomputing the same percentage and repeating
+ * the same 80/95 thresholds. They are one component with two layouts, which
+ * matters now that the dashboard shows the same readings: a threshold that
+ * disagrees between two screens is worse than no threshold.
+ */
+export function UsageMeter({
+	label,
+	current,
+	limit,
+	monthly,
+	variant = 'tile',
+	format = (value) => value.toLocaleString(),
+	className
+}: UsageMeterProps) {
+	const { unlimited, percent, level } = readUsage(current, limit)
+	const limitLabel = limit === null || limit <= 0 ? '∞' : format(limit)
+	const value = `${format(current)} / ${limitLabel}`
+
+	const bar = unlimited ? (
+		// A flat rail rather than no rail: the meters stay aligned in a grid
+		// whether or not a given key is capped on this plan.
+		<div className="ds-sunken h-1 rounded-full" />
+	) : (
+		<Progress value={percent} className={cn('h-1', LEVEL_BAR[level])} />
+	)
+
+	if (variant === 'row') {
+		return (
+			<div className={cn('space-y-1.5', className)}>
+				<div className="flex items-center justify-between gap-2">
+					<span className="text-muted-foreground text-xs">
+						{label}
+						{monthly ? (
+							<span className="text-muted-foreground/50 ml-1">/mo</span>
+						) : null}
+					</span>
+					<span
+						className={cn(
+							'text-xs font-medium tabular-nums',
+							LEVEL_TEXT[level]
+						)}
+					>
+						{value}
+					</span>
+				</div>
+				{unlimited ? null : bar}
+			</div>
+		)
+	}
+
+	return (
+		<div className={cn('ds-sunken space-y-3 rounded-xl p-4', className)}>
+			<p className="text-muted-foreground text-eyebrow">
+				{label}
+				{monthly ? (
+					<span className="text-muted-foreground/60 ml-1 tracking-normal normal-case">
+						/mo
+					</span>
+				) : null}
+			</p>
+			<p
+				className={cn(
+					'text-2xl font-semibold tracking-tight tabular-nums',
+					LEVEL_TEXT[level]
+				)}
+			>
+				{format(current)}
+				<span className="text-muted-foreground ml-0.5 text-sm font-normal">
+					{` / ${limitLabel}`}
+				</span>
+			</p>
+			{bar}
+		</div>
+	)
+}
+
+interface UsageMeterGridProps {
+	children: ReactNode
+	className?: string
+}
+
+/** Responsive grid for `UsageMeter` tiles. */
+export function UsageMeterGrid({ children, className }: UsageMeterGridProps) {
+	return (
+		<div
+			className={cn(
+				'grid grid-cols-2 gap-3 lg:grid-cols-4',
+				className
+			)}
+		>
+			{children}
+		</div>
+	)
+}

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.thumbnail.$assetId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.thumbnail.$assetId.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { LoaderFunctionArgs } from 'react-router'
 
 import { getDbClient } from '../../db/client'
@@ -47,6 +47,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		})
 	}
 
+	// Deliberately not filtered by `assets.ownerId`. Access to a thumbnail is
+	// decided by access to the scene it belongs to, which the two checks below
+	// establish: the metadata binds the asset to this scene, and `getScene` runs
+	// `verifyProjectAccess` for the requesting user. Requiring ownership on top
+	// of that was strictly narrower and broke teams - a scene you are entitled to
+	// open returned 404 for its thumbnail whenever a colleague had uploaded it.
 	const [asset] = await db
 		.select({
 			id: assets.id,
@@ -55,7 +61,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 			updatedAt: assets.updatedAt
 		})
 		.from(assets)
-		.where(and(eq(assets.id, assetId), eq(assets.ownerId, auth.user.id)))
+		.where(eq(assets.id, assetId))
 		.limit(1)
 
 	if (!asset) {
@@ -67,7 +73,19 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		return new Response('Thumbnail not found', { status: 404, headers })
 	}
 
-	const scene = await getScene(sceneId, auth.user.id)
+	// `getScene` returns null for a missing scene but *throws* from
+	// `verifyProjectAccess` when the user is not a member of the owning org.
+	// Both mean the same thing to a caller who should not see this image, and
+	// both must answer 404 rather than leaking the distinction - or, worse,
+	// surfacing an unhandled error. While the query above still filtered on
+	// `ownerId`, a non-member never reached this line.
+	let scene: Awaited<ReturnType<typeof getScene>> = null
+	try {
+		scene = await getScene(sceneId, auth.user.id)
+	} catch {
+		scene = null
+	}
+
 	if (!scene) {
 		return new Response('Thumbnail not found', { status: 404, headers })
 	}

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -20,7 +20,11 @@ const require = createRequire(import.meta.url)
 const config: StorybookConfig = {
 	stories: [
 		'../../shared/components/src/**/*.@(mdx|stories.@(js|jsx|ts|tsx))',
-		'../../packages/viewer/src/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'
+		'../../packages/viewer/src/**/*.@(mdx|stories.@(js|jsx|ts|tsx))',
+		// App-level components too. The dashboard's cards and meters carry as much
+		// design decision as the shared primitives do, and until now nothing
+		// visual regression-tested them.
+		'../../apps/vectreal-platform/app/components/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'
 	],
 	addons: [getAbsolutePath('@storybook/addon-docs')],
 	docs: {


### PR DESCRIPTION
PR 1 of 3 in the dashboard landing + projects browse overhaul. No visible dashboard change yet — **the billing page is this PR's regression surface**.

### Two commits, deliberately separable

**1. `fix(api)`: thumbnail access follows the scene, not the asset owner**

The route made three checks. Two establish authorization: the asset metadata binds the asset to the requested scene, and `getScene` runs `verifyProjectAccess` for the requesting user via org membership. The third — `assets.ownerId = auth.user.id` — was strictly narrower and broke teams: **a scene you are entitled to open returned 404 for its thumbnail whenever a colleague uploaded it.**

Removing that filter changes a failure mode, which is the part to review. `getScene` returns null for a missing scene but *throws* for a non-member, and while the query filtered on `ownerId` a non-member never reached that call — the empty asset result answered 404 first. Left alone, the same request would now surface an unhandled error. Both cases are caught and answer 404, so a non-member still cannot distinguish "not yours" from "does not exist".

An automated review flagged this as IDOR. Reasoning through it: to be served asset `A` at `/api/scenes/{S}/thumbnail/{A}`, a request must pass (1) `A` exists, (2) `A.metadata.sceneId === S`, (3) the user may open scene `S`. Gate 2 blocks the classic swap — an attacker cannot point a victim's asset at a scene they control, because they cannot write that asset's metadata; and binding *their own* asset to a victim's scene id still requires passing gate 3. The reachable set is exactly "assets bound to scenes you may already open".

What genuinely changed is the audience: asset owner → any member of the owning org. That is the intended fix, which is why it is its own commit and revertible alone. **The negative case wants proof, not argument: please confirm a non-member still gets 404 with two real accounts before merge.**

**2. `feat(dashboard)`: the shared pieces**

| Component | Why |
|---|---|
| `UsageMeter` / `UsageMeterGrid` | **One meter, not two.** `billing-settings-section.tsx` had `StatTile` and `MeterRow` side by side, each recomputing the same percentage and restating the same 80/95 thresholds. The dashboard is about to show the same readings — a threshold that disagrees between two screens is worse than none. |
| `SceneThumbnail` | A missing image is the *normal* case: `thumbnailUrl` is only written after a publisher save with a viewport capture. Load failure renders identically. Placeholder tint is derived from the name, so it stays stable across renders. |
| `StatusBreakdown` | The loader already computes per-project status counts and discards them, so a project could only say "12 scenes" — not the question people actually have. |
| `ProjectCard` | Composes the two. Edit control sits *outside* the card link: an anchor inside an anchor is invalid and the browser drops one. |

`readUsage` treats `limit === null` as first-class (every plan above free is unlimited on at least one key); an unlimited meter never warns, and keeps a flat rail so grids stay aligned.

### Storybook

Now globs app components, not just shared ones. The dashboard's cards and meters carry as much design decision as the shared primitives and nothing was visual regression-testing them. Stories lead with the states that matter — unlimited, at-limit, no thumbnail, no scenes — rather than the happy path.

### Verification

- `nx typecheck vectreal-platform` ✅
- `nx run-many --target=lint --projects=vectreal-platform,shared/components,storybook` ✅ (incl. #678 adherence rules)
- `nx test vectreal-platform` ✅ (221 passed)
- `nx build vectreal-platform` ✅ · `nx build-storybook storybook` ✅
- **Still needed from a human:** the billing page rendered in both themes (it now consumes the shared meter), and the two-account thumbnail check above.