### PR TITLE
chore(terraform): name Supabase custom domain api.vectreal.com

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -34,13 +34,13 @@ variable "turnstile_staging_hostname" {
 }
 
 variable "supabase_project_ref_prod" {
-  description = "Production Supabase project ref (the <ref> in <ref>.supabase.co), used as the custom domain CNAME target"
+  description = "Production Supabase project ref (the <ref> in <ref>.supabase.co). Used as the CNAME target for the api.vectreal.com custom domain, which fronts the entire Supabase API (auth, REST, storage, realtime, functions)."
   type        = string
   default     = ""
 }
 
 variable "supabase_custom_domain_acme_challenge" {
-  description = "TXT value for _acme-challenge.auth.vectreal.com, from `supabase domains create` output. Leave empty until that command has been run."
+  description = "TXT value for _acme-challenge.api.vectreal.com, from `supabase domains create` output. Leave empty until that command has been run."
   type        = string
   default     = ""
 }
@@ -374,7 +374,7 @@ resource "cloudflare_record" "supabase_custom_domain_cname" {
   count           = local.enable_cloudflare && var.cloudflare_zone_id != "" && var.supabase_project_ref_prod != "" ? 1 : 0
   zone_id         = var.cloudflare_zone_id
   allow_overwrite = true
-  name            = "auth"
+  name            = "api"
   type            = "CNAME"
   content         = "${var.supabase_project_ref_prod}.supabase.co"
   proxied         = false
@@ -384,7 +384,7 @@ resource "cloudflare_record" "supabase_custom_domain_acme_challenge" {
   count           = local.enable_cloudflare && var.cloudflare_zone_id != "" && var.supabase_custom_domain_acme_challenge != "" ? 1 : 0
   zone_id         = var.cloudflare_zone_id
   allow_overwrite = true
-  name            = "_acme-challenge.auth"
+  name            = "_acme-challenge.api"
   type            = "TXT"
   content         = var.supabase_custom_domain_acme_challenge
   proxied         = false

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -7,3 +7,7 @@ cloudflare_zone_id            = ""
 turnstile_production_hostname = "vectreal.com"
 turnstile_staging_hostname    = "staging.vectreal.com"
 supabase_project_ref_prod     = ""
+
+# TXT value for _acme-challenge.api.vectreal.com, from `supabase domains create` output.
+# Leave empty until that command has been run; the ACME record is only created once set.
+supabase_custom_domain_acme_challenge = ""


### PR DESCRIPTION
## What

Renames the placeholder Cloudflare DNS records for the Supabase custom domain from `auth` to `api`, and documents the missing tfvars variable.

The Supabase custom domain fronts the **entire** project API — auth, REST, storage (`/storage/v1/object/public/...`), realtime, and Edge Functions (`/functions/v1/...`) — not just auth. `api.vectreal.com` is Supabase's recommended naming and keeps the public URL vendor-neutral and portable if the project is ever migrated.

## Changes

- `terraform/cloudflare.tf`
  - CNAME record `auth` → `api` (`api.vectreal.com` → `<ref>.supabase.co`, DNS-only)
  - TXT record `_acme-challenge.auth` → `_acme-challenge.api` (custom-domain TLS)
  - Updated variable descriptions to reflect the whole-API scope and the `api.vectreal.com` hostname
- `terraform/terraform.tfvars.example`
  - Added the previously missing `supabase_custom_domain_acme_challenge` entry

## Safety

Both records remain `count`-gated on `supabase_project_ref_prod` and `supabase_custom_domain_acme_challenge`. With those unset, this diff provisions nothing — it's inert until the values are filled in `terraform.tfvars`.

## Rollout (post-merge, prod only)

1. Set `supabase_project_ref_prod` → `terraform apply` (creates the CNAME)
2. `supabase domains create --custom-hostname api.vectreal.com` → yields the `_acme-challenge` TXT value (CNAME must resolve first)
3. Set `supabase_custom_domain_acme_challenge` → `terraform apply` (creates the TXT)
4. `supabase domains get` until verified → `supabase domains activate`
5. Flip `SUPABASE_URL_PROD=https://api.vectreal.com` (Fly secret) and deploy in a low-traffic window — activation changes the JWT `iss`, so live sessions re-authenticate

Staging is intentionally out of scope (only the prod custom domain is wired).