### PR TITLE
fix(auth): correct legal links and separator chip on sign-in/up

### DIFF
--- a/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
@@ -231,7 +231,14 @@ const SigninLayout = ({ loaderData }: Route.ComponentProps) => {
 							</AnimatePresence>
 							<span className="relative">
 								<Separator />
-								<p className="ds-raised text-muted-foreground absolute left-1/2 -translate-x-1/2 -translate-y-3 px-2">
+								{/*
+									Paint the chip with the panel's base raised surface (4% mix)
+									so it masks the separator seamlessly. Not `ds-raised`: nested
+									inside the ds-raised panel it steps up to 8% (see
+									`.ds-raised .ds-raised` in globals.css) and reads as a darker
+									box, most visibly in light mode.
+								*/}
+								<p className="text-muted-foreground absolute left-1/2 -translate-x-1/2 -translate-y-3 bg-[color-mix(in_oklch,var(--foreground)_4%,var(--background))] px-2">
 									or
 								</p>
 							</span>

--- a/apps/vectreal-platform/app/routes/signup-page/signup-page.tsx
+++ b/apps/vectreal-platform/app/routes/signup-page/signup-page.tsx
@@ -718,7 +718,7 @@ const SignupPage = ({ loaderData, actionData }: Route.ComponentProps) => {
 							>
 								I agree to the{' '}
 								<Link
-									to="/legal/terms"
+									to="/terms-of-service"
 									target="_blank"
 									rel="noopener noreferrer"
 									className="text-foreground underline-offset-2 hover:underline"
@@ -727,7 +727,7 @@ const SignupPage = ({ loaderData, actionData }: Route.ComponentProps) => {
 								</Link>{' '}
 								and{' '}
 								<Link
-									to="/legal/privacy"
+									to="/privacy-policy"
 									target="_blank"
 									rel="noopener noreferrer"
 									className="text-foreground underline-offset-2 hover:underline"


### PR DESCRIPTION
## What

Two small fixes on the sign-in/sign-up screens.

### 1. Broken legal links (404) on the sign-up page

The ToS checkbox linked to `/legal/terms` and `/legal/privacy`, neither of which exists. The actual routes are `/terms-of-service` and `/privacy-policy` (see `app/routes.tsx`). Both links now point at the real paths — matching what the sign-in layout already uses.

### 2. "or" separator chip color mismatch

The chip that masks the separator line used `ds-raised`, but it's nested inside the `ds-raised` auth panel. The `.ds-raised .ds-raised` elevation rule (`shared/components/src/styles/globals.css`) intentionally steps a nested raised surface from 4% → 8% foreground-mix, so the chip rendered as a darker box against the 4% panel — most visible in light mode.

Repainted it with the panel's base raised surface (`color-mix(in oklch, var(--foreground) 4%, var(--background))`) so it matches the panel regardless of nesting, with a comment so it isn't reverted to `ds-raised`.

## Testing

- Verified `/legal/*` no longer appears anywhere in the app
- Confirmed every remaining link on both pages resolves to a real route
- Chip color best eyeballed in light mode (before: darker box; after: seamless)