### PR TITLE
feat(dashboard): grid and table views for projects browse

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/data-table.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/data-table.tsx
@@ -166,36 +166,44 @@ export function DataTable<TData, TValue>({
 				)}
 
 				{hasSelection && (onDelete || onRename) && (
-					<div className="flex items-center gap-2">
+					<div className="ml-auto flex items-center gap-2">
 						<span className="text-muted-foreground text-sm">
 							{selectedRows.length} selected
 						</span>
-						<Button
-							disabled={disableSelectionActions || selectedRows.length !== 1}
-							variant="outline"
-							size="sm"
-							onClick={() => {
-								if (onRename) {
+						{/*
+						  Rename appears only when a caller handles it. It used to render
+						  whenever `onDelete` was passed, so the projects page - which
+						  passes only `onDelete` - offered a Rename button that did
+						  nothing at all when clicked.
+						*/}
+						{onRename ? (
+							<Button
+								disabled={disableSelectionActions || selectedRows.length !== 1}
+								variant="outline"
+								size="sm"
+								onClick={() => {
 									onRename(selectedRows.at(0)!)
 									onRowSelectionChange({})
-								}
-							}}
-						>
-							<TextCursor className="mr-2 h-4 w-4" />
-							Rename
-						</Button>
-						<Button
-							variant="destructive"
-							size="sm"
-							disabled={disableSelectionActions}
-							onClick={() => {
-								onDelete?.(selectedRows)
-								onRowSelectionChange({})
-							}}
-						>
-							<Trash2 className="mr-2 h-4 w-4" />
-							Delete
-						</Button>
+								}}
+							>
+								<TextCursor className="mr-2 h-4 w-4" />
+								Rename
+							</Button>
+						) : null}
+						{onDelete ? (
+							<Button
+								variant="destructive"
+								size="sm"
+								disabled={disableSelectionActions}
+								onClick={() => {
+									onDelete(selectedRows)
+									onRowSelectionChange({})
+								}}
+							>
+								<Trash2 className="mr-2 h-4 w-4" />
+								Delete
+							</Button>
+						) : null}
 					</div>
 				)}
 			</div>

--- a/apps/vectreal-platform/app/components/dashboard/index.ts
+++ b/apps/vectreal-platform/app/components/dashboard/index.ts
@@ -8,7 +8,21 @@ export { DataTable, SortableHeader, createCheckboxColumn } from './data-table'
 export { DynamicBreadcrumb } from './dynamic-breadcrumb'
 export { InlineEditableMetadataField } from './inline-editable-metadata-field'
 export { default as LogoSidebar } from './logo-sidebar'
+export { ProjectCard, type ProjectCardData } from './project-card'
 export { ProjectMultiSelect, type ProjectOption } from './project-multi-select'
+export {
+	ProjectsBrowser,
+	type ProjectBrowseItem,
+	type StatusFilter
+} from './projects-browser'
+export { SceneThumbnail } from './scene-thumbnail'
+export { StatusBreakdown, type SceneStatusCounts } from './status-breakdown'
+export {
+	UsageMeter,
+	UsageMeterGrid,
+	readUsage,
+	hasUsagePressure
+} from './usage-meter'
 export {
 	SceneAssetListItem,
 	buildAssetListItemProps

--- a/apps/vectreal-platform/app/components/dashboard/projects-browser.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/projects-browser.tsx
@@ -1,0 +1,272 @@
+import { Button } from '@shared/components/ui/button'
+import { Input } from '@shared/components/ui/input'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@shared/components/ui/select'
+import { ToggleGroup, ToggleGroupItem } from '@shared/components/ui/toggle-group'
+import { LayoutGrid, Rows3, Search } from 'lucide-react'
+import { useMemo } from 'react'
+
+import { DataTable } from './data-table'
+import { ProjectCard } from './project-card'
+import { type SceneStatusCounts } from './status-breakdown'
+import { projectColumns, type ProjectRow } from './table-columns'
+
+import type { DashboardView } from '../../hooks/use-dashboard-table-state'
+import type { useDashboardTableState } from '../../hooks/use-dashboard-table-state'
+
+/** Everything both layouts need for one project, derived once by the route. */
+export interface ProjectBrowseItem {
+	id: string
+	name: string
+	organizationId: string
+	organizationName: string
+	canDelete: boolean
+	sceneCount: number
+	counts: SceneStatusCounts
+	/** Borrowed from the project's most recently updated scene that has one. */
+	thumbnailUrl: null | string
+	/** Null when the project has no scenes. Never a fabricated "today". */
+	updatedAt: Date | null
+}
+
+/** Which scene state a project must contain to pass the filter. */
+type StatusFilter = 'all' | keyof SceneStatusCounts
+
+const STATUS_FILTERS: Array<{ value: StatusFilter; label: string }> = [
+	{ value: 'all', label: 'Any scenes' },
+	{ value: 'published', label: 'Has published' },
+	{ value: 'draft', label: 'Has drafts' },
+	{ value: 'archived', label: 'Has archived' }
+]
+
+interface ProjectsBrowserProps {
+	items: ProjectBrowseItem[]
+	organizations: Array<{ id: string; name: string }>
+	tableState: ReturnType<typeof useDashboardTableState>
+	organizationFilter: string
+	onOrganizationFilterChange: (value: string) => void
+	statusFilter: StatusFilter
+	onStatusFilterChange: (value: StatusFilter) => void
+	isUpdating?: boolean
+	onDelete: (rows: ProjectRow[]) => void
+	onRename: (row: ProjectRow) => void
+}
+
+/*
+  One control surface. Search, both filters and the layout toggle sit in a
+  single toolbar above the content, and the same filtered list feeds whichever
+  layout is showing - so switching views cannot change what is in front of you.
+
+  This is why `DataTable` is given no `searchKey`: its built-in search filters
+  the table only, which would silently disagree with the grid.
+*/
+export function ProjectsBrowser({
+	items,
+	organizations,
+	tableState,
+	organizationFilter,
+	onOrganizationFilterChange,
+	statusFilter,
+	onStatusFilterChange,
+	isUpdating,
+	onDelete,
+	onRename
+}: ProjectsBrowserProps) {
+	const query = tableState.searchValue.trim().toLowerCase()
+
+	const filtered = useMemo(
+		() =>
+			items.filter((item) => {
+				if (
+					organizationFilter !== 'all' &&
+					item.organizationId !== organizationFilter
+				) {
+					return false
+				}
+
+				if (statusFilter !== 'all' && item.counts[statusFilter] === 0) {
+					return false
+				}
+
+				if (!query) {
+					return true
+				}
+
+				return (
+					item.name.toLowerCase().includes(query) ||
+					item.organizationName.toLowerCase().includes(query)
+				)
+			}),
+		[items, organizationFilter, query, statusFilter]
+	)
+
+	const rows: ProjectRow[] = useMemo(
+		() =>
+			filtered.map((item) => ({
+				id: item.id,
+				name: item.name,
+				organizationName: item.organizationName,
+				canDelete: item.canDelete,
+				sceneCount: item.sceneCount,
+				counts: item.counts,
+				createdAt: item.updatedAt,
+				updatedAt: item.updatedAt
+			})),
+		[filtered]
+	)
+
+	const hasFilters =
+		query !== '' || organizationFilter !== 'all' || statusFilter !== 'all'
+
+	const clearFilters = () => {
+		tableState.setSearchValue('')
+		onOrganizationFilterChange('all')
+		onStatusFilterChange('all')
+	}
+
+	return (
+		<div className="space-y-4">
+			<div className="flex flex-wrap items-center gap-2">
+				<div className="relative min-w-48 flex-1">
+					<Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+					<Input
+						placeholder="Search projects..."
+						value={tableState.searchValue}
+						onChange={(event) => tableState.setSearchValue(event.target.value)}
+						className="ds-sunken h-10 rounded-xl border-0 pl-9 shadow-none focus-visible:ring-2"
+					/>
+				</div>
+
+				{/*
+				  The organization filter earns its place only for someone in more
+				  than one - below that it is a control with a single answer.
+				*/}
+				{organizations.length > 1 ? (
+					<Select
+						value={organizationFilter}
+						onValueChange={onOrganizationFilterChange}
+					>
+						<SelectTrigger
+							aria-label="Filter by organization"
+							className="ds-sunken h-10 rounded-xl border-0 shadow-none"
+						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All organizations</SelectItem>
+							{organizations.map((organization) => (
+								<SelectItem key={organization.id} value={organization.id}>
+									{organization.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				) : null}
+
+				<Select
+					value={statusFilter}
+					onValueChange={(value) => onStatusFilterChange(value as StatusFilter)}
+				>
+					<SelectTrigger
+						aria-label="Filter by scene status"
+						className="ds-sunken h-10 rounded-xl border-0 shadow-none"
+					>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{STATUS_FILTERS.map((filter) => (
+							<SelectItem key={filter.value} value={filter.value}>
+								{filter.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+
+				<ToggleGroup
+					type="single"
+					value={tableState.view}
+					onValueChange={(value) => {
+						// Radix clears the value when the active item is pressed again.
+						// There is no "no layout" state, so an empty value is ignored.
+						if (value) {
+							tableState.setView(value as DashboardView)
+						}
+					}}
+					className="ds-sunken h-10 rounded-xl p-1"
+				>
+					<ToggleGroupItem
+						value="grid"
+						aria-label="Grid view"
+						className="size-8 rounded-lg first:rounded-l-lg last:rounded-r-lg"
+					>
+						<LayoutGrid className="size-4" />
+					</ToggleGroupItem>
+					<ToggleGroupItem
+						value="table"
+						aria-label="Table view"
+						className="size-8 rounded-lg first:rounded-l-lg last:rounded-r-lg"
+					>
+						<Rows3 className="size-4" />
+					</ToggleGroupItem>
+				</ToggleGroup>
+			</div>
+
+			{filtered.length === 0 ? (
+				<div className="ds-raised rounded-2xl p-12 text-center">
+					<p className="font-medium">No projects match these filters</p>
+					<p className="text-muted-foreground mt-1 text-sm">
+						{hasFilters
+							? 'Try a different search term, or clear the filters.'
+							: 'Nothing to show here.'}
+					</p>
+					{hasFilters ? (
+						<Button variant="secondary" className="mt-4" onClick={clearFilters}>
+							Clear filters
+						</Button>
+					) : null}
+				</div>
+			) : tableState.view === 'grid' ? (
+				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+					{filtered.map((item) => (
+						<ProjectCard
+							key={item.id}
+							project={{
+								id: item.id,
+								name: item.name,
+								organizationName: item.organizationName,
+								counts: item.counts,
+								thumbnailUrl: item.thumbnailUrl,
+								updatedAt: item.updatedAt
+							}}
+						/>
+					))}
+				</div>
+			) : (
+				<DataTable
+					columns={projectColumns}
+					data={rows}
+					isUpdating={isUpdating}
+					disableSelectionActions={isUpdating}
+					searchValue={tableState.searchValue}
+					onSearchValueChange={tableState.setSearchValue}
+					sorting={tableState.sorting}
+					onSortingChange={tableState.onSortingChange}
+					pagination={tableState.pagination}
+					onPaginationChange={tableState.onPaginationChange}
+					rowSelection={tableState.rowSelection}
+					onRowSelectionChange={tableState.onRowSelectionChange}
+					getRowCanSelect={(row) => row.canDelete}
+					onRename={onRename}
+					onDelete={onDelete}
+				/>
+			)}
+		</div>
+	)
+}
+
+export type { StatusFilter }

--- a/apps/vectreal-platform/app/components/dashboard/projects-browser.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/projects-browser.tsx
@@ -120,9 +120,6 @@ export function ProjectsBrowser({
 		[filtered]
 	)
 
-	const hasFilters =
-		query !== '' || organizationFilter !== 'all' || statusFilter !== 'all'
-
 	const clearFilters = () => {
 		tableState.setSearchValue('')
 		onOrganizationFilterChange('all')
@@ -216,19 +213,20 @@ export function ProjectsBrowser({
 				</ToggleGroup>
 			</div>
 
+			{/*
+			  The caller only renders this when there is at least one project, so
+			  an empty result here always means the filters excluded everything -
+			  which is why clearing them is offered unconditionally.
+			*/}
 			{filtered.length === 0 ? (
 				<div className="ds-raised rounded-2xl p-12 text-center">
 					<p className="font-medium">No projects match these filters</p>
 					<p className="text-muted-foreground mt-1 text-sm">
-						{hasFilters
-							? 'Try a different search term, or clear the filters.'
-							: 'Nothing to show here.'}
+						Try a different search term, or clear the filters.
 					</p>
-					{hasFilters ? (
-						<Button variant="secondary" className="mt-4" onClick={clearFilters}>
-							Clear filters
-						</Button>
-					) : null}
+					<Button variant="secondary" className="mt-4" onClick={clearFilters}>
+						Clear filters
+					</Button>
 				</div>
 			) : tableState.view === 'grid' ? (
 				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
@@ -37,6 +37,7 @@ import { Link } from 'react-router'
 
 import { createCheckboxColumn, SortableHeader } from './data-table'
 import { SceneThumbnail } from './scene-thumbnail'
+import { StatusBreakdown, type SceneStatusCounts } from './status-breakdown'
 
 import type { ColumnDef } from '@tanstack/react-table'
 
@@ -49,8 +50,17 @@ export interface ProjectRow {
 	organizationName: string
 	canDelete: boolean
 	sceneCount: number
-	createdAt: Date
-	updatedAt: Date
+	counts: SceneStatusCounts
+	/**
+	 * Null when the project has no scenes.
+	 *
+	 * `projects` has no timestamp column of its own, so both dates are derived
+	 * from the project's scenes. The derivation used to fall back to `new Date()`,
+	 * which made every empty project report as updated today - a date the system
+	 * invented rather than recorded.
+	 */
+	createdAt: Date | null
+	updatedAt: Date | null
 }
 
 export const projectColumns: ColumnDef<ProjectRow>[] = [
@@ -92,9 +102,9 @@ export const projectColumns: ColumnDef<ProjectRow>[] = [
 		header: ({ column }) => (
 			<SortableHeader column={column}>Scenes</SortableHeader>
 		),
-		cell: ({ row }) => (
-			<Badge variant="secondary">{row.getValue('sceneCount')} scenes</Badge>
-		)
+		// Sorts on the count, reads as the breakdown. "12 scenes" never answered
+		// the question people have about a project, which is how much of it is live.
+		cell: ({ row }) => <StatusBreakdown counts={row.original.counts} verbose />
 	},
 	{
 		accessorKey: 'updatedAt',
@@ -102,14 +112,17 @@ export const projectColumns: ColumnDef<ProjectRow>[] = [
 			<SortableHeader column={column}>Last Updated</SortableHeader>
 		),
 		cell: ({ row }) => {
-			const date = row.getValue('updatedAt') as Date
+			const date = row.original.updatedAt
+
 			return (
 				<span className="text-muted-foreground text-sm">
-					{new Date(date).toLocaleDateString('en-US', {
-						month: 'short',
-						day: 'numeric',
-						year: 'numeric'
-					})}
+					{date
+						? new Date(date).toLocaleDateString('en-US', {
+								month: 'short',
+								day: 'numeric',
+								year: 'numeric'
+							})
+						: 'Never'}
 				</span>
 			)
 		}

--- a/apps/vectreal-platform/app/components/skeletons/projects-grid-skeleton.tsx
+++ b/apps/vectreal-platform/app/components/skeletons/projects-grid-skeleton.tsx
@@ -1,12 +1,45 @@
-import { SkeletonDataTable } from './skeleton-data-table'
+import { Skeleton } from '@shared/components/ui/skeleton'
 
 /**
- * Skeleton loader for the projects page, which renders a data table.
+ * Skeleton loader for the projects browse page.
+ *
+ * Mirrors the grid, which is the default layout: a toolbar, then cards with a
+ * thumbnail above their meta. It used to render a table skeleton, so every
+ * navigation showed rows for 200ms and then jumped to a grid.
  */
 export function ProjectsGridSkeleton() {
 	return (
-		<div className="p-6">
-			<SkeletonDataTable rows={6} />
+		<div className="space-y-4 p-6" role="status" aria-label="Loading projects">
+			<div className="flex flex-wrap items-center gap-2">
+				<Skeleton className="h-10 min-w-48 flex-1 rounded-xl" />
+				<Skeleton className="h-10 w-36 rounded-xl" />
+				<Skeleton className="h-10 w-20 rounded-xl" />
+			</div>
+
+			<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				{Array.from({ length: 6 }, (_, index) => (
+					<div key={index} className="ds-raised overflow-hidden rounded-2xl">
+						<Skeleton
+							className="aspect-video w-full rounded-none"
+							style={{ animationDelay: `${index * 70}ms` }}
+						/>
+						<div className="space-y-2 p-4">
+							<Skeleton
+								className="h-4 w-32"
+								style={{ animationDelay: `${index * 70 + 30}ms` }}
+							/>
+							<Skeleton
+								className="h-3 w-20"
+								style={{ animationDelay: `${index * 70 + 60}ms` }}
+							/>
+							<Skeleton
+								className="h-3 w-24"
+								style={{ animationDelay: `${index * 70 + 90}ms` }}
+							/>
+						</div>
+					</div>
+				))}
+			</div>
 		</div>
 	)
 }

--- a/apps/vectreal-platform/app/hooks/use-dashboard-table-state.ts
+++ b/apps/vectreal-platform/app/hooks/use-dashboard-table-state.ts
@@ -8,9 +8,13 @@ import type {
 	Updater
 } from '@tanstack/react-table'
 
+/** How a collection is laid out. Grid reads visually, table reads densely. */
+export type DashboardView = 'grid' | 'table'
+
 interface UseDashboardTableStateOptions {
 	namespace: string
 	defaultPageSize?: number
+	defaultView?: DashboardView
 }
 
 interface DashboardTableStateResult {
@@ -22,6 +26,8 @@ interface DashboardTableStateResult {
 	onPaginationChange: (updater: Updater<PaginationState>) => void
 	rowSelection: RowSelectionState
 	onRowSelectionChange: (updater: Updater<RowSelectionState>) => void
+	view: DashboardView
+	setView: (value: DashboardView) => void
 }
 
 function applyUpdater<T>(updater: Updater<T>, current: T): T {
@@ -34,7 +40,8 @@ function applyUpdater<T>(updater: Updater<T>, current: T): T {
 
 export function useDashboardTableState({
 	namespace,
-	defaultPageSize = 10
+	defaultPageSize = 10,
+	defaultView = 'grid'
 }: UseDashboardTableStateOptions): DashboardTableStateResult {
 	const [searchParams, setSearchParams] = useSearchParams()
 
@@ -43,6 +50,7 @@ export function useDashboardTableState({
 	const pageSizeKey = `${namespace}-pageSize`
 	const sortKey = `${namespace}-sort`
 	const sortDirKey = `${namespace}-sortDir`
+	const viewKey = `${namespace}-view`
 
 	const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
 
@@ -169,6 +177,39 @@ export function useDashboardTableState({
 		[]
 	)
 
+	/*
+	  The layout choice lives in the URL with the rest of the table state rather
+	  than in component state or localStorage: it survives reload and back
+	  navigation for the same reason the search term does, and a shared link
+	  arrives showing what the sender was looking at.
+	*/
+	const view: DashboardView =
+		searchParams.get(viewKey) === 'table'
+			? 'table'
+			: searchParams.get(viewKey) === 'grid'
+				? 'grid'
+				: defaultView
+
+	const setView = useCallback(
+		(value: DashboardView) => {
+			setSearchParams(
+				(prevParams) => {
+					const nextParams = new URLSearchParams(prevParams)
+					if (value === defaultView) {
+						nextParams.delete(viewKey)
+					} else {
+						nextParams.set(viewKey, value)
+					}
+					return nextParams
+				},
+				// Switching layout is not a place to come back to - it would take two
+				// Backs to leave the page after one toggle.
+				{ replace: true }
+			)
+		},
+		[defaultView, setSearchParams, viewKey]
+	)
+
 	return {
 		searchValue,
 		setSearchValue,
@@ -177,6 +218,8 @@ export function useDashboardTableState({
 		pagination,
 		onPaginationChange,
 		rowSelection,
-		onRowSelectionChange
+		onRowSelectionChange,
+		view,
+		setView
 	}
 }

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/projects.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/projects.tsx
@@ -6,16 +6,25 @@ import {
 	EmptyHeader
 } from '@shared/components/ui/empty'
 import { Plus } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
-import { data, Link, Outlet, useFetcher, useRevalidator } from 'react-router'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+	data,
+	Link,
+	Outlet,
+	useFetcher,
+	useNavigate,
+	useRevalidator,
+	useSearchParams
+} from 'react-router'
 import { useAuthenticityToken } from 'remix-utils/csrf/react'
 import { toast } from 'sonner'
 
 import { Route } from './+types/projects'
 import {
-	DataTable,
-	projectColumns,
-	type ProjectRow
+	ProjectsBrowser,
+	type ProjectBrowseItem,
+	type ProjectRow,
+	type StatusFilter
 } from '../../../components/dashboard'
 import { WrittenConfirmationModal } from '../../../components/shared/written-confirmation-modal'
 import { ProjectsGridSkeleton } from '../../../components/skeletons'
@@ -302,13 +311,42 @@ const ProjectsPage = ({ loaderData }: Route.ComponentProps) => {
 	const fetcher = useFetcher<typeof action>()
 	const csrfToken = useAuthenticityToken()
 	const revalidator = useRevalidator()
+	const navigate = useNavigate()
 	const lastHandledResponseRef = useRef<string | null>(null)
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
 	const [projectIdsToDelete, setProjectIdsToDelete] = useState<string[]>([])
 	const tableState = useDashboardTableState({
 		namespace: 'projects-list'
 	})
+	const [searchParams, setSearchParams] = useSearchParams()
 	const isDeletingProjects = fetcher.state !== 'idle'
+
+	/*
+	  Both filters live in the URL beside the rest of the table state, under the
+	  same `projects-list` namespace, so a filtered view survives reload and
+	  back-navigation and can be shared as a link.
+	*/
+	const organizationFilter = searchParams.get('projects-list-org') ?? 'all'
+	const statusFilter = (searchParams.get('projects-list-status') ??
+		'all') as StatusFilter
+
+	const setFilterParam = useCallback(
+		(key: string, value: string) => {
+			setSearchParams((prevParams) => {
+				const nextParams = new URLSearchParams(prevParams)
+				if (value === 'all') {
+					nextParams.delete(key)
+				} else {
+					nextParams.set(key, value)
+				}
+				// Narrowing the list while on page 3 would otherwise land on an empty
+				// page, which reads as "no projects" rather than as a filter.
+				nextParams.set('projects-list-page', '1')
+				return nextParams
+			})
+		},
+		[setSearchParams]
+	)
 
 	useEffect(() => {
 		if (fetcher.state !== 'idle' || !fetcher.data) {
@@ -360,40 +398,74 @@ const ProjectsPage = ({ loaderData }: Route.ComponentProps) => {
 		)
 	}
 
-	const projectTableData: ProjectRow[] = projects.map(
-		({ project, organizationId }) => {
-			const projectScenes = scenes.filter(
-				(scene) => scene.projectId === project.id
-			)
-			const latestSceneUpdate = projectScenes.reduce<Date | null>(
-				(latest, scene) => {
-					const sceneUpdatedAt = new Date(scene.updatedAt)
+	/*
+	  Everything both layouts show, derived from data the loader already has.
+	  No new queries: the scene rows are here for the counts, and the status
+	  breakdown and card thumbnail come out of the same pass.
+	*/
+	const projectItems: ProjectBrowseItem[] = useMemo(
+		() =>
+			projects.map(({ project, organizationId }) => {
+				const projectScenes = scenes.filter(
+					(scene) => scene.projectId === project.id
+				)
 
-					if (!latest || sceneUpdatedAt > latest) {
-						return sceneUpdatedAt
+				const counts = { published: 0, draft: 0, archived: 0 }
+				let latestSceneUpdate: Date | null = null
+				let thumbnailUrl: null | string = null
+				let thumbnailUpdatedAt: Date | null = null
+
+				for (const scene of projectScenes) {
+					if (scene.status in counts) {
+						counts[scene.status as keyof typeof counts] += 1
 					}
 
-					return latest
-				},
-				null
-			)
+					const sceneUpdatedAt = new Date(scene.updatedAt)
 
-			const stableTimestamp = latestSceneUpdate ?? new Date()
+					if (!latestSceneUpdate || sceneUpdatedAt > latestSceneUpdate) {
+						latestSceneUpdate = sceneUpdatedAt
+					}
 
-			return {
-				id: project.id,
-				name: project.name,
-				organizationName:
-					organizations.find(
-						({ organization }) => organization.id === organizationId
-					)?.organization.name || 'Unknown',
-				canDelete:
-					projectCreationCapabilities[organizationId]?.canDelete ?? false,
-				sceneCount: projectScenes.length,
-				createdAt: stableTimestamp,
-				updatedAt: stableTimestamp
-			}
-		}
+					// The card borrows the most recently updated scene that actually has
+					// a thumbnail, rather than the most recent scene - which is usually
+					// the one just created, and so the one without a capture yet.
+					if (
+						scene.thumbnailUrl &&
+						(!thumbnailUpdatedAt || sceneUpdatedAt > thumbnailUpdatedAt)
+					) {
+						thumbnailUrl = scene.thumbnailUrl
+						thumbnailUpdatedAt = sceneUpdatedAt
+					}
+				}
+
+				return {
+					id: project.id,
+					name: project.name,
+					organizationId,
+					organizationName:
+						organizations.find(
+							({ organization }) => organization.id === organizationId
+						)?.organization.name || 'Unknown',
+					canDelete:
+						projectCreationCapabilities[organizationId]?.canDelete ?? false,
+					sceneCount: projectScenes.length,
+					counts,
+					thumbnailUrl,
+					// Null, not today. `projects` has no timestamp of its own, so a
+					// project with no scenes genuinely has no date to report.
+					updatedAt: latestSceneUpdate
+				}
+			}),
+		[organizations, projectCreationCapabilities, projects, scenes]
+	)
+
+	const organizationOptions = useMemo(
+		() =>
+			organizations.map(({ organization }) => ({
+				id: organization.id,
+				name: organization.name
+			})),
+		[organizations]
 	)
 
 	const canCreateProjects = Object.values(projectCreationCapabilities).some(
@@ -403,27 +475,28 @@ const ProjectsPage = ({ loaderData }: Route.ComponentProps) => {
 	return (
 		<>
 			<div className="p-6">
-				{projectTableData.length > 0 ? (
-					<DataTable
-						columns={projectColumns}
-						data={projectTableData}
+				{projectItems.length > 0 ? (
+					<ProjectsBrowser
+						items={projectItems}
+						organizations={organizationOptions}
+						tableState={tableState}
+						organizationFilter={organizationFilter}
+						onOrganizationFilterChange={(value) =>
+							setFilterParam('projects-list-org', value)
+						}
+						statusFilter={statusFilter}
+						onStatusFilterChange={(value) =>
+							setFilterParam('projects-list-status', value)
+						}
 						isUpdating={isDeletingProjects}
-						disableSelectionActions={isDeletingProjects}
-						searchKey="name"
-						searchPlaceholder="Search projects..."
-						searchValue={tableState.searchValue}
-						onSearchValueChange={tableState.setSearchValue}
-						sorting={tableState.sorting}
-						onSortingChange={tableState.onSortingChange}
-						pagination={tableState.pagination}
-						onPaginationChange={tableState.onPaginationChange}
-						rowSelection={tableState.rowSelection}
-						onRowSelectionChange={tableState.onRowSelectionChange}
-						getRowCanSelect={(row) => row.canDelete}
-						onDelete={(selectedRows) => {
-							const projectIds = (selectedRows as ProjectRow[]).map(
-								(row) => row.id
-							)
+						// Rename opens the edit dialog that already exists at this route's
+						// `/edit` child. The button used to render with nothing behind it,
+						// because the page never passed a handler.
+						onRename={(row: ProjectRow) =>
+							navigate(`/dashboard/projects/${row.id}/edit`)
+						}
+						onDelete={(selectedRows: ProjectRow[]) => {
+							const projectIds = selectedRows.map((row) => row.id)
 
 							if (projectIds.length === 0) {
 								toast.error('Select at least one project first')


### PR DESCRIPTION
Part B of the dashboard overhaul. Independent of #681 — different files, no overlap.

## What was wrong

- **A project row said "12 scenes."** That never answered the question people actually have about a project, which is how much of it is live.
- **Rename did nothing.** `DataTable` rendered the button whenever `onDelete` was passed; this page passed no `onRename`. Clicking it was a no-op.
- **Empty projects reported as updated today.** The derived timestamp fell back to `new Date()`, so a project with no scenes showed a date the system invented rather than recorded.
- **The skeleton mirrored a table** the page no longer leads with.

## What this does

**Grid + table toggle**, defaulting to grid. The choice is a `view` param in the existing `projects-list` namespace, so it survives reload and back-navigation like the search term, and a shared link arrives showing what the sender was looking at. `replace: true` — one toggle should not cost two Backs to leave the page.

**`ProjectCard` in the grid** (landed in #679, unused until now): thumbnail borrowed from the project's most recently updated scene *that has one* — not simply the most recent, which is usually the one just created and so the one without a capture yet — plus the published/draft/archived breakdown. No new queries; the loader already fetched every scene row.

**Organization and status filters**, persisted in the URL under the same namespace. The organization filter renders only for someone in more than one; below that it is a control with a single answer.

**One filtered list feeds both layouts.** This is why `DataTable` is given no `searchKey` — its built-in search filters the table only, which would silently disagree with the grid.

## Fixes

| Fix | Where |
|---|---|
| Rename gated on a handler, and wired to the existing `/edit` dialog | `data-table.tsx`, `projects.tsx` |
| `updatedAt` nullable, renders "Never" instead of a fabricated today | `table-columns.tsx`, `projects.tsx` |
| Skeleton mirrors the grid | `projects-grid-skeleton.tsx` |

The Delete button is now gated on `onDelete` too, for the same reason.

## Verification

- `nx typecheck vectreal-platform` ✅
- `nx lint vectreal-platform` ✅ (includes the #678 adherence rules)
- `nx test vectreal-platform` ✅ 221 passed
- `nx build vectreal-platform` ✅, and the new classes confirmed present in the built CSS (`min-w-48`, `first:rounded-l-lg`, `xl:grid-cols-3`)

Browser pass still wanted on: grid ↔ table surviving reload and back, a project with zero scenes reading "Never", and the filter-empty state.