### PR TITLE
fix(auth): re-mint CSRF tokens stranded by the remix-utils v10 signature change

### DIFF
--- a/apps/vectreal-platform/app/lib/http/csrf.server.ts
+++ b/apps/vectreal-platform/app/lib/http/csrf.server.ts
@@ -1,6 +1,6 @@
 import { ApiResponse } from '@shared/utils'
 
-import { csrfSession } from '../sessions/csrf-session.server'
+import { buildCsrfCarrier, csrfSession } from '../sessions/csrf-session.server'
 
 function parseOrigin(value: null | string): null | string {
 	if (!value) {
@@ -158,11 +158,8 @@ export async function ensureValidCsrfToken(
 
 	// `csrfSession` reads the token out of a `FormData` under `formDataKey`, so
 	// hand it one holding just that field.
-	const carrier = new FormData()
-	carrier.set('csrf', token)
-
 	try {
-		await csrfSession.validate(carrier, request.headers)
+		await csrfSession.validate(buildCsrfCarrier(token), request.headers)
 		return null
 	} catch {
 		return ApiResponse.forbidden('Invalid CSRF token')

--- a/apps/vectreal-platform/app/lib/sessions/csrf-session.server.spec.ts
+++ b/apps/vectreal-platform/app/lib/sessions/csrf-session.server.spec.ts
@@ -1,0 +1,174 @@
+import { createHash } from 'node:crypto'
+
+import { CSRFError } from 'remix-utils/csrf/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+	buildCsrfCarrier,
+	commitValidCsrfToken,
+	cookie,
+	csrfSession
+} from './csrf-session.server'
+
+/**
+ * Reproduce the token signature remix-utils v8.8 produced.
+ *
+ * v8 signed with an *unkeyed* `base64url(sha256(token))`; v10 signs with an
+ * HMAC keyed by the CSRF secret. Because v8's variant took no secret, a legacy
+ * token can be forged here without knowing this app's secret.
+ *
+ * `@oslojs/encoding` is an optional peer of remix-utils and pnpm does not hoist
+ * it, so base64url is spelled out. The padding is deliberate: `encodeBase64url`
+ * pads, and v10's `decodeBase64url` *requires* padding - an unpadded signature
+ * throws `Invalid padding` rather than failing the signature comparison, which
+ * is a different bug than the one that shipped.
+ */
+function signLikeRemixUtilsV8(value: string): string {
+	return createHash('sha256')
+		.update(value, 'utf8')
+		.digest('base64')
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+}
+
+const LEGACY_VALUE = 'PZ0ncPYaqQrHnHNJ1SsYJRJ4mLZgz3rXdrOKFYRIfMY'
+const LEGACY_TOKEN = `${LEGACY_VALUE}.${signLikeRemixUtilsV8(LEGACY_VALUE)}`
+
+/** Turn a `Set-Cookie` header into the `Cookie` header a browser sends back. */
+function asRequestCookie(setCookieHeader: string): string {
+	return setCookieHeader.split(';')[0]
+}
+
+function requestWithCookie(cookieHeader: string): Request {
+	return new Request('https://vectreal.com/sign-in', {
+		headers: { cookie: cookieHeader }
+	})
+}
+
+async function requestCarrying(token: string): Promise<Request> {
+	return requestWithCookie(asRequestCookie(await cookie.serialize(token)))
+}
+
+describe('legacy remix-utils v8 token (the shipped regression)', () => {
+	it('still unsigns at the cookie layer, so the failure is not a null parse', async () => {
+		const setCookieHeader = await cookie.serialize(LEGACY_TOKEN)
+
+		// The cookie's own signature layer uses the same secret before and after
+		// the upgrade, so it is unaffected - which is exactly why the stale token
+		// survives long enough to reach `verifySignature`.
+		await expect(cookie.parse(asRequestCookie(setCookieHeader))).resolves.toBe(
+			LEGACY_TOKEN
+		)
+	})
+
+	it('is echoed back by commitToken with no Set-Cookie, so it never heals', async () => {
+		const request = await requestCarrying(LEGACY_TOKEN)
+
+		const [token, setCookieHeader] = await csrfSession.commitToken(request)
+
+		expect(token).toBe(LEGACY_TOKEN)
+		expect(setCookieHeader).toBeNull()
+	})
+
+	it('fails validation with tampered_token_in_cookie', async () => {
+		const request = await requestCarrying(LEGACY_TOKEN)
+
+		const error = await csrfSession
+			.validate(buildCsrfCarrier(LEGACY_TOKEN), request.headers)
+			.then(
+				() => null,
+				(caught: unknown) => caught
+			)
+
+		expect(error).toBeInstanceOf(CSRFError)
+		expect((error as CSRFError).code).toBe('tampered_token_in_cookie')
+	})
+})
+
+describe('commitValidCsrfToken', () => {
+	it('re-mints a stale v8 token and returns one that validates', async () => {
+		const request = await requestCarrying(LEGACY_TOKEN)
+
+		const [token, setCookieHeader] = await commitValidCsrfToken(request)
+
+		expect(token).not.toBe(LEGACY_TOKEN)
+		expect(setCookieHeader).not.toBeNull()
+
+		// The visitor is unstuck on their very next request: replay the emitted
+		// cookie the way a browser would, and the token now validates.
+		const nextRequest = requestWithCookie(
+			asRequestCookie(setCookieHeader as string)
+		)
+
+		await expect(
+			csrfSession.validate(buildCsrfCarrier(token), nextRequest.headers)
+		).resolves.toBeUndefined()
+	})
+
+	it('overwrites the csrf cookie in place rather than orphaning it', async () => {
+		const request = await requestCarrying(LEGACY_TOKEN)
+
+		const [, setCookieHeader] = await commitValidCsrfToken(request)
+
+		expect(setCookieHeader).toMatch(/^csrf=/)
+		expect(setCookieHeader).toContain('Path=/')
+		expect(setCookieHeader).toContain('HttpOnly')
+	})
+
+	it('is a no-op for a healthy cookie - same token, still no Set-Cookie', async () => {
+		const healthyToken = csrfSession.generate()
+		const request = await requestCarrying(healthyToken)
+
+		const [token, setCookieHeader] = await commitValidCsrfToken(request)
+
+		// Emitting a redundant Set-Cookie here would be a caching regression.
+		expect(token).toBe(healthyToken)
+		expect(setCookieHeader).toBeNull()
+	})
+
+	it('mints exactly once for a first-time visitor with no csrf cookie', async () => {
+		const request = new Request('https://vectreal.com/sign-in')
+
+		// The probe has to be skipped on this path: the freshly minted cookie is
+		// not on the *inbound* request, so validating against it would throw
+		// `missing_token_in_cookie` and mint a second time. Counting mints is what
+		// pins that down - the assertions below pass either way.
+		const generate = vi.spyOn(csrfSession, 'generate')
+
+		const [token, setCookieHeader] = await commitValidCsrfToken(request)
+
+		expect(generate).toHaveBeenCalledTimes(1)
+		expect(setCookieHeader).not.toBeNull()
+
+		const nextRequest = requestWithCookie(
+			asRequestCookie(setCookieHeader as string)
+		)
+
+		await expect(
+			csrfSession.validate(buildCsrfCarrier(token), nextRequest.headers)
+		).resolves.toBeUndefined()
+
+		generate.mockRestore()
+	})
+
+	it('heals a cookie whose payload is not a string', async () => {
+		// React Router's `decodeData` returns `{}` for a malformed payload, and
+		// `commitToken` treats that truthy non-string as "cookie already set" while
+		// refusing to reuse it as a token - a fresh token with no matching cookie,
+		// i.e. permanent `mismatched_token`.
+		const corrupted = await cookie.serialize({ notAToken: true })
+		const request = requestWithCookie(asRequestCookie(corrupted))
+
+		const [token, setCookieHeader] = await commitValidCsrfToken(request)
+
+		expect(setCookieHeader).not.toBeNull()
+
+		const nextRequest = requestWithCookie(
+			asRequestCookie(setCookieHeader as string)
+		)
+
+		await expect(
+			csrfSession.validate(buildCsrfCarrier(token), nextRequest.headers)
+		).resolves.toBeUndefined()
+	})
+})

--- a/apps/vectreal-platform/app/lib/sessions/csrf-session.server.ts
+++ b/apps/vectreal-platform/app/lib/sessions/csrf-session.server.ts
@@ -23,10 +23,86 @@ export const cookie = createCookie('csrf', {
 	secrets: [resolvedCsrfSecret]
 })
 
+/**
+ * Key the CSRF token travels under inside a `FormData` body.
+ *
+ * Must stay in sync with the `formDataKey` handed to `CSRF` below - anything
+ * building a carrier `FormData` for `CSRF#validate` has to use the same key, or
+ * validation fails with `missing_token_in_body` and reads like a client bug.
+ */
+export const CSRF_FORM_DATA_KEY = 'csrf'
+
 export const csrfSession = new CSRF({
 	cookie,
 	// what key in FormData objects will be used for the token, defaults to `csrf`
-	formDataKey: 'csrf',
+	formDataKey: CSRF_FORM_DATA_KEY,
 	// an optional secret used to sign the token, recommended for extra safety
 	secret: resolvedCsrfSecret
 })
+
+/**
+ * Wrap a bare token in the one-field `FormData` that `CSRF#validate` expects.
+ *
+ * `CSRF#validate` only ever reads the token out of a `FormData` under
+ * `formDataKey`; there is no public entry point taking a bare string, so any
+ * caller holding just the token has to hand it a carrier.
+ */
+export function buildCsrfCarrier(token: string): FormData {
+	const carrier = new FormData()
+	carrier.set(CSRF_FORM_DATA_KEY, token)
+	return carrier
+}
+
+/**
+ * Commit a CSRF token that is guaranteed to validate, re-minting a stale one.
+ *
+ * `CSRF#commitToken` mints a new token only when the `csrf` cookie is absent
+ * entirely - a cookie that parses but carries an unusable token is echoed back
+ * verbatim with a `null` Set-Cookie, forever. Two ways that happens:
+ *
+ *   1. The token was signed by an older remix-utils. v8 signed with an unkeyed
+ *      `sha256`, v10 with an HMAC. The cookie's own signature layer
+ *      (`secrets: [resolvedCsrfSecret]`) is untouched by that change, so the
+ *      cookie still unsigns cleanly and `commitToken` sees a perfectly good
+ *      string - it is the *inner* token signature that no longer verifies.
+ *   2. The cookie payload decodes to a non-string. React Router's `decodeData`
+ *      returns `{}` for malformed JSON, and `commitToken` tests the raw value
+ *      for truthiness when deciding whether to emit Set-Cookie but for
+ *      `typeof === 'string'` when deciding whether to reuse it - so a truthy
+ *      non-string yields a fresh token with no cookie to match it.
+ *
+ * Either way every subsequent POST 403s until the visitor clears cookies by
+ * hand. So probe the committed token and, when it will not validate, force a
+ * fresh mint plus the Set-Cookie that makes it stick.
+ *
+ * @returns The same `[token, setCookieHeader]` tuple shape as `commitToken`. On
+ * the happy path this is exactly what `commitToken` returned, `null` header
+ * included, so no redundant Set-Cookie is emitted.
+ */
+export async function commitValidCsrfToken(
+	request: Request
+): Promise<readonly [string, null | string]> {
+	const [token, setCookieHeader] = await csrfSession.commitToken(request)
+
+	// A non-null header means `commitToken` just minted this token, so it is
+	// valid by construction - and the cookie carrying it is not on the *inbound*
+	// request yet, so probing would fail with `missing_token_in_cookie`.
+	if (setCookieHeader !== null) {
+		return [token, setCookieHeader] as const
+	}
+
+	try {
+		// Throws unless the cookie's token signature verifies AND it matches the
+		// token about to be handed to the page. Both sides come from the same
+		// commit, so only the signature check can realistically fail here.
+		await csrfSession.validate(buildCsrfCarrier(token), request.headers)
+		return [token, setCookieHeader] as const
+	} catch {
+		// Deliberately catching everything rather than just `CSRFError`:
+		// `verifySignature` decodes the signature as base64url, which *throws* on
+		// malformed padding instead of returning false. Letting that escape would
+		// 500 the root loader for exactly the visitors this heals.
+		const freshToken = csrfSession.generate()
+		return [freshToken, await cookie.serialize(freshToken)] as const
+	}
+}

--- a/apps/vectreal-platform/app/root.tsx
+++ b/apps/vectreal-platform/app/root.tsx
@@ -35,7 +35,7 @@ import {
 	buildWebApplicationJsonLd,
 	buildWebSiteJsonLd
 } from './lib/seo-registry'
-import { csrfSession } from './lib/sessions/csrf-session.server'
+import { commitValidCsrfToken } from './lib/sessions/csrf-session.server'
 
 import type { ShouldRevalidateFunction } from 'react-router'
 import '@shared/components/styles/globals.css'
@@ -81,7 +81,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 		}
 	}
 
-	const [csrf, cookieHeader] = await csrfSession.commitToken(request)
+	const [csrf, cookieHeader] = await commitValidCsrfToken(request)
 
 	const loaderData = {
 		csrf,


### PR DESCRIPTION
Fixes the 403 "Invalid CSRF token" on sign-in that appeared on staging and prod after #705.

## Root cause

#705 bumped `remix-utils` 8.8.0 → 10.0.0, which changed the CSRF token signature:

| | v8.8.0 (was deployed) | v10.0.0 (shipping) |
| --- | --- | --- |
| `sign(token)` | `base64url(sha256(token))` — unkeyed | `base64url(hmac(SHA256, secret, token))` — keyed |

Both emit `"<value>.<signature>"`, and the cookie's *own* signature layer (`secrets: [resolvedCsrfSecret]`) is keyed by an unchanged secret. So a pre-upgrade cookie still unsigns cleanly and `cookie.parse()` returns an intact string — only the inner token signature fails, as `CSRFError('tampered_token_in_cookie')` → 403.

The failure is **sticky**, which is why it read as an outage rather than a blip. `CSRF#commitToken` re-mints only when the cookie is absent *entirely*:

```js
let existingToken = await this.cookie.parse(headers.get("cookie"));
let token = typeof existingToken === "string" ? existingToken : this.generate(bytes);
let cookie = existingToken ? null : await this.cookie.serialize(token);
```

Every returning visitor kept getting their stale token echoed back with a `null` Set-Cookie. All 16 CSRF-gated actions — sign-in, sign-up, social-signin, forgot/reset password, confirm-pending, contact, dashboard settings, api-keys, organizations, projects, `/api/dashboard/mutations`, `update-scene-metadata` — stayed 403 until the visitor cleared cookies by hand.

## Fix

`commitValidCsrfToken` wraps `commitToken`, probes the committed token, and forces a fresh mint when it will not validate. The probe is skipped when `commitToken` just minted the token, since the new cookie is not on the inbound request yet and validating against it would fail and mint a second time.

No-op on the happy path: a valid cookie returns the original tuple untouched, `null` header included, so no redundant Set-Cookie is emitted and caching behavior is unchanged. The `/health` and `isAnonymousCacheableRequest` early returns in the root loader are untouched, so no CDN-cacheable response can pick up a Set-Cookie it did not have before.

Uses only the public remix-utils API — `verifySignature` and `sign` are `private`. The `catch` is deliberately bare rather than `instanceof CSRFError`: `verifySignature` decodes the signature as base64url, which *throws* on malformed padding instead of returning false, and letting that escape would 500 the root loader for exactly the visitors being healed.

Also heals a latent case unrelated to the upgrade: `commitToken` tests the parsed cookie for truthiness when deciding whether to emit Set-Cookie but for `typeof === 'string'` when deciding whether to reuse it, so a payload decoding to a non-string yields a token with no cookie to match it.

## Verification

- 444 unit tests pass, typecheck and lint clean.
- New spec forges a real v8.8 token (hand-rolled unkeyed sha256, padding retained — Node's `base64url` strips padding and would throw `Invalid padding` instead of reproducing the bug) and asserts the full arc: the cookie layer still unsigns, `commitToken` echoes it with a null header, `validate` fails with `tampered_token_in_cookie`, and the new helper re-mints into a token that validates.
- Live round trip against the dev server holding a forged pre-#705 cookie: `/sign-in` emits a fresh `Set-Cookie`, a POST with the healed token returns 400 (credentials rejected, CSRF passed), and a POST with a wrong token still returns 403.

## Testing on staging

Use a browser that **still holds a pre-#705 `csrf` cookie** — do not clear it first, that is the whole point. Load `/sign-in`, confirm a fresh `Set-Cookie: csrf=…` on the response, then sign in and confirm it succeeds.

Check on `/sign-in`, not `/`. The root is anonymous-cacheable and returns `csrf: ''` with no Set-Cookie, so looking there will make it seem like nothing happened. The heal lands on the first `no-store` root loader response.

## Not in scope

The other #705 regression — model loading hanging on a logged-in session — is a **separate root cause** and is not addressed here. That path is entirely GET-based and never touches CSRF. Leading hypothesis is SSR stream truncation: `publisher-layout.tsx` inlines the whole parsed glTF JSON into loader data for logged-in users only, `streamTimeout` aborts at 6s, and React Router 8 emits `streamController.close()` only on the final chunk, so a truncated stream leaves the client's decode promise permanently pending and the app never hydrates. Confirm by viewing source on a stuck scene and searching for `streamController.close()`.
