### PR TITLE
docs(legal): rewrite Terms of Service, refresh Privacy Policy and Imprint

### DIFF
--- a/apps/vectreal-platform/app/routes/imprint-page.mdx
+++ b/apps/vectreal-platform/app/routes/imprint-page.mdx
@@ -1,22 +1,23 @@
 # Imprint
 
-**Last Updated: Jan 19 2026**
+**Last Updated: August 2, 2026**
 
-This Imprint page provides important information about Vectreal ("we," "us," or "our") and our services. By using our services, you agree to the terms outlined in this Imprint. If you have any questions or concerns, please contact us at
-info@vectreal.com.
+This Imprint provides the legally required information about Vectreal ("we," "us," or "our") and our services, in accordance with § 5 of the German Digital Services Act (Digitale-Dienste-Gesetz, DDG). If you have any questions or concerns, please contact us at info@vectreal.com.
 
-## Information
+## Information pursuant to § 5 DDG
 Vectreal is operated by:  
 Moritz Becker  
 Wandsbeker Stieg 31  
 22087 Hamburg  
 Germany  
-Email: info@vectreal.com
+Email: info@vectreal.com  
 Website: [www.vectreal.com](https://www.vectreal.com)
 
-## Responsible for Content
+## Responsible for Content pursuant to § 18 (2) MStV
 Moritz Becker  
-Chief Developing Officer  
+Wandsbeker Stieg 31  
+22087 Hamburg  
+Germany  
 Email: vectreal@moritzbecker.com
 
 ## Disclaimer
@@ -26,8 +27,11 @@ In no event will Vectreal be liable for any loss or damage including without lim
 ## External Links
 Through this Imprint, you may be able to link to other websites which are not under the control of Vectreal. We have no control over the nature, content, and availability of those sites. The inclusion of any links does not necessarily imply a recommendation or endorse the views expressed within them.
 
+## Consumer Dispute Resolution
+We are neither obligated nor willing to participate in dispute resolution proceedings before a consumer arbitration board within the meaning of the German Consumer Dispute Resolution Act (Verbraucherstreitbeilegungsgesetz, VSBG).
+
 ## Governing Law
-This Imprint and any dispute or claim arising out of or in connection with it or its subject matter or formation (including non-contractual disputes or claims) shall be governed by and construed in accordance with the laws of the Country, without giving effect to any choice or conflict of law provision or rule (whether of the Country or any other jurisdiction).
+This Imprint and any dispute or claim arising out of or in connection with it or its subject matter or formation (including non-contractual disputes or claims) shall be governed by and construed in accordance with the laws of the Federal Republic of Germany, without giving effect to any choice or conflict of law provision or rule of another jurisdiction.
 
 
 

--- a/apps/vectreal-platform/app/routes/privacy-policy-page.mdx
+++ b/apps/vectreal-platform/app/routes/privacy-policy-page.mdx
@@ -1,8 +1,8 @@
 # Privacy Policy
 
-**Last updated: April 8, 2026**
+**Last Updated: August 2, 2026**
 
-This Privacy Policy explains how Vectreal collects, uses, and protects personal data when you use our services.
+This Privacy Policy explains how Vectreal collects, uses, shares, and protects personal data when you use our services. It also serves as our cookie notice: we do not maintain a separate cookies page, and Section 4 is the authoritative description of the cookies and similar technologies we use.
 
 If you have questions, contact us at [info@vectreal.com](mailto:info@vectreal.com).
 
@@ -10,92 +10,122 @@ If you have questions, contact us at [info@vectreal.com](mailto:info@vectreal.co
 
 Vectreal provides tooling for preparing, managing, and publishing 3D content for the web.
 
+The controller responsible for your personal data is:
+
+Moritz Becker
+Wandsbeker Stieg 31, 22087 Hamburg, Germany
+Email: [info@vectreal.com](mailto:info@vectreal.com)
+
+Further details are available in our [Imprint](/imprint).
+
 ## 2. Data We Collect
 
 We collect the following categories of data, depending on how you use the platform:
 
-- Account and profile data: name, email address, account identifiers.
-- Authentication data: session and identity data processed through Supabase Auth (including optional Google sign-in).
-- Billing and subscription data: billing status, plan, and payment-related metadata. Payment processing is handled by Stripe.
-- Workspace and content data: projects, scenes, uploads, optimization-related metadata, and related logs.
-- Contact and support data: information you submit through the contact form, including message content and your email address.
-- Consent and preference data: consent choices for functional, analytics, and marketing categories; policy version; anonymous identifier where applicable.
-- Technical and security data: IP-derived country, user agent, request metadata, and security/session tokens required to operate the service.
+- **Account and profile data:** name, email address, and account identifiers.
+- **Onboarding data:** optional information you provide during onboarding, such as your role, use case, company name, and how you heard about Vectreal.
+- **Authentication data:** session and identity data processed through Supabase Auth, including sign-in with email and password, magic link, one-time passcode (OTP), or optional Google or GitHub single sign-on.
+- **Billing and subscription data:** plan, billing status, and payment-related identifiers (such as Stripe customer and subscription IDs). Card payments are processed by Stripe; we do not store full card numbers.
+- **Workspace and content data:** organizations and memberships, projects, scenes, uploaded 3D models and related assets, optimization metadata, thumbnails, and related logs. Uploaded assets are stored in private storage and served through our application with permission checks.
+- **API keys:** keys you generate to access or embed content are stored in hashed form together with a short non-sensitive preview.
+- **Contact and support data:** information you submit through the contact form, including your name, email address, inquiry type, and message. This contact data is encrypted at rest.
+- **Consent and preference data:** your consent choices for functional, analytics, and marketing categories, the consent policy version, a country derived from your IP address, your browser user agent, and an anonymous identifier where applicable.
+- **Technical and security data:** IP address and request metadata used transiently for security, rate limiting, and bot protection, and session and CSRF tokens required to operate the service. We do not persist your full IP address for consent records; we store only the derived country.
 
-We do not intentionally collect sensitive personal data unless you choose to provide it in free-text fields.
+We do not intentionally collect special categories of data. Please do not submit sensitive personal data in free-text fields.
 
 ## 3. How We Use Data
 
 We process data to:
 
 - Provide, maintain, and secure the platform.
-- Authenticate users and manage access.
+- Authenticate users and manage accounts, organizations, and access.
 - Deliver billing and subscription functionality.
-- Operate and improve core features.
-- Respond to support and contact requests.
+- Store, process, optimize, publish, and serve your 3D content as you instruct.
+- Send transactional and support emails, such as sign-in links, account notifications, and replies.
+- Protect the service against abuse, fraud, and automated attacks (including bot protection and rate limiting).
 - Measure product usage and performance where analytics consent is granted.
 - Comply with legal obligations and enforce our terms.
 
 ## 4. Cookies, Consent, and Tracking
 
-Vectreal uses cookies and similar storage mechanisms for core operation and optional features.
+Vectreal uses cookies and similar storage mechanisms for core operation and, with your consent, for optional features. We load product analytics (PostHog) only after you opt in.
 
 ### Consent Categories
 
-- Strictly necessary: always enabled; required for authentication, CSRF protection, and core platform operation.
-- Functional: remembers preferences such as UI settings.
-- Analytics and performance: enables product analytics (PostHog) when opted in.
-- Marketing and personalisation: optional category for future marketing features.
+- **Strictly necessary:** always enabled; required for authentication, CSRF protection, storing your consent choice, and core platform operation.
+- **Functional:** remembers preferences such as your theme and UI settings.
+- **Analytics and performance:** enables product analytics (PostHog) when opted in.
+- **Marketing and personalization:** optional category reserved for future marketing features.
+
+### Cookies and Local Storage We Use
+
+| Name | Type | Purpose | Storage |
+| --- | --- | --- | --- |
+| `sb-<project>-auth-token` | Strictly necessary | Supabase authentication session | Cookie |
+| `csrf` | Strictly necessary | Cross-site request forgery protection | Cookie |
+| `consent_prefs` | Strictly necessary | Stores your cookie consent choices (up to 1 year) | Cookie |
+| `theming` | Functional | Remembers your theme preference (up to 1 week) | Cookie |
+| `ph_*` | Analytics | PostHog product analytics; set only after analytics consent | Cookie and local storage |
+| `vr_referral` | Attribution | Remembers how you arrived (referrer, campaign source) for attribution | Local storage |
+
+Before you grant analytics consent, PostHog runs in a memory-only mode that does not store identifiers on your device, and page-view capture is disabled.
 
 ### How Consent Works in the App
 
 - On first visit, users are shown a consent banner.
 - Users can choose Accept all, Reject all, or Manage preferences.
-- Preferences can be updated later from dashboard settings.
-- Consent choices are stored server-side and associated with either a user account or anonymous identifier.
-
-### Current Tracking State
-
-- Analytics events are processed through PostHog only when analytics consent is enabled.
-- We do not currently provide a separate /cookies page; this Privacy Policy is the authoritative cookie and consent notice.
+- Preferences can be updated later from the footer "Cookie Preferences" control or from dashboard settings.
+- Consent choices are stored server-side and associated with either your account or an anonymous identifier, together with the policy version, derived country, and user agent, so we can demonstrate valid consent.
+- If we materially change our consent categories, we increment the consent policy version (currently 1.0.0) and ask you again.
 
 ## 5. Legal Bases for Processing
 
-Where required by law, we rely on one or more of:
+Where the GDPR applies, we rely on one or more of the following:
 
-- Contractual necessity.
-- Legitimate interests (for security, reliability, and product operations).
-- Consent (for optional categories such as analytics/marketing).
-- Legal obligations.
-
-You can withdraw optional consent at any time through in-app consent controls.
+- **Contractual necessity** (Art. 6(1)(b)): to provide the platform, accounts, and billing you request.
+- **Legitimate interests** (Art. 6(1)(f)): for security, reliability, abuse prevention, and product operations, balanced against your rights.
+- **Consent** (Art. 6(1)(a)): for optional categories such as analytics and marketing. You can withdraw consent at any time through the in-app consent controls, without affecting prior lawful processing.
+- **Legal obligations** (Art. 6(1)(c)): for example, tax and accounting requirements.
 
 ## 6. Sharing With Service Providers
 
-We share data only as needed with processors that help us run the service, such as:
+We share personal data only as needed with processors and service providers ("subprocessors") that help us run the service. Each acts under a data processing agreement and processes data only on our instructions, except where they act as independent controllers for their own operations.
 
-- Supabase (authentication and data platform services).
-- Stripe (billing and payments).
-- Cloudflare and hosting/network infrastructure providers.
-- PostHog (analytics, subject to consent).
-- Email delivery providers used for support/contact workflows.
+| Provider | Purpose | Data involved |
+| --- | --- | --- |
+| Supabase | Authentication, database, and file storage | Account, content, and most platform data |
+| Stripe | Billing and payment processing | Billing identifiers and payment data you enter at checkout |
+| Cloudflare | Network delivery and bot protection (Turnstile) | IP address and request metadata |
+| Fly.io | Application hosting | Data processed while operating the service |
+| PostHog | Product analytics (only with consent) | Usage events and, for signed-in users, user ID, email, and name |
+| Resend | Transactional and support email delivery | Recipient email, name, and message content |
+| Google / GitHub | Optional single sign-on | Identity data you authorize during sign-in |
 
-We do not sell personal data.
+We do not sell personal data, and we do not use your content to train third-party generative AI models.
 
 ## 7. Data Retention
 
-We retain data for as long as necessary to provide services, comply with legal obligations, resolve disputes, and enforce agreements. Retention periods vary by data type and business/legal requirements.
+We retain data for as long as necessary to provide the service, comply with legal obligations, resolve disputes, and enforce agreements. Account and content data is retained while your account is active and for a limited period afterward for backups. Consent records are retained to demonstrate compliance. Billing records are retained for the periods required by tax and commercial law. Retention periods otherwise vary by data type and legal requirements.
 
 ## 8. International Transfers
 
-Your data may be processed in countries other than your own, depending on where our providers operate. We use appropriate safeguards where required.
+We host and process data primarily within the EU: our application runs on Fly.io in Frankfurt, analytics use PostHog's EU region, and our database and storage are provided by Supabase. Some providers (such as Stripe, Google, and GitHub) may process data outside the EU, including in the United States. Where data is transferred outside the EEA, we rely on appropriate safeguards such as the European Commission's Standard Contractual Clauses or an adequacy decision.
 
-## 9. Your Rights
+## 9. Security
 
-Depending on your jurisdiction, you may have rights to access, correct, delete, or export your data, and to object to or restrict certain processing.
+We take technical and organizational measures to protect personal data, including encryption in transit (TLS), encryption at rest for sensitive contact submissions, hashing of API keys, access controls on stored files, and CSRF and bot protection. No system is perfectly secure, but we work to protect your data against unauthorized access, loss, or misuse.
 
-To make a privacy request, contact [info@vectreal.com](mailto:info@vectreal.com).
+## 10. Your Rights
 
-## 10. Changes to This Policy
+Depending on your jurisdiction, you may have rights to access, correct, delete, or export your data, to object to or restrict certain processing, and to withdraw consent. Where processing is based on consent or contract and carried out by automated means, you may also have a right to data portability.
 
-We may update this policy from time to time. Material updates will be reflected by updating the date at the top of this page.
+To make a privacy request, contact [info@vectreal.com](mailto:info@vectreal.com). If you are in the EEA and believe we have not handled your data lawfully, you may lodge a complaint with your local supervisory authority. Our lead authority is the Hamburg Commissioner for Data Protection and Freedom of Information (Der Hamburgische Beauftragte für Datenschutz und Informationsfreiheit).
+
+## 11. Children
+
+The Service is not directed to children under 16, and we do not knowingly collect their personal data. If you believe a child has provided us personal data, contact us and we will delete it.
+
+## 12. Changes to This Policy
+
+We may update this policy from time to time. Material updates will be reflected by updating the date at the top of this page and, where appropriate, through an in-app notice.

--- a/apps/vectreal-platform/app/routes/terms-of-service-page.mdx
+++ b/apps/vectreal-platform/app/routes/terms-of-service-page.mdx
@@ -1,103 +1,145 @@
 # Terms of Service for Vectreal
 
-**Last Updated: April 03, 2025**
+**Last Updated: August 2, 2026**
 
-These Terms of Service ("Terms") govern your access to and use of the services, features, content, and applications offered by Vectreal ("we," "us," or "our") at Vectreal (the "Service"). By accessing or using the Service, you agree to be bound by these Terms. If you do not agree to these Terms, please do not use the Service.
+These Terms of Service ("Terms") govern your access to and use of the services, features, content, and applications offered by Vectreal ("we," "us," or "our") at [www.vectreal.com](https://www.vectreal.com) (the "Service"). By creating an account, accessing, or using the Service, you agree to be bound by these Terms and by our [Privacy Policy](/privacy-policy). If you do not agree to these Terms, do not use the Service.
+
+Vectreal is operated by Moritz Becker, Wandsbeker Stieg 31, 22087 Hamburg, Germany. Full operator details are set out in our [Imprint](/imprint).
 
 ## 1. Acceptance of Terms
 
-By accessing and using the Service, you acknowledge that you have read, understood, and agree to be bound by these Terms, including our Privacy Policy (available at [](Vectreal/privacy)). These Terms constitute a legally binding agreement between you and Vectreal.
+By accessing and using the Service, you acknowledge that you have read, understood, and agree to be bound by these Terms, including our [Privacy Policy](/privacy-policy), which is incorporated by reference. These Terms constitute a legally binding agreement between you and Vectreal. Where you accept these Terms during account creation, we record the time of your acceptance.
+
 ## 2. Description of Service
 
-Vectreal provides an AI-powered tool that allows users to restore and enhance old photographs. The Service includes features such as:
+Vectreal provides tooling for preparing, managing, and publishing 3D content for the web. The Service includes features such as:
 
-* **Image Improvement:** Utilizing AI to enhance the quality of uploaded images.
-* **Gallery:** A personal gallery where users can securely store their uploaded and processed images. This storage is managed via Supabase.
-* **Profile:** A user account management section.
+- **3D content processing:** Uploading, optimizing, and converting 3D models, textures, materials, and environment assets.
+- **Projects and scenes:** Organizing assets into projects and configurable scenes, including a browser-based 3D viewer.
+- **Publishing and embedding:** Publishing scenes and embedding them on external websites via iframe or our JavaScript SDK, subject to access controls you configure.
+- **Collaboration:** Organizations and workspaces that let multiple members work together under defined roles.
+- **Account and billing management:** Managing your account, organization, plan, and subscription.
 
-## 3. User Accounts
+We may add, change, or remove features over time as described in Section 12.
 
-To access certain features of the Service, you may be required to create an account. You are responsible for maintaining the confidentiality of your account credentials and for all activities that occur under your account. You agree to provide accurate, current, and complete information during the registration process and to update such information to keep it accurate, current, and complete.
+## 3. Eligibility
 
-## 4. User Content
+You must be at least 16 years old, or the age of digital consent in your country if higher, to use the Service. If you use the Service on behalf of an organization, you represent that you are authorized to bind that organization to these Terms, and "you" refers to both you and that organization.
 
-a.  **Uploaded Images:** The Service allows users to upload images for enhancement and storage. You are solely responsible for the images you upload to the Service. You represent and warrant that you have all necessary rights to upload and use your images and that your images comply with these Terms.
+## 4. Accounts and Organizations
 
-b.  **Free Quota:** Users are provided with a free quota that allows the upload of up to fifteen (15) images for saved cloud storage and free optimization runs. Once this free quota is reached, additional uploads and optimization runs may be limited.
+To access most features you must create an account. Authentication is provided through Supabase Auth and supports email and password, magic link, one-time passcode (OTP), and single sign-on with Google or GitHub. You are responsible for maintaining the confidentiality of your credentials and for all activity that occurs under your account. You agree to provide accurate, current, and complete information and to keep it up to date.
 
-c.  **Quota Increases and Additional Features:** Increases to the free quota and access to additional features, such as image processing model options, are available through:
-    * Beta functionalities (on a voluntary basis or through public release).
-    * Paid plans.
+Accounts operate within organizations. Organization owners and admins can invite members, assign roles (owner, admin, or member), and manage projects, billing, and settings for that organization. You are responsible for the actions of members you invite.
 
-d.  **SFW Usage:** The Service is intended for SFW (Safe For Work) usage only. You agree not to upload or process any images that are unlawful, harmful, threatening, abusive, harassing, tortious, defamatory, vulgar, obscene, libelous, invasive of another's privacy, hateful, or racially, ethnically, or otherwise objectionable.
+## 5. Your Content
 
-e.  **Inclusivity:** We are committed to promoting inclusivity through our platform and support the principles of open source.
+**a. Ownership.** You retain all ownership rights in the 3D models, textures, materials, environments, images, metadata, and other content you upload to or create with the Service ("Your Content"). We do not claim ownership of Your Content.
 
-## 5. Paid Plans and Pricing
+**b. License to us.** You grant us a non-exclusive, worldwide, royalty-free license to host, store, reproduce, process, optimize, convert, transmit, and display Your Content, solely to the extent necessary to operate and provide the Service to you and to anyone you authorize (for example, viewers of a scene you publish or embed). This license ends when you delete Your Content or close your account, except for content you have published or shared that others have already accessed, and except for backups retained for a limited period or where retention is required by law.
 
-Information regarding paid plans, including quotas and features, and their associated pricing is available at [](vectreal.com/pricing). By subscribing to a paid plan, you agree to pay the applicable fees as described on the pricing page. Payments are processed via Stripe.
+**c. Publishing and embedding.** If you publish or embed a scene, you instruct us to make that content available to the audiences and on the domains you configure. You are responsible for the access controls, API keys, and allowed embed domains you set. Published or embedded content may be cached by browsers, content delivery networks, or third parties that access it.
+
+**d. Your responsibilities.** You are solely responsible for Your Content. You represent and warrant that you own or have all rights, licenses, and permissions necessary to upload, process, publish, and distribute Your Content through the Service, and that Your Content and its use do not infringe any third party's intellectual property, privacy, publicity, or other rights, and do not violate any law.
+
+**e. Prohibited content.** You agree not to upload, process, or publish content that is unlawful, infringing, defamatory, obscene, harassing, hateful, or that contains malware or is designed to disrupt the Service or harm others. We may remove content that violates these Terms.
 
 ## 6. Acceptable Use
 
 By using the Service, you agree to:
 
-* Comply with all applicable laws and regulations.
-* Use the Service only for lawful purposes.
-* Not engage in any activity that could disrupt, damage, or interfere with the operation of the Service or the experience of other users.
-* Not attempt to gain unauthorized access to any part of the Service, user accounts, or our systems.
-* Not use the Service to transmit any viruses, malware, or other harmful code.
-* Respect the intellectual property rights of others and Vectreal.
+- Comply with all applicable laws and regulations and use the Service only for lawful purposes.
+- Not disrupt, damage, overload, or interfere with the operation of the Service or with other users.
+- Not attempt to gain unauthorized access to any part of the Service, other accounts, or our systems, and not circumvent authentication, rate limits, quotas, or usage restrictions.
+- Not scrape, resell, or provide the Service to third parties except as expressly permitted, and not use the Service to build a competing product.
+- Not transmit viruses, malware, or other harmful code.
+- Respect the intellectual property and other rights of Vectreal and others.
 
-## 7. Intellectual Property
+## 7. Plans, Billing, and Payments
 
-a.  **User Content:** You retain ownership of the images you upload to the Service. By uploading images, you grant us a non-exclusive, worldwide, royalty-free license to access, use, process, display, and store your images solely for the purpose of providing the Service to you.
+The Service offers free and paid plans (currently free, pro, business, and enterprise). Plan features, limits, and pricing are described on our [pricing page](/pricing).
 
-b.  **Service Content:** All content and materials included on the Service, such as the design, software, text, graphics, logos, and trademarks, are owned by or licensed to Vectreal and are protected by copyright, trademark, and other intellectual property laws. You may not reproduce, modify, distribute, or otherwise use any of our content without our prior written consent.
+- **Subscriptions.** Paid plans are billed on a recurring basis (monthly or annually) until cancelled. Payment processing is handled by Stripe; by subscribing you also agree to Stripe's terms. We do not store your full payment card details.
+- **Changes and proration.** If you upgrade, downgrade, or change your billing period, charges may be prorated in accordance with the checkout flow shown at the time.
+- **Renewals and cancellation.** Subscriptions renew automatically for the same period unless cancelled before the renewal date. You can cancel at any time from your billing settings; cancellation takes effect at the end of the current billing period.
+- **Taxes.** Prices may exclude applicable taxes (such as VAT), which will be added where required.
+- **Non-payment.** If a payment fails, we may suspend or limit paid features until the amount due is settled.
 
-## 8. Third-Party Services
+Statutory consumer rights, including any applicable right of withdrawal, are addressed in Section 17 and are not affected by this Section.
 
-Our Service relies on third-party providers for various functionalities, including:
+## 8. Beta and Experimental Features
 
-* **Cloud Infrastructure:** Cloudflare for website hosting and security.
-* **Backend Services:** Supabase for authentication, database services, and photo storage.
-* **Payment Processing:** Stripe for processing payments for paid plans.
-* **AI Services:** Replicate (or other providers) for AI-powered image enhancement.
+We may offer features labeled beta, preview, or experimental. These are provided "as is," may change or be withdrawn at any time, and may be less reliable than generally available features. We may set additional usage limits for such features.
 
-Your use of these third-party services is subject to their respective terms of service and privacy policies. We are not responsible for the performance or security of these third-party services.
+## 9. Intellectual Property
 
-## 9. Disclaimer of Warranties
+**a. Our IP.** All content and materials that make up the Service, including its design, software, text, graphics, logos, and trademarks, are owned by or licensed to Vectreal and are protected by intellectual property laws. Except as expressly permitted, you may not copy, modify, distribute, or create derivative works from the Service without our prior written consent.
 
-THE SERVICE IS PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND ANY WARRANTIES ARISING OUT OF COURSE OF DEALING OR USAGE OF TRADE. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, SECURE, OR FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS.
+**b. Open-source components.** Parts of the Vectreal ecosystem, including certain client libraries and the 3D viewer, are distributed as open-source packages under their own licenses. Those licenses govern your use of the corresponding components and prevail over these Terms for that code.
 
-## 10. Limitation of Liability
+**c. Feedback.** If you send us feedback or suggestions, you grant us a perpetual, irrevocable, royalty-free license to use them without restriction or obligation to you.
 
-TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL VECTREAL, ITS AFFILIATES, OFFICERS, DIRECTORS, EMPLOYEES, AGENTS, SUPPLIERS, OR LICENSORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES) ARISING OUT OF OR RELATING TO YOUR USE OF OR INABILITY TO USE THE SERVICE, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. OUR TOTAL LIABILITY TO YOU FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THESE TERMS OR THE SERVICE SHALL NOT EXCEED THE AMOUNT YOU PAID TO US, IF ANY, IN THE TWELVE (12) MONTHS PRIOR TO THE EVENT GIVING RISE TO THE CLAIM.
+## 10. Third-Party Services
 
-## 11. Termination
+The Service relies on third-party providers to operate, including:
 
-We may terminate or suspend your access to the Service at any time, with or without cause, and without prior notice. Reasons for termination may include, but are not limited to, your breach of these Terms, violation of our SFW usage policy, or engagement in any activity that we deem harmful to the Service or other users. You may also terminate your account at any time. Upon termination, your right to use the Service will immediately cease.
+- **Supabase:** authentication, database, and file storage.
+- **Stripe:** payment and subscription processing.
+- **Cloudflare:** network delivery and bot protection (Turnstile).
+- **Fly.io:** application hosting.
+- **PostHog:** product analytics, used only where you consent.
+- **Resend:** transactional and support email delivery.
+- **Google and GitHub:** optional single sign-on.
 
-## 12. Governing Law and Dispute Resolution
+Your use of these providers may be subject to their own terms and privacy policies. We are not responsible for the performance, availability, or security of third-party services outside our control. How these providers process personal data is described in our [Privacy Policy](/privacy-policy).
 
-These Terms shall be governed by and construed in accordance with the laws of **Germany**, without regard to its conflict of law provisions. Any dispute arising out of or relating to these Terms or the Service shall be subject to the exclusive jurisdiction of the courts located in **Hamburg, Germany**.
+## 11. Privacy
 
-## 13. Changes to These Terms
+Our collection and use of personal data is described in our [Privacy Policy](/privacy-policy), which also serves as our cookie notice. By using the Service, you acknowledge that data will be processed as described there.
 
-We may update these Terms from time to time. We will notify you of any material changes by posting the new Terms on the Service and updating the "Last Updated" date. Your continued use of the Service after the effective date of the revised Terms constitutes your acceptance of the changes. We encourage you to review these Terms periodically for any updates or changes.
+## 12. Service Availability and Changes
 
-## 14. Contact Us
+We aim to keep the Service available and reliable, but we do not guarantee uninterrupted or error-free operation. We may modify, suspend, or discontinue all or part of the Service, and may change features or limits, at any time. Where a change materially reduces core functionality of a paid plan, we will make reasonable efforts to notify you in advance.
 
-If you have any questions or concerns about these Terms or the Service, please contact us at:
+## 13. Disclaimer of Warranties
 
-info@vectreal.com
+TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, THE SERVICE IS PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR SECURE, OR THAT CONTENT WILL NOT BE LOST. NOTHING IN THESE TERMS LIMITS WARRANTIES OR RIGHTS THAT CANNOT BE LIMITED UNDER APPLICABLE LAW.
 
-## 15. Entire Agreement
+## 14. Limitation of Liability
 
-These Terms, together with our Privacy Policy, constitute the entire agreement between you and Vectreal regarding your use of the Service and supersede all prior or contemporaneous communications and proposals, whether oral or written.
-## 16. Severability
+TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, VECTREAL SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR FOR ANY LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR RELATING TO YOUR USE OF OR INABILITY TO USE THE SERVICE. OUR TOTAL LIABILITY FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THESE TERMS OR THE SERVICE SHALL NOT EXCEED THE GREATER OF (A) THE AMOUNT YOU PAID US IN THE TWELVE (12) MONTHS BEFORE THE EVENT GIVING RISE TO THE CLAIM, OR (B) EUR 100.
 
-If any provision of these Terms is held to be invalid or unenforceable, such provision shall be struck and the remaining provisions shall remain in full force and effect.
+Nothing in these Terms excludes or limits our liability for death or personal injury caused by negligence, for fraud or fraudulent misrepresentation, for intent or gross negligence, or for any other liability that cannot be excluded or limited under applicable mandatory law (including the German Product Liability Act).
 
-## 17. No Waiver
+## 15. Indemnification
 
-Our failure to enforce any right or provision of these Terms will not be considered a waiver of those rights.
+To the extent permitted by law, you agree to indemnify and hold Vectreal harmless from claims, damages, and reasonable expenses arising out of Your Content or your breach of these Terms or of applicable law, except to the extent such claims result from our own wrongdoing.
+
+## 16. Termination
+
+You may stop using the Service and close your account at any time. We may suspend or terminate your access if you materially breach these Terms, if required by law, or if your use poses a security or legal risk to the Service or others. Where reasonable and lawful, we will give notice before suspension or termination. On termination, your right to use the Service ends; provisions that by their nature should survive (including Sections 5b backups, 9, 13, 14, 15, and 17) will survive.
+
+## 17. Governing Law, Consumers, and Dispute Resolution
+
+These Terms are governed by the laws of the Federal Republic of Germany, excluding the UN Convention on Contracts for the International Sale of Goods. If you are a consumer with habitual residence in the EU, you also enjoy the protection of mandatory provisions of the law of your country of residence, and this choice of law does not deprive you of those protections.
+
+For users who are merchants, legal entities under public law, or special funds under public law, the exclusive place of jurisdiction is Hamburg, Germany. For consumers, the statutory places of jurisdiction apply.
+
+**Consumer withdrawal.** If you are a consumer, you may have a statutory right to withdraw from a paid subscription within 14 days. Where you request that a digital service begin during the withdrawal period and acknowledge that you thereby lose your withdrawal right once the service has been fully provided, the right may lapse accordingly.
+
+**Consumer dispute resolution.** We are not obligated and not willing to participate in dispute resolution proceedings before a consumer arbitration board within the meaning of the German Consumer Dispute Resolution Act (VSBG).
+
+## 18. Changes to These Terms
+
+We may update these Terms from time to time. We will post the updated Terms and update the "Last Updated" date, and, where changes are material, take reasonable steps to notify you. Your continued use of the Service after the changes take effect constitutes acceptance. If you do not agree to a material change, you should stop using the Service and may close your account.
+
+## 19. General
+
+- **Entire agreement.** These Terms and the Privacy Policy constitute the entire agreement between you and Vectreal regarding the Service and supersede prior agreements on that subject.
+- **Severability.** If any provision is held invalid or unenforceable, the remaining provisions remain in full force.
+- **No waiver.** Our failure to enforce any right or provision is not a waiver of it.
+- **Assignment.** You may not assign these Terms without our consent. We may assign them to an affiliate or in connection with a merger, acquisition, or sale of assets.
+
+## 20. Contact
+
+If you have questions about these Terms or the Service, contact us at [info@vectreal.com](mailto:info@vectreal.com).


### PR DESCRIPTION
## Summary

Updates all three legal documents to accurately reflect what the Vectreal platform actually does. Grounded in a code investigation of the app's data flows, subprocessors, cookies, and auth, not boilerplate.

### Terms of Service — full rewrite
The previous version described an **AI photo-restoration product** (image enhancement, a 15-image quota, "SFW" image rules, Replicate) and was dated April 2025 with broken markdown links. Rewritten for the 3D content platform:
- Accurate service description (3D asset upload/optimization, projects/scenes, publishing and iframe/SDK embedding)
- Your-content ownership with a scoped hosting/processing/display license
- Correct plans and billing (free/pro/business/enterprise via Stripe, proration)
- Accurate third-party list and a Privacy cross-reference
- German-law terms: governing law, consumer withdrawal, VSBG, and mandatory-liability carve-outs
- Fixed broken links (`/privacy-policy`, `/pricing`)

### Privacy / Cookie Policy — accuracy pass
- Data-controller identity (Moritz Becker, Hamburg)
- Concrete **cookie table** (`sb-*-auth-token`, `csrf`, `consent_prefs`, `theming`, `ph_*`, `vr_referral`)
- Full **subprocessor table** with data received (Supabase, Stripe, Cloudflare/Turnstile, Fly.io, PostHog-EU, Resend, Google/GitHub)
- Security section (encryption at rest for contact data, hashed API keys, TLS), EU data residency, GDPR legal bases, Hamburg supervisory-authority complaint right
- Remains the authoritative cookie notice (no separate `/cookies` page)

### Imprint — legal fixes
- Replaced the literal `the Country` placeholder with Germany
- Cites the current **§ 5 DDG** (replaced the TMG in May 2024) and § 18(2) MStV
- Added a VSBG statement; **removed** any reliance on the EU ODR platform (permanently shut down 20 July 2025, linking it is now a cease-and-desist risk)

## Notes / follow-ups
- **Known code gap, tracked separately:** `vr_referral` is written to `localStorage` on the sign-in page without a consent check (`referral-attribution.ts` called unconditionally in `signin-layout.tsx`), which conflicts with the policy's opt-in stance. Gating it behind a consent category is being handled in a separate change; the cookie table labels it neutrally as "Attribution" until then.
- **Contact email:** the Imprint's § 18 responsible-content block intentionally keeps `vectreal@moritzbecker.com`; all other contact points use `info@vectreal.com`.
- All dates aligned to August 2, 2026. No em dashes; GFM tables verified (remark-gfm is configured).

## Caveats
Not legal advice. These are accurate, well-structured drafts grounded in actual data practices; the German consumer-law and international-transfer clauses in particular warrant a review by a data-protection lawyer before relying on them.