### PR TITLE
fix(ci): resolve workspace protocol at publish time and publish via OIDC

### DIFF
--- a/.github/workflows/cd-packages-release.yaml
+++ b/.github/workflows/cd-packages-release.yaml
@@ -112,7 +112,9 @@ jobs:
     # root "." component bumps. The linked-versions plugin keeps @vctrl/* in sync,
     # but a release can bump the packages without a root change — gating on the
     # root previously skipped publishing entirely (npm stalled at 0.18.0).
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    # Also run on manual workflow_dispatch to (re)publish the current versions;
+    # the per-package idempotency check below skips anything already on npm.
+    if: ${{ needs.release-please.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
     environment: packages-releasing
     runs-on: ubuntu-22.04
     permissions:
@@ -132,6 +134,22 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
+          # NOTE: intentionally NO `registry-url`. setup-node's registry-url writes
+          # a `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` line into ~/.npmrc;
+          # with no real token that resolves to `_authToken=` (empty), which npm reads
+          # as "auth configured" and SKIPS the OIDC exchange, breaking trusted
+          # publishing. OIDC needs no .npmrc token line — default registry is npmjs.org.
+
+      - name: Ensure OIDC-capable npm
+        shell: bash
+        run: |
+          set -euo pipefail
+          # OIDC trusted publishing needs npm >= 11.5.1. pnpm 10 has no native
+          # OIDC and delegates `pnpm publish` to the npm CLI on PATH, so we pin
+          # a recent npm here for both the pnpm-delegated publish and any direct
+          # npm calls to mint the OIDC token.
+          npm install -g npm@latest
+          npm --version
 
       - name: Enforce trusted publishing auth mode
         shell: bash
@@ -173,19 +191,25 @@ jobs:
         run: npx nx report
         shell: bash
 
-      - name: Build released packages
-        run: pnpm nx run-many -t build -p vctrl/core vctrl/hooks vctrl/viewer vctrl/embed
+      - name: Prepare released packages for publish
+        # prepare-publish chains build -> copy-md -> rewrite-manifest, so this
+        # builds all four packages AND rewrites their built manifests: strips
+        # devDependencies and resolves `workspace:*` @vctrl/* deps to `^<version>`.
+        # The leak-guard below then runs on already-rewritten manifests.
+        run: pnpm nx run-many -t prepare-publish -p vctrl/core vctrl/hooks vctrl/viewer vctrl/embed
         shell: bash
 
       - name: Guard - no workspace specifiers in built manifests
         shell: bash
         run: |
           set -euo pipefail
-          # release-please's node-workspace plugin must rewrite every `workspace:*`
-          # specifier to a real version before release. If any survive into a built
-          # manifest's consumer-facing fields, the published package is broken
-          # (uninstallable, or pnpm silently drops the dep). Fail loudly here rather
-          # than ship it. devDependencies are exempt: consumers never install them.
+          # Safety net for the prepare-publish rewrite. release-please v4 does NOT
+          # rewrite the `workspace:` protocol (by design), so tools/publish/rewrite-manifest.mjs
+          # (run by the prepare-publish step above) resolves every `workspace:*` @vctrl/*
+          # dep to a real version. If any survive into a built manifest's consumer-facing
+          # fields, the published package is broken (uninstallable, or pnpm silently drops
+          # the dep). Fail loudly here rather than ship it. devDependencies are stripped by
+          # the rewrite, so they cannot leak.
           node -e '
             const fs = require("fs");
             const manifests = [
@@ -265,58 +289,27 @@ jobs:
           npm view @vctrl/hooks name --json || true
           npm view @vctrl/viewer name --json || true
 
-      - name: Preflight pack @vctrl/core
-        run: |
-          npx nx run vctrl/core:copy-md
-          cd build/packages/vctrl/core
-          npm pack --dry-run
-        shell: bash
-
-      - name: Publish @vctrl/core
-        run: npx nx run vctrl/core:publish
+      - name: Publish packages to npm (idempotent, OIDC + provenance)
+        # Publish core first so its version exists for hooks' `^<version>` dep.
+        # Each package is skipped if that exact version is already on npm, so
+        # this is safe to re-run and to trigger manually via workflow_dispatch.
+        # `pnpm publish` (nx publish target) delegates to npm on pnpm 10, so the
+        # OIDC handshake and provenance are performed by the pinned npm CLI.
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
-
-      - name: Preflight pack @vctrl/hooks
         run: |
-          npx nx run vctrl/hooks:copy-md
-          cd build/packages/vctrl/hooks
-          npm pack --dry-run
-        shell: bash
-
-      - name: Publish @vctrl/hooks
-        run: npx nx run vctrl/hooks:publish
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
-
-      - name: Preflight pack @vctrl/viewer
-        run: |
-          npx nx run vctrl/viewer:copy-md
-          cd build/packages/vctrl/viewer
-          npm pack --dry-run
-        shell: bash
-
-      - name: Publish @vctrl/viewer
-        run: npx nx run vctrl/viewer:publish
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
-
-      - name: Preflight pack @vctrl/embed
-        run: |
-          npx nx run vctrl/embed:copy-md
-          cd build/packages/vctrl/embed
-          npm pack --dry-run
-        shell: bash
-
-      - name: Publish @vctrl/embed
-        run: npx nx run vctrl/embed:publish
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
+          set -euo pipefail
+          for p in core hooks viewer embed; do
+            dir="build/packages/vctrl/$p"
+            name=$(node -p "require('./$dir/package.json').name")
+            version=$(node -p "require('./$dir/package.json').version")
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "✓ $name@$version already on npm — skipping"
+              continue
+            fi
+            echo "→ Publishing $name@$version"
+            ( cd "$dir" && npm pack --dry-run )
+            npx nx run "vctrl/$p:publish"
+          done

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -58,7 +58,7 @@
 			}
 		},
 		"publish": {
-			"dependsOn": ["copy-md"],
+			"dependsOn": ["prepare-publish"],
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
@@ -72,6 +72,14 @@
 			"outputs": [],
 			"options": {
 				"commands": ["rsync -rat packages/core/*.md build/packages/vctrl/core/"]
+			}
+		},
+		"prepare-publish": {
+			"dependsOn": ["copy-md"],
+			"executor": "nx:run-commands",
+			"outputs": [],
+			"options": {
+				"command": "node tools/publish/rewrite-manifest.mjs --dir build/packages/vctrl/core"
 			}
 		}
 	}

--- a/packages/embed/project.json
+++ b/packages/embed/project.json
@@ -50,8 +50,16 @@
 				]
 			}
 		},
-		"publish": {
+		"prepare-publish": {
 			"dependsOn": ["copy-md"],
+			"executor": "nx:run-commands",
+			"outputs": [],
+			"options": {
+				"command": "node tools/publish/rewrite-manifest.mjs --dir build/packages/vctrl/embed"
+			}
+		},
+		"publish": {
+			"dependsOn": ["prepare-publish"],
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {

--- a/packages/hooks/project.json
+++ b/packages/hooks/project.json
@@ -17,7 +17,7 @@
 			}
 		},
 		"publish": {
-			"dependsOn": ["copy-md"],
+			"dependsOn": ["prepare-publish"],
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
@@ -33,6 +33,14 @@
 				"commands": [
 					"rsync -rat packages/hooks/*.md build/packages/vctrl/hooks/"
 				]
+			}
+		},
+		"prepare-publish": {
+			"dependsOn": ["copy-md"],
+			"executor": "nx:run-commands",
+			"outputs": [],
+			"options": {
+				"command": "node tools/publish/rewrite-manifest.mjs --dir build/packages/vctrl/hooks"
 			}
 		},
 		"build": {

--- a/packages/viewer/project.json
+++ b/packages/viewer/project.json
@@ -25,7 +25,7 @@
 			}
 		},
 		"publish": {
-			"dependsOn": ["copy-md"],
+			"dependsOn": ["prepare-publish"],
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
@@ -41,6 +41,14 @@
 				"commands": [
 					"rsync -rat packages/viewer/*.md build/packages/vctrl/viewer/"
 				]
+			}
+		},
+		"prepare-publish": {
+			"dependsOn": ["copy-md"],
+			"executor": "nx:run-commands",
+			"outputs": [],
+			"options": {
+				"command": "node tools/publish/rewrite-manifest.mjs --dir build/packages/vctrl/viewer"
 			}
 		},
 		"build": {

--- a/tools/publish/rewrite-manifest.mjs
+++ b/tools/publish/rewrite-manifest.mjs
@@ -1,0 +1,60 @@
+// Prepares a built package manifest for `pnpm publish`.
+//
+// This repo is intentionally not a real pnpm workspace (it relies on
+// tsconfig-path resolution), so `pnpm publish` cannot convert the
+// `workspace:*` protocol on its own. This script rewrites the built
+// manifest in place before publishing:
+//   - strips devDependencies (irrelevant to consumers, and the source of
+//     unpublishable workspace-only deps like @shared/*)
+//   - rewrites `workspace:*` @vctrl/* deps to `^<published version>`,
+//     read from the sibling package source so unified versioning is honored
+//   - fails loudly on any other unresolved workspace: protocol
+//
+// Usage: node tools/publish/rewrite-manifest.mjs --dir build/packages/vctrl/<name>
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+
+const args = process.argv.slice(2)
+const dirIdx = args.indexOf('--dir')
+if (dirIdx === -1 || !args[dirIdx + 1]) {
+	console.error('Usage: rewrite-manifest.mjs --dir <buildDir>')
+	process.exit(1)
+}
+
+const repoRoot = process.cwd()
+const buildDir = resolve(repoRoot, args[dirIdx + 1])
+const manifestPath = join(buildDir, 'package.json')
+const pkg = JSON.parse(readFileSync(manifestPath, 'utf8'))
+
+// devDependencies never belong in a published library manifest.
+delete pkg.devDependencies
+
+const resolveVctrlVersion = (name) => {
+	const short = name.replace(/^@vctrl\//, '')
+	const src = JSON.parse(
+		readFileSync(join(repoRoot, 'packages', short, 'package.json'), 'utf8')
+	)
+	return `^${src.version}`
+}
+
+for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+	const deps = pkg[field]
+	if (!deps) continue
+	for (const [name, spec] of Object.entries(deps)) {
+		if (typeof spec !== 'string' || !spec.startsWith('workspace:')) continue
+		if (!name.startsWith('@vctrl/')) {
+			console.error(
+				`Cannot publish ${pkg.name}: unpublishable workspace dependency "${name}": "${spec}" in ${field}.`
+			)
+			process.exit(1)
+		}
+		deps[name] = resolveVctrlVersion(name)
+	}
+}
+
+writeFileSync(manifestPath, JSON.stringify(pkg, null, '\t') + '\n')
+console.log(
+	`Prepared ${pkg.name}@${pkg.version} for publish — dependencies: ${JSON.stringify(pkg.dependencies ?? {})}`
+)


### PR DESCRIPTION
## Why

Source and git tags are at **0.24.0**, but npm is stuck at **core/hooks/viewer 0.23.0, embed 0.22.0**. Every release the publish job aborts.

Root cause (confirmed against release-please source): release-please v4 / `node-workspace` **intentionally preserves the `workspace:` protocol** — `updateDependencies()` skips any spec matching `/^[a-z]+:/` (added in [release-please#2173](https://github.com/googleapis/release-please/issues/2173) after pnpm users complained it rewrote their lockfiles). It assumes a workspace-aware publisher resolves `workspace:*` at pack time. This repo is not a real pnpm workspace, so nothing does: built `@vctrl/hooks` (`dependencies.@vctrl/core: workspace:*`) and `@vctrl/viewer` (`devDependencies`) manifests keep the protocol, the workflow leak-guard trips, and publish never runs.

## What changed

- **`tools/publish/rewrite-manifest.mjs`** + a **`prepare-publish`** nx target on `core/hooks/viewer/embed`, chaining `build → copy-md → prepare-publish → publish`. The rewrite runs against the *built* manifest: strips `devDependencies`, resolves `@vctrl/*` `workspace:*` → `^<sibling version>`, and hard-fails on any other `workspace:` dep. Idempotent. (This is the pattern `nx release` uses internally, not a hand-patch.)
- **`cd-packages-release.yaml` publish job:**
  - Pin `npm install -g npm@latest` (OIDC trusted publishing needs npm ≥ 11.5.1; pnpm 10 delegates `pnpm publish` to the npm CLI).
  - Run `prepare-publish` for all four before the leak-guard, so the guard validates rewritten manifests.
  - Add a `workflow_dispatch` force-publish path and a single **idempotent publish loop** (skips any version already on npm; publishes `core → hooks → viewer → embed`).
  - **Drop `registry-url` from `setup-node`** — it writes an empty `_authToken=` into `.npmrc`, which makes npm treat auth as configured and **skip the OIDC exchange**. OIDC needs no token line.

## Verification

- `nx run-many -t prepare-publish -p vctrl/{core,hooks,viewer,embed}` → clean manifests: `hooks → @vctrl/core: ^0.24.0`, no `workspace:` leaks, no `devDependencies`.
- `nx e2e vctrl/viewer-e2e` (verdaccio + Playwright real-consumer install + render) passes.
- Workflow YAML validated.

## Required before this publishes (npm dashboard, manual)

Per package (`@vctrl/core`, `hooks`, `viewer`, `embed`), add a Trusted Publisher at `npmjs.com/package/@vctrl/<pkg>/access` → GitHub Actions: org `Vectreal`, repo `vectreal-platform`, workflow filename `cd-packages-release.yaml` (basename), environment `packages-releasing`, allowed action `npm publish`. Confirm the `packages-releasing` GitHub environment exists.

After merge + dashboard config, `workflow_dispatch` this workflow to ship **0.24.0** (idempotency skips anything already published). Then harden each package to "require 2FA + disallow tokens" and revoke the old automation token.