### PR TITLE
fix(nav): pick the navbar with CSS and unify it across the publisher

### DIFF
--- a/apps/vectreal-platform/app/components/home/grid-bg.tsx
+++ b/apps/vectreal-platform/app/components/home/grid-bg.tsx
@@ -1,28 +1,48 @@
 import { cn } from '@shared/utils'
 
-interface GridBgProps {
-	isMobile: boolean
-}
+/*
+  The grid is already sized in CSS — 16 columns at desktop, 8 below `md`, four
+  rows either way — so the cell count follows the same breakpoint instead of a
+  prop. Cells past the mobile count are dropped from grid flow with
+  `max-md:hidden` rather than never rendered.
 
-const GridBg = ({ isMobile }: GridBgProps) => {
+  The count used to come from a user-agent sniff in the home loader, which
+  cannot be right here: `/` is prerendered, so that sniff ran with no request
+  at all and every visitor received the 64-cell desktop grid until hydration
+  redrew it.
+*/
+const DESKTOP_CELLS = 64
+const MOBILE_CELLS = 32
+
+const GridCells = () => (
+	<>
+		{Array.from({ length: DESKTOP_CELLS }).map((_, index) => (
+			<div
+				key={index}
+				className={cn(
+					'bg-background rounded-sm',
+					index >= MOBILE_CELLS && 'max-md:hidden'
+				)}
+			/>
+		))}
+	</>
+)
+
+const GridBg = () => {
 	return (
 		<div className="bg-background absolute inset-0 z-0 h-full w-full">
 			{/* Radial background behind grid items  */}
 			<div className="from-orange/35 absolute inset-0 bg-radial-[ellipse_at_center] to-transparent transform-3d" />
 			{/* Grid items */}
 			<div className="absolute inset-0 grid grid-cols-16 grid-rows-4 gap-[1px] max-md:grid-cols-8">
-				{Array.from({ length: isMobile ? 32 : 64 }).map((_, index) => (
-					<div key={index} className={cn('bg-background rounded-sm')} />
-				))}
+				<GridCells />
 			</div>
 
 			{/* Overlay to create glow effect */}
 			<div className="absolute inset-0 mix-blend-color-dodge blur-xl">
 				<div className="from-orange/50 absolute inset-0 bg-radial-[ellipse_at_center] to-transparent transform-3d" />
 				<div className="absolute inset-0 grid grid-cols-16 grid-rows-4 gap-[1px] max-md:grid-cols-8 max-md:grid-rows-4">
-					{Array.from({ length: isMobile ? 32 : 64 }).map((_, index) => (
-						<div key={index} className={cn('bg-background rounded-sm')} />
-					))}
+					<GridCells />
 				</div>
 			</div>
 

--- a/apps/vectreal-platform/app/components/navigation/desktop-nav.tsx
+++ b/apps/vectreal-platform/app/components/navigation/desktop-nav.tsx
@@ -2,9 +2,9 @@ import { VectrealLogoAnimated } from '@shared/components/assets/icons/vectreal-l
 import { Button } from '@shared/components/ui/button'
 import { cn } from '@shared/utils'
 import { LayoutDashboard, LogIn, Rocket } from 'lucide-react'
-import { useRef } from 'react'
 import { useLocation, Link } from 'react-router'
 
+import { isNavItemActive } from './nav-items'
 import { UserMenu } from '../user-menu'
 import { NavItem } from './types'
 
@@ -14,25 +14,25 @@ interface DesktopNavProps {
 	user: User | null
 	navItems: NavItem[]
 	onLogout: () => void
-
 	isAuthPage: boolean
+	className?: string
 }
 
-function getActiveIndex(items: NavItem[], pathname: string): number {
-	return items.findIndex((item) => {
-		if (item.to === '/') return pathname === '/' || pathname === '/home'
-		return pathname.startsWith(item.to)
-	})
-}
-
-function DesktopNav({ user, navItems, onLogout, isAuthPage }: DesktopNavProps) {
+function DesktopNav({
+	user,
+	navItems,
+	onLogout,
+	isAuthPage,
+	className
+}: DesktopNavProps) {
 	const { pathname } = useLocation()
-	const containerRef = useRef<HTMLDivElement>(null)
-	const activeIndex = getActiveIndex(navItems, pathname)
 
 	return (
 		<nav
-			className="fixed top-0 right-0 left-0 z-50 flex items-center justify-center p-4"
+			className={cn(
+				'fixed top-0 right-0 left-0 z-50 items-center justify-center p-4',
+				className
+			)}
 			aria-label="Main navigation"
 		>
 			<div className="from-background absolute inset-0 z-0 h-16 bg-linear-to-b to-transparent backdrop-blur-sm" />
@@ -46,19 +46,16 @@ function DesktopNav({ user, navItems, onLogout, isAuthPage }: DesktopNavProps) {
 					<VectrealLogoAnimated className="text-muted-foreground h-6" colored />
 				</Link>
 
-				{/* Center nav links with sliding pill */}
+				{/* Center nav links */}
 				{navItems.length > 0 && (
-					<div
-						ref={containerRef}
-						className="relative flex items-center gap-0.5"
-					>
-						{navItems.map((item, i) => (
+					<div className="relative flex items-center gap-0.5">
+						{navItems.map((item) => (
 							<Link
 								key={item.to}
 								to={item.to}
 								className={cn(
 									'relative z-10 rounded-xl px-3 py-1.5 text-sm font-medium transition-colors',
-									activeIndex === i
+									isNavItemActive(item, pathname)
 										? 'text-foreground'
 										: 'text-muted-foreground hover:text-foreground'
 								)}

--- a/apps/vectreal-platform/app/components/navigation/global-nav-visibility.tsx
+++ b/apps/vectreal-platform/app/components/navigation/global-nav-visibility.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect, type ReactNode } from 'react'
+
+/**
+ * Runtime escape hatch for the one nav-visibility case the URL cannot express.
+ *
+ * `routePageChrome` decides chrome from the path, which is what keeps SSR and
+ * hydration in agreement. The publisher has a single transition outside that
+ * model: dropping a model at `/publisher` hands the top of the viewport to
+ * `PublisherHeader` without navigating.
+ *
+ * Hide-only by design. A channel that could also turn the nav back *on* would be
+ * able to reveal it a frame after paint, which is exactly the flash this work
+ * removes. Restoring the nav is the cleanup's job, not a caller's.
+ *
+ * Single-consumer by design too: `controls-overlay` is the only caller, so there
+ * is no reference counting. Add it when a second consumer actually exists.
+ */
+const HideGlobalNavContext = createContext<
+	((hidden: boolean) => void) | null
+>(null)
+
+export function GlobalNavVisibilityProvider({
+	onHiddenChange,
+	children
+}: {
+	onHiddenChange: (hidden: boolean) => void
+	children: ReactNode
+}) {
+	return (
+		<HideGlobalNavContext.Provider value={onHiddenChange}>
+			{children}
+		</HideGlobalNavContext.Provider>
+	)
+}
+
+export function useHideGlobalNav(hidden: boolean): void {
+	const setHidden = useContext(HideGlobalNavContext)
+	if (!setHidden) {
+		throw new Error(
+			'useHideGlobalNav must be used inside GlobalNavVisibilityProvider'
+		)
+	}
+
+	useEffect(() => {
+		setHidden(hidden)
+		return () => setHidden(false)
+	}, [hidden, setHidden])
+}

--- a/apps/vectreal-platform/app/components/navigation/index.tsx
+++ b/apps/vectreal-platform/app/components/navigation/index.tsx
@@ -1,59 +1,36 @@
 import { usePostHog } from '@posthog/react'
-import { useIsMobile } from '@shared/components/hooks/use-mobile'
-import { Rocket, DollarSign, BookOpen, Newspaper, Mail } from 'lucide-react'
 import { useCallback } from 'react'
 import { useFetcher, useLocation } from 'react-router'
 
 import DesktopNav from './desktop-nav'
 import MobileNav from './mobile-nav'
+import { MARKETING_ITEMS } from './nav-items'
+import { useCurrentUser } from '../../hooks/use-current-user'
 
-import type { NavItem, NavigationProps } from './types'
-
-type NavContext = 'marketing' | 'docs' | 'auth'
-
-function getNavContext(pathname: string): NavContext {
-	if (pathname.startsWith('/sign-in') || pathname.startsWith('/sign-up')) {
-		return 'auth'
-	}
-	if (pathname.startsWith('/docs')) {
-		return 'docs'
-	}
-	return 'marketing'
+function isAuthPath(pathname: string): boolean {
+	return pathname.startsWith('/sign-in') || pathname.startsWith('/sign-up')
 }
 
-const MARKETING_ITEMS: NavItem[] = [
-	{
-		label: 'Publisher',
-		to: '/publisher',
-		icon: <Rocket className="size-4" />
-	},
-	{
-		label: 'Pricing',
-		to: '/pricing',
-		icon: <DollarSign className="size-4" />
-	},
-	{ label: 'Docs', to: '/docs', icon: <BookOpen className="size-4" /> },
-	{
-		label: 'Newsroom',
-		to: '/news-room',
-		icon: <Newspaper className="size-4" />
-	},
-	{
-		label: 'Contact',
-		to: '/contact',
-		icon: <Mail className="size-4" />
-	}
-]
-
-export const Navigation = ({ user, isMobileRequest }: NavigationProps) => {
-	const isMobile = useIsMobile(isMobileRequest)
+/**
+ * Both shells render; media queries pick one.
+ *
+ * Branching on a device class in JS is what made the desktop bar paint on mobile
+ * and flip after hydration: the seed came from a user-agent sniff, and public
+ * pages are prerendered at build time (no request, so no user-agent) and cached
+ * at the edge without `Vary: User-Agent`. A user-agent also answers the wrong
+ * question — the branch is a 768px breakpoint, not a device.
+ *
+ * `md` is Tailwind's default 48rem, which matches `MOBILE_BREAKPOINT` exactly, so
+ * `hidden md:flex` and `flex md:hidden` are a precise complement.
+ */
+export const Navigation = () => {
+	const { user } = useCurrentUser()
 	const { submit } = useFetcher()
 	const posthog = usePostHog()
 	const { pathname } = useLocation()
 
-	const context = getNavContext(pathname)
 	const isHomePage = pathname === '/' || pathname === '/home'
-	const isAuthPage = context === 'auth'
+	const isAuthPage = isAuthPath(pathname)
 
 	const handleLogout = useCallback(async () => {
 		posthog?.reset()
@@ -63,24 +40,23 @@ export const Navigation = ({ user, isMobileRequest }: NavigationProps) => {
 		})
 	}, [posthog, submit])
 
-	if (isMobile) {
-		return (
+	return (
+		<>
+			<DesktopNav
+				className="hidden md:flex"
+				user={user}
+				navItems={MARKETING_ITEMS}
+				onLogout={handleLogout}
+				isAuthPage={isAuthPage}
+			/>
 			<MobileNav
+				className="flex md:hidden"
 				user={user}
 				navItems={MARKETING_ITEMS}
 				onLogout={handleLogout}
 				isHomePage={isHomePage}
 				isAuthPage={isAuthPage}
 			/>
-		)
-	}
-
-	return (
-		<DesktopNav
-			user={user}
-			navItems={MARKETING_ITEMS}
-			onLogout={handleLogout}
-			isAuthPage={isAuthPage}
-		/>
+		</>
 	)
 }

--- a/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
+++ b/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
@@ -1,4 +1,5 @@
 import { VectrealLogoAnimated } from '@shared/components/assets/icons/vectreal-logo-animated'
+import { useIsMobile } from '@shared/components/hooks/use-mobile'
 import { Button } from '@shared/components/ui/button'
 import { Separator } from '@shared/components/ui/separator'
 import {
@@ -22,6 +23,7 @@ import {
 import { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router'
 
+import { isNavItemActive } from './nav-items'
 import { ThemeToggleButton } from '../theme-toggle-button'
 import { UserMenu } from '../user-menu'
 import { NavItem } from './types'
@@ -32,6 +34,7 @@ interface MobileNavProps {
 	onLogout: () => void
 	isHomePage: boolean
 	isAuthPage: boolean
+	className?: string
 }
 
 const drawerItemVariants = {
@@ -53,15 +56,31 @@ function MobileNav({
 	navItems,
 	onLogout,
 	isHomePage,
-	isAuthPage
+	isAuthPage,
+	className
 }: MobileNavProps) {
 	const { pathname } = useLocation()
+	const isMobile = useIsMobile()
 	const [drawerOpen, setDrawerOpen] = useState(false)
 
 	// Close drawer on route change
 	useEffect(() => {
 		setDrawerOpen(false)
 	}, [pathname])
+
+	/*
+	  This nav hides itself at the desktop breakpoint with `md:hidden`, but the
+	  drawer cannot: `SheetContent` renders `SheetOverlay` as a sibling inside its
+	  portal and does not forward `className` to it, so hiding the panel alone
+	  would strand a full-screen scrim over the desktop layout. Close it instead.
+
+	  Reading the viewport here does not reintroduce the hydration flip this
+	  component's `md:hidden` exists to fix — the drawer is always closed at first
+	  paint, so there is nothing for server and client to disagree about.
+	*/
+	useEffect(() => {
+		if (!isMobile) setDrawerOpen(false)
+	}, [isMobile])
 
 	const allDrawerItems: NavItem[] = [
 		...(user
@@ -80,7 +99,10 @@ function MobileNav({
 	return (
 		<>
 			<nav
-				className="fixed top-0 right-0 left-0 z-50 flex items-center justify-between p-2"
+				className={cn(
+					'fixed top-0 right-0 left-0 z-50 items-center justify-between p-2',
+					className
+				)}
 				aria-label="Main navigation"
 			>
 				<div
@@ -166,10 +188,7 @@ function MobileNav({
 					{/* Nav links */}
 					<div className="flex flex-1 flex-col gap-1 px-4 py-4">
 						{allDrawerItems.map((item, i) => {
-							const isActive =
-								item.to === '/'
-									? pathname === '/' || pathname === '/home'
-									: pathname.startsWith(item.to)
+							const isActive = isNavItemActive(item, pathname)
 							return (
 								<motion.div
 									key={item.to}

--- a/apps/vectreal-platform/app/components/navigation/nav-items.spec.tsx
+++ b/apps/vectreal-platform/app/components/navigation/nav-items.spec.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { isNavItemActive, MARKETING_ITEMS } from './nav-items'
+
+import type { NavItem } from './types'
+
+const item = (to: string): NavItem => ({ label: to, to, icon: null })
+
+describe('isNavItemActive', () => {
+	it('matches home exactly, so it cannot claim every route', () => {
+		expect(isNavItemActive(item('/'), '/')).toBe(true)
+		expect(isNavItemActive(item('/'), '/home')).toBe(true)
+		expect(isNavItemActive(item('/'), '/pricing')).toBe(false)
+	})
+
+	it('matches other items by prefix, so nested pages stay highlighted', () => {
+		expect(isNavItemActive(item('/docs'), '/docs')).toBe(true)
+		expect(isNavItemActive(item('/docs'), '/docs/guides/upload')).toBe(true)
+		expect(isNavItemActive(item('/docs'), '/pricing')).toBe(false)
+	})
+
+	it('marks the publisher item active from the publisher', () => {
+		const publisher = MARKETING_ITEMS.find((i) => i.to === '/publisher')
+		expect(publisher).toBeDefined()
+		expect(isNavItemActive(publisher!, '/publisher/abc123')).toBe(true)
+	})
+})

--- a/apps/vectreal-platform/app/components/navigation/nav-items.tsx
+++ b/apps/vectreal-platform/app/components/navigation/nav-items.tsx
@@ -1,0 +1,39 @@
+import { BookOpen, DollarSign, Mail, Newspaper, Rocket } from 'lucide-react'
+
+import type { NavItem } from './types'
+
+export const MARKETING_ITEMS: NavItem[] = [
+	{
+		label: 'Publisher',
+		to: '/publisher',
+		icon: <Rocket className="size-4" />
+	},
+	{
+		label: 'Pricing',
+		to: '/pricing',
+		icon: <DollarSign className="size-4" />
+	},
+	{ label: 'Docs', to: '/docs', icon: <BookOpen className="size-4" /> },
+	{
+		label: 'Newsroom',
+		to: '/news-room',
+		icon: <Newspaper className="size-4" />
+	},
+	{
+		label: 'Contact',
+		to: '/contact',
+		icon: <Mail className="size-4" />
+	}
+]
+
+/**
+ * Home is matched exactly because it would otherwise prefix-match every path.
+ * `/home` is the same page for signed-in visitors, so both spellings count.
+ */
+export function isNavItemActive(item: NavItem, pathname: string): boolean {
+	if (item.to === '/') {
+		return pathname === '/' || pathname === '/home'
+	}
+
+	return pathname.startsWith(item.to)
+}

--- a/apps/vectreal-platform/app/components/navigation/types.ts
+++ b/apps/vectreal-platform/app/components/navigation/types.ts
@@ -1,13 +1,6 @@
-import type { User } from '@supabase/supabase-js'
-
 export interface NavItem {
 	label: string
 	to: string
 	icon: React.ReactNode
 	external?: boolean
-}
-
-export interface NavigationProps {
-	user: User | null
-	isMobileRequest?: boolean
 }

--- a/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
+++ b/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
@@ -1,3 +1,4 @@
+import { useIsMobile } from '@shared/components/hooks/use-mobile'
 import { useModelContext } from '@vctrl/hooks/use-load-model'
 import { useAtomValue, useSetAtom } from 'jotai/react'
 import posthog from 'posthog-js'
@@ -15,7 +16,7 @@ import { PublisherHeader } from './shell/publisher-header'
 import { PUBLISHER_LAYER } from './shell/shell-layout'
 import { DASHBOARD_ROUTES } from '../../constants/dashboard'
 import { useOptimizationModalFlow, useSceneLoader } from '../../hooks'
-import { Navigation } from '../navigation'
+import { useHideGlobalNav } from '../navigation/global-nav-visibility'
 import PublishSidebarContent from './sidebars/publish-sidebar/publish-sidebar-content'
 import { PublishSidebarProvider } from './sidebars/publish-sidebar/publish-sidebar-context'
 import { useSceneSizeInitializer } from './sidebars/use-scene-size-initializer'
@@ -52,6 +53,13 @@ const OverlayControls = ({
 }: PublisherLoaderData & { children: ReactNode }) => {
 	const navigate = useNavigate()
 	const submit = useSubmit()
+	/*
+	  The request hint only seeds the first paint. `/publisher` is `no-store` and
+	  never prerendered, so the user-agent is a real signal here — but it answers
+	  the wrong question after that, since the sidebars swap to drawers on a 768px
+	  breakpoint, not on a device class. A narrow desktop window wants drawers too.
+	*/
+	const isMobile = useIsMobile(isMobileRequest)
 	const { file, isFileLoading, optimizer } = useModelContext(true)
 	const { step, showPublishPanel } = useAtomValue(controlsOverlayStateAtom)
 	const arePublisherActionsDisabled = useAtomValue(
@@ -110,6 +118,19 @@ const OverlayControls = ({
 	})
 
 	const isUploadStep = !file?.model && step === 'uploading'
+
+	/*
+	  Pre-upload with no scene: there is nothing to frame yet, so the site nav
+	  stands in for the header. Everywhere else the publisher owns the top of the
+	  viewport, so the nav (owned by nav-layout) steps aside.
+
+	  `routePageChrome` already covers this for `/publisher/:sceneId` at SSR. The
+	  case only this can catch is a model dropped at `/publisher`, which swaps the
+	  nav for the header without navigating.
+	*/
+	const showSiteNav = isUploadStep && !sceneId
+	useHideGlobalNav(!showSiteNav)
+
 	const sceneDetailsHref =
 		sceneId && projectId
 			? DASHBOARD_ROUTES.SCENE_DETAIL(projectId, sceneId)
@@ -274,15 +295,10 @@ const OverlayControls = ({
 		[setProcessState]
 	)
 
-	// Pre-upload with no scene: there is nothing to frame yet, so the marketing
-	// nav stands in for the header and the stage chrome has nothing to show.
-	if (isUploadStep && !sceneId) {
-		return (
-			<>
-				<Navigation user={user} isMobileRequest={isMobileRequest} />
-				<div className="relative flex min-h-0 flex-1 flex-col">{children}</div>
-			</>
-		)
+	// Pre-upload with no scene: the site nav (kept mounted by nav-layout) stands
+	// in for the header, and the stage chrome has nothing to show.
+	if (showSiteNav) {
+		return <div className="relative flex min-h-0 flex-1 flex-col">{children}</div>
 	}
 
 	return (
@@ -310,7 +326,7 @@ const OverlayControls = ({
 			<div className="relative flex min-h-0 flex-1 flex-col">
 				{children}
 
-<ToolSidebar user={user} isMobile={isMobileRequest} />
+				<ToolSidebar user={user} isMobile={isMobile} />
 
 				<PublishCard
 					sceneBytes={currentSceneBytes}
@@ -326,7 +342,7 @@ const OverlayControls = ({
 					open={showPublishPanel}
 					onOpenChange={handlePublishPanelChange}
 					zIndexClassName={PUBLISHER_LAYER.sidebar}
-					isMobile={isMobileRequest}
+					isMobile={isMobile}
 					direction="right"
 					title="Scene Info & Publish"
 					description="Save, publish, and embed your latest scene."
@@ -343,7 +359,7 @@ const OverlayControls = ({
 					isOverSizeLimit={requiresSizeReduction}
 					maxSceneBytes={maxSceneBytes}
 					dashboardHref={sceneDetailsHref ?? '/dashboard'}
-					isMobile={isMobileRequest}
+					isMobile={isMobile}
 				/>
 
 				<PreviewModeBadge />

--- a/apps/vectreal-platform/app/lib/navigation/page-chrome.spec.ts
+++ b/apps/vectreal-platform/app/lib/navigation/page-chrome.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { routePageChrome } from './page-chrome'
+
+describe('routePageChrome', () => {
+	it('gives public pages both nav and footer', () => {
+		for (const pathname of [
+			'/',
+			'/home',
+			'/pricing',
+			'/contact',
+			'/docs/guides/upload',
+			'/news-room/some-article',
+			'/sign-in'
+		]) {
+			expect(routePageChrome(pathname)).toEqual({ nav: true, footer: true })
+		}
+	})
+
+	it('keeps the nav on the empty publisher, where it stands in for the header', () => {
+		expect(routePageChrome('/publisher')).toEqual({ nav: true, footer: false })
+		expect(routePageChrome('/publisher/')).toEqual({ nav: true, footer: false })
+	})
+
+	/*
+	  This is the case that must be right during SSR. With a scene id the publisher
+	  header owns the top of the viewport from the first paint, so a nav rendered
+	  here would be visibly dropped on hydration.
+	*/
+	it('drops the nav once there is a scene to frame', () => {
+		expect(routePageChrome('/publisher/abc123')).toEqual({
+			nav: false,
+			footer: false
+		})
+	})
+
+	it('does not let the publisher prefix swallow unrelated paths', () => {
+		expect(routePageChrome('/publisher-guide')).toEqual({
+			nav: true,
+			footer: true
+		})
+	})
+})

--- a/apps/vectreal-platform/app/lib/navigation/page-chrome.ts
+++ b/apps/vectreal-platform/app/lib/navigation/page-chrome.ts
@@ -1,0 +1,36 @@
+/**
+ * Which global chrome a route wants, derived from the path alone.
+ *
+ * Path-derived on purpose: this runs during SSR and prerendering, where the only
+ * thing known about the page is its URL. Anything client-state-derived would
+ * paint one way on the server and another after hydration, which is the class of
+ * bug this module exists to prevent.
+ *
+ * The publisher is the only route family that suppresses chrome. It never shows
+ * the footer, and it hands the top of the viewport to `PublisherHeader` as soon
+ * as there is a scene to frame. With no scene id there is nothing to frame yet,
+ * so the marketing nav stands in.
+ *
+ * `/publisher` with a model loaded but no scene id is the one case the URL cannot
+ * express — that transition happens without navigating. It is handled at runtime
+ * by `useHideGlobalNav`, which may only ever hide.
+ */
+
+export interface PageChrome {
+	nav: boolean
+	footer: boolean
+}
+
+const PUBLISHER_PATH = '/publisher'
+
+export function routePageChrome(pathname: string): PageChrome {
+	if (pathname === PUBLISHER_PATH || pathname === `${PUBLISHER_PATH}/`) {
+		return { nav: true, footer: false }
+	}
+
+	if (pathname.startsWith(`${PUBLISHER_PATH}/`)) {
+		return { nav: false, footer: false }
+	}
+
+	return { nav: true, footer: true }
+}

--- a/apps/vectreal-platform/app/routes.tsx
+++ b/apps/vectreal-platform/app/routes.tsx
@@ -98,6 +98,17 @@ export default [
 		// loads, which is a better trade than an untyped route.
 		route('__scenes', './routes/news-room-page/newsroom-scene-preview.tsx'),
 
+		// Publisher. Nested here, rather than in its own top-level branch, so the
+		// nav survives navigating into it instead of being torn down and rebuilt.
+		// It suppresses the footer (and, once there is a scene to frame, the nav)
+		// through routePageChrome.
+		layout('./routes/layouts/publisher-layout.tsx', [
+			route(
+				'publisher/:sceneId?',
+				'./routes/publisher-page/publisher.$sceneId.tsx'
+			)
+		]),
+
 		// News room page
 		layout('./routes/layouts/news-room-layout.tsx', [
 			route('news-room', './routes/news-room-page/news-room-page.tsx'),
@@ -151,14 +162,6 @@ export default [
 
 	// First-run onboarding (standalone page, no nav layout)
 	route('onboarding', './routes/onboarding-page/onboarding-page.tsx'),
-
-	// Publisher
-	layout('./routes/layouts/publisher-layout.tsx', [
-		route(
-			'publisher/:sceneId?',
-			'./routes/publisher-page/publisher.$sceneId.tsx'
-		)
-	]),
 
 	// External embeds: preview API key only, never internal chrome
 	layout('./routes/layouts/embed-layout.tsx', [

--- a/apps/vectreal-platform/app/routes/home-page/home-page.tsx
+++ b/apps/vectreal-platform/app/routes/home-page/home-page.tsx
@@ -1,4 +1,3 @@
-import { useIsMobile } from '@shared/components'
 import { GithubLogo } from '@shared/components/assets/icons/github-logo'
 import {
 	Accordion,
@@ -31,7 +30,6 @@ import {
 	buildOrganizationJsonLd,
 	PUBLIC_SEO_PAGES
 } from '../../lib/seo-registry'
-import { identifyMobileRequest } from '../../lib/utils/identify-mobile-request'
 
 /*
   Literal colours, deliberately outside the token system.
@@ -52,11 +50,6 @@ const SYNTAX = {
 	component: '#e0af68',
 	attribute: '#9ece6a'
 } as const
-
-export async function loader({ request }: Route.LoaderArgs) {
-	const isMobile = identifyMobileRequest(request)
-	return { isMobile }
-}
 
 export function meta(_: Route.MetaArgs) {
 	return buildPageMeta(PUBLIC_SEO_PAGES.home, undefined, {
@@ -164,8 +157,7 @@ const FAQ_ITEMS: { value: string; q: string; a: string }[] = [
 		a: 'Yes. Once published, you can generate embed snippets and configure domain/API constraints for controlled integration into product pages and apps.'
 	}
 ]
-const HomePage = ({ loaderData }: Route.ComponentProps) => {
-	const isMobile = useIsMobile(loaderData.isMobile)
+const HomePage = () => {
 
 	return (
 		<main className="bg-background overflow-x-clip">
@@ -189,7 +181,7 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 					<HowItWorksShowcase />
 				</div>
 
-				<GridBg isMobile={isMobile} />
+				<GridBg />
 			</Section>
 
 			{/* 5. Optimization value prop */}
@@ -281,7 +273,7 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 					</SnapRow>
 				</div>
 
-				<GridBg isMobile={isMobile} />
+				<GridBg />
 			</Section>
 
 			{/* 7. Format carousel */}
@@ -400,7 +392,7 @@ const HomePage = ({ loaderData }: Route.ComponentProps) => {
 					</div>
 				</div>
 
-				<GridBg isMobile={isMobile} />
+				<GridBg />
 			</Section>
 
 			{/* 9. FAQ */}

--- a/apps/vectreal-platform/app/routes/layouts/nav-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/nav-layout.tsx
@@ -1,34 +1,42 @@
-import { Outlet } from 'react-router'
+import { cn } from '@shared/utils'
+import { useState } from 'react'
+import { Outlet, useLocation } from 'react-router'
 
-import { Route } from './+types/nav-layout'
 import { Footer } from '../../components/footer'
 import { Navigation } from '../../components/navigation'
-import {
-	CurrentUserProvider,
-	useCurrentUser
-} from '../../hooks/use-current-user'
-import { identifyMobileRequest } from '../../lib/utils/identify-mobile-request'
+import { GlobalNavVisibilityProvider } from '../../components/navigation/global-nav-visibility'
+import { CurrentUserProvider } from '../../hooks/use-current-user'
+import { routePageChrome } from '../../lib/navigation/page-chrome'
 
-export async function loader({ request }: Route.LoaderArgs) {
-	// Public pages are CDN-cacheable, so this loader must stay free of
-	// per-visitor state. Auth is hydrated on the client via CurrentUserProvider.
-	// `isMobile` is only an SSR hint; useIsMobile re-detects on the client.
-	// The `.data` cache policy is applied centrally in entry.server's
-	// handleDataRequest via the same predicate used for documents.
-	return { isMobile: identifyMobileRequest(request) }
+/**
+ * Owns the site chrome for every route that has any, the publisher included.
+ *
+ * The publisher used to sit in its own top-level branch and mount a second
+ * `Navigation` of its own, so entering it tore down this layout and rebuilt the
+ * nav from scratch — visibly, because the logo replays a fade on mount. Nesting
+ * it here keeps one nav element alive across the navigation.
+ *
+ * The nav is hidden with a class rather than unmounted for the same reason: a
+ * round trip through the publisher should not cost a remount.
+ */
+const Layout = () => {
+	const { pathname } = useLocation()
+	const chrome = routePageChrome(pathname)
+	const [navHiddenAtRuntime, setNavHiddenAtRuntime] = useState(false)
+
+	const showNav = chrome.nav && !navHiddenAtRuntime
+
+	return (
+		<CurrentUserProvider>
+			<GlobalNavVisibilityProvider onHiddenChange={setNavHiddenAtRuntime}>
+				<div className={cn(!showNav && 'hidden')}>
+					<Navigation />
+				</div>
+				<Outlet />
+				{chrome.footer && <Footer />}
+			</GlobalNavVisibilityProvider>
+		</CurrentUserProvider>
+	)
 }
-
-function NavigationWithUser({ isMobileRequest }: { isMobileRequest: boolean }) {
-	const { user } = useCurrentUser()
-	return <Navigation user={user} isMobileRequest={isMobileRequest} />
-}
-
-const Layout = ({ loaderData }: Route.ComponentProps) => (
-	<CurrentUserProvider>
-		<NavigationWithUser isMobileRequest={loaderData.isMobile} />
-		<Outlet />
-		<Footer />
-	</CurrentUserProvider>
-)
 
 export default Layout

--- a/apps/vectreal-platform/app/routes/publisher-page/drop-zone.tsx
+++ b/apps/vectreal-platform/app/routes/publisher-page/drop-zone.tsx
@@ -80,13 +80,9 @@ export const DropZone = ({ isMobile }: Props) => {
 			>
 				<div className="w-full max-w-6xl p-4">
 					<header className="mb-8 text-left">
-						<p className="text-muted-foreground mb-2 text-xs font-semibold tracking-[0.22em] uppercase">
-							Publisher
-						</p>
-						<h1 className="max-w-4xl text-4xl leading-[1.02] font-medium tracking-tight text-balance md:text-6xl">
-							Upload Your 3D Assets
-						</h1>
-						<p className="text-muted-foreground mt-2 max-w-3xl text-base leading-relaxed md:text-lg">
+						<p className="text-eyebrow text-muted-foreground mb-2">Publisher</p>
+						<h1 className="text-headline max-w-4xl">Upload Your 3D Assets</h1>
+						<p className="text-body-lg text-muted-foreground mt-2 max-w-3xl">
 							Drop your files here to optimize them for web and AR viewing
 						</p>
 					</header>
@@ -142,7 +138,13 @@ export const DropZone = ({ isMobile }: Props) => {
 													/>
 												</div>
 
-												<h2 className="mb-2 text-xl! font-semibold md:text-2xl!">
+												{/*
+												  No `!` flags here. They dated from when the app's
+												  unlayered CSS-module heading rules beat every
+												  Tailwind size; those defaults now live in `base` and
+												  lose to any utility the markup asks for.
+												*/}
+												<h2 className="text-h3 mb-2">
 													{isDragActive
 														? 'Drop to Start Processing'
 														: 'Drop Your 3D Files Anywhere'}
@@ -177,8 +179,8 @@ export const DropZone = ({ isMobile }: Props) => {
 											<Book className="h-4 w-4" />
 										</div>
 										<div className="text-left">
-											<div className="font-medium">Your First Model Guide</div>
-											<div className="text-muted-foreground text-xs">
+											<div className="text-h4">Your First Model Guide</div>
+											<div className="text-label-xs text-muted-foreground">
 												Step-by-step upload to publish walkthrough
 											</div>
 										</div>
@@ -195,8 +197,8 @@ export const DropZone = ({ isMobile }: Props) => {
 											<FileQuestion className="h-4 w-4" />
 										</div>
 										<div className="text-left">
-											<div className="font-medium">Upload Format Guide</div>
-											<div className="text-muted-foreground text-xs">
+											<div className="text-h4">Upload Format Guide</div>
+											<div className="text-label-xs text-muted-foreground">
 												Supported file types, bundles, and tips
 											</div>
 										</div>
@@ -213,8 +215,8 @@ export const DropZone = ({ isMobile }: Props) => {
 											<ExternalLink className="h-4 w-4" />{' '}
 										</div>
 										<div className="overflow-hidden text-left">
-											<div className="font-medium">Documentation Hub</div>
-											<div className="text-muted-foreground text-xs whitespace-break-spaces">
+											<div className="text-h4">Documentation Hub</div>
+											<div className="text-label-xs text-muted-foreground whitespace-break-spaces">
 												Full guides, package references, and deployment docs
 											</div>
 										</div>


### PR DESCRIPTION
## Summary

The mobile navbar painted as the desktop bar and flipped after hydration, and the whole nav remounted on entry to the publisher. Both trace to one root cause: UI shape was decided in JS from a server-side user-agent sniff, and the nav was mounted twice in two unrelated route branches. The same sniff was also sizing the home page's grid background, so that is fixed here too.

## Changes

- **Both nav shells now render; media queries choose.** `hidden md:flex` / `flex md:hidden`, where Tailwind's `md` is the default 768px — identical to `MOBILE_BREAKPOINT`, so the two are an exact complement. `isMobileRequest` leaves `NavigationProps`, and nav-layout's loader is deleted along with it.
- **`publisher-layout` nests inside `nav-layout`**, and the second `Navigation` in `controls-overlay` is deleted, so one nav element survives the navigation.
- **New `routePageChrome(pathname)`** (`app/lib/navigation/page-chrome.ts`), a pure path predicate modeled on the existing `consent-surfaces.ts`, deciding nav and footer visibility. Path-derived so it is already correct during SSR and prerendering.
- **New hide-only `useHideGlobalNav`** for the one case a URL cannot express: a model dropped at `/publisher`, which swaps nav for `PublisherHeader` without navigating. Hiding uses a class rather than an unmount, so a publisher round trip costs no remount.
- **`GridBg` sizes itself from the breakpoint.** The grid was already responsive in CSS (16 columns at desktop, 8 below `md`); only the child count came from JS. Cells past the mobile count now drop out of grid flow with `max-md:hidden`. GridBg needs no props, home-page needs no `useIsMobile`, and its loader — which existed only to carry the sniff — is deleted.
- **Publisher sidebars derive `isMobile` from the breakpoint**, not the user-agent, so a narrow desktop window gets drawers.
- **Dropzone typography moved onto the token scale** — `text-eyebrow`, `text-headline`, `text-body-lg`, `text-h3`, `text-h4`, `text-label-xs`.
- **Dead code removed**: an unused `containerRef` and an index indirection left from a removed sliding pill, mobile-nav's duplicate active-route match, a computed-but-never-read `'docs'` nav context, and the two duplicated 64-cell maps in GridBg.

## Why the user-agent seed was wrong

Two independent routes, either sufficient on its own:

1. **Prerendering.** `/`, `/about`, the legal pages, `/docs/*` and `/news-room/*` are prerendered at build time. There is no request, so `identifyMobileRequest` returned `false` and *every* visitor got desktop markup. The home page reproduced this 100% of the time, for both the nav and the grid.
2. **CDN caching.** Public documents ship `Vary: Accept-Encoding` with no `Vary: User-Agent`, so whichever agent warmed the edge decided the HTML everyone else received.

It also answered the wrong question regardless: these are 768px breakpoint decisions, not device-class ones.

`identifyMobileRequest` now survives only in the publisher, which is `no-store` and never prerendered — the one place the hint is a sound SSR seed.

## Reviewer notes

- **The drawer still reads the viewport, deliberately.** `SheetContent` renders `SheetOverlay` as a portal sibling and does not forward its `className`, so `md:hidden` on the content would hide the panel and strand a full-screen scrim on desktop. `MobileNav` closes the drawer on breakpoint exit instead. This cannot reintroduce the flip — the drawer is always closed at first paint, so there is nothing for server and client to disagree about.
- **The `!` flags on the dropzone card heading were dropped, not ported.** They date from when the app's heading defaults lived in an unlayered CSS module and beat every Tailwind font-size; those defaults now sit in `base` and lose to any utility, so the overrides were fighting nothing.
- **Accepted behavior change:** on `/publisher`, a signed-in user's nav now resolves through `/auth/session` client-side rather than the publisher loader. This already matches how `/pricing` behaves when signed in. `PublisherHeader` still uses the loader `user`, so the publisher proper is unaffected.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [x] Refactor / chore (no functional change)

## Testing

Verified in the browser against the running dev server, not just by reading:

- **`/` now returns byte-identical HTML to a desktop UA and an iPhone UA** (112,255 bytes each, `diff`-clean). That is the property a prerendered, CDN-cached document needs and previously did not have.
- At 375px the desktop bar computes `display: none` and the mobile nav `display: flex`, with no JS involved.
- Tagged the nav DOM nodes, then navigated `/` → `/publisher` → `/` client-side: **all probes survived**, including the logo SVG, confirming no remount and no replayed logo fade. Footer disappears on `/publisher` and returns on `/`.
- SSR nav wrapper class is `""` for `/` and `/publisher`, and `"hidden"` for `/publisher/<sceneId>` — correct in the first bytes, so there is no flash to hydrate away.
- Grid background: 32 visible cells in an 8x4 grid at 375px, 64 in a 16x4 grid at desktop, with no overflow into implicit rows at either.
- Dropzone type ramps measured against the tokens: eyebrow 11px/500/1.54px tracking, h1 35.76px/500, h2 21.6px (no `!` needed), card titles 16px/500, captions 11px.

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

New unit coverage: `page-chrome.spec.ts` (route table, including that `/publisher-guide` is not swallowed by the prefix) and `nav-items.spec.tsx` (home matched exactly, others by prefix).

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes (443 passed)
- [ ] I updated documentation where needed
- [ ] I linked the related issue above

🤖 Generated with [Claude Code](https://claude.com/claude-code)