### PR TITLE
feat(newsroom): morph the featured card into the article hero

### DIFF
--- a/apps/vectreal-platform/app/components/layout-components/article-hero.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/article-hero.tsx
@@ -2,6 +2,7 @@ import { cn } from '@shared/utils'
 
 import { ArticleMeta } from './article-meta'
 import BasicCard from './basic-card'
+import { newsroomMorphNames } from '../../lib/news/article-view-transition'
 import { formatNewsDate } from '../../lib/news/news-manifest'
 import { SCENE_SURFACE } from '../../lib/newsroom-thumbnail/palette'
 
@@ -34,8 +35,15 @@ interface ArticleHeroProps {
  * The fixed dark surface is deliberate: the scene is near-white hairlines and
  * would be invisible on a light-theme card, so the hero pins its own background
  * and type colours and reads identically in both themes.
+ *
+ * The `view-transition-name`s pair this header with the listing's featured
+ * card, so arriving from the newsroom index grows the card into the hero
+ * instead of cross-fading. The names sit on `cardStyle`, which BasicCard
+ * forwards to the inner `Card` - the element that actually carries the
+ * background, border and radius. See `lib/news/article-view-transition.ts`.
  */
 export function ArticleHero({
+	slug,
 	title,
 	category,
 	publishedAt,
@@ -45,29 +53,41 @@ export function ArticleHero({
 	className
 }: ArticleHeroProps) {
 	const image = heroImage ?? sceneImage
+	const morph = newsroomMorphNames(slug)
 
 	return (
 		<BasicCard
 			as="header"
 			cardClassName={cn(
-				'relative isolate overflow-hidden border-white/10 p-0',
+				'vt-news-plate relative isolate overflow-hidden border-white/10 p-0',
 				className
 			)}
-			cardStyle={{ backgroundColor: SCENE_SURFACE.background }}
+			cardStyle={{
+				backgroundColor: SCENE_SURFACE.background,
+				viewTransitionName: morph.card
+			}}
 		>
 			<div className="relative z-20 flex min-h-[20rem] flex-col justify-end p-6 md:min-h-[26rem] md:p-9">
-				<p className="text-orange text-eyebrow mb-3">{category}</p>
+				<p
+					className="text-orange text-eyebrow vt-news-text mb-3"
+					style={{ viewTransitionName: morph.eyebrow }}
+				>
+					{category}
+				</p>
 
 				<h1
-					className="text-headline max-w-3xl text-balance"
-					style={{ color: SCENE_SURFACE.text }}
+					className="text-headline vt-news-text max-w-3xl text-balance"
+					style={{ color: SCENE_SURFACE.text, viewTransitionName: morph.title }}
 				>
 					{title}
 				</h1>
 
 				<ArticleMeta
-					className="mt-4"
-					style={{ color: SCENE_SURFACE.mutedText }}
+					className="vt-news-text mt-4"
+					style={{
+						color: SCENE_SURFACE.mutedText,
+						viewTransitionName: morph.meta
+					}}
 					items={[
 						formatNewsDate(publishedAt),
 						...(updatedAt ? [`Updated ${formatNewsDate(updatedAt)}`] : [])
@@ -77,9 +97,10 @@ export function ArticleHero({
 
 			<div
 				aria-hidden
-				className="absolute inset-0 z-10"
+				className="vt-news-plate absolute inset-0 z-10 rounded-2xl"
 				style={{
-					background: `linear-gradient(to top, ${SCENE_SURFACE.background} 4%, rgba(8, 8, 10, 0.72) 42%, rgba(8, 8, 10, 0) 82%)`
+					background: `linear-gradient(to top, ${SCENE_SURFACE.background} 4%, rgba(8, 8, 10, 0.72) 42%, rgba(8, 8, 10, 0) 82%)`,
+					viewTransitionName: morph.scrim
 				}}
 			/>
 
@@ -91,7 +112,8 @@ export function ArticleHero({
 					width={1200}
 					height={630}
 					fetchPriority="high"
-					className="absolute inset-0 z-0 h-full w-full object-cover object-center"
+					className="vt-news-image absolute inset-0 z-0 h-full w-full rounded-2xl object-cover object-center"
+					style={{ viewTransitionName: morph.scene }}
 				/>
 			) : null}
 		</BasicCard>

--- a/apps/vectreal-platform/app/components/layout-components/featured-article.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/featured-article.tsx
@@ -1,6 +1,8 @@
 import { cn } from '@shared/utils'
 import { Link } from 'react-router'
 
+import BasicCard from './basic-card'
+import { newsroomMorphNames } from '../../lib/news/article-view-transition'
 import { formatNewsDate } from '../../lib/news/news-manifest'
 import { SCENE_SURFACE } from '../../lib/newsroom-thumbnail/palette'
 
@@ -25,62 +27,98 @@ interface FeaturedArticleProps {
  * Composition matches the article hero and the og:image: scene full-bleed,
  * bottom scrim, text over it. Fixed dark surface because the scene is
  * near-white hairlines and would vanish on a light-theme card.
+ *
+ * It is built on the same `BasicCard` as the hero rather than a hand-rolled
+ * bordered `Link`, so "matches the article hero" is structural instead of two
+ * class lists that have to be kept in step by hand. The `Link` wraps the card
+ * because `BasicCard` renders a block element, not an anchor.
+ *
+ * Every layer carries a `view-transition-name` so clicking through morphs this
+ * card into the article hero rather than cross-fading to it. The scene and the
+ * scrim repeat the card's `rounded-2xl` because a named element is snapshotted
+ * without its ancestors' clipping - without it the corners square off for the
+ * length of the flight. The excerpt is named but deliberately unpaired: it has
+ * no counterpart inside the hero, so it fades where it sits instead of flying
+ * down to the article's standfirst. See `lib/news/article-view-transition.ts`.
  */
 export function FeaturedArticle({ article, className }: FeaturedArticleProps) {
+	const morph = newsroomMorphNames(article.slug)
+
 	return (
 		<Link
 			to={`/news-room/${article.slug}`}
 			viewTransition
-			className={cn(
-				'group relative block overflow-hidden rounded-2xl border border-white/10',
-				className
-			)}
-			style={{ backgroundColor: SCENE_SURFACE.background }}
+			className={cn('group block', className)}
 		>
-			<div className="relative z-20 flex min-h-[19rem] flex-col justify-end p-6 md:min-h-[24rem] md:p-9">
-				<p className="text-orange text-eyebrow mb-3">
-					{article.category} · Featured
-				</p>
-
-				<h2
-					className="text-headline mb-3 max-w-[19ch] text-balance transition-opacity group-hover:opacity-85"
-					style={{ color: SCENE_SURFACE.text }}
-				>
-					{article.title}
-				</h2>
-
-				<p
-					className="mb-4 line-clamp-2 max-w-[56ch] text-sm leading-relaxed md:text-base"
-					style={{ color: SCENE_SURFACE.excerptText }}
-				>
-					{article.excerpt}
-				</p>
-
-				<p className="text-xs" style={{ color: SCENE_SURFACE.mutedText }}>
-					{formatNewsDate(article.publishedAt)} · {article.readingTimeMinutes}{' '}
-					min read
-				</p>
-			</div>
-
-			<div
-				aria-hidden
-				className="absolute inset-0 z-10"
-				style={{
-					background: `linear-gradient(to top, ${SCENE_SURFACE.background} 6%, rgba(8, 8, 10, 0.72) 44%, rgba(8, 8, 10, 0) 84%)`
+			<BasicCard
+				cardClassName="vt-news-plate relative isolate overflow-hidden border-white/10 p-0"
+				cardStyle={{
+					backgroundColor: SCENE_SURFACE.background,
+					viewTransitionName: morph.card
 				}}
-			/>
+			>
+				<div className="relative z-20 flex min-h-[19rem] flex-col justify-end p-6 md:min-h-[24rem] md:p-9">
+					<p
+						className="text-orange text-eyebrow vt-news-text mb-3"
+						style={{ viewTransitionName: morph.eyebrow }}
+					>
+						{article.category} · Featured
+					</p>
 
-			{article.sceneImage ? (
-				<img
-					src={article.sceneImage}
-					alt=""
+					<h2
+						className="text-headline vt-news-text mb-3 max-w-[19ch] text-balance transition-opacity group-hover:opacity-85"
+						style={{
+							color: SCENE_SURFACE.text,
+							viewTransitionName: morph.title
+						}}
+					>
+						{article.title}
+					</h2>
+
+					<p
+						className="vt-news-text mb-4 line-clamp-2 max-w-[56ch] text-sm leading-relaxed md:text-base"
+						style={{
+							color: SCENE_SURFACE.excerptText,
+							viewTransitionName: morph.excerpt
+						}}
+					>
+						{article.excerpt}
+					</p>
+
+					<p
+						className="vt-news-text text-xs"
+						style={{
+							color: SCENE_SURFACE.mutedText,
+							viewTransitionName: morph.meta
+						}}
+					>
+						{formatNewsDate(article.publishedAt)} · {article.readingTimeMinutes}{' '}
+						min read
+					</p>
+				</div>
+
+				<div
 					aria-hidden
-					width={1200}
-					height={630}
-					fetchPriority="high"
-					className="absolute inset-0 z-0 h-full w-full object-cover object-center"
+					className="vt-news-plate absolute inset-0 z-10 rounded-2xl"
+					style={{
+						background: `linear-gradient(to top, ${SCENE_SURFACE.background} 6%, rgba(8, 8, 10, 0.72) 44%, rgba(8, 8, 10, 0) 84%)`,
+						viewTransitionName: morph.scrim
+					}}
 				/>
-			) : null}
+
+				{article.sceneImage ? (
+					<img
+						src={article.sceneImage}
+						alt=""
+						aria-hidden
+						width={1200}
+						height={630}
+						fetchPriority="high"
+						className="vt-news-image absolute inset-0 z-0 h-full w-full rounded-2xl object-cover object-center"
+						style={{ viewTransitionName: morph.scene }}
+					/>
+				) : null}
+			</BasicCard>
 		</Link>
 	)
 }

--- a/apps/vectreal-platform/app/lib/news/article-view-transition.spec.ts
+++ b/apps/vectreal-platform/app/lib/news/article-view-transition.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * A view transition pairs by name, and a name with no counterpart fails
+ * silently: no error, no warning, the layer just fades on its own while
+ * everything around it morphs. Naming one side and forgetting the other is
+ * therefore the whole failure mode, and it survives review easily because both
+ * pages still look correct standing still.
+ *
+ * So the interesting assertion is not what the builder returns - it is that
+ * both ends of the pairing consume every key it hands out.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { newsroomMorphNames } from './article-view-transition'
+
+const APP_DIR = join(dirname(fileURLToPath(import.meta.url)), '../..')
+
+/** The listing side of the morph. */
+const LISTING_SOURCES = ['components/layout-components/featured-article.tsx']
+
+/** The article side. */
+const ARTICLE_SOURCES = ['components/layout-components/article-hero.tsx']
+
+/**
+ * Named on the listing only. The hero has no excerpt, so this layer is meant
+ * to fade in place rather than pair - see the note on the builder.
+ */
+const LISTING_ONLY_KEYS = ['excerpt']
+
+function read(paths: string[]): string {
+	return paths.map((path) => readFileSync(join(APP_DIR, path), 'utf8')).join('\n')
+}
+
+const MORPH_KEYS = Object.keys(newsroomMorphNames('x')) as Array<
+	keyof ReturnType<typeof newsroomMorphNames>
+>
+
+const PAIRED_KEYS = MORPH_KEYS.filter((key) => !LISTING_ONLY_KEYS.includes(key))
+
+describe('newsroomMorphNames', () => {
+	it('scopes every name to the slug', () => {
+		const names = Object.values(newsroomMorphNames('gltf-vs-glb'))
+
+		expect(names.length).toBeGreaterThan(0)
+
+		for (const name of names) {
+			expect(name.endsWith('-gltf-vs-glb')).toBe(true)
+		}
+	})
+
+	it('never collides between two articles', () => {
+		const a = Object.values(newsroomMorphNames('api-keys-101'))
+		const b = Object.values(newsroomMorphNames('optimization-presets'))
+
+		expect(new Set([...a, ...b]).size).toBe(a.length + b.length)
+	})
+
+	it('emits valid CSS custom-idents', () => {
+		// Slugs are `[a-z0-9-]+` via `normalizeSlug`, but a name starting with a
+		// digit is not a valid ident - the constant prefix is what guarantees it.
+		for (const name of Object.values(newsroomMorphNames('3d-model-basics'))) {
+			expect(name).toMatch(/^-?[a-zA-Z_][\w-]*$/)
+		}
+	})
+})
+
+describe('morph pairing', () => {
+	it.each(PAIRED_KEYS)('wires `%s` up on both sides', (key) => {
+		const reference = new RegExp(`\\bmorph\\.${key}\\b`)
+
+		expect(reference.test(read(LISTING_SOURCES))).toBe(true)
+		expect(reference.test(read(ARTICLE_SOURCES))).toBe(true)
+	})
+
+	it.each(LISTING_ONLY_KEYS)('keeps `%s` on the listing only', (key) => {
+		const reference = new RegExp(`\\bmorph\\.${key}\\b`)
+
+		expect(reference.test(read(LISTING_SOURCES))).toBe(true)
+		expect(reference.test(read(ARTICLE_SOURCES))).toBe(false)
+	})
+
+	it('gives every named layer a view-transition-class', () => {
+		// Without a class the group is unselectable from CSS - the names are
+		// per-slug, so there is no static selector to fall back on - and the
+		// layer silently runs the browser default instead of the tuned timing.
+		for (const source of [...LISTING_SOURCES, ...ARTICLE_SOURCES]) {
+			const text = readFileSync(join(APP_DIR, source), 'utf8')
+			const named = text.match(/viewTransitionName:/g) ?? []
+			const classed = text.match(/vt-news-(plate|image|text)/g) ?? []
+
+			expect(classed.length).toBeGreaterThanOrEqual(named.length)
+		}
+	})
+})

--- a/apps/vectreal-platform/app/lib/news/article-view-transition.ts
+++ b/apps/vectreal-platform/app/lib/news/article-view-transition.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared-element names for the featured-card ⇄ article-hero morph.
+ *
+ * The listing's featured block and the article header are the same composition
+ * at two sizes, so the navigation between them is a resize rather than a page
+ * change. Naming the matching parts on both sides lets the browser tween them.
+ *
+ * Every name is scoped to the slug, which is what keeps the morph honest: the
+ * pairing only fires when the card you clicked is the article you land on.
+ * Click any other row and the names on the two pages simply do not match, so
+ * the browser falls back to the plain root cross-fade with no extra logic.
+ *
+ * The alternative - static names gated by `useViewTransitionState` - only works
+ * one way. That hook is true only on the page owning the clicked link, so the
+ * return trip from "Back to Newsroom" would find no name on the listing side.
+ *
+ * Every visible layer needs a name, not just the ones worth animating. Unnamed
+ * descendants are flattened into their nearest named ancestor's snapshot, and
+ * sibling groups paint in capture order - so the copy, which paints above the
+ * scene in the live page, would paint *under* the scene mid-flight and vanish.
+ *
+ * Slugs are `[a-z0-9-]+` (see `normalizeSlug`), so every name is a valid CSS
+ * custom-ident.
+ */
+export function newsroomMorphNames(slug: string) {
+	return {
+		/** The card surface: background, hairline border, radius. */
+		card: `news-card-${slug}`,
+		/** The generated scene artwork, identical on both sides. */
+		scene: `news-scene-${slug}`,
+		/** The gradient that the copy sits on. */
+		scrim: `news-scrim-${slug}`,
+		eyebrow: `news-eyebrow-${slug}`,
+		title: `news-title-${slug}`,
+		/**
+		 * Listing only, and deliberately so. The article page does carry the same
+		 * excerpt, but below the hero rather than inside it - pairing the two made
+		 * the line fly the length of the card while cross-fading between a clamped
+		 * two-line version and the full one, which read as a smear. Left unpaired
+		 * it simply fades where it sits. It still needs a name: unnamed copy would
+		 * be folded into the card's snapshot and paint *under* the scene image
+		 * mid-flight, so it would blink out rather than fade.
+		 */
+		excerpt: `news-excerpt-${slug}`,
+		meta: `news-meta-${slug}`
+	} as const
+}
+
+export type NewsroomMorphNames = ReturnType<typeof newsroomMorphNames>

--- a/apps/vectreal-platform/app/root.tsx
+++ b/apps/vectreal-platform/app/root.tsx
@@ -39,6 +39,7 @@ import { csrfSession } from './lib/sessions/csrf-session.server'
 
 import type { ShouldRevalidateFunction } from 'react-router'
 import '@shared/components/styles/globals.css'
+import './styles/view-transitions.css'
 
 export const meta: MetaFunction = () => [
 	...buildMeta([], undefined, {

--- a/apps/vectreal-platform/app/styles/view-transitions.css
+++ b/apps/vectreal-platform/app/styles/view-transitions.css
@@ -1,0 +1,78 @@
+/*
+ * Shared-element morph: newsroom featured card ⇄ article hero.
+ *
+ * The names are per-slug, so they are built in TypeScript (see
+ * `lib/news/article-view-transition.ts`) and land on elements as inline
+ * `view-transition-name`. The *classes* below are static, which is what makes
+ * the groups selectable from CSS at all - there is no way to write a selector
+ * for a name that only exists at runtime.
+ *
+ * `view-transition-class` is Baseline newly available (Chrome 125, Safari 18.2,
+ * Firefox 144). Anywhere it is missing these rules simply do not match and the
+ * morph runs on the browser's default 250ms group animation, which is still a
+ * morph - just a plainer one.
+ */
+
+.vt-news-plate {
+	view-transition-class: news-morph news-plate;
+}
+
+.vt-news-image {
+	view-transition-class: news-morph news-image;
+}
+
+.vt-news-text {
+	view-transition-class: news-morph news-text;
+}
+
+::view-transition-group(.news-morph),
+::view-transition-old(.news-morph),
+::view-transition-new(.news-morph) {
+	animation-duration: var(--duration-slow);
+	animation-timing-function: var(--ease-out);
+}
+
+/*
+ * Flat surface and the scrim gradient: stretch to the tweening box so the
+ * hairline border stays on the edge and the gradient stays vertical.
+ */
+::view-transition-old(.news-plate),
+::view-transition-new(.news-plate) {
+	block-size: 100%;
+	inline-size: 100%;
+	object-fit: fill;
+}
+
+/* The scene is `object-cover` live; crop it the same way mid-flight. */
+::view-transition-old(.news-image),
+::view-transition-new(.news-image) {
+	block-size: 100%;
+	inline-size: 100%;
+	object-fit: cover;
+}
+
+/*
+ * Type never scales. Both sides sit on the same rung of the scale, so the
+ * snapshots ride at their natural size, pinned to the group's start corner,
+ * and only the group travels. Stretching them instead would smear the
+ * headline across the whole flight.
+ */
+::view-transition-old(.news-text),
+::view-transition-new(.news-text) {
+	block-size: auto;
+	inline-size: auto;
+}
+
+/*
+ * App-wide, not just this morph. `viewTransition` links are spread across the
+ * dashboard, docs and sign-in, and none of them honoured a reduced-motion
+ * preference before this file existed - there was no view-transition CSS in
+ * the repo at all.
+ */
+@media (prefers-reduced-motion: reduce) {
+	::view-transition-group(*),
+	::view-transition-old(*),
+	::view-transition-new(*) {
+		animation: none;
+	}
+}


### PR DESCRIPTION
## Summary

The newsroom listing's featured block and the article header are deliberately the same composition at two sizes, but the navigation between them was the default full-page cross-fade — the repo carried no view-transition CSS at all, so `viewTransition` on the links bought nothing beyond a root fade. This names the shared layers on both sides so the card grows into the hero, and back again on "Back to Newsroom".

## Changes

- **Per-slug shared-element names** (`app/lib/news/article-view-transition.ts`). One builder, called by both sides so they cannot drift. Scoping to the slug is what keeps the morph honest: the pairing only fires when the card you clicked is the article you land on, so every other newsroom link falls back to the plain cross-fade with no conditional logic.
- **`app/styles/view-transitions.css`**, imported from `root.tsx`. Timing on the existing `--duration-slow` / `--ease-out` tokens, plus per-layer geometry: plates stretch, the scene crops the way `object-cover` crops it live, and type rides at natural size so the headline translates instead of smearing.
- **Featured card rebuilt on `BasicCard`**, the same primitive as the hero. "Matches the article hero" was previously two class lists kept in step by hand; it is now structural, and the shared-element boxes line up by construction. The `Link` wraps the card because `BasicCard` renders a block element, not an anchor.
- **Reduced motion handled app-wide**, not just for this morph — `viewTransition` links are spread across the dashboard, docs and sign-in, and none of them honoured the preference before this file existed.

### Two decisions worth a reviewer's attention

**Every visible layer is named, not just the ones worth animating.** Unnamed descendants are folded into their nearest named ancestor's snapshot, and sibling groups paint in capture order — so the copy, which paints above the scene image in the live page, would paint *under* it mid-flight and blink out. That is why the eyebrow, title, excerpt and meta line all carry names. Related: the scene and scrim repeat the card's `rounded-2xl`, because a named element is snapshotted without its ancestors' clipping and the corners would otherwise square off for the length of the flight.

**Static names gated by `useViewTransitionState` were rejected.** That hook is only true on the page owning the clicked link, so the return trip from "Back to Newsroom" would never find a name on the listing side and the morph would only work one way.

**The excerpt is named but deliberately unpaired.** The article page carries the same text, but below the hero rather than inside it. Pairing them made the line fly the length of the card while cross-fading between a clamped two-line version and the full one, which read as a smear. Unpaired, it fades where it sits. It still needs a name for the paint-order reason above, or it would blink out rather than fade.

## Type of Change

- [x] New feature (non-breaking, adds functionality)
- [x] Refactor / chore (no functional change) — the `BasicCard` adoption on the featured card

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser

`article-view-transition.spec.ts` guards the actual failure mode: a name with no counterpart fails silently — no error, no warning, both pages still look correct standing still. It asserts each key is wired on both sides, and that `excerpt` is one-sided *on purpose* rather than by omission.

Verified in the browser at `/news-room` and on an article: all 7 names and classes resolve on the listing, exactly 6 on the article with the excerpt at `none`, every CSS rule parsed, and the title box is 416×102 on both pages so it translates without scaling.

### Not verified — worth a look before merge

The motion itself could not be filmed. The preview pane runs with `document.visibilityState: hidden`, and the View Transitions API aborts outright when the document isn't visible (`InvalidStateError`), so both slow-motion and animation-freezing returned the settled page. The specific case I'd want eyes on is clicking the featured card **from a scrolled-down listing**: if React Router's scroll reset lands after the new-state capture, the hero group would start from the wrong offset and jump.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [x] I updated documentation where needed — rationale lives in the component and builder doc comments, matching the surrounding files
- [ ] I linked the related issue above — no tracking issue for this
