### PR TITLE
fix(newsroom): make the author card reachable on touch and link to LinkedIn

### DIFF
--- a/apps/vectreal-platform/app/components/layout-components/author-card.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/author-card.tsx
@@ -1,0 +1,125 @@
+import { Button } from '@shared/components/ui/button'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger
+} from '@shared/components/ui/popover'
+import { useEffect, useRef, useState } from 'react'
+
+import { AuthorChip } from './author-chip'
+
+interface AuthorCardAuthor {
+	name: string
+	role?: string
+	avatar?: string
+	bio?: string
+	linkedinUrl?: string
+}
+
+interface AuthorCardProps {
+	author: AuthorCardAuthor
+}
+
+const HOVER_OPEN_DELAY = 130
+const HOVER_CLOSE_DELAY = 120
+
+/**
+ * The article byline, expanding into the author's bio and LinkedIn profile.
+ *
+ * Built on Popover rather than HoverCard: HoverCard ignores touch pointers
+ * outright and strips the tabindex off everything inside its content, so on a
+ * phone or a keyboard the card was unreachable. Popover opens on tap, click and
+ * Enter; the hover intent below is layered on top so mice keep the old feel.
+ */
+export function AuthorCard({ author }: AuthorCardProps) {
+	const [open, setOpen] = useState(false)
+	const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const openedByHover = useRef(false)
+
+	useEffect(
+		() => () => {
+			if (hoverTimer.current) {
+				clearTimeout(hoverTimer.current)
+			}
+		},
+		[]
+	)
+
+	function scheduleHover(nextOpen: boolean, pointerType: string) {
+		// Touch fires pointerenter on tap as well, and would race the trigger's
+		// own click handler into reopening what the tap just closed.
+		if (pointerType !== 'mouse') {
+			return
+		}
+
+		if (hoverTimer.current) {
+			clearTimeout(hoverTimer.current)
+		}
+
+		hoverTimer.current = setTimeout(
+			() => {
+				openedByHover.current = nextOpen
+				setOpen(nextOpen)
+			},
+			nextOpen ? HOVER_OPEN_DELAY : HOVER_CLOSE_DELAY
+		)
+	}
+
+	function handleOpenChange(nextOpen: boolean) {
+		if (hoverTimer.current) {
+			clearTimeout(hoverTimer.current)
+		}
+
+		openedByHover.current = false
+		setOpen(nextOpen)
+	}
+
+	return (
+		<Popover open={open} onOpenChange={handleOpenChange}>
+			<PopoverTrigger asChild>
+				<Button
+					variant="ghost"
+					className="h-[unset] gap-2 text-left"
+					onPointerEnter={(event) => scheduleHover(true, event.pointerType)}
+					onPointerLeave={(event) => scheduleHover(false, event.pointerType)}
+				>
+					<AuthorChip author={author} />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="start"
+				sideOffset={10}
+				collisionPadding={16}
+				className="w-80 max-w-[calc(100vw-2rem)] p-4"
+				onPointerEnter={(event) => scheduleHover(true, event.pointerType)}
+				onPointerLeave={(event) => scheduleHover(false, event.pointerType)}
+				// Hovering should not yank focus out of the article; a click or a
+				// keypress still hands focus to the card as usual.
+				onOpenAutoFocus={(event) => {
+					if (openedByHover.current) {
+						event.preventDefault()
+					}
+				}}
+			>
+				<div className="flex flex-col gap-3">
+					<AuthorChip author={author} />
+					<div className="min-w-0 flex-1">
+						<p className="text-muted-foreground text-sm leading-relaxed">
+							{author.bio ?? 'Author at Vectreal.'}
+						</p>
+						{author.linkedinUrl ? (
+							<a
+								href={author.linkedinUrl}
+								target="_blank"
+								rel="noreferrer"
+								className="text-orange text-label-xs mt-2 inline-block font-medium hover:underline"
+							>
+								Connect on LinkedIn
+							</a>
+						) : null}
+					</div>
+				</div>
+			</PopoverContent>
+		</Popover>
+	)
+}

--- a/apps/vectreal-platform/app/components/layout-components/author-chip.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/author-chip.tsx
@@ -34,14 +34,20 @@ function initials(name: string) {
  * card, identical markup written twice) and two on the index, where the
  * featured card stacked name over role and the grid cards ran them inline at
  * different weights.
+ *
+ * Both variants sit on scale rungs rather than raw Tailwind sizes. The name was
+ * `font-semibold`, a 600 the scale never uses - every rung it defines is 500 -
+ * so the byline read heavier than the h3 article titles above it.
  */
 export function AuthorChip({ author, compact, className }: AuthorChipProps) {
 	if (compact) {
 		return (
-			<div className={cn('flex items-center gap-1.5', className)}>
-				<span className="text-xs font-semibold">{author.name}</span>
+			<div
+				className={cn('text-label-xs flex items-center gap-1.5', className)}
+			>
+				<span className="font-medium">{author.name}</span>
 				{author.role ? (
-					<span className="text-muted-foreground text-xs">{author.role}</span>
+					<span className="text-muted-foreground">{author.role}</span>
 				) : null}
 			</div>
 		)
@@ -56,9 +62,13 @@ export function AuthorChip({ author, compact, className }: AuthorChipProps) {
 				<AvatarFallback>{initials(author.name)}</AvatarFallback>
 			</Avatar>
 			<div>
-				<p className="text-sm font-semibold tracking-tight">{author.name}</p>
+				<p className="text-h4">{author.name}</p>
 				{author.role ? (
-					<p className="text-muted-foreground text-xs">{author.role}</p>
+					// `text-label-xs` sets no weight, so the role inherited 500 from the
+					// byline's Button and 400 inside the card - one chip, two weights.
+					<p className="text-muted-foreground text-label-xs font-normal">
+						{author.role}
+					</p>
 				) : null}
 			</div>
 		</div>

--- a/apps/vectreal-platform/app/components/layout-components/index.ts
+++ b/apps/vectreal-platform/app/components/layout-components/index.ts
@@ -1,6 +1,7 @@
 export { AdjacentPager } from './adjacent-pager'
 export { ArticleCard } from './article-card'
 export { ArticleMeta } from './article-meta'
+export { AuthorCard } from './author-card'
 export { AuthorChip } from './author-chip'
 export { default as BasicCard } from './basic-card'
 export { CtaPanel } from './cta-panel'

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/01_launch-article.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/01_launch-article.mdx
@@ -17,7 +17,7 @@ author:
     bio: "Open infrastructure for publishing 3D on the web."
     avatar: "/assets/images/logo-192.png"
     xUrl: "https://github.com/Vectreal"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/company/vectreal"
 coverImage: "/assets/images/newsroom/01/og-launch-article.webp"
 draft: false
 thumbnailImage: "/assets/images/newsroom/01/thumbnail-launch-article.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/02_the-vectreal-publisher-walkthrough.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/02_the-vectreal-publisher-walkthrough.mdx
@@ -17,7 +17,7 @@ author:
     bio: "Building open infrastructure for practical 3D on the web."
     avatar: "/assets/images/author-image.jpeg"
     xUrl: "https://github.com/schlomoh"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/in/moritz-becker-5751851a1"
 coverImage: "/assets/images/newsroom/02/og-the-vectreal-publisher-walkthrough.webp"
 draft: false
 thumbnailImage: "/assets/images/newsroom/02/thumbnail-the-vectreal-publisher-walkthrough.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/03_react-viewer-integration.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/03_react-viewer-integration.mdx
@@ -16,7 +16,7 @@ author:
     bio: "Building open infrastructure for practical 3D on the web."
     avatar: "/assets/images/author-image.jpeg"
     xUrl: "https://github.com/schlomoh"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/in/moritz-becker-5751851a1"
 coverImage: "/assets/images/newsroom/03/og-react-viewer-integration.webp"
 draft: false
 thumbnailImage: "/assets/images/newsroom/03/thumbnail-react-viewer-integration.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx
@@ -16,7 +16,7 @@ author:
     bio: "Building open infrastructure for practical 3D on the web."
     avatar: "/assets/images/author-image.jpeg"
     xUrl: "https://github.com/schlomoh"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/in/moritz-becker-5751851a1"
 coverImage: "/assets/images/newsroom/04/og-api-keys-101.webp"
 draft: false
 thumbnailImage: "/assets/images/newsroom/04/thumbnail-api-keys-101.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/05_camera-presets-and-transitions.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/05_camera-presets-and-transitions.mdx
@@ -16,7 +16,7 @@ author:
     bio: "Building open infrastructure for practical 3D on the web."
     avatar: "/assets/images/author-image.jpeg"
     xUrl: "https://github.com/schlomoh"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/in/moritz-becker-5751851a1"
 coverImage: "/assets/images/newsroom/05/og-camera-presets-and-transitions.webp"
 draft: false
 thumbnailImage: "/assets/images/newsroom/05/thumbnail-camera-presets-and-transitions.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/06_optimization-presets.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/06_optimization-presets.mdx
@@ -16,7 +16,7 @@ author:
     bio: "Building open infrastructure for practical 3D on the web."
     avatar: "/assets/images/author-image.jpeg"
     xUrl: "https://github.com/schlomoh"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/in/moritz-becker-5751851a1"
 coverImage: "/assets/images/newsroom/06/og-optimization-presets-and-texture-compression.webp"
 draft: false
 thumbnailImage: "/assets/images/newsroom/06/thumbnail-optimization-presets-and-texture-compression.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/07_how-to-add-3d-model-to-website.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/07_how-to-add-3d-model-to-website.mdx
@@ -16,7 +16,7 @@ author:
     bio: "Building open infrastructure for practical 3D on the web."
     avatar: "/assets/images/author-image.jpeg"
     xUrl: "https://github.com/schlomoh"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/in/moritz-becker-5751851a1"
 coverImage: "/assets/images/newsroom/07/og-how-to-add-3d-model-to-website.webp"
 draft: false
 thumbnailImage: "/assets/images/newsroom/07/thumbnail-how-to-add-3d-model-to-website.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/08_optimize-3d-model-for-web.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/08_optimize-3d-model-for-web.mdx
@@ -16,7 +16,7 @@ author:
     bio: "Building open infrastructure for practical 3D on the web."
     avatar: "/assets/images/author-image.jpeg"
     xUrl: "https://github.com/schlomoh"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/in/moritz-becker-5751851a1"
 coverImage: "/assets/images/newsroom/08/og-optimize-3d-model-for-web.webp"
 draft: false
 thumbnailImage: "/assets/images/newsroom/08/thumbnail-optimize-3d-model-for-web.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/09_gltf-vs-glb-what-actually-matters.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/09_gltf-vs-glb-what-actually-matters.mdx
@@ -16,7 +16,7 @@ author:
     bio: "Building open infrastructure for practical 3D on the web."
     avatar: "/assets/images/author-image.jpeg"
     xUrl: "https://github.com/schlomoh"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/in/moritz-becker-5751851a1"
 draft: false
 thumbnailImage: "/assets/images/newsroom/09/thumbnail-gltf-vs-glb-what-actually-matters.webp"
 coverImage: "/assets/images/newsroom/09/og-gltf-vs-glb-what-actually-matters.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/10_draco-geometry-compression-in-the-publisher.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/10_draco-geometry-compression-in-the-publisher.mdx
@@ -16,7 +16,7 @@ author:
     bio: "Open infrastructure for publishing 3D on the web."
     avatar: "/assets/images/logo-192.png"
     xUrl: "https://github.com/Vectreal"
-    linkedinUrl: ""
+    linkedinUrl: "https://www.linkedin.com/company/vectreal"
 draft: false
 thumbnailImage: "/assets/images/newsroom/10/thumbnail-draco-geometry-compression-in-the-publisher.webp"
 coverImage: "/assets/images/newsroom/10/og-draco-geometry-compression-in-the-publisher.webp"

--- a/apps/vectreal-platform/app/routes/news-room-page/news-room-article-page.tsx
+++ b/apps/vectreal-platform/app/routes/news-room-page/news-room-article-page.tsx
@@ -1,11 +1,6 @@
 import { usePostHog } from '@posthog/react'
 import { Badge } from '@shared/components/ui/badge'
 import { Button } from '@shared/components/ui/button'
-import {
-	HoverCard,
-	HoverCardContent,
-	HoverCardTrigger
-} from '@shared/components/ui/hover-card'
 import { ScrollArea } from '@shared/components/ui/scroll-area'
 import { cn } from '@shared/utils'
 import { ArrowRight, ChevronLeft, Copy } from 'lucide-react'
@@ -19,7 +14,7 @@ import {
 	AdjacentPager,
 	ArticleCard,
 	ArticleMeta,
-	AuthorChip,
+	AuthorCard,
 	BasicCard,
 	CtaPanel
 } from '../../components/layout-components'
@@ -40,19 +35,6 @@ import styles from '../../styles/mdx.module.css'
 
 import type { Route } from './+types/news-room-article-page'
 
-
-function githubHandle(url: string | undefined): string | null {
-	if (!url) {
-		return null
-	}
-
-	const match = url.match(/github\.com\/([^/?#]+)/i)
-	if (!match?.[1]) {
-		return null
-	}
-
-	return `@${match[1]}`
-}
 
 export async function loader({ params }: Route.LoaderArgs) {
 	const slug = params.slug ?? ''
@@ -157,7 +139,6 @@ export default function NewsRoomArticlePage({
 	const startedAtRef = useRef(Date.now())
 	const { headings, activeId } = useDocToc(contentRef, article.slug)
 	const [copied, setCopied] = useState(false)
-	const authorGithubHandle = githubHandle(article.author.xUrl)
 
 	useEffect(() => {
 		if (!consent?.analytics || viewTrackedRef.current) {
@@ -310,37 +291,7 @@ export default function NewsRoomArticlePage({
 				</BasicCard>
 
 				<div className="mb-8 flex flex-wrap items-center gap-3 pt-4 md:mb-16">
-					<HoverCard openDelay={130} closeDelay={120}>
-						<HoverCardTrigger asChild>
-							<Button variant="ghost" className="h-[unset] gap-2 text-left">
-								<AuthorChip author={article.author} />
-							</Button>
-						</HoverCardTrigger>
-						<HoverCardContent
-							align="start"
-							sideOffset={10}
-							className="w-80 p-4"
-						>
-							<div className="flex flex-col gap-3">
-								<AuthorChip author={article.author} />
-								<div className="min-w-0 flex-1">
-									<p className="text-muted-foreground text-xs leading-relaxed">
-										{article.author.bio ?? 'Author at Vectreal.'}
-									</p>
-									{article.author.xUrl ? (
-										<a
-											href={article.author.xUrl}
-											target="_blank"
-											rel="noreferrer"
-											className="text-orange mt-2 inline-block text-xs font-medium hover:underline"
-										>
-											{authorGithubHandle ?? 'GitHub Profile'}
-										</a>
-									) : null}
-								</div>
-							</div>
-						</HoverCardContent>
-					</HoverCard>
+					<AuthorCard author={article.author} />
 					<div className="ml-auto flex items-center gap-2">
 						<Button variant="secondary" size="sm" onClick={copyArticleLink}>
 							<Copy className="mr-2 h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

The article byline's author card was built on Radix `HoverCard`, which is hover-only by design, so it never opened on mobile. It is rebuilt on `Popover` — opens on tap, click and Enter — and the profile link now points at LinkedIn rather than GitHub.

## Changes

- **New `AuthorCard` component** (`app/components/layout-components/author-card.tsx`) replacing the inline `HoverCard` block in `news-room-article-page.tsx`. `HoverCard` is hover-only by design: its trigger calls `preventDefault()` on `touchstart` (killing the synthetic click), its pointer handlers are wrapped in an `excludeTouch` guard, and its content sets `tabindex="-1"` on every focusable child — so on a phone it never opened, and with a keyboard the profile link was unreachable even when it did.
- Mouse hover intent is layered back on `Popover` at the same 130ms/120ms delays, with `onOpenAutoFocus` prevented for hover-opens so pointing at the byline does not pull focus out of the article.
- Content is `w-80 max-w-[calc(100vw-2rem)]` with `collisionPadding={16}` so it fits a 375px viewport.
- **Link target moved to LinkedIn.** All ten articles carried `linkedinUrl: ""`; those are filled in (8 personal bylines, 2 company). The GitHub URLs stay in `xUrl`, where they still feed the `sameAs` array in the article and author JSON-LD — they are just no longer the visible link. The `githubHandle` helper is removed.
- **Typography aligned to the type scale.** The name was `text-sm font-semibold` — a 600 the scale never uses, since every rung in `globals.css` is 500 — so the byline read heavier than the `text-h3` titles above it. Name → `text-h4`, role → `text-label-xs`, compact variant → `text-label-xs`, matching the `ArticleMeta` row in the same card. Bio → `text-sm`, LinkedIn link → `text-label-xs`.
- `text-label-xs` sets no weight, so the role line inherited 500 from the byline's `Button` and 400 inside the popover — the same chip at two weights. Pinned with `font-normal`.

Note that `AuthorChip` is shared with the newsroom index, so the typography change lands on the article page and the index together.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [ ] Unit / integration tests added or updated
- [x] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [x] No tests required (explain why)

Verified in the dev server at 375px and desktop width:

- At 375px a tap opens the card, with the correct LinkedIn `href` and a tabbable link (`tabIndex: 0`) — the `HoverCard` regression is gone.
- At desktop width hover opens it, moving from the trigger into the card keeps it open, moving away closes it, Escape dismisses it.
- Computed styles confirm the rungs land: name `16px / 500`, role `11px / 400` in both the byline and the card, bio `14px / 400`.
- No console errors.

No new unit tests: this is presentational composition over shared Radix primitives, and the behavior that broke (touch and keyboard reachability) is a jsdom blind spot rather than something a unit test would have caught. The existing `type-scale-adherence` spec guards the scale rungs in `shared/components/src/ui`.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes (41 files, 390 tests)
- [ ] I updated documentation where needed
- [ ] I linked the related issue above

One environment note for reviewers: `@vitest/coverage-v8` is declared in `package.json` and pinned in the lockfile but was not linked into `node_modules`, so `nx test` aborted before running. A `pnpm install --frozen-lockfile` fixed it; no manifest or lockfile changes were needed.
