### PR TITLE
chore(build): use Vite's native tsconfig paths resolution

### DIFF
--- a/apps/vectreal-platform/vite.config.ts
+++ b/apps/vectreal-platform/vite.config.ts
@@ -10,7 +10,6 @@ import remarkGfm from 'remark-gfm'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
 import { defineConfig, type PluginOption, type Rolldown } from 'vite'
 import devtoolsJson from 'vite-plugin-devtools-json'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 const prettyCodeOptions = {
 	theme: 'github-dark',
@@ -103,9 +102,9 @@ export default defineConfig(({ command }) => {
 			host: 'localhost'
 		},
 		assetsInclude: ['**/*.gltf', '**/*.glb', '**/*.hdr'],
+		resolve: { tsconfigPaths: true },
 		plugins: [
 			tailwindcss(),
-			tsconfigPaths(),
 			mdx({
 				format: 'mdx',
 				remarkPlugins: [remarkGfm, remarkFrontmatter, remarkMdxFrontmatter],
@@ -135,9 +134,6 @@ export default defineConfig(({ command }) => {
 			!process.env.VITEST && reactRouter(),
 			reactCompilerPlugin(reactCompilerEnabled)
 		],
-		// worker: {
-		//  plugins: [ tsconfigPaths() ],
-		// },
 		// Removed 'ssr.external' because it's incompatible with Cloudflare Vite plugin
 		// Externals are now only handled in rolldownOptions.external
 		ssr: {

--- a/apps/vectreal-platform/vitest.config.ts
+++ b/apps/vectreal-platform/vitest.config.ts
@@ -2,7 +2,6 @@ import mdx from '@mdx-js/rollup'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { configDefaults, defineConfig, mergeConfig } from 'vitest/config'
 
 import sharedConfig from '../../vitest.shared.mts'
@@ -10,8 +9,8 @@ import sharedConfig from '../../vitest.shared.mts'
 export default mergeConfig(
 	sharedConfig,
 	defineConfig({
+		resolve: { tsconfigPaths: true },
 		plugins: [
-			tsconfigPaths(),
 			// Must mirror vite.config.ts. Without the frontmatter plugins the MDX
 			// modules compile but export no `frontmatter`, so the news and docs
 			// manifests resolve to zero entries and any test over them passes

--- a/apps/vectreal-platform/vitest.integration.config.ts
+++ b/apps/vectreal-platform/vitest.integration.config.ts
@@ -1,4 +1,3 @@
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig, mergeConfig } from 'vitest/config'
 
 import sharedConfig from '../../vitest.shared.mts'
@@ -6,7 +5,8 @@ import sharedConfig from '../../vitest.shared.mts'
 export default mergeConfig(
 	sharedConfig,
 	defineConfig({
-		plugins: [tsconfigPaths()],
+		plugins: [],
+		resolve: { tsconfigPaths: true },
 		test: {
 			environment: 'node',
 			include: ['tests/integration/**/*.spec.{ts,tsx}'],

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
 		"vite": "^8.2.1",
 		"vite-plugin-devtools-json": "^1.1.0",
 		"vite-plugin-dts": "5.0.3",
-		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "4.1.10"
 	},
 	"nx": {

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -2,14 +2,13 @@ import * as path from 'path'
 
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
 	root: import.meta.dirname,
 	cacheDir: '../../node_modules/.vite/packages/@vctrl/core',
 
+	resolve: { tsconfigPaths: true },
 	plugins: [
-		tsconfigPaths(),
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json')

--- a/packages/embed/vite.config.ts
+++ b/packages/embed/vite.config.ts
@@ -2,13 +2,12 @@ import * as path from 'path'
 
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
 	root: import.meta.dirname,
 	cacheDir: '../../node_modules/.vite/packages/@vctrl/embed',
+	resolve: { tsconfigPaths: true },
 	plugins: [
-		tsconfigPaths(),
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json')

--- a/packages/hooks/vite.config.ts
+++ b/packages/hooks/vite.config.ts
@@ -3,25 +3,20 @@ import * as path from 'path'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
 	root: import.meta.dirname,
 	cacheDir: '../../node_modules/.vite/packages/@vctrl/hooks',
 
+	resolve: { tsconfigPaths: true },
 	plugins: [
 		react(),
-		tsconfigPaths(),
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json')
 		})
 	],
 
-	// Uncomment this if you are using workers.
-	// worker: {
-	//  plugins: [ tsconfigPaths() ],
-	// },
 
 	// Configuration for building your library.
 	// See: https://vitejs.dev/guide/build.html#library-mode

--- a/packages/viewer/vite.config.ts
+++ b/packages/viewer/vite.config.ts
@@ -4,15 +4,14 @@ import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
 	root: import.meta.dirname,
 	cacheDir: '../../node_modules/.vite/packages/@vctrl/viewer',
+	resolve: { tsconfigPaths: true },
 	plugins: [
 		tailwindcss(),
 		react(),
-		tsconfigPaths(),
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,9 +498,6 @@ importers:
       vite-plugin-dts:
         specifier: 5.0.3
         version: 5.0.3(@microsoft/api-extractor@7.58.7(@types/node@22.19.17))(@rspack/core@2.1.4(@module-federation/runtime-tools@2.3.3(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@6.0.3)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.47(@swc/helpers@0.5.21))(esbuild@0.28.2))
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0)(canvas@3.2.3))(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -7714,9 +7711,6 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   glsl-noise@0.0.0:
     resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
 
@@ -10804,17 +10798,6 @@ packages:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
     engines: {node: '>=6.10'}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -11160,11 +11143,6 @@ packages:
         optional: true
       vite:
         optional: true
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
@@ -19077,8 +19055,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globrex@0.1.2: {}
-
   glsl-noise@0.0.0: {}
 
   gopd@1.2.0: {}
@@ -22950,10 +22926,6 @@ snapshots:
 
   ts-dedent@2.3.0: {}
 
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -23405,16 +23377,6 @@ snapshots:
       - supports-color
       - typescript
       - webpack
-
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:

--- a/shared/components/vite.config.ts
+++ b/shared/components/vite.config.ts
@@ -3,23 +3,18 @@ import * as path from 'path'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig(() => ({
 	root: import.meta.dirname,
 	cacheDir: '../../node_modules/.vite/shared/ui',
+	resolve: { tsconfigPaths: true },
 	plugins: [
 		react(),
-		tsconfigPaths(),
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json')
 		})
 	],
-	// Uncomment this if you are using workers.
-	// worker: {
-	//  plugins: [ tsconfigPaths() ],
-	// },
 	// Configuration for building your library.
 	// See: https://vitejs.dev/guide/build.html#library-mode
 	build: {

--- a/shared/utils/vite.config.ts
+++ b/shared/utils/vite.config.ts
@@ -2,22 +2,17 @@ import * as path from 'path'
 
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig(() => ({
 	root: import.meta.dirname,
 	cacheDir: '../../node_modules/.vite/shared/utils',
+	resolve: { tsconfigPaths: true },
 	plugins: [
-		tsconfigPaths(),
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json')
 		})
 	],
-	// Uncomment this if you are using workers.
-	// worker: {
-	//  plugins: [ tsconfigPaths() ],
-	// },
 	// Configuration for building your library.
 	// See: https://vitejs.dev/guide/build.html#library-mode
 	build: {

--- a/shared/utils/vitest.config.ts
+++ b/shared/utils/vitest.config.ts
@@ -1,4 +1,3 @@
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig, mergeConfig } from 'vitest/config'
 
 import sharedConfig from '../../vitest.shared.mts'
@@ -6,7 +5,8 @@ import sharedConfig from '../../vitest.shared.mts'
 export default mergeConfig(
 	sharedConfig,
 	defineConfig({
-		plugins: [tsconfigPaths()],
+		plugins: [],
+		resolve: { tsconfigPaths: true },
 		test: {
 			environment: 'node',
 			include: ['src/**/*.spec.ts'],

--- a/storybook/vite.config.ts
+++ b/storybook/vite.config.ts
@@ -1,9 +1,47 @@
-import path from 'path'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
+
+const workspaceRoot = path.resolve(import.meta.dirname, '..')
+
+/**
+ * Workspace aliases, derived from tsconfig.base.json.
+ *
+ * Every other project resolves these through Vite's native
+ * `resolve.tsconfigPaths`, which matches each importer against the tsconfig
+ * nearest to it. Storybook is the exception: it compiles stories that live
+ * inside *other* projects, and those projects' root tsconfigs are
+ * solution-style (`"include": []` plus `references`), so the lookup finds
+ * nothing declaring `paths` and the cross-project imports fail to resolve.
+ *
+ * Reading the base config keeps this derived from the one source of truth
+ * rather than restating the alias table here.
+ */
+function workspaceAliases() {
+	const base = JSON.parse(
+		readFileSync(path.join(workspaceRoot, 'tsconfig.base.json'), 'utf8')
+	) as { compilerOptions: { paths: Record<string, string[]> } }
+
+	const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+	return Object.entries(base.compilerOptions.paths).map(
+		([pattern, [target]]) => {
+			const wildcard = pattern.endsWith('/*')
+
+			return {
+				find: new RegExp(
+					wildcard ? `^${escape(pattern.slice(0, -2))}/(.*)$` : `^${escape(pattern)}$`
+				),
+				replacement: wildcard
+					? path.join(workspaceRoot, target.slice(0, -2), '$1')
+					: path.join(workspaceRoot, target)
+			}
+		}
+	)
+}
 
 /**
  * Vite config for the workspace Storybook.
@@ -16,16 +54,6 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 export default defineConfig(() => ({
 	root: import.meta.dirname,
 	cacheDir: '../node_modules/.vite/storybook',
-	plugins: [
-		react(),
-		// Stories live in other projects (shared/components, packages/viewer) and
-		// those projects' own tsconfigs declare `include: []`, so crawling finds no
-		// matcher covering the story files and the workspace aliases fail to
-		// resolve. tsconfig.base.json declares the `paths` and has no `include`,
-		// so it covers the whole repo.
-		tsconfigPaths({
-			projects: [path.resolve(import.meta.dirname, '../tsconfig.base.json')]
-		}),
-		tailwindcss()
-	]
+	resolve: { alias: workspaceAliases() },
+	plugins: [react(), tailwindcss()]
 }))


### PR DESCRIPTION
Follow-up to #705. That PR replaced the deprecated `nxViteTsPaths` with the `vite-tsconfig-paths` plugin — but Vite 8 resolves tsconfig `paths` natively and warns once per config when it detects that plugin, so the change traded one deprecation warning for a louder, repeated one.

Every project except Storybook now sets `resolve: { tsconfigPaths: true }`, and the plugin is dropped from devDependencies.

## Storybook is the exception

Native resolution matches each importer against the tsconfig **nearest to it**. Storybook is the only project that compiles sources owned by other projects, and those projects' root tsconfigs are solution-style (`"include": []` plus `references`), so the lookup finds nothing declaring `paths` and cross-project imports fail:

```
Rolldown failed to resolve import "@shared/utils" from
shared/components/src/ui/overlay-surfaces.stories.tsx
```

Two things I checked before settling on the workaround:

- **It isn't about `include` coverage.** `apps/vectreal-platform/tsconfig.json` is also `"include": []` and resolves fine, so an empty root config isn't the discriminator on its own.
- **It isn't about the Vite root.** Pointing Storybook's root at the workspace root doesn't help either — the lookup is per-importer, not per-root.

So Storybook derives `resolve.alias` from `tsconfig.base.json` instead. That keeps the alias table with a single source of truth rather than restating it.

## Verification

`lint,typecheck,test,build-ci,build-storybook` across all 9 projects, run with the Quality Gate's env vars. 455 tests pass. `build-storybook` is deliberately included — it is not part of the Quality Gate target set, and it is the only target that would have caught the Storybook breakage.

Warning counts in a full run, all zero: `vite-tsconfig-paths`, `__dirname`, `nxViteTsPaths`, `nxCopyAssetsPlugin`.
