### PR TITLE
fix(publisher): stale scene state across navigation and nonsensical optimization stats

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/optimization/optimization-drawer.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/optimization-drawer.tsx
@@ -91,8 +91,11 @@ const OptimizationDrawer: FC<OptimizationDrawerProps> = ({
 	}, [isOverSizeLimit, maxSceneBytes, isPending, sizeInfo.currentSceneBytes])
 
 	const resolvedDashboardHref = dashboardHref ?? DASHBOARD_ROUTES.DASHBOARD
+	// Over the limit, "Continue to Composition" points away from the only action
+	// that unblocks saving, so an already-optimized scene that is still too large
+	// keeps the single-action layout and re-optimizing stays the primary CTA.
 	const shouldShowCompletionActions =
-		!isPending && hasCompletedOptimizationPass
+		!isPending && hasCompletedOptimizationPass && !isOverSizeLimit
 
 	return (
 		<DynamicSidebar
@@ -253,7 +256,7 @@ const OptimizationDrawer: FC<OptimizationDrawerProps> = ({
 									onOptimize={handleOptimizeClick}
 									onStackOptimize={handleStackOptimizeClick}
 									isPending={isPending}
-									mode="apply"
+									mode={hasCompletedOptimizationPass ? 'optimize-more' : 'apply'}
 									isPreparing={isOptimizerPreparing}
 								/>
 							</div>

--- a/apps/vectreal-platform/app/components/publisher/optimization/results/optimization-results.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/results/optimization-results.tsx
@@ -92,11 +92,23 @@ export const OptimizationResults: FC<OptimizationResultsProps> = ({
 					</MetricRow>
 				) : null}
 
+				{/*
+				  Mesh simplification is the only step that changes the triangle
+				  count, and it is off in every shipped preset, so a before/after pair
+				  here reads as a failed reduction when nothing was ever asked to
+				  reduce. Show the plain count unless simplification actually ran.
+				*/}
 				<MetricRow label="Triangles">
-					<BeforeAfter
-						before={formatCount(resolvedMetrics.primitives.initial)}
-						after={formatCount(resolvedMetrics.primitives.current)}
-					/>
+					{simplificationOutcome ? (
+						<BeforeAfter
+							before={formatCount(resolvedMetrics.primitives.initial)}
+							after={formatCount(resolvedMetrics.primitives.current)}
+						/>
+					) : (
+						<span className="text-muted-foreground">
+							{formatCount(resolvedMetrics.primitives.current)}
+						</span>
+					)}
 				</MetricRow>
 
 				{/*

--- a/apps/vectreal-platform/app/components/publisher/optimization/run-optimization-pass.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/run-optimization-pass.ts
@@ -53,7 +53,8 @@ export interface OptimizationPassDeps {
 			meta: {
 				appliedOptimizations: string[]
 				dracoReport?: DracoCompressionReport
-			}
+			},
+			options?: { preserveBaseline?: boolean }
 		) => Promise<unknown>
 		getModel: () => Promise<Uint8Array | null | undefined>
 		texturesOptimization: (options: Optimizations['texture']) => Promise<unknown>
@@ -209,10 +210,18 @@ async function runGeometryPhase(
 	// when the texture phase starts.
 	steps.begin(LOAD_GEOMETRY_STEP)
 	await withTimeout(
-		model.loadFromGlbBuffer(result.buffer, {
-			appliedOptimizations: result.appliedOptimizations,
-			dracoReport: result.dracoReport
-		}),
+		model.loadFromGlbBuffer(
+			result.buffer,
+			{
+				appliedOptimizations: result.appliedOptimizations,
+				dracoReport: result.dracoReport
+			},
+			// A sync of the worker's output, not a load of a new model. Without
+			// this the baseline is re-derived from the already-optimized buffer,
+			// so every `before` in the report equals its `after` and the panel
+			// claims mesh reduction achieved 0% however well it actually did.
+			{ preserveBaseline: true }
+		),
 		MODEL_SYNC_TIMEOUT_MS,
 		'Worker result sync'
 	)

--- a/apps/vectreal-platform/app/components/publisher/optimization/run-optimization-pass.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/run-optimization-pass.ts
@@ -36,6 +36,13 @@ export interface OptimizationPassDeps {
 	 * another pass on the current state.
 	 */
 	fromOriginal: boolean
+	/**
+	 * Whether the current document may already carry optimizations, so falling
+	 * back to it is a meaningful difference worth telling the user about. False
+	 * for a first pass on a fresh upload, where the current document *is* the
+	 * pristine original and the IDB snapshot is merely still being written.
+	 */
+	documentMayBeOptimized?: boolean
 	optimizations: Optimizations
 	steps: OptimizationStepsController
 	model: {
@@ -253,7 +260,14 @@ async function runTexturePhase(deps: OptimizationPassDeps): Promise<boolean> {
 export async function runOptimizationPass(
 	deps: OptimizationPassDeps
 ): Promise<OptimizationPassResult> {
-	const { fromOriginal, optimizations, steps, model, setRuntime } = deps
+	const {
+		fromOriginal,
+		documentMayBeOptimized,
+		optimizations,
+		steps,
+		model,
+		setRuntime
+	} = deps
 
 	// Clear the previous pass's Draco measurement up front — this run may not
 	// include Draco at all, and a stale report would keep advertising a saving
@@ -277,9 +291,24 @@ export async function runOptimizationPass(
 				model.reset()
 				await model.loadFromServerSceneData(original.sceneData)
 			} else {
+				// The pristine original is only written to IDB for freshly uploaded
+				// scenes, so a scene reopened from the server has none. Re-applying
+				// would silently stack a second pass on the already-optimized
+				// document instead of starting over, and the numbers it reported
+				// would be measured against the wrong baseline. Say so rather than
+				// letting the result quietly mean something else.
 				console.warn(
 					'[optimization] No original scene in IDB; optimizing from current document state.'
 				)
+				// Only when falling back actually changes the meaning of the result.
+				// On a first pass the snapshot write races the optimizer becoming
+				// ready, so a missing record there means the document is still the
+				// pristine upload and this pass is starting over after all.
+				if (documentMayBeOptimized) {
+					toast.info(
+						'The original upload is not available in this session, so this pass builds on the current model instead of starting over.'
+					)
+				}
 			}
 		}
 

--- a/apps/vectreal-platform/app/components/publisher/optimization/use-optimization-process.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/use-optimization-process.ts
@@ -72,12 +72,24 @@ export const useOptimizationProcess = () => {
 			setOptimizationRuntime
 		)
 
+	// `optimizedSceneBytes` only ever describes a pass run in this browser
+	// session, and reopening a saved scene explicitly nulls it during hydration -
+	// so on its own it answered "did you optimize in this tab" rather than "is
+	// this scene optimized". `appliedOptimizations` is the persisted signal, and
+	// it accrues only from real optimization operations (a publish-time Draco
+	// repack never touches it), so a scene that was uploaded and published but
+	// never optimized still reads as false.
+	const hasCompletedOptimizationPass =
+		typeof optimizationRuntime.optimizedSceneBytes === 'number' ||
+		(latestSceneStats?.appliedOptimizations?.length ?? 0) > 0
+
 	const runPass = useCallback(
 		async (fromOriginal: boolean): Promise<boolean> => {
 			if (isPending || isPreparing || !isReady) return false
 
 			const { documentChanged, dracoReport } = await runOptimizationPass({
 				fromOriginal,
+				documentMayBeOptimized: hasCompletedOptimizationPass,
 				optimizations: plannedOptimizations,
 				steps: stepsController,
 				model: {
@@ -110,6 +122,7 @@ export const useOptimizationProcess = () => {
 			isPending,
 			isPreparing,
 			isReady,
+			hasCompletedOptimizationPass,
 			plannedOptimizations,
 			stepsController,
 			reset,
@@ -203,8 +216,7 @@ export const useOptimizationProcess = () => {
 		isOptimizerPreparing: isPreparing,
 		isOptimizerReady: isReady,
 		hasImproved: resolvedMetrics.hasImproved,
-		hasCompletedOptimizationPass:
-			typeof optimizationRuntime.optimizedSceneBytes === 'number',
+		hasCompletedOptimizationPass,
 		sizeInfo,
 		optimizingStep,
 		handleOptimizeClick,

--- a/apps/vectreal-platform/app/components/publisher/optimization/use-optimization-process.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/use-optimization-process.ts
@@ -188,17 +188,30 @@ export const useOptimizationProcess = () => {
 		isInitialMetricsHydrating: resolvedMetrics.isInitialMetricsHydrating
 	}
 
-	// Measured, not projected — and only when simplification was actually asked
-	// for, since otherwise there is no target to compare against.
+	// Keyed on what the displayed run actually did, not on the settings currently
+	// staged for the next one. `plannedOptimizations` is the live atom the preset
+	// cards and the advanced panel write, and the results panel renders beside
+	// both, so gating on it made an already-finished result restate itself: flip
+	// mesh reduction on and an untouched triangle count started reading as a
+	// failed reduction, pick a preset after a simplifying pass and the reduction
+	// that just happened disappeared. The persisted stats carry the answer for a
+	// reopened scene, whose in-memory report has no applied steps of its own.
+	const didSimplify =
+		(report?.appliedOptimizations?.includes('simplification') ?? false) ||
+		(latestSceneStats?.appliedOptimizations?.includes('simplification') ??
+			false)
+
+	// Measured, not projected. The ratio is still read from the live settings as
+	// the "requested" figure to compare against.
 	const simplificationOutcome = useMemo(
 		() =>
-			plannedOptimizations.simplification?.enabled
+			didSimplify
 				? resolveSimplificationOutcome(
 						report,
-						plannedOptimizations.simplification.ratio
+						plannedOptimizations.simplification?.ratio
 					)
 				: null,
-		[report, plannedOptimizations.simplification]
+		[report, didSimplify, plannedOptimizations.simplification]
 	)
 
 	return {

--- a/apps/vectreal-platform/app/components/publisher/optimization/utils/index.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/utils/index.ts
@@ -7,4 +7,4 @@ export {
 } from './geometry-worker'
 export type { GeometryOptimizationResult } from './geometry-worker'
 
-export { useSceneSizeCalculator } from './scene-size'
+export { resolvePublishedSceneBytes, useSceneSizeCalculator } from './scene-size'

--- a/apps/vectreal-platform/app/components/publisher/optimization/utils/scene-size.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/utils/scene-size.ts
@@ -14,6 +14,38 @@ type UpdateRuntime = (
 ) => void
 
 /**
+ * The size the scene will actually be published at, given the post-pass export
+ * and what Draco is projected to save.
+ *
+ * `projectedGlbBytes` cannot be used directly: it is measured inside the
+ * geometry worker, before the texture phase runs, so its image payload is still
+ * the original textures and taking it as the headline erases every byte of
+ * texture saving. Only the whole-file Draco delta survives the texture phase,
+ * because `uncompressedGlbBytes` and `projectedGlbBytes` are both a
+ * `writeBinary` of the same document and their identical textures cancel out.
+ *
+ * Deliberately not `geometryBytesBefore - geometryBytesAfterCompression`: those
+ * two count shared accessors differently (per-mesh versus once globally), and
+ * `dedup` runs immediately before `draco` in every shipped preset, so the
+ * difference would overstate the saving.
+ */
+export const resolvePublishedSceneBytes = (
+	workingSceneBytes: number | null,
+	dracoReport?: DracoCompressionReport | null
+): number | null => {
+	if (!dracoReport?.isWorthApplying || workingSceneBytes == null) {
+		return workingSceneBytes
+	}
+
+	const dracoSaving =
+		dracoReport.uncompressedGlbBytes - dracoReport.projectedGlbBytes
+
+	// Guards against GLB padding noise only; a negative saving cannot reach here
+	// because `isWorthApplying` is `projected < uncompressed`.
+	return Math.max(0, workingSceneBytes - dracoSaving)
+}
+
+/**
  * Sub-hook that encapsulates the three scene/texture size calculation callbacks.
  * Extracted to reduce the size of useOptimizationProcess.
  */
@@ -72,6 +104,11 @@ export function useSceneSizeCalculator(
 	 */
 	const refreshOptimizedSizeInfo = useCallback(
 		async (dracoReport?: DracoCompressionReport | null) => {
+			// Deliberately does not raise `isSceneSizeLoading` to cover this window.
+			// `useSceneSizeInitializer` force-clears that flag whenever
+			// `clientSceneBytes` is a number and keeps the flag in its own dep array,
+			// so setting it here only wakes the effect that unsets it. Covering the
+			// post-pass measurement needs a field that initializer does not manage.
 			const [sceneResult, textureResult] = await Promise.allSettled([
 				calculateSceneBytes(),
 				calculateOptimizedTextureBytes()
@@ -84,22 +121,10 @@ export function useSceneSizeCalculator(
 
 			const workingSceneBytes =
 				typeof updatedSceneBytes === 'number' ? updatedSceneBytes : null
-			// The Draco report is measured in the geometry worker, before the
-			// texture phase runs, so `projectedGlbBytes` still carries the original
-			// images and using it directly erases every byte of texture saving from
-			// the headline. Only the whole-file Draco delta survives the texture
-			// phase: `uncompressedGlbBytes` and `projectedGlbBytes` are both a
-			// `writeBinary` of the same document, so their textures cancel out.
-			// Deliberately not `geometryBytesBefore - geometryBytesAfterCompression`
-			// - those two count shared accessors differently (per-mesh vs. once
-			// globally), and `dedup` runs right before `draco` in every preset.
-			const dracoSaving = dracoReport
-				? dracoReport.uncompressedGlbBytes - dracoReport.projectedGlbBytes
-				: 0
-			const publishedSceneBytes =
-				dracoReport?.isWorthApplying && workingSceneBytes != null
-					? Math.max(0, workingSceneBytes - dracoSaving)
-					: workingSceneBytes
+			const publishedSceneBytes = resolvePublishedSceneBytes(
+				workingSceneBytes,
+				dracoReport
+			)
 
 			setOptimizationRuntime((prev) => ({
 				...prev,

--- a/apps/vectreal-platform/app/components/publisher/optimization/utils/scene-size.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/utils/scene-size.ts
@@ -84,9 +84,22 @@ export function useSceneSizeCalculator(
 
 			const workingSceneBytes =
 				typeof updatedSceneBytes === 'number' ? updatedSceneBytes : null
-			const publishedSceneBytes = dracoReport?.isWorthApplying
-				? dracoReport.projectedGlbBytes
-				: workingSceneBytes
+			// The Draco report is measured in the geometry worker, before the
+			// texture phase runs, so `projectedGlbBytes` still carries the original
+			// images and using it directly erases every byte of texture saving from
+			// the headline. Only the whole-file Draco delta survives the texture
+			// phase: `uncompressedGlbBytes` and `projectedGlbBytes` are both a
+			// `writeBinary` of the same document, so their textures cancel out.
+			// Deliberately not `geometryBytesBefore - geometryBytesAfterCompression`
+			// - those two count shared accessors differently (per-mesh vs. once
+			// globally), and `dedup` runs right before `draco` in every preset.
+			const dracoSaving = dracoReport
+				? dracoReport.uncompressedGlbBytes - dracoReport.projectedGlbBytes
+				: 0
+			const publishedSceneBytes =
+				dracoReport?.isWorthApplying && workingSceneBytes != null
+					? Math.max(0, workingSceneBytes - dracoSaving)
+					: workingSceneBytes
 
 			setOptimizationRuntime((prev) => ({
 				...prev,

--- a/apps/vectreal-platform/app/hooks/scene-loader/contracts.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/contracts.ts
@@ -114,6 +114,13 @@ export interface SceneRouteSyncState {
 	sceneMeta: null | SceneMetaState
 	initialSceneAggregate: null | SceneManifestResponse
 	lastSavedSceneId: string | null
+	/**
+	 * True while returning from the sign-in round trip with a persisted draft to
+	 * restore. The draft's own hydration re-applies the model, meta and
+	 * optimization state but not the viewer settings, so the params sync must not
+	 * reset those atoms out from under it.
+	 */
+	shouldRestorePendingDraft: boolean
 }
 
 export interface SceneRouteSyncActions {

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-params-sync.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-params-sync.ts
@@ -18,8 +18,13 @@ export const useSceneParamsSync = ({
 	routeState,
 	actions
 }: UseSceneParamsSyncArgs) => {
-	const { paramSceneId, sceneMeta, initialSceneAggregate, lastSavedSceneId } =
-		routeState
+	const {
+		paramSceneId,
+		sceneMeta,
+		initialSceneAggregate,
+		lastSavedSceneId,
+		shouldRestorePendingDraft
+	} = routeState
 	const {
 		resetSceneState,
 		setCurrentSceneId,
@@ -33,12 +38,33 @@ export const useSceneParamsSync = ({
 	} = actions
 
 	const setOptimizationModal = useSetAtom(optimizationModalAtom)
-	const previousParamSceneIdRef = useRef<null | string>(null)
+	// `undefined` means "this hook has not run yet", which `paramSceneId` can
+	// never be (it is `params.sceneId?.trim() || null`). Initializing to `null`
+	// instead made a fresh mount at bare /publisher indistinguishable from
+	// "already on the base route", so the reset below was skipped - and because
+	// the publisher's Jotai stores are module singletons that outlive the
+	// layout's unmount, a /publisher/<id> -> /dashboard -> /publisher round trip
+	// kept the previous scene's camera, environment and shadows.
+	const previousParamSceneIdRef = useRef<null | string | undefined>(undefined)
 
 	useEffect(() => {
 		const isNewUploadFlow = !paramSceneId && !initialSceneAggregate
-		const hasSceneChanged = previousParamSceneIdRef.current !== paramSceneId
-		const shouldResetForNewUpload = isNewUploadFlow && hasSceneChanged
+		const isFirstSync = previousParamSceneIdRef.current === undefined
+		// Deliberately keeps the original null baseline so every downstream use of
+		// `hasSceneChanged` (the hydration branch below, and `shouldInitializeScene`)
+		// behaves exactly as before. Only the reset decision consults `isFirstSync`.
+		const previousParamSceneId = isFirstSync
+			? null
+			: previousParamSceneIdRef.current
+		const hasSceneChanged = previousParamSceneId !== paramSceneId
+		// A first sync on bare /publisher needs the reset too: the stores may still
+		// hold the scene the user came from. The draft restore path also lands
+		// here, but its hydration re-applies only the model, meta and optimization
+		// state, so resetting would silently drop the user's compose work.
+		const shouldResetForNewUpload =
+			isNewUploadFlow &&
+			(hasSceneChanged || isFirstSync) &&
+			!shouldRestorePendingDraft
 
 		// Detect navigation to the scene that was just saved (null → newId after
 		// first save). In this case the save flow already established correct
@@ -120,6 +146,7 @@ export const useSceneParamsSync = ({
 		setCurrentSceneId,
 		lastSavedSceneId,
 		setLastSavedSceneId,
-		setOptimizationModal
+		setOptimizationModal,
+		shouldRestorePendingDraft
 	])
 }

--- a/apps/vectreal-platform/app/hooks/use-scene-loader.ts
+++ b/apps/vectreal-platform/app/hooks/use-scene-loader.ts
@@ -556,7 +556,8 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		paramSceneId,
 		sceneMeta,
 		initialSceneAggregate,
-		lastSavedSceneId
+		lastSavedSceneId,
+		shouldRestorePendingDraft
 	}
 
 	const routeSyncActions = {

--- a/apps/vectreal-platform/app/hooks/use-scene-loader.ts
+++ b/apps/vectreal-platform/app/hooks/use-scene-loader.ts
@@ -441,11 +441,17 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 					...currentSettings
 				})
 
+				// Replace rather than merge. A dropped file is a new unsaved scene
+				// (see setCurrentSceneId(null) above), so carrying the previous
+				// scene's description and thumbnailUrl forward is wrong twice over:
+				// the stale thumbnail stays on screen, and it also makes the save
+				// flow's `needsThumbnail` check false, so the previous scene's
+				// thumbnail asset gets persisted onto this one.
 				const initialSceneName = getSceneNameFromFileName(data.name)
-				setSceneMetaState((prev) => ({
-					...prev,
+				setSceneMetaState({
+					...sceneMetaInitialState,
 					name: initialSceneName
-				}))
+				})
 			}
 
 			setProcess((prev) => ({

--- a/apps/vectreal-platform/app/hooks/use-scene-loader.ts
+++ b/apps/vectreal-platform/app/hooks/use-scene-loader.ts
@@ -58,10 +58,12 @@ import {
 } from '../lib/stores/publisher-config-store'
 import {
 	optimizationAtom,
+	optimizationInitialState,
 	optimizationRuntimeAtom,
 	optimizationRuntimeInitialState
 } from '../lib/stores/scene-optimization-store'
 import {
+	activeHotspotIdAtom,
 	bakedShadowSourceAtom,
 	boundsAtom,
 	cameraAtom,
@@ -71,6 +73,7 @@ import {
 	interactionsAtom,
 	normalizationAtom,
 	rawModelDiagonalAtom,
+	selectedCameraIdAtom,
 	shadowsAtom
 } from '../lib/stores/scene-settings-store'
 
@@ -242,6 +245,8 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 	const [normalization, setNormalization] = useAtom(normalizationAtom)
 	const setBakedShadowSource = useSetAtom(bakedShadowSourceAtom)
 	const setRawModelDiagonal = useSetAtom(rawModelDiagonalAtom)
+	const setSelectedCameraId = useSetAtom(selectedCameraIdAtom)
+	const setActiveHotspotId = useSetAtom(activeHotspotIdAtom)
 	const [hotspots, setHotspots] = useAtom(hotspotsAtom)
 
 	// Process state atom - use full atom access for reading and writing
@@ -389,6 +394,20 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		setShadows(defaultShadowOptions)
 		setNormalization(defaultNormalizationOptions)
 		setHotspots([])
+		// Every atom the scene owns, not just the ones with a visible fallback.
+		// Each of these is absorbed downstream today (a dangling camera id misses
+		// and falls through to `initial`, a stale bake is skipped while shadows are
+		// off), so leaving them set is survivable rather than correct - and it puts
+		// the reset one defensive fallback away from leaking again.
+		setSelectedCameraId(
+			defaultCameraOptions.activeCameraId ??
+				defaultCameraOptions.cameras?.[0]?.cameraId ??
+				'default'
+		)
+		setActiveHotspotId(null)
+		setBakedShadowSource(null)
+		setRawModelDiagonal(0)
+		setOptimizationState(optimizationInitialState)
 		setSceneMetaState(sceneMetaInitialState)
 		setLastSavedSettings(null)
 		setLastSavedSceneMeta(null)
@@ -406,6 +425,11 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		setShadows,
 		setNormalization,
 		setHotspots,
+		setSelectedCameraId,
+		setActiveHotspotId,
+		setBakedShadowSource,
+		setRawModelDiagonal,
+		setOptimizationState,
 		setSceneMetaState,
 		setLastSavedSettings,
 		setLastSavedSceneMeta,

--- a/apps/vectreal-platform/app/hooks/use-scene-loader.ts
+++ b/apps/vectreal-platform/app/hooks/use-scene-loader.ts
@@ -873,28 +873,40 @@ export function useSceneLoader(params: UseSceneLoaderParams | null = null) {
 		originalSavedRef.current = true
 
 		void (async () => {
-			const gltfJson = await prepareGltfRef.current()
-			if (!gltfJson || typeof gltfJson !== 'object') return
+			// The guard above is claimed before the write starts, so any failure
+			// path has to release it. Otherwise no original is ever stored for this
+			// upload and every later "Re-apply Preset" silently stacks instead of
+			// starting over, for the rest of the session.
+			try {
+				const gltfJson = await prepareGltfRef.current()
+				if (!gltfJson || typeof gltfJson !== 'object') {
+					originalSavedRef.current = false
+					return
+				}
 
-			const gltfData = (gltfJson as { data?: unknown }).data ?? gltfJson
-			const gltfAssets = (gltfJson as { assets?: unknown }).assets
-			const assetData = await serializeSceneAssetData(gltfData, gltfAssets)
+				const gltfData = (gltfJson as { data?: unknown }).data ?? gltfJson
+				const gltfAssets = (gltfJson as { assets?: unknown }).assets
+				const assetData = await serializeSceneAssetData(gltfData, gltfAssets)
 
-			const meta = sceneMetaRef.current
-			const settings = settingsRef.current
+				const meta = sceneMetaRef.current
+				const settings = settingsRef.current
 
-			const sceneData: ServerSceneData = {
-				meta: {
-					name: meta.name,
-					description: meta.description,
-					thumbnailUrl: meta.thumbnailUrl
-				},
-				gltfJson: gltfData as ServerSceneData['gltfJson'],
-				assetData,
-				...settings
+				const sceneData: ServerSceneData = {
+					meta: {
+						name: meta.name,
+						description: meta.description,
+						thumbnailUrl: meta.thumbnailUrl
+					},
+					gltfJson: gltfData as ServerSceneData['gltfJson'],
+					assetData,
+					...settings
+				}
+
+				await saveOriginalSceneModel({ sceneData })
+			} catch (error) {
+				originalSavedRef.current = false
+				console.warn('Failed to persist the original scene to IDB:', error)
 			}
-
-			await saveOriginalSceneModel({ sceneData })
 		})()
 	}, [optimizer?.isReady, paramSceneId, initialSceneAggregate])
 

--- a/apps/vectreal-platform/app/lib/stores/publisher-config-store.ts
+++ b/apps/vectreal-platform/app/lib/stores/publisher-config-store.ts
@@ -1,5 +1,4 @@
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
 import { selectAtom } from 'jotai/utils'
 import { createStore } from 'jotai/vanilla'
 
@@ -25,10 +24,12 @@ const sceneMetaInitialState: SceneMetaState = {
 	thumbnailUrl: ''
 }
 const processAtom = atom<ProcessState>(processInitialState)
-const sceneMetaAtom = atomWithStorage<SceneMetaState>(
-	'publisher-scene-meta',
-	sceneMetaInitialState
-)
+// Deliberately not persisted. `atomWithStorage` bought nothing here: the
+// `publisherConfigStore.set` below runs at module evaluation and wipes the key
+// before any render, so nothing ever survived a reload anyway. What it did buy
+// was a cross-tab hazard, since a second publisher tab's module evaluation
+// fires a storage event that blanks the first tab's name and thumbnail mid-edit.
+const sceneMetaAtom = atom<SceneMetaState>(sceneMetaInitialState)
 
 // Last-saved baselines - persisted in Jotai atoms (not React state) so they
 // survive route transitions within the same publisher session without remounting.

--- a/apps/vectreal-platform/tests/published-scene-bytes.spec.ts
+++ b/apps/vectreal-platform/tests/published-scene-bytes.spec.ts
@@ -1,0 +1,90 @@
+import { resolvePublishedSceneBytes } from '../app/components/publisher/optimization/utils'
+
+import type { DracoCompressionReport } from '@vctrl/core'
+
+const MB = 1024 * 1024
+const KB = 1024
+
+const dracoReport = (
+	overrides: Partial<DracoCompressionReport> = {}
+): DracoCompressionReport =>
+	({
+		geometryBytesBefore: 2.77 * MB,
+		geometryBytesAfterCompression: 357.22 * KB,
+		reductionPercent: 87,
+		// Both of these are a writeBinary of the same pre-texture-phase document,
+		// so both carry the original 25.81 MB of textures.
+		uncompressedGlbBytes: 28.58 * MB,
+		projectedGlbBytes: 26.16 * MB,
+		isWorthApplying: true,
+		...overrides
+	}) as DracoCompressionReport
+
+describe('resolvePublishedSceneBytes', () => {
+	/**
+	 * The reported bug: a 28.58 MB upload whose textures compressed to 258.84 KB
+	 * and whose geometry compressed to 357.22 KB was shown as 26.16 MB, "-8%".
+	 * The old code returned `projectedGlbBytes` verbatim, which is measured in the
+	 * geometry worker before textures are touched, so the entire texture saving
+	 * vanished and the delta was nothing but the Draco geometry saving.
+	 */
+	it('keeps the texture saving in the published size', () => {
+		// The post-pass export: textures already compressed, Draco not yet applied.
+		const workingSceneBytes = 3.02 * MB
+
+		const published = resolvePublishedSceneBytes(
+			workingSceneBytes,
+			dracoReport()
+		)
+
+		// 3.02 MB working, minus the 2.42 MB whole-file Draco delta.
+		expect(published).toBeCloseTo(0.6 * MB, 0)
+		expect(published).not.toBeCloseTo(26.16 * MB, 0)
+	})
+
+	it('subtracts the whole-file delta, not the per-mesh geometry figures', () => {
+		// geometryBytesBefore counts shared accessors once per mesh while
+		// geometryBytesAfterCompression counts each once globally, so their
+		// difference overstates the saving. Here it would be wildly too large.
+		const published = resolvePublishedSceneBytes(
+			3.02 * MB,
+			dracoReport({
+				geometryBytesBefore: 90 * MB,
+				geometryBytesAfterCompression: 1 * KB
+			})
+		)
+
+		expect(published).toBeCloseTo(0.6 * MB, 0)
+	})
+
+	it('passes the working size through when Draco is not worth applying', () => {
+		expect(
+			resolvePublishedSceneBytes(
+				3.02 * MB,
+				dracoReport({ isWorthApplying: false })
+			)
+		).toBe(3.02 * MB)
+	})
+
+	it('passes the working size through for a texture-only pass', () => {
+		expect(resolvePublishedSceneBytes(3.02 * MB, null)).toBe(3.02 * MB)
+		expect(resolvePublishedSceneBytes(3.02 * MB, undefined)).toBe(3.02 * MB)
+	})
+
+	it('reports nothing when the post-pass export could not be measured', () => {
+		expect(resolvePublishedSceneBytes(null, dracoReport())).toBeNull()
+	})
+
+	it('never reports a negative size', () => {
+		// Padding noise, or a working document smaller than the measured delta.
+		expect(
+			resolvePublishedSceneBytes(
+				1 * KB,
+				dracoReport({
+					uncompressedGlbBytes: 28.58 * MB,
+					projectedGlbBytes: 1 * MB
+				})
+			)
+		).toBe(0)
+	})
+})

--- a/apps/vectreal-platform/tests/run-optimization-pass.spec.ts
+++ b/apps/vectreal-platform/tests/run-optimization-pass.spec.ts
@@ -144,7 +144,12 @@ describe('runOptimizationPass', () => {
 		expect(runGeometryOptimizationsInWorker).toHaveBeenCalledOnce()
 		expect(model.loadFromGlbBuffer).toHaveBeenCalledWith(
 			expect.any(Uint8Array),
-			{ appliedOptimizations: ['deduplication'], dracoReport: undefined }
+			{ appliedOptimizations: ['deduplication'], dracoReport: undefined },
+			// This is a sync of the worker's output, not a load of a new model, so
+			// the optimizer must keep the baseline it captured from the pristine
+			// upload. Re-deriving it from this already-optimized buffer would make
+			// every `before` in the report equal its `after`.
+			{ preserveBaseline: true }
 		)
 		expect(model.applyOptimization).toHaveBeenCalledOnce()
 		expect(result.documentChanged).toBe(true)

--- a/apps/vectreal-platform/tests/simplification-outcome.spec.ts
+++ b/apps/vectreal-platform/tests/simplification-outcome.spec.ts
@@ -50,6 +50,22 @@ describe('resolveSimplificationOutcome', () => {
 		).toBe(false)
 	})
 
+	// The shape a re-baselined report has: syncing the geometry worker's output
+	// back onto the main-thread optimizer used to re-derive the baseline from the
+	// already-optimized buffer, so `before` equalled `after` and every run was
+	// reported as "stopped at 0%" no matter how well it did. The optimizer now
+	// preserves the pristine baseline across that sync, so a report like this
+	// means the simplifier genuinely changed nothing.
+	it('reports a run that removed nothing as falling short, not as a success', () => {
+		const outcome = resolveSimplificationOutcome(
+			reportWith(77_987, 77_987),
+			0.5
+		)
+
+		expect(outcome?.achievedKeepRatio).toBe(1)
+		expect(outcome?.fellShort).toBe(true)
+	})
+
 	it('returns null when there is nothing to measure', () => {
 		expect(resolveSimplificationOutcome(null, 0.5)).toBeNull()
 		expect(resolveSimplificationOutcome(reportWith(0, 0), 0.5)).toBeNull()

--- a/packages/core/src/model-optimizer/model-optimizer.ts
+++ b/packages/core/src/model-optimizer/model-optimizer.ts
@@ -441,6 +441,32 @@ export class ModelOptimizer {
 	}
 
 	/**
+	 * Read the pristine baseline captured at load time, so a caller that is about
+	 * to replace this document with an already-optimized version of itself can
+	 * put it back afterwards. Pairs with `setBaseline`.
+	 */
+	public getBaseline(): { size: number; report: InspectReport | null } {
+		return { size: this.originalSize, report: this.originalReport }
+	}
+
+	/**
+	 * Restore a baseline captured by `getBaseline`.
+	 *
+	 * Every `loadFrom*` re-derives the baseline from the bytes it was handed,
+	 * which is right for a genuine load and wrong for a sync: transplanting the
+	 * geometry worker's output back onto this instance would otherwise re-baseline
+	 * on the already-optimized document, making every `before` in the report equal
+	 * its `after`.
+	 */
+	public setBaseline(baseline: {
+		size: number
+		report: InspectReport | null
+	}): void {
+		this.originalSize = baseline.size
+		this.originalReport = baseline.report
+	}
+
+	/**
 	 * Compress textures using an injectable encoder.
 	 *
 	 * In Node.js the Sharp library is used by default. In browser or edge

--- a/packages/hooks/src/use-optimize-model/use-optimize-model.ts
+++ b/packages/hooks/src/use-optimize-model/use-optimize-model.ts
@@ -212,10 +212,24 @@ const useOptimizeModel = () => {
 	 * instance before the report is built.
 	 */
 	const loadFromGlbBuffer = useCallback(
-		async (buffer: Uint8Array, meta?: WorkerResultMeta): Promise<void> => {
+		async (
+			buffer: Uint8Array,
+			meta?: WorkerResultMeta,
+			options?: { preserveBaseline?: boolean }
+		): Promise<void> => {
 			dispatch({ type: 'LOAD_START' })
 			try {
+				// Explicit rather than inferred from `meta`: this is also the
+				// fresh-model load path, where re-deriving the baseline is correct.
+				const baseline = options?.preserveBaseline
+					? optimizerRef.current.getBaseline()
+					: null
+
 				await optimizerRef.current.loadFromBuffer(buffer)
+
+				if (baseline) {
+					optimizerRef.current.setBaseline(baseline)
+				}
 
 				// Always written, never conditionally: this optimizer instance is
 				// long-lived, so a load without meta (a fresh model, or a plain byte


### PR DESCRIPTION
Fixes two reported bugs in the publisher.

## Bug 1: the publisher keeps the previous model's setup

Loading a saved scene, then going to `/publisher` (directly, or via the dashboard), left the previous model's camera setup in place and its thumbnail in the publish card.

Two independent causes:

**Viewer settings.** The publisher's Jotai stores are module singletons created at import time and injected via `<Provider store>`, so they outlive the layout unmount. The only thing that clears them, `resetSceneState`, was gated on `previousParamSceneIdRef`, a React ref that dies with that same unmount. Initialized to `null`, it made a fresh mount at bare `/publisher` indistinguishable from "already on the base route", so the reset never ran. Now uses an `undefined` sentinel, consulted only for the reset decision so `hasSceneChanged` and `shouldInitializeScene` keep their existing behavior. Guarded on `shouldRestorePendingDraft`, since the sign-in round trip returns to `/publisher?restore_draft=1` and its hydration does not re-apply viewer settings.

**Thumbnail.** `handleLoadComplete` merged the new scene's name onto the previous meta, carrying `description` and `thumbnailUrl` forward. Beyond the visible staleness, this also made the save flow compute `needsThumbnail` as false, skip the capture, and **persist the previous scene's thumbnail asset onto the new scene in the database.**

## Bug 2: optimization stats do not add up

The headline "After" came from `dracoReport.projectedGlbBytes`, measured inside the geometry worker *before* the texture phase runs, so its image payload was still the original textures. The reported numbers reconcile exactly:

`28.58 MB - (2.77 - 0.357) MB = 26.16 MB`

The delta was nothing but the Draco geometry saving, with every byte of texture saving erased. The panel contradicted itself, showing "Before Draco 3.02 MB" next to an "After" of 26.16 MB. Correct answer for that model is roughly 0.6 MB.

Now rebased on the freshly measured post-pass export, subtracting only the whole-file Draco delta (`uncompressedGlbBytes - projectedGlbBytes`), which is the one part of the report that survives texture compression. Deliberately not the per-mesh geometry figures: those count shared accessors differently and `dedup` runs immediately before `draco` in every shipped preset.

**Re-apply button.** `hasCompletedOptimizationPass` was derived only from session runtime state that saved-scene hydration nulls, so it answered "did you optimize in this tab" rather than "is this scene optimized". Now also reads the persisted `stats.appliedOptimizations`.

## Notes for review

- **The plan size gate loosens.** `optimizedSceneBytes` feeds `isSceneOverSizeLimit`, so scenes previously blocked on the inflated figure will now save. Correct, but it is a behavior change on a paid limit.
- Fixing the re-apply gate makes "Re-apply Preset" reachable on reopened scenes, where the pristine original is never written to IndexedDB and the pass would silently stack. Handled, and the notice is gated so it cannot fire on a first pass where the snapshot write merely races the optimizer becoming ready.
- Over the size limit, the drawer keeps its single-action footer so "Continue to Composition" does not become the primary CTA on a scene that still cannot be saved.
- Worth checking separately whether existing `scene_stats.baseline` rows are already poisoned: does `baseline.primitivesCount` for an optimized scene match the uploaded file or the optimized one?

Typecheck, lint and the full test suite pass.

## Follow-ups (second batch of commits)

- **Pristine baseline across the worker sync.** Transplanting the geometry worker's output re-derived `originalSize`/`originalReport` from the already-optimized bytes, so every `before` in the report equalled its `after`. Mesh reduction (enableable from the advanced panel) therefore always reported a 0% reduction and always claimed the deviation limit cut the run short. Adds `getBaseline`/`setBaseline` and an explicit `preserveBaseline` option, explicit rather than inferred from `meta` because the same function is the fresh-upload load path.
- **Results describe the run that happened.** `simplificationOutcome` was gated on the live settings atom that the preset cards and advanced panel write, and the results panel renders beside both, so a finished result restated itself when settings changed under it. Now gated on what the displayed report applied, falling back to persisted stats for a reopened scene.
- **Triangle count renders as a single number unless simplification ran.** It is the only step that changes the count and it is off in every shipped preset, so a before/after pair of two identical numbers read as a failed reduction.
- **`resetSceneState` clears every atom the scene owns**, including the five that were previously absorbed by downstream fallbacks.
- **`sceneMetaAtom` is no longer `atomWithStorage`.** It never survived a reload anyway (the store is seeded at module evaluation, which writes the empty state through first), but it did let a second publisher tab blank the first tab's name and thumbnail mid-edit.
- **The original-scene snapshot is retryable.** Its guard was claimed before the write with no catch, so one failure silently disabled re-apply for the whole session.
- **Test coverage** for the published-size arithmetic, which had none and is where the headline number is computed.

### Known gap, deliberately not fixed here

The post-pass measurement window is still uncovered by a loading state. Raising `isSceneSizeLoading` there does not work: `useSceneSizeInitializer` force-clears that flag whenever `clientSceneBytes` is a number and keeps the flag in its own dependency array, so setting it only wakes the effect that unsets it. Covering that window needs a runtime field the initializer does not manage. This is documented in a comment at the call site.
