### PR TITLE
fix(ui): size full-viewport surfaces with dvh so mobile browser chrome cannot clip them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Components are in `shared/components/src/ui/` (shadcn-based, Radix UI primitives
 - **Versioning**: Managed by Release Please. Do not use `nx release`. Use `workspace:*` for internal deps.
 - **Docs pages**: MDX files in `app/routes/docs/`. Adding a new page also requires a route in `app/routes.tsx` and an entry in the `docsPages` array in `app/lib/docs/docs-manifest.ts`, which is what `DocsTreeNav` renders.
 - **Server-only modules**: Files that must not be bundled client-side are named `*.server.ts`.
+- **Viewport height**: Size full-viewport surfaces with `h-dvh` / `min-h-dvh` — or `h-svh` where a shell owns the height and scrolls its own content, as `dashboard-layout.tsx` does. Never Tailwind's `screen` height utilities: they compile to `100vh`, the *large* viewport, which overhangs persistent mobile browser chrome — pushing bottom-anchored UI behind the bar and leaving the page scrolled with no way back when a canvas holds `touch-action: none`. (Spelling those class names out here would be self-defeating: the Tailwind scanner reads this file and would re-emit the very utilities the codebase dropped.)
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/apps/vectreal-platform/app/components/errors/auth-error-boundary.tsx
+++ b/apps/vectreal-platform/app/components/errors/auth-error-boundary.tsx
@@ -36,7 +36,7 @@ export function AuthErrorBoundary() {
 	}
 
 	return (
-		<div className="flex min-h-screen items-center justify-center p-6">
+		<div className="flex min-h-dvh items-center justify-center p-6">
 			<div className="w-full max-w-lg rounded-2xl border p-6 text-center">
 				<div className="bg-destructive/10 mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full">
 					<AlertCircle className="text-destructive h-7 w-7" />

--- a/apps/vectreal-platform/app/components/errors/dashboard-error-boundary.tsx
+++ b/apps/vectreal-platform/app/components/errors/dashboard-error-boundary.tsx
@@ -42,7 +42,7 @@ export function DashboardErrorBoundary() {
 	}
 
 	return (
-		<div className="flex min-h-[calc(100vh-4rem)] items-center justify-center p-6">
+		<div className="flex min-h-[calc(100dvh-4rem)] items-center justify-center p-6">
 			<div className="w-full max-w-md space-y-6 text-center">
 				{/* Error Icon */}
 				<div className="bg-destructive/10 mx-auto flex h-20 w-20 items-center justify-center rounded-full">

--- a/apps/vectreal-platform/app/components/errors/public-error-boundary.tsx
+++ b/apps/vectreal-platform/app/components/errors/public-error-boundary.tsx
@@ -30,7 +30,7 @@ export function PublicErrorBoundary() {
 	}
 
 	return (
-		<div className="flex min-h-[calc(100vh-5rem)] items-center justify-center p-6">
+		<div className="flex min-h-[calc(100dvh-5rem)] items-center justify-center p-6">
 			<div className="w-full max-w-lg rounded-2xl border p-6 text-center">
 				<div className="bg-destructive/10 mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full">
 					<AlertCircle className="text-destructive h-7 w-7" />

--- a/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-embed-client.tsx
+++ b/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-embed-client.tsx
@@ -437,7 +437,7 @@ export default function MockShopEmbedClient({
 				typeof document !== 'undefined' &&
 				createPortal(
 					<div className="fixed inset-0 z-60 bg-black/95">
-						<div className="relative h-[100dvh] w-screen overflow-hidden">
+						<div className="relative h-[100dvh] w-full overflow-hidden">
 							{viewerFrame}
 							<div
 								className="pointer-events-none absolute inset-x-0 bottom-0 h-28"

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
@@ -129,12 +129,12 @@ const SceneEmbedPage = ({
 	)
 
 	if (isLoadingScene && !file?.model) {
-		return <CenteredSpinner className="h-screen" text="Loading scene..." />
+		return <CenteredSpinner className="h-dvh" text="Loading scene..." />
 	}
 
 	if (loadError && !file?.model) {
 		return (
-			<div className="bg-background flex h-screen w-full items-center justify-center p-6">
+			<div className="bg-background flex h-dvh w-full items-center justify-center p-6">
 				<div className="border-border bg-card w-full max-w-lg space-y-4 rounded-2xl border p-6">
 					<h1 className="text-lg font-semibold">Unable to Load Scene Preview</h1>
 					<p className="text-muted-foreground text-sm">{loadError.message}</p>
@@ -156,7 +156,23 @@ const SceneEmbedPage = ({
 	}
 
 	return (
-		<div className="relative h-screen w-full">
+		/*
+		  `dvh`, never `vh`. `100vh` is the *large* viewport - the height the page
+		  would have with the browser toolbars retracted - so on any browser with
+		  persistent bottom chrome (Arc mobile, Safari iOS, Chrome Android) this box
+		  overhangs the visible area by exactly the bar height. Everything anchored
+		  to its bottom edge, which is the whole preview chrome, lands behind the
+		  bar, and the overhang makes `<body>` scrollable.
+
+		  That body scroll is unrecoverable: the canvas fills this box and
+		  OrbitControls sets `touch-action: none` on it, so every touch is consumed
+		  as an orbit gesture and never reaches the page. The user is left stuck
+		  mid-scroll with the controls clipped off.
+
+		  `overflow-hidden` is the backstop - this surface never scrolls, so no
+		  child can reintroduce the trap.
+		*/
+		<div className="relative h-dvh w-full overflow-hidden">
 			<SceneEmbedViewer
 				file={file}
 				sceneData={sceneData}

--- a/apps/vectreal-platform/app/root.tsx
+++ b/apps/vectreal-platform/app/root.tsx
@@ -227,7 +227,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
 	}
 
 	return (
-		<div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8">
+		<div className="flex min-h-dvh flex-col items-center justify-center gap-4 p-8">
 			<h1 className="text-2xl font-semibold">Something went wrong</h1>
 			<pre className="text-muted-foreground max-w-lg text-sm break-words whitespace-pre-wrap">
 				{errorMessage}

--- a/apps/vectreal-platform/app/routes/dashboard-page/billing-upgrade.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/billing-upgrade.tsx
@@ -256,7 +256,7 @@ function BillingUpgradeContent({
 
 	return (
 		<>
-			<div className="relative mx-auto max-h-screen w-full max-w-7xl space-y-10 overflow-auto px-6 py-6 pb-44 md:max-h-[80vh]">
+			<div className="relative mx-auto max-h-dvh w-full max-w-7xl space-y-10 overflow-auto px-6 py-6 pb-44 md:max-h-[80dvh]">
 				<PricingCardsSection
 					period={billingPeriod}
 					onPeriodChange={setBillingPeriod}

--- a/apps/vectreal-platform/app/routes/layouts/news-room-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/news-room-layout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from 'react-router'
 
 const NewsRoomLayout = () => {
 	return (
-		<div className="bg-background min-h-screen">
+		<div className="bg-background min-h-dvh">
 			<Outlet />
 		</div>
 	)

--- a/apps/vectreal-platform/app/routes/layouts/publisher-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/publisher-layout.tsx
@@ -244,7 +244,7 @@ const PublisherLayoutContent = ({
 				  can bound the sidebars instead of them floating over the whole
 				  viewport.
 				*/}
-				<main className="flex h-screen w-full flex-col overflow-hidden">
+				<main className="flex h-dvh w-full flex-col overflow-hidden">
 					<UpgradeModal />
 					<ControlsOverlay {...loaderData}>
 						<Outlet />

--- a/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
@@ -163,8 +163,8 @@ const SigninLayout = ({ loaderData }: Route.ComponentProps) => {
 	}
 
 	return (
-		<main className="h-full min-h-screen w-full overflow-hidden">
-			<section className="flex min-h-screen w-full flex-col overflow-hidden">
+		<main className="h-full min-h-dvh w-full overflow-hidden">
+			<section className="flex min-h-dvh w-full flex-col overflow-hidden">
 				<div className="grid grow overflow-hidden md:grid-cols-[1fr_1fr]">
 					<div className="ds-raised relative flex flex-col justify-center p-8 shadow-2xl">
 						<div className="mx-auto flex max-w-md flex-col gap-8 py-16">

--- a/apps/vectreal-platform/app/routes/onboarding-page/onboarding-page.tsx
+++ b/apps/vectreal-platform/app/routes/onboarding-page/onboarding-page.tsx
@@ -241,7 +241,7 @@ const OnboardingPage = ({ loaderData }: Route.ComponentProps) => {
 					name={user.user_metadata?.full_name}
 				/>
 			)}
-			<div className="bg-background flex h-screen w-screen overflow-hidden">
+			<div className="bg-background flex h-dvh w-full overflow-hidden">
 				{/* ── Left panel: animated visual ────────────────────────────── */}
 				<div className="relative hidden flex-3 overflow-hidden md:flex">
 					<WelcomeVisual />


### PR DESCRIPTION
Tailwind's `screen` height utilities compile to `100vh`, which is the large
viewport - the height the page would have with the browser toolbars retracted.
On any browser with persistent bottom chrome (Arc mobile, Safari iOS, Chrome
Android) every full-viewport surface was therefore taller than the visible
area by exactly the bar height.

On /preview and /embed that had two consequences. The preview chrome anchored
to the bottom of the box - the camera switcher pill - rendered behind the
browser bar, and the overhang made <body> scrollable. That scroll was
unrecoverable: the canvas fills the box and OrbitControls sets
`touch-action: none` on it, so every touch was consumed as an orbit gesture
and never reached the page, leaving the user stuck mid-scroll with the
controls clipped off.

Both routes hang off a single sizing box in scene-embed-page, so switching it
to `h-dvh` fixes the whole chain, which is `h-full` percentage inheritance the
rest of the way down. `overflow-hidden` goes on alongside it as a backstop so
no future child can reintroduce the page scroll.

The same swap covers the other full-viewport shells (publisher, onboarding)
and the `min-h`/`max-h` surfaces that could overhang the same way. This
finishes a migration the repo had already started: dashboard-layout and the
sidebar primitive were on `svh`, and the marketing surfaces on `dvh`;
/preview and /embed were the last two on `100vh`.

Left alone deliberately: the desktop-gated `calc(100vh-…)` docs and newsroom
sidebars, the decorative full-bleed `w-screen` in optimization-grid-bg, and
the home scroll section's `h-[300vh]`, which is coupled to scroll math over
window.innerHeight and needs reworking together.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014fdAAdxfzjW1r57x8KjNP3