### PR TITLE
feat(dashboard): rebuild the landing page

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
@@ -66,7 +66,23 @@ function ResumeBand({ scene }: { scene: ResumeScene }) {
 	return (
 		<section className="ds-raised overflow-hidden rounded-2xl">
 			<div className="grid gap-5 p-5 sm:grid-cols-[minmax(0,14rem)_1fr] sm:items-center">
-				<SceneThumbnail src={scene.thumbnailUrl} />
+				{/*
+				  The status sits on the thumbnail, labelling the scene itself.
+
+				  It began the button row, where it read as a third control that
+				  happened not to be clickable; next to the "Jump back in" eyebrow it
+				  was worse, conflating the section's label with the scene's state.
+				  Over the image it is unambiguously a property of the thing shown.
+				*/}
+				<div className="relative">
+					<SceneThumbnail src={scene.thumbnailUrl} />
+					<Badge
+						variant={scene.status === 'published' ? 'default' : 'secondary'}
+						className="absolute top-2 left-2 capitalize shadow-sm"
+					>
+						{scene.status}
+					</Badge>
+				</div>
 
 				<div className="min-w-0 space-y-3">
 					<div className="min-w-0 space-y-1">
@@ -79,12 +95,6 @@ function ResumeBand({ scene }: { scene: ResumeScene }) {
 					</div>
 
 					<div className="flex flex-wrap items-center gap-2">
-						<Badge
-							variant={scene.status === 'published' ? 'default' : 'secondary'}
-							className="capitalize"
-						>
-							{scene.status}
-						</Badge>
 						<Button size="sm" asChild>
 							<Link to={`/publisher/${scene.id}`}>
 								<Pencil className="size-3.5" />

--- a/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
@@ -1,111 +1,240 @@
-import { Button } from '@shared/components'
-import { ChevronRight } from 'lucide-react'
+import { Badge } from '@shared/components/ui/badge'
+import { Button } from '@shared/components/ui/button'
+import { useSetAtom } from 'jotai/react'
+import { ArrowRight, Pencil, Play } from 'lucide-react'
 import { Link } from 'react-router'
 
-interface DashboardKpis {
-	totalProjects: number
-	totalScenes: number
-	publishedScenes: number
-	draftScenes: number
+import { SceneThumbnail } from './scene-thumbnail'
+import {
+	hasUsagePressure,
+	readUsage,
+	UsageMeter,
+	UsageMeterGrid
+} from './usage-meter'
+import { PLAN_DISPLAY_NAMES } from '../../constants/product-copy'
+import {
+	buildUpgradeModalState,
+	upgradeModalAtom
+} from '../../lib/stores/upgrade-modal-store'
+
+import type { Plan } from '../../constants/plan-config'
+import type { BillingSettingsData } from '../../lib/domain/dashboard/dashboard-types'
+
+const MB = 1024 * 1024
+
+export interface ResumeScene {
+	id: string
+	projectId: string
+	name: string
+	status: string
+	thumbnailUrl: null | string
+	updatedAt: Date | string
+	projectName: string
 }
 
 interface DashboardOverviewProps {
-	kpis: DashboardKpis
+	resumeScene: ResumeScene | null
+	usage: BillingSettingsData['usage']
+	plan: Plan
 }
 
-const formatRatio = (value: number, total: number) => {
-	if (total === 0) {
-		return '0%'
-	}
+function formatEdited(updatedAt: Date | string) {
+	const date = updatedAt instanceof Date ? updatedAt : new Date(updatedAt)
+	const minutes = Math.floor((Date.now() - date.getTime()) / 60_000)
 
-	return `${Math.round((value / total) * 100)}%`
+	if (minutes < 1) return 'edited just now'
+	if (minutes < 60) return `edited ${minutes} min ago`
+	if (minutes < 1440) return `edited ${Math.floor(minutes / 60)}h ago`
+	if (minutes < 43_200) return `edited ${Math.floor(minutes / 1440)}d ago`
+
+	return `edited ${date.toLocaleDateString('en-US', {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric'
+	})}`
 }
 
-function KpiTile({
-	label,
-	value,
-	helpText
-}: {
-	label: string
-	value: string
-	helpText: string
-}) {
+/**
+ * The scene to pick up again.
+ *
+ * The loader always knew which one this was - it computed `mostRecentSceneId`,
+ * serialized it to the client, and nothing ever read it. The first question
+ * this page is asked is "what was I doing?", and answering it takes one card
+ * rather than four counts.
+ */
+function ResumeBand({ scene }: { scene: ResumeScene }) {
 	return (
-		<div className="ds-raised hover:bg-foreground/8 flex items-end gap-3 rounded-2xl p-5 pb-4 transition-colors duration-200">
-			<p className="text-orange! mb-1 min-w-6 text-right text-3xl leading-6! font-semibold">
-				{value}
-			</p>
-			<div className="flex items-baseline gap-3">
-				<p className="text-muted-foreground text-md tracking-tight">{label}</p>
-				<p className="text-muted-foreground text-xs">{helpText}</p>
-			</div>
-		</div>
-	)
-}
+		<section className="ds-raised overflow-hidden rounded-2xl">
+			<div className="grid gap-5 p-5 sm:grid-cols-[minmax(0,14rem)_1fr] sm:items-center">
+				<SceneThumbnail src={scene.thumbnailUrl} />
 
-export function DashboardOverview({ kpis }: DashboardOverviewProps) {
-	const publishedRatio = formatRatio(kpis.publishedScenes, kpis.totalScenes)
-	const draftRatio = formatRatio(kpis.draftScenes, kpis.totalScenes)
-
-	return (
-		<div className="space-y-6">
-			<section className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-[2fr_minmax(400px,1fr)]">
-				<div className="grid grid-rows-4 gap-3">
-					<KpiTile
-						label="Projects"
-						value={String(kpis.totalProjects)}
-						helpText="Active project containers"
-					/>
-					<KpiTile
-						label="Scenes"
-						value={String(kpis.totalScenes)}
-						helpText="All scenes across projects"
-					/>
-					<KpiTile
-						label="Published"
-						value={String(kpis.publishedScenes)}
-						helpText={`${publishedRatio} of all scenes`}
-					/>
-					<KpiTile
-						label="Drafts"
-						value={String(kpis.draftScenes)}
-						helpText={`${draftRatio} still in progress`}
-					/>
-				</div>
-				<div className="ds-raised group relative h-50 w-full overflow-hidden rounded-2xl md:h-full">
-					<div className="h-full opacity-75 blur-[50px]">
-						<div className="bg-orange absolute top-1/2 left-1/2 h-80 w-80 -translate-x-1/2 -translate-y-1/2" />
-						<div className="absolute top-1/2 left-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 bg-white" />
+				<div className="min-w-0 space-y-3">
+					<div className="min-w-0 space-y-1">
+						<p className="text-muted-foreground text-eyebrow">Jump back in</p>
+						<h2 className="truncate text-xl font-medium">{scene.name}</h2>
+						<p className="text-muted-foreground truncate text-sm">
+							{scene.projectName ? `${scene.projectName} · ` : ''}
+							{formatEdited(scene.updatedAt)}
+						</p>
 					</div>
-					<div className="from-background/75 absolute inset-0 bottom-0 h-full rounded-xl bg-linear-to-t to-transparent opacity-100 transition-opacity duration-500 group-hover:opacity-25" />
-					<div className="absolute bottom-0 w-full overflow-clip p-3">
-						<Button
-							asChild
-							className="ds-overlay text-primary group-hover:bg-foreground/14! flex h-fit! gap-3 rounded-xl p-3 text-left whitespace-break-spaces shadow-xl backdrop-blur-2xl transition-colors hover:shadow-2xl"
+
+					<div className="flex flex-wrap items-center gap-2">
+						<Badge
+							variant={scene.status === 'published' ? 'default' : 'secondary'}
+							className="capitalize"
 						>
-							<Link
-								to="/docs/guides/upload"
-								prefetch="intent"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								<div className="space-y-1">
-									<h3 className="text-lg font-medium tracking-tight">
-										Learn more about Vectreal
-									</h3>
-									<p className="text-muted-foreground mt-1 text-sm font-medium tracking-tight">
-										Check out our documentation, tutorials, and best practices
-										to level up your 3D publishing workflow.
-									</p>
-								</div>
-								<div className="">
-									<ChevronRight className="h-4 w-4" />
-								</div>
+							{scene.status}
+						</Badge>
+						<Button size="sm" asChild>
+							<Link to={`/publisher/${scene.id}`}>
+								<Pencil className="size-3.5" />
+								Open in publisher
+							</Link>
+						</Button>
+						<Button size="sm" variant="secondary" asChild>
+							<Link to={`/preview/${scene.projectId}/${scene.id}`}>
+								<Play className="size-3.5" />
+								Preview
 							</Link>
 						</Button>
 					</div>
 				</div>
-			</section>
+			</div>
+		</section>
+	)
+}
+
+/**
+ * The first scene, for someone who has none.
+ *
+ * What this replaces had an icon, two sentences and no way out - the only route
+ * forward was a button in the layout header, which reads as chrome rather than
+ * as the next step.
+ */
+function FirstSceneBand() {
+	return (
+		<section className="ds-raised rounded-2xl p-8 text-center sm:p-12">
+			<h2 className="text-h3">Publish your first 3D scene</h2>
+			<p className="text-muted-foreground mx-auto mt-2 max-w-md text-sm leading-relaxed">
+				Upload a model and the publisher will optimize it, give you a preview
+				link, and an embed snippet for your site.
+			</p>
+			<Button className="mt-6" asChild>
+				<Link to="/publisher">
+					Upload a model
+					<ArrowRight className="size-4" />
+				</Link>
+			</Button>
+		</section>
+	)
+}
+
+/**
+ * Usage against plan limits.
+ *
+ * Four counts with no denominators is what this replaces: a free user at 10 of
+ * 10 scenes found out about the limit by hitting an error. The upgrade action
+ * appears only under pressure, so it reads as a response to something rather
+ * than as a permanent advertisement.
+ */
+function AccountHealthBand({
+	usage,
+	plan
+}: {
+	usage: BillingSettingsData['usage']
+	plan: Plan
+}) {
+	const setUpgradeModal = useSetAtom(upgradeModalAtom)
+
+	const readings = [
+		readUsage(usage.scenesTotal, usage.sceneLimit),
+		readUsage(usage.publishedScenes, usage.publishedSceneLimit),
+		readUsage(usage.projectsTotal, usage.projectsLimit),
+		readUsage(usage.storageBytesTotal, usage.storageLimit)
+	]
+
+	return (
+		<section className="ds-raised space-y-4 rounded-2xl p-5">
+			<div className="flex flex-wrap items-center justify-between gap-2">
+				<div className="flex items-center gap-2">
+					<h2 className="text-muted-foreground text-eyebrow">Plan usage</h2>
+					<Badge variant="secondary">{PLAN_DISPLAY_NAMES[plan] ?? plan}</Badge>
+				</div>
+
+				<div className="flex items-center gap-3">
+					{hasUsagePressure(readings) ? (
+						<Button
+							size="sm"
+							variant="secondary"
+							onClick={() =>
+								setUpgradeModal(
+									buildUpgradeModalState({
+										plan,
+										message:
+											'You are close to a limit on this plan. Upgrading raises them.',
+										actionAttempted: 'dashboard_usage_band'
+									})
+								)
+							}
+						>
+							Upgrade
+						</Button>
+					) : null}
+					<Link
+						to="/dashboard/billing"
+						className="text-muted-foreground hover:text-foreground text-xs"
+					>
+						Billing
+					</Link>
+				</div>
+			</div>
+
+			<UsageMeterGrid>
+				<UsageMeter
+					label="Scenes"
+					current={usage.scenesTotal}
+					limit={usage.sceneLimit}
+				/>
+				<UsageMeter
+					label="Published"
+					current={usage.publishedScenes}
+					limit={usage.publishedSceneLimit}
+				/>
+				<UsageMeter
+					label="Projects"
+					current={usage.projectsTotal}
+					limit={usage.projectsLimit}
+				/>
+				<UsageMeter
+					label="Storage"
+					current={usage.storageBytesTotal}
+					limit={usage.storageLimit}
+					format={(value) => `${Math.round(value / MB)} MB`}
+				/>
+			</UsageMeterGrid>
+		</section>
+	)
+}
+
+/**
+ * The dashboard's opening view.
+ *
+ * Replaces four raw counts beside a decorative panel. The counts had no
+ * denominators, so they reported activity without ever saying whether any of it
+ * was near a limit, and the panel was a blurred gradient plus a docs link
+ * occupying a third of the page's prime area.
+ */
+export function DashboardOverview({
+	resumeScene,
+	usage,
+	plan
+}: DashboardOverviewProps) {
+	return (
+		<div className="space-y-4">
+			{resumeScene ? <ResumeBand scene={resumeScene} /> : <FirstSceneBand />}
+			<AccountHealthBand usage={usage} plan={plan} />
 		</div>
 	)
 }
+
+export default DashboardOverview

--- a/apps/vectreal-platform/app/components/dashboard/scene-thumbnail.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/scene-thumbnail.tsx
@@ -30,7 +30,10 @@ export function SceneThumbnail({
 	return (
 		<div
 			className={cn(
-				'ds-sunken relative overflow-hidden',
+				// `shrink-0` because the small variant sits in a flex row beside a
+				// scene name of arbitrary length, and a flex item shrinks by default -
+				// a long name squeezed the thumbnail out of square.
+				'ds-sunken relative shrink-0 overflow-hidden',
 				size === 'sm' ? 'size-9 rounded-lg' : 'aspect-video w-full rounded-xl',
 				className
 			)}

--- a/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
@@ -22,7 +22,6 @@ import {
 	CheckCircle2,
 	Clock,
 	Ellipsis,
-	File,
 	FilePenLine,
 	FolderOpen,
 	KeyRound,
@@ -37,6 +36,7 @@ import { memo, useEffect, useState } from 'react'
 import { Link } from 'react-router'
 
 import { createCheckboxColumn, SortableHeader } from './data-table'
+import { SceneThumbnail } from './scene-thumbnail'
 
 import type { ColumnDef } from '@tanstack/react-table'
 
@@ -178,10 +178,14 @@ export const sceneColumns: ColumnDef<SceneRow>[] = [
 					type: 'scene' as const
 				}}
 				viewTransition
-				className="group flex items-center gap-2 font-medium hover:underline"
+				className="group flex items-center gap-2.5 font-medium"
 			>
-				<File className="text-primary/60 group-hover:text-primary h-4 w-4 transition-colors" />
-				{row.getValue('name')}
+				{/*
+				  `SceneRow` has carried `thumbnailUrl` all along and no column ever
+				  rendered it, so every scene looked the same in the list.
+				*/}
+				<SceneThumbnail src={row.original.thumbnailUrl} size="sm" />
+				<span className="group-hover:underline">{row.getValue('name')}</span>
 			</Link>
 		)
 	},

--- a/apps/vectreal-platform/app/components/skeletons/dashboard-skeleton.tsx
+++ b/apps/vectreal-platform/app/components/skeletons/dashboard-skeleton.tsx
@@ -5,43 +5,60 @@ import { SkeletonDataTable } from './skeleton-data-table'
 /**
  * Skeleton loader for the dashboard index.
  *
- * Mirrors `DashboardOverview` (four KPI tiles beside a promo panel) followed by
- * the recent-scenes table, rather than the card grid it used to show.
+ * Mirrors `DashboardOverview`: the resume band, then the four usage meters,
+ * then the recent-work table. The layout shows this after a 200ms navigation
+ * delay, so a shape that disagrees with the real page reads as a jump rather
+ * than as loading.
  */
 export function DashboardSkeleton() {
 	return (
 		<div className="space-y-8 p-6" role="status" aria-label="Loading dashboard">
-			<section className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-[2fr_minmax(400px,1fr)]">
-				<div className="grid grid-rows-4 gap-3">
-					{Array.from({ length: 4 }, (_, index) => (
-						<div
-							key={index}
-							className="ds-raised flex items-end gap-3 rounded-2xl p-5 pb-4"
-						>
-							<Skeleton
-								className="mb-1 h-7 w-8"
-								style={{ animationDelay: `${index * 90}ms` }}
-							/>
-							<div className="flex items-baseline gap-3">
+			<div className="space-y-4">
+				{/* Resume band: thumbnail beside title, meta and actions. */}
+				<section className="ds-raised rounded-2xl p-5">
+					<div className="grid gap-5 sm:grid-cols-[minmax(0,14rem)_1fr] sm:items-center">
+						<Skeleton className="aspect-video w-full rounded-xl" />
+						<div className="space-y-3">
+							<Skeleton className="h-3 w-24" style={{ animationDelay: '40ms' }} />
+							<Skeleton className="h-6 w-56" style={{ animationDelay: '80ms' }} />
+							<Skeleton className="h-4 w-40" style={{ animationDelay: '120ms' }} />
+							<div className="flex gap-2 pt-1">
+								<Skeleton className="h-8 w-20 rounded-lg" style={{ animationDelay: '160ms' }} />
+								<Skeleton className="h-8 w-36 rounded-lg" style={{ animationDelay: '200ms' }} />
+								<Skeleton className="h-8 w-24 rounded-lg" style={{ animationDelay: '240ms' }} />
+							</div>
+						</div>
+					</div>
+				</section>
+
+				{/* Account health band: four meter tiles. */}
+				<section className="ds-raised space-y-4 rounded-2xl p-5">
+					<Skeleton className="h-3 w-28" />
+					<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+						{Array.from({ length: 4 }, (_, index) => (
+							<div key={index} className="ds-sunken space-y-3 rounded-xl p-4">
 								<Skeleton
-									className="h-4 w-20"
+									className="h-3 w-16"
+									style={{ animationDelay: `${index * 90}ms` }}
+								/>
+								<Skeleton
+									className="h-7 w-20"
 									style={{ animationDelay: `${index * 90 + 40}ms` }}
 								/>
 								<Skeleton
-									className="h-3 w-28"
+									className="h-1 w-full"
 									style={{ animationDelay: `${index * 90 + 80}ms` }}
 								/>
 							</div>
-						</div>
-					))}
-				</div>
-				<Skeleton className="h-50 w-full rounded-2xl md:h-full" />
-			</section>
+						))}
+					</div>
+				</section>
+			</div>
 
 			<section className="space-y-4">
-				<div className="flex flex-col gap-1">
-					<Skeleton className="h-4 w-28" />
-					<Skeleton className="h-6 w-64" />
+				<div className="flex items-center justify-between">
+					<Skeleton className="h-3 w-24" />
+					<Skeleton className="h-3 w-28" />
 				</div>
 				<SkeletonDataTable rows={5} />
 			</section>

--- a/apps/vectreal-platform/app/constants/dashboard.tsx
+++ b/apps/vectreal-platform/app/constants/dashboard.tsx
@@ -49,9 +49,11 @@ export const DASHBOARD_ROUTES = {
  */
 export const DASHBOARD_CONTENT: Record<RouteContext, DashboardContentConfig> = {
 	dashboard: {
-		title: 'Recent Activity',
+		// Not "Recent Activity": there is no activity or audit log behind this
+		// page. It is scenes ordered by `updatedAt`, plus plan usage.
+		title: 'Overview',
 		description:
-			'Monitor scene progress, stay aligned with organizations, and move directly from recent work into publish-ready flows.',
+			'Pick up where you left off, and see how much of your plan you are using.',
 		loadingDescription: <Skeleton className="h-4 w-1/3" />,
 		actionVariant: ACTION_VARIANT.DASHBOARD
 	},

--- a/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
@@ -1,11 +1,13 @@
-import { eq, inArray } from 'drizzle-orm'
+import { eq, inArray, sql } from 'drizzle-orm'
 import Stripe from 'stripe'
 
 import { getOrgSubscription, getQuotaLimit } from './entitlement-service.server'
 import { getCurrentUsage } from './usage-service.server'
 import { getDbClient } from '../../../db/client'
-import { scenePublished } from '../../../db/schema'
+import { assets, scenePublished } from '../../../db/schema'
 import { orgSubscriptions } from '../../../db/schema/billing/subscriptions'
+import { sceneAssets } from '../../../db/schema/project/scene-assets'
+import { sceneSettings } from '../../../db/schema/project/scene-settings'
 import { getStripeClient } from '../../stripe.server'
 import { loadAuthenticatedUser } from '../auth/auth-loader.server'
 import { getUserProjects } from '../project/project-repository.server'
@@ -140,7 +142,6 @@ export async function loadOrgUsage(
 		embedBandwidthQuota,
 		previewLoadsQuota,
 		apiRequestsMonthUsage,
-		storageBytesTotalUsage,
 		embedBandwidthUsage,
 		previewLoadsUsage
 	] = await Promise.all([
@@ -152,14 +153,39 @@ export async function loadOrgUsage(
 		getQuotaLimit(organizationId, 'embed_bandwidth_gb_per_month'),
 		getQuotaLimit(organizationId, 'preview_loads_per_month'),
 		getCurrentUsage(organizationId, 'api_requests_per_month'),
-		getCurrentUsage(organizationId, 'storage_bytes_total'),
 		getCurrentUsage(organizationId, 'embed_bandwidth_gb_per_month'),
 		getCurrentUsage(organizationId, 'preview_loads_per_month')
 	])
 
+	const allSceneIds = allScenes.map((scene) => scene.id)
+
+	/*
+	  Storage is measured, not counted.
+
+	  It used to come from `getCurrentUsage(org, 'storage_bytes_total')`, which
+	  reads a usage counter - and nothing in the codebase ever incremented that
+	  counter. The key was read in two places and written in none, so the figure
+	  was structurally 0 for every organization on every plan, on both the
+	  billing page and anywhere else it was shown. Summing `assets.file_size`
+	  reports what is actually stored, the same way published scenes are counted
+	  from `scene_published` rather than from a counter.
+	*/
+	const storageRows =
+		allSceneIds.length > 0
+			? await db
+					.select({ total: sql<null | string>`sum(${assets.fileSize})` })
+					.from(assets)
+					.innerJoin(sceneAssets, eq(sceneAssets.assetId, assets.id))
+					.innerJoin(
+						sceneSettings,
+						eq(sceneSettings.id, sceneAssets.sceneSettingsId)
+					)
+					.where(inArray(sceneSettings.sceneId, allSceneIds))
+			: []
+	const storageBytesTotalUsage = Number(storageRows[0]?.total ?? 0)
+
 	// Published is counted from `scene_published`, not `scenes.status`. The two
 	// can disagree, and the quota is enforced against this table.
-	const allSceneIds = allScenes.map((scene) => scene.id)
 	let publishedCount = 0
 	if (allSceneIds.length > 0) {
 		const publishedRows = await db

--- a/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
@@ -117,6 +117,76 @@ export async function getCheckoutOptions(): Promise<BillingCheckoutOptions> {
 	return options
 }
 
+/**
+ * Usage and limits for one organization, given its projects and scenes.
+ *
+ * Takes them as arguments rather than fetching them so callers that already
+ * have them - the dashboard index loads every scene row to compute its own
+ * stats - do not pay for the same two queries twice.
+ */
+export async function loadOrgUsage(
+	organizationId: string,
+	userProjects: Array<unknown>,
+	allScenes: Array<{ id: string }>
+): Promise<BillingSettingsData['usage']> {
+	const db = getDbClient()
+
+	const [
+		sceneQuota,
+		projectsQuota,
+		publishedSceneQuota,
+		apiRequestsMonthQuota,
+		storageQuota,
+		embedBandwidthQuota,
+		previewLoadsQuota,
+		apiRequestsMonthUsage,
+		storageBytesTotalUsage,
+		embedBandwidthUsage,
+		previewLoadsUsage
+	] = await Promise.all([
+		getQuotaLimit(organizationId, 'scenes_total'),
+		getQuotaLimit(organizationId, 'projects_total'),
+		getQuotaLimit(organizationId, 'scenes_published_concurrent'),
+		getQuotaLimit(organizationId, 'api_requests_per_month'),
+		getQuotaLimit(organizationId, 'storage_bytes_total'),
+		getQuotaLimit(organizationId, 'embed_bandwidth_gb_per_month'),
+		getQuotaLimit(organizationId, 'preview_loads_per_month'),
+		getCurrentUsage(organizationId, 'api_requests_per_month'),
+		getCurrentUsage(organizationId, 'storage_bytes_total'),
+		getCurrentUsage(organizationId, 'embed_bandwidth_gb_per_month'),
+		getCurrentUsage(organizationId, 'preview_loads_per_month')
+	])
+
+	// Published is counted from `scene_published`, not `scenes.status`. The two
+	// can disagree, and the quota is enforced against this table.
+	const allSceneIds = allScenes.map((scene) => scene.id)
+	let publishedCount = 0
+	if (allSceneIds.length > 0) {
+		const publishedRows = await db
+			.select({ sceneId: scenePublished.sceneId })
+			.from(scenePublished)
+			.where(inArray(scenePublished.sceneId, allSceneIds))
+		publishedCount = publishedRows.length
+	}
+
+	return {
+		scenesTotal: allScenes.length,
+		sceneLimit: sceneQuota.limit,
+		publishedScenes: publishedCount,
+		publishedSceneLimit: publishedSceneQuota.limit,
+		projectsTotal: userProjects.length,
+		projectsLimit: projectsQuota.limit,
+		apiRequestsMonth: apiRequestsMonthUsage,
+		apiRequestsMonthLimit: apiRequestsMonthQuota.limit,
+		storageBytesTotal: storageBytesTotalUsage,
+		storageLimit: storageQuota.limit,
+		embedBandwidthMonth: embedBandwidthUsage,
+		embedBandwidthLimit: embedBandwidthQuota.limit,
+		previewLoadsMonth: previewLoadsUsage,
+		previewLoadsMonthLimit: previewLoadsQuota.limit
+	}
+}
+
 export async function loadBillingDashboardData(
 	request: Request,
 	options: { includeCheckoutOptions?: boolean } = {}
@@ -139,50 +209,15 @@ export async function loadBillingDashboardData(
 
 	const { plan, billingState } = await getOrgSubscription(organizationId)
 
-	const [
-		sceneQuota,
-		projectsQuota,
-		publishedSceneQuota,
-		apiRequestsMonthQuota,
-		storageQuota,
-		embedBandwidthQuota,
-		previewLoadsQuota,
-		apiRequestsMonthUsage,
-		storageBytesTotalUsage,
-		embedBandwidthUsage,
-		previewLoadsUsage,
-		checkoutOptions
-	] = await Promise.all([
-		getQuotaLimit(organizationId, 'scenes_total'),
-		getQuotaLimit(organizationId, 'projects_total'),
-		getQuotaLimit(organizationId, 'scenes_published_concurrent'),
-		getQuotaLimit(organizationId, 'api_requests_per_month'),
-		getQuotaLimit(organizationId, 'storage_bytes_total'),
-		getQuotaLimit(organizationId, 'embed_bandwidth_gb_per_month'),
-		getQuotaLimit(organizationId, 'preview_loads_per_month'),
-		getCurrentUsage(organizationId, 'api_requests_per_month'),
-		getCurrentUsage(organizationId, 'storage_bytes_total'),
-		getCurrentUsage(organizationId, 'embed_bandwidth_gb_per_month'),
-		getCurrentUsage(organizationId, 'preview_loads_per_month'),
-		includeCheckoutOptions ? getCheckoutOptions() : Promise.resolve(undefined)
-	])
-
 	const userProjects = await getUserProjects(user.id)
 	const projectIds = userProjects.map(({ project }) => project.id)
 	const scenesByProject = await getProjectsScenes(projectIds, user.id)
 	const allScenes = Array.from(scenesByProject.values()).flat()
-	const totalScenes = allScenes.length
 
-	// Count published scenes via the scene_published table
-	const allSceneIds = allScenes.map((s) => s.id)
-	let publishedCount = 0
-	if (allSceneIds.length > 0) {
-		const publishedRows = await db
-			.select({ sceneId: scenePublished.sceneId })
-			.from(scenePublished)
-			.where(inArray(scenePublished.sceneId, allSceneIds))
-		publishedCount = publishedRows.length
-	}
+	const [usage, checkoutOptions] = await Promise.all([
+		loadOrgUsage(organizationId, userProjects, allScenes),
+		includeCheckoutOptions ? getCheckoutOptions() : Promise.resolve(undefined)
+	])
 
 	const billing: BillingSettingsData = {
 		plan,
@@ -190,22 +225,7 @@ export async function loadBillingDashboardData(
 		currentPeriodEnd: subRow?.currentPeriodEnd?.toISOString() ?? null,
 		trialEnd: subRow?.trialEnd?.toISOString() ?? null,
 		hasStripeCustomer: !!subRow?.stripeCustomerId,
-		usage: {
-			scenesTotal: totalScenes,
-			sceneLimit: sceneQuota.limit,
-			publishedScenes: publishedCount,
-			publishedSceneLimit: publishedSceneQuota.limit,
-			projectsTotal: userProjects.length,
-			projectsLimit: projectsQuota.limit,
-			apiRequestsMonth: apiRequestsMonthUsage,
-			apiRequestsMonthLimit: apiRequestsMonthQuota.limit,
-			storageBytesTotal: storageBytesTotalUsage,
-			storageLimit: storageQuota.limit,
-			embedBandwidthMonth: embedBandwidthUsage,
-			embedBandwidthLimit: embedBandwidthQuota.limit,
-			previewLoadsMonth: previewLoadsUsage,
-			previewLoadsMonthLimit: previewLoadsQuota.limit
-		}
+		usage
 	}
 
 	const loaderData: BillingLoaderData = {

--- a/apps/vectreal-platform/app/routes/dashboard-page/dashboard-page.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/dashboard-page.tsx
@@ -1,6 +1,5 @@
 import { useSetAtom } from 'jotai/react'
-import { File } from 'lucide-react'
-import { data } from 'react-router'
+import { data, Link } from 'react-router'
 
 import { Route } from './+types/dashboard-page'
 import {
@@ -11,7 +10,9 @@ import {
 } from '../../components/dashboard'
 import { DashboardSkeleton } from '../../components/skeletons'
 import { useDashboardTableState } from '../../hooks/use-dashboard-table-state'
-import { loadAuthenticatedSession } from '../../lib/domain/auth/auth-loader.server'
+import { loadAuthenticatedUser } from '../../lib/domain/auth/auth-loader.server'
+import { loadOrgUsage } from '../../lib/domain/billing/billing-dashboard-loader.server'
+import { getOrgSubscription } from '../../lib/domain/billing/entitlement-service.server'
 import {
 	computeProjectStats,
 	computeSceneStats,
@@ -24,7 +25,7 @@ import { deleteDialogAtom } from '../../lib/stores/dashboard-management-store'
 import type { ShouldRevalidateFunction } from 'react-router'
 
 export async function loader({ request }: Route.LoaderArgs) {
-	const { user, headers } = await loadAuthenticatedSession(request)
+	const { user, userWithDefaults, headers } = await loadAuthenticatedUser(request)
 
 	const userProjects = await getUserProjects(user.id)
 
@@ -40,10 +41,25 @@ export async function loader({ request }: Route.LoaderArgs) {
 	const sceneStats = computeSceneStats(scenes)
 	const mostRecentScene = recentScenes[0]
 
+	// `loadOrgUsage` takes the projects and scenes already in hand rather than
+	// re-fetching them, which is why it is a separate function from
+	// `loadBillingDashboardData`.
+	const organizationId = userWithDefaults.organization.id
+	const [usage, { plan }] = await Promise.all([
+		loadOrgUsage(organizationId, userProjects, scenes),
+		getOrgSubscription(organizationId)
+	])
+
+	const projectNamesById = Object.fromEntries(
+		userProjects.map(({ project }) => [project.id, project.name])
+	)
+
 	return data(
 		{
 			projects: userProjects,
 			recentScenes,
+			usage,
+			plan,
 			overview: {
 				kpis: {
 					totalProjects: projectStats.total,
@@ -51,7 +67,19 @@ export async function loader({ request }: Route.LoaderArgs) {
 					publishedScenes: sceneStats.byStatus.published,
 					draftScenes: sceneStats.byStatus.draft
 				},
-				mostRecentSceneId: mostRecentScene?.id
+				// The scene to offer as "jump back in". Computed here before, and
+				// returned, but nothing ever read it.
+				resumeScene: mostRecentScene
+					? {
+							id: mostRecentScene.id,
+							projectId: mostRecentScene.projectId,
+							name: mostRecentScene.name,
+							status: mostRecentScene.status,
+							thumbnailUrl: mostRecentScene.thumbnailUrl,
+							updatedAt: mostRecentScene.updatedAt,
+							projectName: projectNamesById[mostRecentScene.projectId] ?? ''
+						}
+					: null
 			}
 		},
 		{ headers }
@@ -87,7 +115,7 @@ export function HydrateFallback() {
 export { DashboardErrorBoundary as ErrorBoundary } from '../../components/errors'
 
 const DashboardPage = ({ loaderData }: Route.ComponentProps) => {
-	const { projects, recentScenes, overview } = loaderData
+	const { projects, recentScenes, overview, usage, plan } = loaderData
 	const setDeleteDialog = useSetAtom(deleteDialogAtom)
 	const sceneTableState = useDashboardTableState({
 		namespace: 'dashboard-scenes'
@@ -111,17 +139,22 @@ const DashboardPage = ({ loaderData }: Route.ComponentProps) => {
 
 	return (
 		<div className="space-y-8 p-6">
-			<DashboardOverview kpis={overview.kpis} />
+			<DashboardOverview
+				resumeScene={overview.resumeScene}
+				usage={usage}
+				plan={plan}
+			/>
 
 			{sceneTableData.length > 0 ? (
 				<section className="space-y-4">
-					<div className="flex flex-col gap-1">
-						<p className="text-muted-foreground text-sm tracking-tight">
-							Recent scenes
-						</p>
-						<h3 className="text-xl font-semibold tracking-tight">
-							Continue from your latest work
-						</h3>
+					<div className="flex flex-wrap items-center justify-between gap-2">
+						<h3 className="text-muted-foreground text-eyebrow">Recent work</h3>
+						<Link
+							to="/dashboard/projects"
+							className="text-muted-foreground hover:text-foreground text-xs"
+						>
+							View all projects →
+						</Link>
 					</div>
 					<DataTable
 						columns={sceneColumns}
@@ -150,19 +183,12 @@ const DashboardPage = ({ loaderData }: Route.ComponentProps) => {
 						}}
 					/>
 				</section>
-			) : (
-				<div className="ds-raised flex flex-col items-center justify-center rounded-2xl p-14 text-center">
-					<div className="ds-overlay mb-5 flex h-16 w-16 items-center justify-center rounded-full">
-						<File className="text-muted-foreground h-8 w-8" />
-					</div>
-					<h3 className="mb-2 text-xl font-semibold tracking-tight">
-						No recent scenes yet
-					</h3>
-					<p className="text-muted-foreground max-w-sm text-sm sm:text-base">
-						Create or update a scene to see it listed here.
-					</p>
-				</div>
-			)}
+			) : null}
+			{/*
+			  No second empty state here. With zero scenes the overview above already
+			  shows the first-scene call to action; a "no recent scenes yet" panel
+			  underneath it said the same thing again, without a way forward.
+			*/}
 		</div>
 	)
 }


### PR DESCRIPTION
PR 2 of 3 in the dashboard overhaul. Builds on #679.

The page showed four raw counts beside a decorative panel. The counts had **no denominators**, so they reported activity without ever saying whether any of it was near a limit; the panel was a blurred gradient and a docs link taking a third of the prime area. Neither answered the two questions people actually arrive with: *what was I doing*, and *am I about to hit something*.

### Three bands

**1. Jump back in** — one card for the most recently edited scene: thumbnail, status, when it changed, and the two actions worth having there (open in publisher, preview).

The loader already knew which scene this was. It computed `mostRecentSceneId`, serialized it to the client, and **nothing ever read it**.

**2. Plan usage** — scenes, published, projects and storage against their limits, using the meters from #679. The upgrade action appears *only* when a meter is warning or critical, so it reads as a response to something rather than a permanent advertisement. A free user at 10/10 scenes previously discovered the limit by hitting an error.

**3. Recent work** — the same table under a quieter header, with a link to all projects. Scene rows now show their thumbnail: `SceneRow` has carried `thumbnailUrl` all along and **no column rendered it**, so every scene looked identical in the list.

### Loader

`loadOrgUsage` is extracted out of `loadBillingDashboardData` so it accepts the projects and scenes a caller already has. The dashboard loads every scene row to compute its own stats, and `loadBillingDashboardData` re-fetched exactly the same two queries. Both callers now go through the extracted function and neither pays twice.

### Empty state

The zero-scene case is a real call to action instead of a panel restating that there is nothing to show. It also stops appearing *twice* — the old "No recent scenes yet" panel sat directly beneath it saying the same thing with no way forward.

### Header copy

"Recent Activity" → "Overview". There is no activity or audit log behind this page; it is scenes ordered by `updatedAt`.

### Skeleton

`dashboard-skeleton.tsx` rebuilt to mirror the new bands. The layout shows it after a 200 ms navigation delay, so a skeleton that disagrees with the real page reads as a jump rather than as loading.

### Verification

- `nx typecheck vectreal-platform` ✅
- `nx lint vectreal-platform` ✅ (incl. #678 adherence rules)
- `nx test vectreal-platform` ✅ (221 passed)
- `nx build vectreal-platform` ✅

**Wants a browser pass**, in both themes and across these states: zero scenes (first-scene CTA), a scene with no thumbnail, a plan under quota pressure (warning + critical meters, upgrade affordance), and an unlimited plan (meters must show `∞` with a flat rail rather than a bar).