### PR TITLE
fix(build): make the package typecheck gates actually compile something

### DIFF
--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -31,14 +31,11 @@
 			}
 		},
 		"typecheck": {
-			"executor": "@nx/js:tsc",
-			"outputs": [
-				"{options.outputPath}"
-			],
+			"executor": "nx:run-commands",
+			"outputs": [],
 			"options": {
-				"tsConfig": "packages/core/tsconfig.json",
-				"outputPath": "build/packages/vctrl/core/typecheck",
-				"main": "packages/core/src/index.ts"
+				"cwd": "packages/core",
+				"command": "tsc --noEmit -p tsconfig.lib.json && tsc --noEmit -p tsconfig.spec.json"
 			}
 		},
 		"build": {

--- a/packages/embed/project.json
+++ b/packages/embed/project.json
@@ -36,7 +36,8 @@
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
-				"command": "tsc --noEmit -p packages/embed/tsconfig.json"
+				"cwd": "packages/embed",
+				"command": "tsc --noEmit -p tsconfig.lib.json && tsc --noEmit -p tsconfig.spec.json"
 			}
 		},
 		"build": {

--- a/packages/embed/tsconfig.json
+++ b/packages/embed/tsconfig.json
@@ -14,6 +14,9 @@
 	"references": [
 		{
 			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
 		}
 	],
 	"extends": "../../tsconfig.base.json"

--- a/packages/embed/tsconfig.spec.json
+++ b/packages/embed/tsconfig.spec.json
@@ -8,14 +8,6 @@
 		// native config loader can resolve it; type-checking is noEmit here.
 		"allowImportingTsExtensions": true
 	},
-	// `exclude` is inherited and beats a child's `include`, and the base config
-	// excludes spec files. Without clearing it this config resolves to zero
-	// spec files and silently checks nothing.
 	"exclude": [],
-	"include": [
-		"vite.config.ts",
-		"vitest.config.ts",
-		"src/**/*.spec.ts",
-		"src/**/*.d.ts"
-	]
+	"include": ["vitest.config.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/packages/viewer/project.json
+++ b/packages/viewer/project.json
@@ -36,7 +36,8 @@
 			"executor": "nx:run-commands",
 			"outputs": [],
 			"options": {
-				"command": "tsc --noEmit -p packages/viewer/tsconfig.json"
+				"cwd": "packages/viewer",
+				"command": "tsc --noEmit -p tsconfig.lib.json && tsc --noEmit -p tsconfig.spec.json"
 			}
 		},
 		"publish": {


### PR DESCRIPTION
## Summary

Two package typecheck gates have been passing unconditionally because they compile zero files, and spec files across the packages are typechecked by nothing at all. Found while verifying #722, which this stacks on.

## Changes

**`vctrl/viewer` and `vctrl/embed` compiled nothing.** Both pointed their typecheck target at their root `tsconfig.json`, which is solution-style — `"files": []`, `"include": []`, and only `references`. Plain `tsc -p` does not follow project references; that requires `--build`. So both commands type-checked an empty file set and always succeeded.

Measured with `--listFiles`:

| project | files compiled by the old command |
|---|---|
| `vctrl/viewer` | **0** |
| `vctrl/embed` | **0** |
| `vctrl/core` | 1258 |
| `storybook` | 896 |

Both now point at `tsconfig.lib.json`, matching how `vctrl/hooks` resolves its inferred target.

**Spec files were checked by nothing.** The `tsconfig.spec.json` files are consumed by the vitest plugin as a cache-key input only, never as a compiler entry point. Core's was inert even when invoked directly: it extends a base whose `exclude` lists `src/**/*.spec.ts`, and `exclude` is inherited and beats a child's `include`, so it resolved to zero spec files. Each typecheck now chains a spec pass the way the platform app already does (`tsc -p tsconfig.app.json --noEmit && tsc -p tsconfig.spec.json --noEmit`), core clears the inherited `exclude`, and `vctrl/embed` gains the spec config it was missing.

**Core moves off `@nx/js:tsc`.** It was emitting into `build/packages/vctrl/core/typecheck`, which nothing consumes, and that executor takes a single `tsConfig` so it could not cover specs. A plain `tsc --noEmit` is both cheaper and the right shape for a typecheck target.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [ ] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [x] No tests required — this is build configuration, verified directly

A gate that has never failed is worth proving rather than assuming, so I injected a type error into **both a source file and a spec file** in each of the three packages and confirmed every target fails:

```
src/components/scene/animation-playback.spec.ts:401:7 - error TS2322: Type 'string' is not assignable to type 'number'.
```

Then reverted every probe and confirmed all four packages pass. Note the `&&` short-circuits, so a source error masks the spec pass — the two were verified separately.

**Expect new failures on other branches.** These gates have been inert for some time, so any pre-existing type error in `packages/viewer` or `packages/embed` source, or in any spec file, surfaces for the first time here. Nothing on this branch or `main` failed, but a branch in flight might.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes — and now means something
- [x] `pnpm nx affected --target=test` passes
- [ ] I updated documentation where needed — no docs describe these targets
- [ ] I linked the related issue above — no tracking issue
