### PR TITLE
fix(packages): match repository.url org casing for npm provenance

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
 	"name": "@vctrl/core",
 	"description": "vctrl/core is the foundational package providing server-side 3D model processing capabilities. It contains the core classes for loading, optimizing, and exporting 3D models using glTF-Transform and Three.js, designed for Node.js environments.",
 	"bugs": {
-		"url": "https://github.com/vectreal/vectreal-platform/issues"
+		"url": "https://github.com/Vectreal/vectreal-platform/issues"
 	},
 	"homepage": "https://vectreal.com",
 	"keywords": [
@@ -21,7 +21,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/vectreal/vectreal-platform.git"
+		"url": "git+https://github.com/Vectreal/vectreal-platform.git"
 	},
 	"license": "AGPL-3.0-only",
 	"types": "./index.d.ts",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -3,7 +3,7 @@
 	"name": "@vctrl/embed",
 	"description": "Framework-agnostic JavaScript SDK for controlling Vectreal embedded 3D scene previews via postMessage.",
 	"bugs": {
-		"url": "https://github.com/vectreal/vectreal-platform/issues"
+		"url": "https://github.com/Vectreal/vectreal-platform/issues"
 	},
 	"homepage": "https://vectreal.com",
 	"keywords": [
@@ -19,7 +19,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/vectreal/vectreal-platform.git"
+		"url": "git+https://github.com/Vectreal/vectreal-platform.git"
 	},
 	"license": "AGPL-3.0-only",
 	"main": "./index.cjs",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -3,7 +3,7 @@
 	"name": "@vctrl/hooks",
 	"description": "vctrl/hooks is a React hooks package designed to simplify 3D model loading and management within React applications. It's part of the vectreal-core ecosystem and is primarily used in the vctrl/viewer React component and the official website application.",
 	"bugs": {
-		"url": "https://github.com/vectreal/vectreal-platform/issues"
+		"url": "https://github.com/Vectreal/vectreal-platform/issues"
 	},
 	"homepage": "https://vectreal.com",
 	"keywords": [
@@ -25,7 +25,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/vectreal/vectreal-platform.git"
+		"url": "git+https://github.com/Vectreal/vectreal-platform.git"
 	},
 	"license": "AGPL-3.0-only",
 	"types": "./index.d.ts",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -3,7 +3,7 @@
 	"name": "@vctrl/viewer",
 	"description": "vctrl/viewer is a React component library for rendering and interacting with 3D models. It's part of the vectreal ecosystem and is designed to work seamlessly with the vctrl/hooks package for model loading and management.",
 	"bugs": {
-		"url": "https://github.com/vectreal/vectreal-platform/issues"
+		"url": "https://github.com/Vectreal/vectreal-platform/issues"
 	},
 	"homepage": "https://vectreal.com",
 	"keywords": [
@@ -24,7 +24,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/vectreal/vectreal-platform.git"
+		"url": "git+https://github.com/Vectreal/vectreal-platform.git"
 	},
 	"license": "AGPL-3.0-only",
 	"main": "./index.js",


### PR DESCRIPTION
## Why

The OIDC pipeline from #689 works end to end — the last publish run authenticated, signed a sigstore provenance statement, and posted it to the transparency log. It then failed npm's provenance verification with **422 Unprocessable Entity**:

```
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/vectreal/vectreal-platform.git",
expected to match "https://github.com/Vectreal/vectreal-platform" from provenance
```

npm compares each package's `repository.url` against the `repository` claim in the GitHub Actions OIDC token, which carries the **canonical org casing** `Vectreal`. The manifests used lowercase `vectreal`, so the exact-match check rejected every publish.

## What changed

`bugs.url` and `repository.url` in `@vctrl/core|hooks|viewer|embed` → `github.com/Vectreal/vectreal-platform`. No code or build changes.

## After merge

`workflow_dispatch` the `CD - Release Packages` workflow to publish 0.24.1 (idempotency skips anything already on npm).