### PR TITLE
fix(assets): stop garbage collection from deleting scene thumbnails

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
@@ -2,10 +2,16 @@ import { randomUUID } from 'crypto'
 import { createHash } from 'node:crypto'
 
 import { createClient } from '@supabase/supabase-js'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm'
 
 import { getDbClient } from '../../../db/client'
-import { assets, folders } from '../../../db/schema'
+import {
+	assets,
+	folders,
+	sceneAssets,
+	scenePublished,
+	scenes
+} from '../../../db/schema'
 
 import type { SceneAssetBinaryDataMap } from '../../../types/api'
 
@@ -344,6 +350,65 @@ export async function downloadAssets(
  *
  * Missing assets are treated as non-fatal and logged as warnings.
  */
+
+/**
+ * Narrows a set of asset ids to the ones nothing points at any more.
+ *
+ * There are three ways an asset is still in use, and every caller that deletes
+ * assets has to respect all of them:
+ *
+ *  1. `scene_assets` - anything a scene's settings link to.
+ *  2. `scene_published` - the live GLB.
+ *  3. `scenes.thumbnail_url` - the scene thumbnail.
+ *
+ * The third is the one that bit us. A thumbnail is referenced by a *URL* rather
+ * than a foreign key, so it joins to nothing, and the save-path GC only ever
+ * asked `scene_assets`. A save unlinks the thumbnail from the scene's asset set,
+ * the GC finds no remaining `scene_assets` row, and deletes the file that
+ * `thumbnail_url` still points at - which is why a freshly published scene lost
+ * its thumbnail. Some thumbnails are not in `scene_assets` at all, so for those
+ * a single GC pass was enough to lose them.
+ *
+ * Uploads are content-addressed and reused, so an asset is frequently shared;
+ * this must run *after* the rows that reference it are gone, and anything still
+ * pointing at it belongs to somebody else.
+ */
+export async function selectUnreferencedAssetIds(
+	assetIds: string[]
+): Promise<string[]> {
+	if (assetIds.length === 0) {
+		return []
+	}
+
+	// The id is the last path segment of `/api/scenes/:sceneId/thumbnail/:assetId`.
+	const thumbnailAssetId = sql<string>`regexp_replace(${scenes.thumbnailUrl}, '^.*/', '')`
+
+	const [attached, published, thumbnails] = await Promise.all([
+		db
+			.selectDistinct({ assetId: sceneAssets.assetId })
+			.from(sceneAssets)
+			.where(inArray(sceneAssets.assetId, assetIds)),
+		db
+			.selectDistinct({ assetId: scenePublished.assetId })
+			.from(scenePublished)
+			.where(inArray(scenePublished.assetId, assetIds)),
+		db
+			.select({ assetId: thumbnailAssetId })
+			.from(scenes)
+			.where(
+				and(isNotNull(scenes.thumbnailUrl), inArray(thumbnailAssetId, assetIds))
+			)
+	])
+
+	const referenced = new Set([
+		...attached.map((row) => row.assetId),
+		...published.map((row) => row.assetId),
+		...thumbnails.map((row) => row.assetId)
+	])
+
+	return assetIds.filter((assetId) => !referenced.has(assetId))
+}
+
 export async function deleteAssets(assetIds: string[]): Promise<void> {
 	await ensureStorageBucketOnce()
 

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
@@ -53,6 +53,7 @@ import {
 	deleteAssets,
 	downloadAsset,
 	downloadAssets,
+	selectUnreferencedAssetIds,
 	uploadSceneAssets
 } from '../../asset/asset-storage.server'
 
@@ -352,7 +353,9 @@ class SceneSettingsService {
 		}
 
 		// Post-commit so storage deletes stay out of the DB transaction.
-		await this.garbageCollectUnreferencedAssets(saveResult.removedAssetIds ?? [])
+		await this.garbageCollectUnreferencedAssets(
+			saveResult.removedAssetIds ?? []
+		)
 
 		return saveResult.savedSettings
 	}
@@ -367,13 +370,10 @@ class SceneSettingsService {
 		if (candidateAssetIds.length === 0) return
 
 		try {
-			const stillReferenced = await this.db
-				.select({ assetId: sceneAssets.assetId })
-				.from(sceneAssets)
-				.where(inArray(sceneAssets.assetId, candidateAssetIds))
-
-			const referenced = new Set(stillReferenced.map((row) => row.assetId))
-			const orphaned = candidateAssetIds.filter((id) => !referenced.has(id))
+			// Asks every reference path, not just `scene_assets`. Checking that one
+			// alone is what deleted scene thumbnails: they are referenced by
+			// `scenes.thumbnail_url`, which joins to nothing.
+			const orphaned = await selectUnreferencedAssetIds(candidateAssetIds)
 
 			if (orphaned.length > 0) {
 				await deleteAssets(orphaned)

--- a/apps/vectreal-platform/tests/asset-reference-counting.integration.spec.ts
+++ b/apps/vectreal-platform/tests/asset-reference-counting.integration.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Asks a real Postgres which assets are safe to delete.
+ *
+ * This cannot be unit tested. The question `selectUnreferencedAssetIds`
+ * answers is three joins and a `regexp_replace` over a column that holds a URL
+ * rather than a foreign key, so a mock proves only that the mock agrees with
+ * itself. The bug it exists to prevent - a thumbnail deleted by the
+ * save-path garbage collector because nothing joined to it - was invisible to
+ * every test in the suite.
+ *
+ * Opt-in, because it writes to whatever `DATABASE_URL` points at:
+ *
+ *   pnpm supabase start
+ *   DASHBOARD_DB_SMOKE=1 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres \
+ *     pnpm nx test vectreal-platform -- --run asset-reference-counting
+ *
+ * Every row it creates is namespaced by a fresh uuid and dropped in `afterAll`.
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const shouldRun = Boolean(process.env.DASHBOARD_DB_SMOKE)
+
+type Schema = typeof import('../app/db/schema')
+type AssetStorage =
+	typeof import('../app/lib/domain/asset/asset-storage.server')
+type Db = ReturnType<typeof import('../app/db/client').getDbClient>
+
+describe.skipIf(!shouldRun)('asset reference counting', () => {
+	// Loaded in `beforeAll` rather than at module scope: `skipIf` still evaluates
+	// this callback to collect the (skipped) tests, and these modules call
+	// `getDbClient()` on import, which throws without a `DATABASE_URL`. That
+	// would fail the file on a normal `nx test` run.
+	let schema: Schema
+	let selectUnreferencedAssetIds: AssetStorage['selectUnreferencedAssetIds']
+	let db: Db
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+	const assetFolderId = randomUUID()
+
+	beforeAll(async () => {
+		schema = await import('../app/db/schema')
+		;({ selectUnreferencedAssetIds } =
+			await import('../app/lib/domain/asset/asset-storage.server'))
+		db = (await import('../app/db/client')).getDbClient()
+
+		await db
+			.insert(schema.users)
+			.values({
+				id: ownerId,
+				email: `owner-${ownerId}@smoke.test`,
+				name: 'Owner'
+			})
+		await db
+			.insert(schema.organizations)
+			.values({ id: organizationId, name: `smoke-${organizationId}`, ownerId })
+		await db.insert(schema.organizationMemberships).values({
+			userId: ownerId,
+			organizationId,
+			role: 'owner'
+		})
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Smoke project',
+			slug: `smoke-${projectId}`
+		})
+		await db
+			.insert(schema.folders)
+			.values({ id: assetFolderId, projectId, name: 'Scene Assets' })
+	})
+
+	afterAll(async () => {
+		// Organizations cascade to projects, folders, scenes and assets.
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, organizationId))
+		await db.delete(schema.users).where(eq(schema.users.id, ownerId))
+	})
+
+	it('keeps an asset a scene thumbnail still points at', async () => {
+		const assetId = randomUUID()
+		const sceneId = randomUUID()
+
+		await db.insert(schema.assets).values({
+			id: assetId,
+			folderId: assetFolderId,
+			name: 'thumb.png',
+			type: 'texture',
+			filePath: `smoke/${assetId}.png`,
+			ownerId
+		})
+		await db.insert(schema.scenes).values({
+			id: sceneId,
+			projectId,
+			folderId: null,
+			name: 'thumbnailed',
+			// Exactly the shape the save orchestrator writes. It is a URL, so it
+			// joins to nothing - which is the whole problem.
+			thumbnailUrl: `/api/scenes/${sceneId}/thumbnail/${assetId}`
+		})
+
+		// Nothing in `scene_assets` or `scene_published` references it. Asking
+		// only those - what the collector used to do - calls this orphaned and
+		// deletes the file the thumbnail is served from.
+		expect(await selectUnreferencedAssetIds([assetId])).toEqual([])
+
+		await db.delete(schema.scenes).where(eq(schema.scenes.id, sceneId))
+		expect(await selectUnreferencedAssetIds([assetId])).toEqual([assetId])
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, assetId))
+	})
+
+	it('keeps an asset the published GLB still points at', async () => {
+		const assetId = randomUUID()
+		const sceneId = randomUUID()
+
+		await db.insert(schema.assets).values({
+			id: assetId,
+			folderId: assetFolderId,
+			name: 'live.glb',
+			type: 'model',
+			filePath: `smoke/${assetId}.glb`,
+			ownerId
+		})
+		await db.insert(schema.scenes).values({
+			id: sceneId,
+			projectId,
+			folderId: null,
+			name: 'live scene',
+			status: 'published'
+		})
+		await db.insert(schema.scenePublished).values({
+			sceneId,
+			assetId,
+			publishedBy: ownerId
+		})
+
+		expect(await selectUnreferencedAssetIds([assetId])).toEqual([])
+
+		await db.delete(schema.scenes).where(eq(schema.scenes.id, sceneId))
+		expect(await selectUnreferencedAssetIds([assetId])).toEqual([assetId])
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, assetId))
+	})
+
+	it('keeps an asset a scene still has attached', async () => {
+		const assetId = randomUUID()
+		const sceneId = randomUUID()
+		const settingsId = randomUUID()
+
+		await db.insert(schema.assets).values({
+			id: assetId,
+			folderId: assetFolderId,
+			name: 'attached.glb',
+			type: 'model',
+			filePath: `smoke/${assetId}.glb`,
+			ownerId
+		})
+		await db
+			.insert(schema.scenes)
+			.values({
+				id: sceneId,
+				projectId,
+				folderId: null,
+				name: 'attached scene'
+			})
+		await db
+			.insert(schema.sceneSettings)
+			.values({ id: settingsId, sceneId, createdBy: ownerId })
+		await db
+			.insert(schema.sceneAssets)
+			.values({ sceneSettingsId: settingsId, assetId })
+
+		expect(await selectUnreferencedAssetIds([assetId])).toEqual([])
+
+		await db.delete(schema.scenes).where(eq(schema.scenes.id, sceneId))
+		expect(await selectUnreferencedAssetIds([assetId])).toEqual([assetId])
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, assetId))
+	})
+
+	it('reports a genuinely unreferenced asset', async () => {
+		const assetId = randomUUID()
+		await db.insert(schema.assets).values({
+			id: assetId,
+			folderId: assetFolderId,
+			name: 'loose.bin',
+			type: 'other',
+			filePath: `smoke/${assetId}.bin`,
+			ownerId
+		})
+
+		expect(await selectUnreferencedAssetIds([assetId])).toEqual([assetId])
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, assetId))
+	})
+
+	it('does not confuse a different asset with a similar id suffix', async () => {
+		// The thumbnail id is parsed out of a URL, so a sloppy match could treat a
+		// substring hit as a reference and keep an asset alive forever.
+		const other = randomUUID()
+		expect(await selectUnreferencedAssetIds([other])).toEqual([other])
+	})
+
+	it('returns nothing for an empty list without touching the database', async () => {
+		expect(await selectUnreferencedAssetIds([])).toEqual([])
+	})
+})


### PR DESCRIPTION
## Summary

Publishing a scene could delete its own thumbnail. `garbageCollectUnreferencedAssets` runs after every scene save, and publishing is a save. It asked only `scene_assets` whether an asset was still in use, but a thumbnail is referenced by `scenes.thumbnail_url`, which stores a **URL** rather than a foreign key and therefore joins to nothing. The moment a save left the thumbnail out of the scene's asset set, the collector saw an unreferenced asset and deleted the file the thumbnail is served from. The scene kept its `thumbnail_url` and started 404ing.

Reported in production: scenes published recently came back with missing thumbnails.

No linked issue.

## Changes

- `selectUnreferencedAssetIds` in `asset-storage.server.ts` consults **all three** reference paths, not one: `scene_assets`, `scene_published`, and the asset id parsed out of `scenes.thumbnail_url`. It returns only the ids that nothing points at.
- `garbageCollectUnreferencedAssets` calls it instead of its single-table check.
- New opt-in database spec covering every reference path.

## How much was lost

Scenes whose thumbnail asset happened to *also* sit in `scene_assets` were protected by accident. On a local database with 8 thumbnailed scenes, 6 were covered that way and 2 were held up by nothing but the URL. The production mechanism is inferred from the code and that local data rather than observed directly, so treat the ratio as illustrative.

To find scenes whose thumbnail asset is already gone:

```sql
select id, name, thumbnail_url
from scenes
where thumbnail_url is not null
  and not exists (
    select 1 from assets a
    where a.id::text = regexp_replace(thumbnail_url, '^.*/', '')
  );
```

This PR stops further loss. It does **not** repair thumbnails already deleted; those files are gone from storage and the affected scenes need a re-publish to regenerate them.

## Follow-up, deliberately out of scope

The root cause is storing a URL where a foreign key belongs. A `thumbnail_asset_id` column with a real FK, plus a backfill, would make this class of bug structurally impossible. That is a migration and belongs in its own change.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

`tests/asset-reference-counting.integration.spec.ts`. Opt-in, because it writes to whatever `DATABASE_URL` points at:

```bash
DASHBOARD_DB_SMOKE=1 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres pnpm nx test vectreal-platform -- --run asset-reference-counting
```

Six cases, all passing against local Supabase. A database spec rather than a mocked one on purpose: the query is three joins and a `regexp_replace` over a text column, so a mocked repository would prove only that the mock agrees with itself, which is exactly why the suite stayed green while this shipped.

Mutation-checked. Removing the thumbnail branch from `selectUnreferencedAssetIds` fails `keeps an asset a scene thumbnail still points at` and nothing else.

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes (221 passed, 6 skipped; plus 6 with the DB flag)
- [ ] I updated documentation where needed
- [ ] I linked the related issue above
