### PR TITLE
fix(dashboard): say what the storage quota measures

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/billing/billing-settings-section.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/billing/billing-settings-section.tsx
@@ -14,7 +14,11 @@ import { useFetcher } from 'react-router'
 import { Link } from 'react-router'
 
 import { DASHBOARD_ROUTES } from '../../../constants/dashboard'
-import { PLAN_DISPLAY_NAMES } from '../../../constants/product-copy'
+import {
+	PLAN_DISPLAY_NAMES,
+	STORAGE_USAGE_HINT,
+	STORAGE_USAGE_LABEL
+} from '../../../constants/product-copy'
 import { UsageMeter } from '../usage-meter'
 
 import type { BillingState } from '../../../constants/plan-config'
@@ -311,7 +315,8 @@ export function BillingSettingsSection({
 					<div className="space-y-3">
 						<UsageMeter
 							variant="row"
-							label="Storage used (MB)"
+							label={`${STORAGE_USAGE_LABEL} (MB)`}
+							hint={STORAGE_USAGE_HINT}
 							current={Math.round(usage.storageBytesTotal / (1024 * 1024))}
 							limit={
 								usage.storageLimit !== null

--- a/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
@@ -11,7 +11,11 @@ import {
 	UsageMeter,
 	UsageMeterGrid
 } from './usage-meter'
-import { PLAN_DISPLAY_NAMES } from '../../constants/product-copy'
+import {
+	PLAN_DISPLAY_NAMES,
+	STORAGE_USAGE_HINT,
+	STORAGE_USAGE_LABEL
+} from '../../constants/product-copy'
 import {
 	buildUpgradeModalState,
 	upgradeModalAtom
@@ -216,7 +220,8 @@ function AccountHealthBand({
 					limit={usage.projectsLimit}
 				/>
 				<UsageMeter
-					label="Storage"
+					label={STORAGE_USAGE_LABEL}
+					hint={STORAGE_USAGE_HINT}
 					current={usage.storageBytesTotal}
 					limit={usage.storageLimit}
 					format={(value) => `${Math.round(value / MB)} MB`}

--- a/apps/vectreal-platform/app/components/dashboard/dashboard-pieces.stories.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dashboard-pieces.stories.tsx
@@ -4,6 +4,10 @@ import { ProjectCard } from './project-card'
 import { SceneThumbnail } from './scene-thumbnail'
 import { StatusBreakdown } from './status-breakdown'
 import { UsageMeter, UsageMeterGrid } from './usage-meter'
+import {
+	STORAGE_USAGE_HINT,
+	STORAGE_USAGE_LABEL
+} from '../../constants/product-copy'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
@@ -37,7 +41,12 @@ export const UsageMeters: Story = {
 				<UsageMeter label="Scenes" current={4} limit={10} />
 				<UsageMeter label="Published" current={8} limit={10} />
 				<UsageMeter label="Projects" current={1} limit={1} />
-				<UsageMeter label="Storage" current={12} limit={null} />
+				<UsageMeter
+					label={STORAGE_USAGE_LABEL}
+					hint={STORAGE_USAGE_HINT}
+					current={12}
+					limit={null}
+				/>
 			</UsageMeterGrid>
 
 			<div className="max-w-sm space-y-3">
@@ -51,7 +60,8 @@ export const UsageMeters: Story = {
 				/>
 				<UsageMeter
 					variant="row"
-					label="Storage used"
+					label={STORAGE_USAGE_LABEL}
+					hint={STORAGE_USAGE_HINT}
 					current={480 * MB}
 					limit={500 * MB}
 					format={(value) => `${Math.round(value / MB)} MB`}

--- a/apps/vectreal-platform/app/components/dashboard/usage-meter.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/usage-meter.tsx
@@ -1,6 +1,8 @@
 import { Progress } from '@shared/components/ui/progress'
 import { cn } from '@shared/utils'
 
+import { InfoTooltip } from '../info-tooltip'
+
 import type { ReactNode } from 'react'
 
 /** At or above this share of the limit, the meter warns. */
@@ -76,6 +78,13 @@ interface UsageMeterProps {
 	/** Appends "/mo" to the label for per-period limits. */
 	monthly?: boolean
 	/**
+	 * Explains what the figure counts, behind an info trigger beside the label.
+	 *
+	 * For meters whose number invites a reasonable "that looks wrong" - storage
+	 * is the one that does - rather than for restating the label.
+	 */
+	hint?: ReactNode
+	/**
 	 * `tile` is a standalone block for a grid; `row` is a compact line for a
 	 * list. They differ only in layout - the reading and its colours are shared.
 	 */
@@ -99,6 +108,7 @@ export function UsageMeter({
 	current,
 	limit,
 	monthly,
+	hint,
 	variant = 'tile',
 	format = (value) => value.toLocaleString(),
 	className
@@ -119,11 +129,12 @@ export function UsageMeter({
 		return (
 			<div className={cn('space-y-1.5', className)}>
 				<div className="flex items-center justify-between gap-2">
-					<span className="text-muted-foreground text-xs">
+					<span className="text-muted-foreground flex items-center gap-1 text-xs">
 						{label}
 						{monthly ? (
-							<span className="text-muted-foreground/50 ml-1">/mo</span>
+							<span className="text-muted-foreground/50">/mo</span>
 						) : null}
+						{hint ? <InfoTooltip content={hint} className="size-3.5" /> : null}
 					</span>
 					<span
 						className={cn(
@@ -141,13 +152,16 @@ export function UsageMeter({
 
 	return (
 		<div className={cn('ds-sunken space-y-3 rounded-xl p-4', className)}>
-			<p className="text-muted-foreground text-eyebrow">
-				{label}
-				{monthly ? (
-					<span className="text-muted-foreground/60 ml-1 tracking-normal normal-case">
-						/mo
-					</span>
-				) : null}
+			<p className="text-muted-foreground text-eyebrow flex items-center gap-1.5">
+				<span>
+					{label}
+					{monthly ? (
+						<span className="text-muted-foreground/60 ml-1 tracking-normal normal-case">
+							/mo
+						</span>
+					) : null}
+				</span>
+				{hint ? <InfoTooltip content={hint} className="size-3.5" /> : null}
 			</p>
 			<p
 				className={cn(

--- a/apps/vectreal-platform/app/components/info-tooltip.tsx
+++ b/apps/vectreal-platform/app/components/info-tooltip.tsx
@@ -4,6 +4,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from '@shared/components/ui/tooltip'
+import { cn } from '@shared/utils'
 import { Info } from 'lucide-react'
 
 import type { ReactNode } from 'react'
@@ -13,16 +14,20 @@ import type { ReactNode } from 'react'
  */
 interface InfoTooltipProps {
 	content: string | ReactNode
+	/** Icon classes. Sized down when the trigger sits beside small label type. */
+	className?: string
 }
 
 /**
  * InfoTooltip component for displaying help information
  */
-export const InfoTooltip = ({ content }: InfoTooltipProps) => (
+export const InfoTooltip = ({ content, className }: InfoTooltipProps) => (
 	<TooltipProvider>
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+				<Info
+					className={cn('text-muted-foreground size-4 cursor-help', className)}
+				/>
 			</TooltipTrigger>
 			<TooltipContent className="max-w-80">{content}</TooltipContent>
 		</Tooltip>

--- a/apps/vectreal-platform/app/constants/product-copy.ts
+++ b/apps/vectreal-platform/app/constants/product-copy.ts
@@ -379,6 +379,25 @@ export const LIMIT_DISPLAY_LABELS: Partial<Record<LimitKey, string>> = {
 }
 
 // ---------------------------------------------------------------------------
+// Storage: what the quota actually measures.
+// ---------------------------------------------------------------------------
+
+/*
+  The publisher reports a scene at ~4 MB while storage reports several times
+  that for the same scene, and both figures are correct - they describe
+  different files. Compression is applied at publish, so the editable copy a
+  scene keeps is necessarily larger than the one that ships.
+
+  Two screens describing one scene with that gap and no explanation reads as a
+  bug, so the label and the tooltip below are shared by the dashboard and the
+  billing page rather than written twice with different wording.
+*/
+export const STORAGE_USAGE_LABEL = 'Scene storage'
+
+export const STORAGE_USAGE_HINT =
+	'What your scenes keep, not what visitors download. Each scene stores an editable copy at full precision, plus the compressed file served when you publish, its thumbnail, and any baked shadow. The size shown in the publisher is the published file alone, so it is the smaller of the two.'
+
+// ---------------------------------------------------------------------------
 // Upgrade success page: entitlement keys to highlight post-upgrade, in priority
 // order. Source: prd/03-entitlements.md § "Upgrade highlights"
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Last item on the dashboard overhaul's account-health band, split out of #680 since that merged first.

## The problem

#680 replaced the storage figure with a real sum of `assets.file_size` — the counter it used before (`getCurrentUsage(org, 'storage_bytes_total')`) was read in two places and incremented in none, so it was structurally `0 MB` for every org on every plan.

That fixed the number and exposed a labelling problem. The publisher reports a scene at ~4 MB, storage reports several times that for the same scene, and **both are correct**:

| Asset per scene | Why it is that size |
|---|---|
| working `scene.gltf` + `.bin` + textures | stored at full precision, uncompressed |
| published GLB | Draco applied at publish, so it is the small one |
| thumbnail | ~100 KB |
| baked shadow, when used | one PNG |

Compression is applied at publish so the editable scene stays at full precision — the editable copy is *necessarily* larger than what ships. `garbageCollectUnreferencedAssets` does remove superseded assets, so this is not accumulation.

## The change

**The number stays.** A storage quota should measure what is actually stored, and `storage_bytes_per_scene` is already enforced against these same bytes. What was missing was the explanation.

- Meter reads **Scene storage**, with the split behind an `InfoTooltip`.
- Label and wording live in `product-copy` and are used by both the dashboard band and the billing page, so the two screens cannot drift.
- `UsageMeter` gains an optional `hint`; `InfoTooltip` gains a `className` so the trigger sizes to `3.5` beside eyebrow type rather than sitting at `4` and towering over it.

## Verification

- `nx typecheck vectreal-platform` ✅
- `nx lint vectreal-platform` ✅ (includes the #678 adherence rules)
- Storybook `Dashboard/Pieces` covers the hint in both tile and row layouts