### PR TITLE
fix(privacy): gate referral attribution behind marketing consent

### DIFF
--- a/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
@@ -9,10 +9,12 @@ import { Link, Outlet, useLocation, useNavigate, useSubmit } from 'react-router'
 import { useAuthenticityToken } from 'remix-utils/csrf/react'
 
 import { Route } from './+types/signin-layout'
+import { useConsent } from '../../components/consent/consent-context'
 import { AuthErrorBoundary } from '../../components/errors'
 import HeroScene from '../../components/home/hero-scene'
 import { TurnstileWidget } from '../../components/turnstile-widget'
 import {
+	clearReferralAttribution,
 	getReferralAttribution,
 	saveReferralAttribution
 } from '../../lib/domain/analytics/referral-attribution'
@@ -56,9 +58,22 @@ const SigninLayout = ({ loaderData }: Route.ComponentProps) => {
 
 	const isSignUp = location.pathname.endsWith('/sign-up')
 
+	const { consent } = useConsent()
+
+	// Referral/campaign attribution (referrer + utm_source) is non-essential and
+	// governed by the marketing consent category, mirroring how PostHog analytics
+	// is gated in ConsentProvider.
+	// null = no decision yet → write nothing (ePrivacy/GDPR-safe).
+	// granted → persist attribution from the current page.
+	// withdrawn → clear any previously stored attribution.
 	useEffect(() => {
-		saveReferralAttribution()
-	}, [])
+		if (consent === null) return
+		if (consent.marketing) {
+			saveReferralAttribution()
+		} else {
+			clearReferralAttribution()
+		}
+	}, [consent?.marketing, consent])
 
 	const [loadingProvider, setLoadingProvider] = useState<
 		null | 'google' | 'github'

--- a/apps/vectreal-platform/app/routes/privacy-policy-page.mdx
+++ b/apps/vectreal-platform/app/routes/privacy-policy-page.mdx
@@ -45,7 +45,7 @@ Vectreal uses cookies and similar storage mechanisms for core operation and opti
 - Strictly necessary: always enabled; required for authentication, CSRF protection, and core platform operation.
 - Functional: remembers preferences such as UI settings.
 - Analytics and performance: enables product analytics (PostHog) when opted in.
-- Marketing and personalisation: optional category for future marketing features.
+- Marketing and personalisation: optional category covering campaign and referral attribution, such as the `vr_referral` entry that stores the page referrer and `utm_source` in your browser's local storage. Also reserved for future marketing features.
 
 ### How Consent Works in the App
 
@@ -57,6 +57,7 @@ Vectreal uses cookies and similar storage mechanisms for core operation and opti
 ### Current Tracking State
 
 - Analytics events are processed through PostHog only when analytics consent is enabled.
+- Referral and campaign attribution (`vr_referral`) is stored only when marketing consent is enabled, and is cleared if you withdraw that consent.
 - We do not currently provide a separate /cookies page; this Privacy Policy is the authoritative cookie and consent notice.
 
 ## 5. Legal Bases for Processing


### PR DESCRIPTION
## Problem

`saveReferralAttribution()` wrote `vr_referral` (page referrer + `utm_source`) to `localStorage` on sign-in/sign-up mount via a bare `useEffect(() => { saveReferralAttribution() }, [])`, with no consent gate. This is non-essential storage written before any consent decision, contradicting the updated Privacy/Cookie Policy and posing an ePrivacy/GDPR concern.

## Change

- **Consent category: `marketing`.** `vr_referral` is campaign-source attribution (referrer + `utm_source`), which falls under "Marketing and personalisation" — the most defensible category.
- Gate the write in [`signin-layout.tsx`](apps/vectreal-platform/app/routes/layouts/signin-layout.tsx) behind `consent.marketing`, mirroring how PostHog analytics is gated in `ConsentProvider`:
  - `consent === null` (no decision yet) → writes nothing
  - marketing granted → `saveReferralAttribution()`
  - marketing withdrawn → `clearReferralAttribution()` clears any stored value
- The existing read paths (`getReferralAttribution()` in `submitSocialLogin` and `signup-page.tsx`) already degrade to `{}` when nothing is stored, so no attribution reaches the server before consent.
- Update [`privacy-policy-page.mdx`](apps/vectreal-platform/app/routes/privacy-policy-page.mdx) to name `vr_referral` under the marketing category and state it is stored only with marketing consent and cleared on withdrawal.

> Note: the policy is prose, not a cookie table — there was no existing `vr_referral` row to relabel, so the relevant prose was updated instead.

## Verification

- `nx typecheck vectreal-platform` — passes
- `nx lint vectreal-platform` — passes
- Live browser test on `/sign-in?utm_source=verify_test`:
  - No consent decision (`utm_source` present, no consent cookie) → `vr_referral` **not written**
  - "Accept all" (marketing granted) → `vr_referral` written
  - Marketing withdrawn → previously-stored `vr_referral` cleared on load

## Tradeoff

Consent-gating means attribution is only captured if marketing is accepted before/during the visit where `utm_source` is in the URL. A visitor who accepts marketing on a later page (after navigating away from the campaign URL) loses `utm_source`. This is the inherent, correct ePrivacy tradeoff — the value can't lawfully be stashed first and gated later.