### PR TITLE
fix(embed): serve embeds the published GLB instead of the editor's assets

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -15,7 +15,10 @@ import { useAtom, useSetAtom } from 'jotai/react'
 import { Crosshair, Eye, EyeOff, Plus, Trash2 } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo } from 'react'
 
-import { resolveDefaultSceneCameraId } from '../../../../lib/domain/scene/scene-camera'
+import {
+	PAIRED_HOTSPOT_CAMERA_ID_PREFIX,
+	resolveDefaultSceneCameraId
+} from '../../../../lib/domain/scene/scene-camera'
 import {
 	addHotspot,
 	relinkHotspot,
@@ -54,7 +57,7 @@ import type {
  */
 const mintHotspotIds = () => ({
 	hotspotId: crypto.randomUUID(),
-	cameraId: `hotspot-camera-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+	cameraId: `${PAIRED_HOTSPOT_CAMERA_ID_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
 })
 
 /**

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-asset-policy.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-asset-policy.ts
@@ -1,0 +1,146 @@
+import { PERSISTED_BAKE_FILENAME } from '@vctrl/core'
+
+import type { SceneAssetRef, SceneAssetRefMap } from '@vctrl/core'
+
+/**
+ * The single owner of "what may an external embed fetch?".
+ *
+ * This rule used to live in two places that had no reason to agree, and they
+ * did not: the manifest offered every `scene_assets` row while the asset route
+ * served only `scene_published.asset_id`, which `uploadPublishedGlb` never
+ * links into `scene_assets`. The two sets were disjoint, so every asset an
+ * embed requested 404'd and no embed could ever render.
+ *
+ * Both sides now call this module. It is pure - no database import and no
+ * `.server` suffix - so a test can import it, which is what makes the
+ * disjointness assertable. Importing a server route module in a test pulls in
+ * the db client and fails with `Missing DATABASE_URL`; `scene-route-params.ts`
+ * is the precedent for extracting the decision instead.
+ */
+
+/** The `scene_assets` columns this policy needs. */
+export interface EmbedAssetRow {
+	id: string
+	name: string
+	mimeType: string | null
+	fileSize: number | null
+}
+
+/** The published GLB, as `getPublishedScenePreview` returns it. */
+export interface PublishedModelRow {
+	assetId: string
+	fileName: string | null
+	mimeType: string | null
+	byteSize: number | null
+}
+
+/**
+ * Every asset id an embed is allowed to fetch, and therefore every asset id the
+ * embed manifest is allowed to reference. Deliberately a closed set of two:
+ * the optimized GLB, and the persisted shadow bake that lives outside it.
+ */
+export interface EmbedServableAssets {
+	publishedAssetId: string
+	bakeAssetId: string | null
+}
+
+const GLB_MIME_TYPE = 'model/gltf-binary'
+const FALLBACK_GLB_FILENAME = 'scene.glb'
+
+/**
+ * Resolves the bake from two independent sources and requires them to agree.
+ *
+ * `settings.shadows.baked.assetId` carries intent but is user-writable through
+ * the save path, so it cannot authorize on its own - otherwise a crafted save
+ * could name any linked asset as "the bake" and have it served to anonymous
+ * embed traffic. The `scene_assets` link plus the stable filename is the
+ * authorization half, and the filename alone is not an identity either, because
+ * assets are deduplicated per project by content hash.
+ */
+export function selectEmbedServableAssets({
+	publishedAssetId,
+	sceneAssets,
+	bakedShadowAssetId
+}: {
+	publishedAssetId: string
+	sceneAssets: readonly EmbedAssetRow[]
+	bakedShadowAssetId?: string | null
+}): EmbedServableAssets {
+	const declaredBakeId = bakedShadowAssetId?.trim() || null
+
+	const bakeAssetId =
+		declaredBakeId &&
+		sceneAssets.some(
+			(asset) =>
+				asset.id === declaredBakeId && asset.name === PERSISTED_BAKE_FILENAME
+		)
+			? declaredBakeId
+			: null
+
+	return { publishedAssetId, bakeAssetId }
+}
+
+export function isEmbedServableAssetId(
+	assetId: string,
+	servable: EmbedServableAssets
+): boolean {
+	return (
+		assetId === servable.publishedAssetId ||
+		(servable.bakeAssetId !== null && assetId === servable.bakeAssetId)
+	)
+}
+
+/**
+ * The manifest's `assetRefs` for an embed: the bake and nothing else. The
+ * published GLB is referenced separately as `publishedModel`, because the
+ * loader treats it as the model rather than as a side asset.
+ */
+export function buildEmbedAssetRefs(
+	servable: EmbedServableAssets,
+	sceneAssets: readonly EmbedAssetRow[],
+	buildAssetUrl: (assetId: string) => string
+): SceneAssetRefMap {
+	if (servable.bakeAssetId === null) {
+		return {}
+	}
+
+	const bakeAsset = sceneAssets.find(
+		(asset) => asset.id === servable.bakeAssetId
+	)
+	if (!bakeAsset) {
+		return {}
+	}
+
+	return {
+		[bakeAsset.id]: {
+			url: buildAssetUrl(bakeAsset.id),
+			fileName: bakeAsset.name,
+			mimeType: bakeAsset.mimeType ?? 'application/octet-stream',
+			byteSize: bakeAsset.fileSize ?? null
+		}
+	}
+}
+
+/**
+ * The filename is forced to end in `.glb` because the client hands it to
+ * `ModelLoader.getFileType`, which throws on an extension it does not
+ * recognize. Publishing has always written `<base>.glb`, but a stored name is
+ * data and a crash here would take the whole embed down.
+ */
+export function buildPublishedModelRef(
+	published: PublishedModelRow,
+	buildAssetUrl: (assetId: string) => string
+): SceneAssetRef {
+	const storedName = published.fileName?.trim()
+	const fileName =
+		storedName && storedName.toLowerCase().endsWith('.glb')
+			? storedName
+			: FALLBACK_GLB_FILENAME
+
+	return {
+		url: buildAssetUrl(published.assetId),
+		fileName,
+		mimeType: published.mimeType ?? GLB_MIME_TYPE,
+		byteSize: published.byteSize ?? null
+	}
+}

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts
@@ -1,0 +1,169 @@
+import { isSceneCamera } from './scene-camera'
+
+import type { SceneSettings } from '@vctrl/core'
+
+/**
+ * The single owner of "what scene settings may an external embed see?".
+ *
+ * Filtering the `hotspots` array is not enough. A hotspot carries a
+ * `linkedCameraId` pointing at an entry in `camera.cameras` with
+ * `kind: 'hotspot'`, and that entry holds the viewpoint's full pose and name.
+ * Dropping the hotspot while keeping its camera leaves the "hidden" viewpoint
+ * readable in the manifest JSON *and* reachable at runtime: `@vctrl/embed`
+ * exposes `activateCamera(cameraId)`, so any third-party page could fly an
+ * anonymous visitor straight to it. `internalOnly` is a visibility contract
+ * (see `SceneSettings.hotspots` in `@vctrl/core`), so it has to hold across
+ * every field that can resurrect the hotspot, not just the array it lives in.
+ *
+ * Pure - no database import and no `.server` suffix - so the rule is testable
+ * on its own rather than only through a route.
+ */
+
+/**
+ * Id prefix the publisher mints every hotspot-paired camera with.
+ *
+ * Exported so the panel that mints them and the policy that recognizes them
+ * share one literal. Only the prefix is shared; the full minted shape is
+ * asserted separately by {@link PAIRED_HOTSPOT_CAMERA_ID}, which is a fallback
+ * for scenes saved before paired cameras carried `kind: 'hotspot'` - current
+ * ones are classified by the tag and never reach it.
+ */
+export const PAIRED_HOTSPOT_CAMERA_ID_PREFIX = 'hotspot-camera-'
+
+/**
+ * The full minted shape: `hotspot-camera-<epoch-millis>-<base36 suffix>`.
+ *
+ * Matching the whole shape rather than the bare prefix, because ordinary camera
+ * ids are slugified from the user's own camera name (`deriveUniqueSlug` in
+ * `@shared/utils`). Someone renaming a camera to "Hotspot Camera 1" gets the id
+ * `hotspot-camera-1`, and a prefix test would classify that perfectly ordinary
+ * camera as a hotspot pair and drop it from the embed - visible nowhere else,
+ * since the publisher, the dashboard and `/preview` all classify by `kind`.
+ * A slugified name cannot produce a 13-digit epoch and a base36 suffix.
+ */
+const PAIRED_HOTSPOT_CAMERA_ID = /^hotspot-camera-\d{10,}-[a-z0-9]{1,8}$/
+
+/** Whether a camera id was minted by the publisher as a hotspot pair. */
+export function isPairedHotspotCameraId(cameraId: string): boolean {
+	return PAIRED_HOTSPOT_CAMERA_ID.test(cameraId)
+}
+
+/**
+ * Removes everything an embed must not see from a scene's settings.
+ *
+ * - `internalOnly` hotspots, and any hotspot camera no surviving hotspot links
+ *   to. A camera counts as a hotspot camera when it is tagged `kind: 'hotspot'`
+ *   or carries a publisher-minted paired-camera id - see the comment on
+ *   `isVisibleCamera`. Orphans go too: a hotspot camera whose hotspot was
+ *   deleted is a viewpoint nothing on the published surface can reach.
+ * - Interactions that would activate a removed camera, and the active-camera
+ *   selection if it pointed at one.
+ * - A `shadows.baked` pointer the asset gate would refuse. `bakeAssetId` is the
+ *   id `selectEmbedServableAssets` authorized; anything else is a stale or
+ *   tampered reference whose bytes the embed cannot fetch anyway, so shipping
+ *   the id would leak an internal identifier for nothing.
+ */
+export function redactSettingsForEmbed(
+	settings: SceneSettings,
+	{ bakeAssetId }: { bakeAssetId: string | null }
+): SceneSettings {
+	const visibleHotspots = settings.hotspots?.filter(
+		(hotspot) => !hotspot.internalOnly
+	)
+
+	const linkedCameraIds = (hotspots: typeof settings.hotspots) =>
+		new Set(
+			(hotspots ?? [])
+				.map((hotspot) => hotspot.linkedCameraId)
+				.filter((cameraId): cameraId is string => Boolean(cameraId))
+		)
+
+	const visibleHotspotLinks = linkedCameraIds(visibleHotspots)
+
+	/*
+	  What makes a camera a hotspot camera: its tag, or the id the publisher
+	  minted it with.
+
+	  The publisher only started writing `kind: 'hotspot'` on paired cameras
+	  recently, so every scene saved before that has an untagged one - and
+	  `isSceneCamera` reads a missing `kind` as "scene". Trusting the tag alone
+	  would keep exactly the cameras this redaction exists to remove, for exactly
+	  the scenes already in the database.
+
+	  The minted id is the reliable second signal - the whole shape, not the bare
+	  prefix, for the reason on `PAIRED_HOTSPOT_CAMERA_ID`.
+
+	  Linkage deliberately is NOT the signal. A hotspot may link any camera the
+	  author picks, including the scene's own default - the picker offers every
+	  camera and the server validates only that the id exists. Promoting a camera
+	  on linkage alone would let one internal hotspot delete the scene's default
+	  view from the embed. That camera is a scene camera in its own right and its
+	  pose is public regardless; only the hotspot has to disappear.
+	*/
+	const isVisibleCamera = (camera: { cameraId?: string; kind?: string }) => {
+		const cameraId = camera.cameraId
+		const isHotspotCamera =
+			camera.kind === 'hotspot' ||
+			(camera.kind === undefined &&
+				cameraId !== undefined &&
+				isPairedHotspotCameraId(cameraId))
+
+		if (isHotspotCamera) {
+			return cameraId !== undefined && visibleHotspotLinks.has(cameraId)
+		}
+
+		return isSceneCamera(camera)
+	}
+
+	const cameras = settings.camera?.cameras
+	const visibleCameras = cameras?.filter(isVisibleCamera)
+
+	const removedCameraIds = new Set(
+		(cameras ?? [])
+			.filter((camera) => !isVisibleCamera(camera))
+			.map((camera) => camera.cameraId)
+	)
+
+	const camera = settings.camera
+		? {
+				...settings.camera,
+				cameras: visibleCameras,
+				activeCameraId:
+					settings.camera.activeCameraId !== undefined &&
+					removedCameraIds.has(settings.camera.activeCameraId)
+						? undefined
+						: settings.camera.activeCameraId
+			}
+		: settings.camera
+
+	// A rule whose only action is now gone would fire as a no-op, so the rule
+	// goes with it rather than being left half-applied.
+	const interactions = settings.interactions
+		?.map((interaction) => ({
+			...interaction,
+			actions: interaction.actions.filter(
+				(action) =>
+					action.type !== 'activate_camera' ||
+					!removedCameraIds.has(action.cameraId)
+			)
+		}))
+		.filter((interaction) => interaction.actions.length > 0)
+
+	const shadows = settings.shadows
+		? {
+				...settings.shadows,
+				baked:
+					settings.shadows.baked && settings.shadows.baked.assetId === bakeAssetId
+						? settings.shadows.baked
+						: undefined
+			}
+		: settings.shadows
+
+	return {
+		...settings,
+		hotspots: visibleHotspots,
+		camera,
+		interactions,
+		shadows
+	}
+}

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts
@@ -1,4 +1,4 @@
-import { isSceneCamera } from './scene-camera'
+import { isPairedHotspotCamera, isSceneCamera } from './scene-camera'
 
 import type { SceneSettings } from '@vctrl/core'
 
@@ -18,35 +18,6 @@ import type { SceneSettings } from '@vctrl/core'
  * Pure - no database import and no `.server` suffix - so the rule is testable
  * on its own rather than only through a route.
  */
-
-/**
- * Id prefix the publisher mints every hotspot-paired camera with.
- *
- * Exported so the panel that mints them and the policy that recognizes them
- * share one literal. Only the prefix is shared; the full minted shape is
- * asserted separately by {@link PAIRED_HOTSPOT_CAMERA_ID}, which is a fallback
- * for scenes saved before paired cameras carried `kind: 'hotspot'` - current
- * ones are classified by the tag and never reach it.
- */
-export const PAIRED_HOTSPOT_CAMERA_ID_PREFIX = 'hotspot-camera-'
-
-/**
- * The full minted shape: `hotspot-camera-<epoch-millis>-<base36 suffix>`.
- *
- * Matching the whole shape rather than the bare prefix, because ordinary camera
- * ids are slugified from the user's own camera name (`deriveUniqueSlug` in
- * `@shared/utils`). Someone renaming a camera to "Hotspot Camera 1" gets the id
- * `hotspot-camera-1`, and a prefix test would classify that perfectly ordinary
- * camera as a hotspot pair and drop it from the embed - visible nowhere else,
- * since the publisher, the dashboard and `/preview` all classify by `kind`.
- * A slugified name cannot produce a 13-digit epoch and a base36 suffix.
- */
-const PAIRED_HOTSPOT_CAMERA_ID = /^hotspot-camera-\d{10,}-[a-z0-9]{1,8}$/
-
-/** Whether a camera id was minted by the publisher as a hotspot pair. */
-export function isPairedHotspotCameraId(cameraId: string): boolean {
-	return PAIRED_HOTSPOT_CAMERA_ID.test(cameraId)
-}
 
 /**
  * Removes everything an embed must not see from a scene's settings.
@@ -81,34 +52,18 @@ export function redactSettingsForEmbed(
 	const visibleHotspotLinks = linkedCameraIds(visibleHotspots)
 
 	/*
-	  What makes a camera a hotspot camera: its tag, or the id the publisher
-	  minted it with.
-
-	  The publisher only started writing `kind: 'hotspot'` on paired cameras
-	  recently, so every scene saved before that has an untagged one - and
-	  `isSceneCamera` reads a missing `kind` as "scene". Trusting the tag alone
-	  would keep exactly the cameras this redaction exists to remove, for exactly
-	  the scenes already in the database.
-
-	  The minted id is the reliable second signal - the whole shape, not the bare
-	  prefix, for the reason on `PAIRED_HOTSPOT_CAMERA_ID`.
-
-	  Linkage deliberately is NOT the signal. A hotspot may link any camera the
-	  author picks, including the scene's own default - the picker offers every
-	  camera and the server validates only that the id exists. Promoting a camera
-	  on linkage alone would let one internal hotspot delete the scene's default
-	  view from the embed. That camera is a scene camera in its own right and its
-	  pose is public regardless; only the hotspot has to disappear.
+	  Linkage deliberately is NOT what makes a camera a hotspot camera. A hotspot
+	  may link any camera the author picks, including the scene's own default -
+	  the picker offers every camera and the server validates only that the id
+	  exists. Promoting a camera on linkage alone would let one internal hotspot
+	  delete the scene's opening view from the embed. That camera is a scene
+	  camera in its own right and its pose is public regardless; only the hotspot
+	  has to disappear.
 	*/
 	const isVisibleCamera = (camera: { cameraId?: string; kind?: string }) => {
 		const cameraId = camera.cameraId
-		const isHotspotCamera =
-			camera.kind === 'hotspot' ||
-			(camera.kind === undefined &&
-				cameraId !== undefined &&
-				isPairedHotspotCameraId(cameraId))
 
-		if (isHotspotCamera) {
+		if (isPairedHotspotCamera(camera)) {
 			return cameraId !== undefined && visibleHotspotLinks.has(cameraId)
 		}
 

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-manifest.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-manifest.server.ts
@@ -1,10 +1,18 @@
 import { SCENE_THUMBNAIL_FILENAME } from '@vctrl/core'
 
 import { sceneSettingsService } from './scene-settings-service.server'
+import {
+	buildEmbedAssetRefs,
+	buildPublishedModelRef,
+	selectEmbedServableAssets,
+	type PublishedModelRow
+} from '../embed-asset-policy'
+import { redactSettingsForEmbed } from '../embed-settings-policy'
 
 import type {
 	SceneAssetRecord,
 	SceneAssetRefMap,
+	SceneEmbedManifestResponse,
 	SceneManifestResponse
 } from '../../../../types/api'
 
@@ -84,15 +92,91 @@ export async function buildSceneManifest(
 }
 
 /**
+ * The manifest an external, token-authenticated embed receives.
+ *
+ * Deliberately a different function rather than a flag on
+ * {@link buildSceneManifest}: `/preview` and the publisher keep the editor
+ * manifest untouched by construction, and the two shapes cannot drift into
+ * each other by someone reading the flag the wrong way round.
+ *
+ * What an embed does NOT get, and why:
+ * - `gltfJson` - the editor scene graph: node hierarchy, material graph, every
+ *   internal name, and URIs of assets this caller may not fetch. Once
+ *   `publishedModel` exists the embed has no use for it.
+ * - `assets` - the raw row array leaks every editor filename and asset id.
+ * - `stats` - nothing on the embed surface reads it.
+ * - anything `redactSettingsForEmbed` strips: `internalOnly` hotspots, the
+ *   hotspot cameras that would resurrect them, interactions targeting those
+ *   cameras, and an unauthorized `shadows.baked` pointer. `SceneSettings`
+ *   documents internal hotspots as excluded from the published runtime payload;
+ *   `getSceneSettings` honors that behind a `forPublicView` flag no caller has
+ *   ever passed, and this path never filtered at all, so they have been
+ *   shipping to embeds.
+ */
+export async function buildEmbedSceneManifest(
+	sceneId: string,
+	published: PublishedModelRow,
+	buildAssetUrl: (assetId: string) => string
+): Promise<SceneEmbedManifestResponse> {
+	const settingsData = await sceneSettingsService.getSceneSettingsWithAssetRefs(
+		sceneId,
+		{ includeGltfJson: false }
+	)
+
+	const publishedModel = buildPublishedModelRef(published, buildAssetUrl)
+
+	if (!settingsData) {
+		return {
+			sceneId,
+			meta: await sceneSettingsService.getSceneMetadata(sceneId),
+			publishedModel,
+			settings: null,
+			assetRefs: {},
+			settingsUpdatedAt: null
+		}
+	}
+
+	const settings = settingsData.settings
+	const servable = selectEmbedServableAssets({
+		publishedAssetId: published.assetId,
+		sceneAssets: settingsData.assets ?? [],
+		bakedShadowAssetId: settings?.shadows?.baked?.assetId
+	})
+
+	return {
+		sceneId,
+		meta: settingsData.meta,
+		publishedModel,
+		settings: settings
+			? redactSettingsForEmbed(settings, { bakeAssetId: servable.bakeAssetId })
+			: null,
+		assetRefs: buildEmbedAssetRefs(
+			servable,
+			settingsData.assets ?? [],
+			buildAssetUrl
+		),
+		settingsUpdatedAt: settingsData.settingsUpdatedAt
+			? settingsData.settingsUpdatedAt.toISOString()
+			: null
+	}
+}
+
+/**
  * Returns a weak ETag for the scene manifest based on the scene ID and the
  * timestamp of the last settings save. Returns null when no timestamp is
  * available so callers can skip caching headers entirely.
+ *
+ * `shape` keeps the embed and session manifests for one scene in separate
+ * cache entries. They carry different fields from the same `settingsUpdatedAt`,
+ * so a shared tag would let one be served in place of the other.
  */
 export function buildSceneManifestEtag(
 	sceneId: string,
-	settingsUpdatedAt: string | null
+	settingsUpdatedAt: string | null,
+	shape: 'session' | 'embed' = 'session'
 ): string | null {
 	if (!settingsUpdatedAt) return null
-	return `W/"scene-${sceneId}-${settingsUpdatedAt}"`
+	const prefix = shape === 'embed' ? 'scene-embed' : 'scene'
+	return `W/"${prefix}-${sceneId}-${settingsUpdatedAt}"`
 }
 

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-preview-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-preview-repository.server.ts
@@ -5,6 +5,8 @@ import { assets } from '../../../../db/schema/project/assets'
 import { scenePublished } from '../../../../db/schema/project/scene-published'
 import { scenes } from '../../../../db/schema/project/scenes'
 
+import type { PublishedModelRow } from '../embed-asset-policy'
+
 const db = getDbClient()
 
 export async function getPublishedScenePreview(
@@ -18,7 +20,9 @@ export async function getPublishedScenePreview(
 			status: scenes.status,
 			publishedAssetId: scenePublished.assetId,
 			publishedAt: scenePublished.publishedAt,
-			publishedAssetSizeBytes: assets.fileSize
+			publishedAssetSizeBytes: assets.fileSize,
+			publishedAssetName: assets.name,
+			publishedAssetMimeType: assets.mimeType
 		})
 		.from(scenes)
 		.innerJoin(scenePublished, eq(scenePublished.sceneId, scenes.id))
@@ -35,4 +39,20 @@ export async function getPublishedScenePreview(
 	}
 
 	return rows[0]
+}
+
+export type PublishedScenePreview = NonNullable<
+	Awaited<ReturnType<typeof getPublishedScenePreview>>
+>
+
+/** Adapts the query row to the shape `embed-asset-policy` reasons about. */
+export function toPublishedModelRow(
+	preview: PublishedScenePreview
+): PublishedModelRow {
+	return {
+		assetId: preview.publishedAssetId,
+		fileName: preview.publishedAssetName,
+		mimeType: preview.publishedAssetMimeType,
+		byteSize: preview.publishedAssetSizeBytes
+	}
 }

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
@@ -537,7 +537,16 @@ class SceneSettingsService {
 	 * Downloads just the glTF JSON asset; binary assets are served by
 	 * reference through the scene asset endpoint instead of being inlined.
 	 */
-	async getSceneSettingsWithAssetRefs(sceneId: string) {
+	/**
+	 * `includeGltfJson` is opt-out because the embed manifest never sends the
+	 * editor glTF document, and downloading plus parsing it would be a storage
+	 * round-trip per embed load for bytes that are then discarded.
+	 */
+	async getSceneSettingsWithAssetRefs(
+		sceneId: string,
+		options: { includeGltfJson?: boolean } = {}
+	) {
+		const { includeGltfJson = true } = options
 		let result: Awaited<ReturnType<typeof getSceneSettingsWithAssetsRow>>
 		let hotspots: import('@vctrl/core').HotspotDefinition[] = []
 
@@ -562,9 +571,9 @@ class SceneSettingsService {
 		const { settings, assets: sceneAssetsData } = result
 
 		let gltfJson: ExtendedGLTFDocument | null = null
-		const gltfAsset = sceneAssetsData.find(
-			(asset) => asset.mimeType === 'model/gltf+json'
-		)
+		const gltfAsset = includeGltfJson
+			? sceneAssetsData.find((asset) => asset.mimeType === 'model/gltf+json')
+			: undefined
 
 		if (gltfAsset) {
 			try {

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.assets.$assetId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.assets.$assetId.ts
@@ -5,8 +5,13 @@ import { getDbClient } from '../../db/client'
 import { sceneAssets, sceneSettings } from '../../db/schema'
 import { downloadAsset } from '../../lib/domain/asset/asset-storage.server'
 import { validatePreviewApiKeyForProject } from '../../lib/domain/auth/preview-api-key-auth.server'
+import {
+	isEmbedServableAssetId,
+	selectEmbedServableAssets
+} from '../../lib/domain/scene/embed-asset-policy'
 import { getScene } from '../../lib/domain/scene/server/scene-folder-repository.server'
 import { getPublishedScenePreview } from '../../lib/domain/scene/server/scene-preview-repository.server'
+import { sceneSettingsService } from '../../lib/domain/scene/server/scene-settings-service.server'
 import { getAuthUser } from '../../lib/http/auth.server'
 
 const db = getDbClient()
@@ -129,7 +134,31 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		}
 
 		const previewScene = await getPublishedScenePreview(projectId, sceneId)
-		if (!previewScene || previewScene.publishedAssetId !== assetId) {
+		if (!previewScene) {
+			return new Response('Asset not found', {
+				status: 404,
+				headers: withNoStoreHeaders()
+			})
+		}
+
+		/*
+		  The servable set is computed by the same module the embed manifest
+		  builds its refs from. This gate used to be an equality against
+		  `publishedAssetId` alone - an id `uploadPublishedGlb` never links into
+		  `scene_assets`, and therefore an id the manifest never referenced. The
+		  two sets were disjoint, so every asset an embed asked for 404'd.
+		*/
+		const settingsData =
+			await sceneSettingsService.getSceneSettingsWithAssetRefs(sceneId, {
+				includeGltfJson: false
+			})
+		const servable = selectEmbedServableAssets({
+			publishedAssetId: previewScene.publishedAssetId,
+			sceneAssets: settingsData?.assets ?? [],
+			bakedShadowAssetId: settingsData?.settings?.shadows?.baked?.assetId
+		})
+
+		if (!isEmbedServableAssetId(assetId, servable)) {
 			return new Response('Asset not found', {
 				status: 404,
 				headers: withNoStoreHeaders()

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
@@ -20,10 +20,14 @@ import {
 	updateSceneMetadata
 } from '../../lib/domain/scene/server/scene-folder-repository.server'
 import {
+	buildEmbedSceneManifest,
 	buildSceneManifest,
 	buildSceneManifestEtag
 } from '../../lib/domain/scene/server/scene-manifest.server'
-import { getPublishedScenePreview } from '../../lib/domain/scene/server/scene-preview-repository.server'
+import {
+	getPublishedScenePreview,
+	toPublishedModelRow
+} from '../../lib/domain/scene/server/scene-preview-repository.server'
 import * as sceneSettingsOps from '../../lib/domain/scene/server/scene-settings.operations.server'
 import { SceneSettingsParser } from '../../lib/domain/scene/server/scene-settings.parser.server'
 import { getAuthUser } from '../../lib/http/auth.server'
@@ -33,6 +37,7 @@ import {
 } from '../../lib/http/csrf.server'
 import { ensurePost, parseActionRequest } from '../../lib/http/requests.server'
 
+import type { PublishedModelRow } from '../../lib/domain/scene/embed-asset-policy'
 import type { SceneSettingsAction } from '../../types/api'
 
 function withNoStoreHeaders(response: Response): Response {
@@ -292,6 +297,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 			return authContext
 		}
 
+		let publishedModelRow: PublishedModelRow | null = null
+
 		if (authContext.mode === 'apiKey') {
 			const previewScene = await getPublishedScenePreview(
 				previewProjectId,
@@ -300,6 +307,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 			if (!previewScene) {
 				return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
 			}
+			publishedModelRow = toPublishedModelRow(previewScene)
 		} else {
 			const scene = await getScene(sceneId, authContext.userId)
 			if (!scene || scene.projectId !== previewProjectId) {
@@ -318,8 +326,18 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		}
 
 		try {
-			const manifest = await buildSceneManifest(sceneId, buildPreviewAssetUrl)
-			const etag = buildSceneManifestEtag(sceneId, manifest.settingsUpdatedAt)
+			const manifest = publishedModelRow
+				? await buildEmbedSceneManifest(
+						sceneId,
+						publishedModelRow,
+						buildPreviewAssetUrl
+					)
+				: await buildSceneManifest(sceneId, buildPreviewAssetUrl)
+			const etag = buildSceneManifestEtag(
+				sceneId,
+				manifest.settingsUpdatedAt,
+				publishedModelRow ? 'embed' : 'session'
+			)
 
 			if (etag && request.headers.get('If-None-Match') === etag) {
 				if (authContext.mode === 'session') {
@@ -458,15 +476,21 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		const previewSessionHeaders =
 			authContext.mode === 'session' ? authContext.headers : undefined
 
+		/*
+		  Token callers get the GET manifest and nothing else.
+
+		  `getSceneSettings` returns every editor asset base64-inlined plus the
+		  full glTF document, which is exactly what the embed manifest is built
+		  to withhold. The client's `fetchManifestPayload` falls back to this
+		  POST whenever a manifest fails its shape check, so leaving it open to
+		  an API key would let the embed quietly re-acquire the editor payload
+		  the moment the manifest stopped carrying it.
+		*/
 		if (authContext.mode === 'apiKey') {
-			const previewScene = await getPublishedScenePreview(
-				previewProjectId,
-				routeSceneId
-			)
-			if (!previewScene) {
-				return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
-			}
-		} else {
+			return withNoStoreHeaders(ApiResponse.forbidden('Forbidden'))
+		}
+
+		{
 			const scene = await getScene(routeSceneId, authContext.userId)
 			if (!scene || scene.projectId !== previewProjectId) {
 				return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
@@ -482,12 +506,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		}
 
 		const effectiveSceneId = parsedRequest.sceneId?.trim() || routeSceneId
-		const requestScope =
-			authContext.mode === 'apiKey'
-				? `preview-api-key-${previewProjectId}`
-				: `preview-session-${authContext.userId}`
 		const requestKey = getSceneSettingsRequestKey(
-			requestScope,
+			`preview-session-${authContext.userId}`,
 			effectiveSceneId
 		)
 

--- a/apps/vectreal-platform/app/types/api.ts
+++ b/apps/vectreal-platform/app/types/api.ts
@@ -10,6 +10,7 @@ import type {
 	ExtendedGLTFDocument,
 	Optimizations,
 	OptimizationReport,
+	SceneAssetRef,
 	SceneAssetRefMap,
 	SceneSettings,
 	SerializedGLTFExportResult
@@ -159,6 +160,23 @@ export interface SceneManifestResponse {
 	readonly assetRefs: SceneAssetRefMap | null
 	readonly assets: SceneAssetRecord[] | null
 	readonly settings?: SceneSettings | null
+	readonly settingsUpdatedAt: string | null
+}
+
+/**
+ * The manifest an external embed receives. Not a `Partial` of
+ * {@link SceneManifestResponse}: the fields it omits are omitted on purpose
+ * (see `buildEmbedSceneManifest`), and a shared optional type would let one of
+ * them be added back without anyone noticing.
+ */
+export interface SceneEmbedManifestResponse {
+	readonly sceneId: string
+	readonly meta: SceneMetaState | null
+	/** The optimized, published GLB. The only model an embed ever loads. */
+	readonly publishedModel: SceneAssetRef
+	/** The persisted shadow bake, which lives outside the GLB. Often empty. */
+	readonly assetRefs: SceneAssetRefMap
+	readonly settings: SceneSettings | null
 	readonly settingsUpdatedAt: string | null
 }
 

--- a/apps/vectreal-platform/tests/embed-asset-policy.spec.ts
+++ b/apps/vectreal-platform/tests/embed-asset-policy.spec.ts
@@ -1,0 +1,231 @@
+import { PERSISTED_BAKE_FILENAME, SCENE_THUMBNAIL_FILENAME } from '@vctrl/core'
+import { describe, expect, it } from 'vitest'
+
+import {
+	buildEmbedAssetRefs,
+	buildPublishedModelRef,
+	isEmbedServableAssetId,
+	selectEmbedServableAssets,
+	type EmbedAssetRow
+} from '../app/lib/domain/scene/embed-asset-policy'
+
+/**
+ * The production shape that broke embeds: `scene_published.asset_id` is written
+ * by `uploadPublishedGlb`, which never links into `scene_assets`, so the
+ * published GLB is deliberately absent from the rows below.
+ */
+const PUBLISHED_ASSET_ID = 'published-glb-id'
+const BAKE_ASSET_ID = 'bake-id'
+
+const SCENE_ASSETS: EmbedAssetRow[] = [
+	{
+		id: 'buffer-id',
+		name: 'buffer.bin',
+		mimeType: 'application/octet-stream',
+		fileSize: 2902308
+	},
+	{
+		id: 'basecolor-id',
+		name: 'Shoe_baseColor.webp',
+		mimeType: 'image/webp',
+		fileSize: 84996
+	},
+	{
+		id: 'normal-id',
+		name: 'Shoe_normal.webp',
+		mimeType: 'image/webp',
+		fileSize: 126712
+	},
+	{
+		id: BAKE_ASSET_ID,
+		name: PERSISTED_BAKE_FILENAME,
+		mimeType: 'image/png',
+		fileSize: 27530
+	},
+	{
+		id: 'thumbnail-id',
+		name: SCENE_THUMBNAIL_FILENAME,
+		mimeType: 'image/webp',
+		fileSize: 4096
+	},
+	{
+		id: 'gltf-id',
+		name: 'scene.gltf',
+		mimeType: 'model/gltf+json',
+		fileSize: 15000
+	}
+]
+
+const buildAssetUrl = (assetId: string) => `/api/assets/${assetId}`
+
+function servableWithBake() {
+	return selectEmbedServableAssets({
+		publishedAssetId: PUBLISHED_ASSET_ID,
+		sceneAssets: SCENE_ASSETS,
+		bakedShadowAssetId: BAKE_ASSET_ID
+	})
+}
+
+describe('embed asset policy', () => {
+	/**
+	 * The invariant the two halves of the embed path violated. Asserting it as
+	 * one property is the whole point: testing the manifest and the gate
+	 * separately is exactly what let them end up disjoint while each looked
+	 * correct on its own.
+	 */
+	it('serves every asset the embed manifest references, and nothing else', () => {
+		const servable = servableWithBake()
+		const refs = buildEmbedAssetRefs(servable, SCENE_ASSETS, buildAssetUrl)
+		const publishedModel = buildPublishedModelRef(
+			{
+				assetId: PUBLISHED_ASSET_ID,
+				fileName: 'shoe.glb',
+				mimeType: 'model/gltf-binary',
+				byteSize: 812345
+			},
+			buildAssetUrl
+		)
+
+		const referenced = [...Object.keys(refs), PUBLISHED_ASSET_ID]
+
+		for (const assetId of referenced) {
+			expect(
+				isEmbedServableAssetId(assetId, servable),
+				`manifest references ${assetId} but the gate would refuse it`
+			).toBe(true)
+		}
+
+		expect(publishedModel.url).toBe(buildAssetUrl(PUBLISHED_ASSET_ID))
+	})
+
+	it('refuses every editor asset the manifest does not reference', () => {
+		const servable = servableWithBake()
+		const refused = SCENE_ASSETS.filter(
+			(asset) => asset.id !== BAKE_ASSET_ID
+		).map((asset) => asset.id)
+
+		for (const assetId of refused) {
+			expect(
+				isEmbedServableAssetId(assetId, servable),
+				`${assetId} is an editor asset and must not be servable`
+			).toBe(false)
+		}
+	})
+
+	it('references only the bake, never the source buffers or textures', () => {
+		const refs = buildEmbedAssetRefs(
+			servableWithBake(),
+			SCENE_ASSETS,
+			buildAssetUrl
+		)
+
+		expect(Object.keys(refs)).toEqual([BAKE_ASSET_ID])
+		expect(refs[BAKE_ASSET_ID]).toEqual({
+			url: buildAssetUrl(BAKE_ASSET_ID),
+			fileName: PERSISTED_BAKE_FILENAME,
+			mimeType: 'image/png',
+			byteSize: 27530
+		})
+	})
+
+	describe('bake resolution requires intent and authorization to agree', () => {
+		it('resolves when the declared id is a linked row with the bake filename', () => {
+			expect(servableWithBake().bakeAssetId).toBe(BAKE_ASSET_ID)
+		})
+
+		it('refuses a declared id that is not linked to the scene', () => {
+			const servable = selectEmbedServableAssets({
+				publishedAssetId: PUBLISHED_ASSET_ID,
+				sceneAssets: SCENE_ASSETS,
+				bakedShadowAssetId: 'some-other-scenes-bake'
+			})
+
+			expect(servable.bakeAssetId).toBeNull()
+			expect(isEmbedServableAssetId('some-other-scenes-bake', servable)).toBe(
+				false
+			)
+		})
+
+		/**
+		 * Settings are user-writable through the save path, so a crafted save must
+		 * not be able to nominate an arbitrary linked asset as "the bake" and have
+		 * it served to anonymous embed traffic.
+		 */
+		it('refuses a declared id that is linked but is not the bake', () => {
+			const servable = selectEmbedServableAssets({
+				publishedAssetId: PUBLISHED_ASSET_ID,
+				sceneAssets: SCENE_ASSETS,
+				bakedShadowAssetId: 'basecolor-id'
+			})
+
+			expect(servable.bakeAssetId).toBeNull()
+			expect(isEmbedServableAssetId('basecolor-id', servable)).toBe(false)
+		})
+
+		it('yields no refs when the scene has no bake', () => {
+			const servable = selectEmbedServableAssets({
+				publishedAssetId: PUBLISHED_ASSET_ID,
+				sceneAssets: SCENE_ASSETS,
+				bakedShadowAssetId: null
+			})
+
+			expect(servable.bakeAssetId).toBeNull()
+			expect(buildEmbedAssetRefs(servable, SCENE_ASSETS, buildAssetUrl)).toEqual(
+				{}
+			)
+		})
+	})
+
+	describe('published model ref', () => {
+		it('keeps a stored .glb filename', () => {
+			const ref = buildPublishedModelRef(
+				{
+					assetId: PUBLISHED_ASSET_ID,
+					fileName: 'blue-vans-shoe.glb',
+					mimeType: 'model/gltf-binary',
+					byteSize: 500
+				},
+				buildAssetUrl
+			)
+
+			expect(ref.fileName).toBe('blue-vans-shoe.glb')
+			expect(ref.mimeType).toBe('model/gltf-binary')
+			expect(ref.byteSize).toBe(500)
+		})
+
+		/**
+		 * The client hands this filename to `ModelLoader.getFileType`, which throws
+		 * on an extension it does not recognize. A stored name is data, and a
+		 * crash there would take down the whole embed.
+		 */
+		it('falls back to a .glb name when the stored one is unusable', () => {
+			for (const fileName of [null, '', '   ', 'scene', 'scene.gltf']) {
+				expect(
+					buildPublishedModelRef(
+						{
+							assetId: PUBLISHED_ASSET_ID,
+							fileName,
+							mimeType: null,
+							byteSize: null
+						},
+						buildAssetUrl
+					).fileName
+				).toBe('scene.glb')
+			}
+		})
+
+		it('defaults a missing mime type to the GLB type', () => {
+			expect(
+				buildPublishedModelRef(
+					{
+						assetId: PUBLISHED_ASSET_ID,
+						fileName: 'scene.glb',
+						mimeType: null,
+						byteSize: null
+					},
+					buildAssetUrl
+				).mimeType
+			).toBe('model/gltf-binary')
+		})
+	})
+})

--- a/apps/vectreal-platform/tests/embed-published-load.spec.ts
+++ b/apps/vectreal-platform/tests/embed-published-load.spec.ts
@@ -1,0 +1,203 @@
+import { loadModelFromServer } from '@vctrl/hooks/use-load-model/scene-loaders'
+
+import type { LoadedModel, ModelSource } from '@vctrl/hooks/use-load-model'
+import type { LoadContext } from '@vctrl/hooks/use-load-model/load-context'
+
+const SCENE_ID = 'scene-1'
+const MANIFEST_URL = `/api/scenes/${SCENE_ID}?projectId=proj-1&preview=1&token=tok`
+const MODEL_URL = '/api/scenes/scene-1/assets/published-glb-id?preview=1'
+const BAKE_URL = '/api/scenes/scene-1/assets/bake-id?preview=1'
+
+const GLB_BYTES = new Uint8Array([0x67, 0x6c, 0x54, 0x46, 1, 2, 3, 4])
+const BAKE_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+
+function embedManifest(overrides: Record<string, unknown> = {}) {
+	return {
+		success: true,
+		data: {
+			sceneId: SCENE_ID,
+			meta: { name: 'Blue Vans Shoe', description: 'A shoe' },
+			publishedModel: {
+				url: MODEL_URL,
+				fileName: 'blue-vans-shoe.glb',
+				mimeType: 'model/gltf-binary',
+				byteSize: GLB_BYTES.byteLength
+			},
+			assetRefs: {
+				'bake-id': {
+					url: BAKE_URL,
+					fileName: 'shadow-bake.png',
+					mimeType: 'image/png',
+					byteSize: BAKE_BYTES.byteLength
+				}
+			},
+			settings: {
+				camera: { cameras: [{ cameraId: 'cam-1', name: 'Front' }] },
+				controls: { autoRotate: true },
+				shadows: { baked: { assetId: 'bake-id', signature: 'sig' } }
+			},
+			settingsUpdatedAt: '2026-08-21T00:00:00.000Z',
+			...overrides
+		}
+	}
+}
+
+/** Records every request so a stray POST to the legacy endpoint is visible. */
+function stubFetch(manifestBody: unknown, manifestStatus = 200) {
+	const calls: { url: string; method: string }[] = []
+
+	const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+		calls.push({ url, method: init?.method ?? 'GET' })
+
+		if (url === MODEL_URL) {
+			return { ok: true, status: 200, arrayBuffer: async () => GLB_BYTES.buffer }
+		}
+		if (url === BAKE_URL) {
+			return {
+				ok: true,
+				status: 200,
+				arrayBuffer: async () => BAKE_BYTES.buffer
+			}
+		}
+
+		return {
+			ok: manifestStatus >= 200 && manifestStatus < 300,
+			status: manifestStatus,
+			statusText: manifestStatus === 404 ? 'Not Found' : 'OK',
+			json: async () => manifestBody
+		}
+	})
+
+	vi.stubGlobal('fetch', fetchMock)
+	return calls
+}
+
+function buildContext() {
+	const published: LoadedModel[] = []
+	// Typed on the parameter so the File assertion below has something to read.
+	const loadToThreeJS = vi.fn(async (_file: File) => ({
+		scene: { name: 'three-scene' },
+		animations: []
+	}))
+
+	const ctx = {
+		modelLoader: { loadToThreeJS },
+		optimizer: undefined,
+		publish: (loaded: LoadedModel) => published.push(loaded),
+		onProgress: () => {}
+	} as unknown as LoadContext
+
+	return { ctx, loadToThreeJS, published }
+}
+
+const source: Extract<ModelSource, { kind: 'server' }> = {
+	kind: 'server',
+	sceneId: SCENE_ID,
+	serverOptions: { endpoint: MANIFEST_URL, apiKey: 'tok' },
+	parseMode: 'direct'
+}
+
+describe('published-GLB embed load', () => {
+	afterEach(() => vi.unstubAllGlobals())
+
+	/**
+	 * The guard for the legacy-POST bypass. `fetchManifestPayload` falls back to
+	 * `POST get-scene-settings` whenever a manifest fails its shape check, and
+	 * that action returns the whole editor payload. An embed manifest has no
+	 * `gltfJson`, so without an explicit `publishedModel` arm in the predicate
+	 * every embed would silently re-acquire exactly what the manifest withholds.
+	 */
+	it('accepts a manifest with no gltfJson and never falls back to the POST', async () => {
+		const calls = stubFetch(embedManifest())
+		const { ctx } = buildContext()
+
+		await loadModelFromServer(source, ctx)
+
+		expect(calls.some((call) => call.method === 'POST')).toBe(false)
+	})
+
+	it('requests exactly the published GLB and the bake', async () => {
+		const calls = stubFetch(embedManifest())
+		const { ctx } = buildContext()
+
+		await loadModelFromServer(source, ctx)
+
+		const assetCalls = calls
+			.filter((call) => call.url !== MANIFEST_URL)
+			.map((call) => call.url)
+			.sort()
+
+		expect(assetCalls).toEqual([BAKE_URL, MODEL_URL].sort())
+	})
+
+	it('hands the loader a File carrying the GLB bytes, name and mime type', async () => {
+		stubFetch(embedManifest())
+		const { ctx, loadToThreeJS } = buildContext()
+
+		await loadModelFromServer(source, ctx)
+
+		expect(loadToThreeJS).toHaveBeenCalledTimes(1)
+		const [file] = loadToThreeJS.mock.calls[0]
+
+		expect(file.name).toBe('blue-vans-shoe.glb')
+		expect(file.type).toBe('model/gltf-binary')
+		expect(Array.from(new Uint8Array(await file.arrayBuffer()))).toEqual(
+			Array.from(GLB_BYTES)
+		)
+	})
+
+	it('keeps settings and meta while reporting no glTF document', async () => {
+		stubFetch(embedManifest())
+		const { ctx, published } = buildContext()
+
+		const loaded = await loadModelFromServer(source, ctx)
+
+		expect(loaded.sceneData?.gltfJson).toBeNull()
+		expect(loaded.sceneData?.camera?.cameras?.[0]?.cameraId).toBe('cam-1')
+		expect(loaded.sceneData?.controls?.autoRotate).toBe(true)
+		expect(loaded.sceneData?.meta?.name).toBe('Blue Vans Shoe')
+		expect(published).toHaveLength(1)
+	})
+
+	it('makes the bake bytes available as scene asset data', async () => {
+		stubFetch(embedManifest())
+		const { ctx } = buildContext()
+
+		const loaded = await loadModelFromServer(source, ctx)
+		const entries = Object.values(loaded.sceneData?.assetData ?? {})
+
+		expect(entries.map((entry) => entry.fileName)).toEqual(['shadow-bake.png'])
+		// The GLB rides in the asset map only while it is fetched; it must not
+		// leak into the data the viewer sees.
+		expect(entries).toHaveLength(1)
+	})
+
+	it('loads a scene that has no shadow bake', async () => {
+		const calls = stubFetch(
+			embedManifest({ assetRefs: {}, settings: { controls: {} } })
+		)
+		const { ctx } = buildContext()
+
+		const loaded = await loadModelFromServer(source, ctx)
+
+		expect(loaded.sceneData?.assetData).toEqual({})
+		expect(calls.some((call) => call.url === BAKE_URL)).toBe(false)
+	})
+
+	/**
+	 * An auth failure is deterministic. Retrying it over the legacy POST only
+	 * fails a second time, doubles the requests, and flattens a precise status
+	 * into a generic "server load failed".
+	 */
+	it('throws a structured not_found on a 404 manifest without retrying', async () => {
+		const calls = stubFetch({ success: false, error: 'Scene not found' }, 404)
+		const { ctx } = buildContext()
+
+		await expect(loadModelFromServer(source, ctx)).rejects.toMatchObject({
+			code: 'not_found',
+			recoverable: false
+		})
+
+		expect(calls.some((call) => call.method === 'POST')).toBe(false)
+	})
+})

--- a/apps/vectreal-platform/tests/embed-settings-policy.spec.ts
+++ b/apps/vectreal-platform/tests/embed-settings-policy.spec.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-	isPairedHotspotCameraId,
-	redactSettingsForEmbed
-} from '../app/lib/domain/scene/embed-settings-policy'
+import { redactSettingsForEmbed } from '../app/lib/domain/scene/embed-settings-policy'
 
 import type { SceneSettings } from '@vctrl/core'
 
@@ -102,31 +99,6 @@ function buildSettings(overrides: Partial<SceneSettings> = {}): SceneSettings {
 
 const redact = (settings: SceneSettings, bakeAssetId: string | null = BAKE_ASSET_ID) =>
 	redactSettingsForEmbed(settings, { bakeAssetId })
-
-describe('paired hotspot camera ids', () => {
-	it('recognizes the shape the publisher mints', () => {
-		expect(isPairedHotspotCameraId('hotspot-camera-1755123456789-a1b2')).toBe(
-			true
-		)
-		expect(isPairedHotspotCameraId('hotspot-camera-1755123456789-a')).toBe(true)
-	})
-
-	/**
-	 * Ordinary camera ids are slugified from the user's camera name, so the bare
-	 * prefix is not a safe test - these are all names someone might type.
-	 */
-	it('does not claim ids that merely slugify to the same prefix', () => {
-		for (const cameraId of [
-			'hotspot-camera-1',
-			'hotspot-camera-2',
-			'hotspot-camera-view',
-			'hotspot-camera',
-			'hotspot-camera-front-detail'
-		]) {
-			expect(isPairedHotspotCameraId(cameraId), cameraId).toBe(false)
-		}
-	})
-})
 
 describe('embed settings policy', () => {
 	it('drops internalOnly hotspots', () => {

--- a/apps/vectreal-platform/tests/embed-settings-policy.spec.ts
+++ b/apps/vectreal-platform/tests/embed-settings-policy.spec.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	isPairedHotspotCameraId,
+	redactSettingsForEmbed
+} from '../app/lib/domain/scene/embed-settings-policy'
+
+import type { SceneSettings } from '@vctrl/core'
+
+const BAKE_ASSET_ID = 'bake-id'
+
+function buildSettings(overrides: Partial<SceneSettings> = {}): SceneSettings {
+	return {
+		camera: {
+			activeCameraId: 'cam-scene',
+			cameras: [
+				{ cameraId: 'cam-scene', name: 'Default', kind: 'scene' },
+				{ cameraId: 'cam-legacy', name: 'Legacy, no kind' },
+				{
+					cameraId: 'cam-public-hotspot',
+					name: 'Sole detail',
+					kind: 'hotspot',
+					position: [1, 1, 1],
+					target: [0, 0, 0]
+				},
+				{
+					cameraId: 'cam-backstage',
+					name: 'Backstage rig',
+					kind: 'hotspot',
+					position: [9, 9, 9],
+					target: [0, 0, 0]
+				},
+				/*
+				  The shape the publisher produced before it started tagging paired
+				  cameras: no `kind` at all, so `isSceneCamera` reads it as a scene
+				  camera. Every scene saved before that fix has one of these.
+				*/
+				{
+					cameraId: 'hotspot-camera-1755123456789-a1b2',
+					name: 'Legacy backstage rig',
+					position: [8, 8, 8],
+					target: [0, 0, 0]
+				},
+				{ cameraId: 'cam-orphan', name: 'Orphaned hotspot cam', kind: 'hotspot' }
+			]
+		},
+		hotspots: [
+			{
+				id: 'h-public',
+				name: 'Sole',
+				worldPosition: [0, 0, 0],
+				linkedCameraId: 'cam-public-hotspot',
+				visible: true,
+				internalOnly: false,
+				stylePreset: 'dot'
+			},
+			{
+				id: 'h-internal',
+				name: 'Backstage note',
+				worldPosition: [1, 1, 1],
+				linkedCameraId: 'cam-backstage',
+				visible: true,
+				internalOnly: true,
+				stylePreset: 'dot'
+			},
+			{
+				id: 'h-internal-legacy',
+				name: 'Legacy backstage note',
+				worldPosition: [2, 2, 2],
+				linkedCameraId: 'hotspot-camera-1755123456789-a1b2',
+				visible: true,
+				internalOnly: true,
+				stylePreset: 'dot'
+			}
+		],
+		interactions: [
+			{
+				id: 'i-public',
+				trigger: { source: 'viewer', type: 'viewer_ready' },
+				actions: [{ type: 'activate_camera', cameraId: 'cam-scene' }]
+			},
+			{
+				id: 'i-internal',
+				trigger: { source: 'viewer', type: 'viewer_ready' },
+				actions: [{ type: 'activate_camera', cameraId: 'cam-backstage' }]
+			},
+			{
+				id: 'i-mixed',
+				trigger: { source: 'viewer', type: 'viewer_ready' },
+				actions: [
+					{ type: 'activate_camera', cameraId: 'cam-backstage' },
+					{ type: 'set_controls_enabled', enabled: false }
+				]
+			}
+		],
+		shadows: {
+			baked: { assetId: BAKE_ASSET_ID, signature: 'sig-1' }
+		},
+		...overrides
+	} as SceneSettings
+}
+
+const redact = (settings: SceneSettings, bakeAssetId: string | null = BAKE_ASSET_ID) =>
+	redactSettingsForEmbed(settings, { bakeAssetId })
+
+describe('paired hotspot camera ids', () => {
+	it('recognizes the shape the publisher mints', () => {
+		expect(isPairedHotspotCameraId('hotspot-camera-1755123456789-a1b2')).toBe(
+			true
+		)
+		expect(isPairedHotspotCameraId('hotspot-camera-1755123456789-a')).toBe(true)
+	})
+
+	/**
+	 * Ordinary camera ids are slugified from the user's camera name, so the bare
+	 * prefix is not a safe test - these are all names someone might type.
+	 */
+	it('does not claim ids that merely slugify to the same prefix', () => {
+		for (const cameraId of [
+			'hotspot-camera-1',
+			'hotspot-camera-2',
+			'hotspot-camera-view',
+			'hotspot-camera',
+			'hotspot-camera-front-detail'
+		]) {
+			expect(isPairedHotspotCameraId(cameraId), cameraId).toBe(false)
+		}
+	})
+})
+
+describe('embed settings policy', () => {
+	it('drops internalOnly hotspots', () => {
+		const result = redact(buildSettings())
+
+		expect(result.hotspots?.map((hotspot) => hotspot.id)).toEqual(['h-public'])
+	})
+
+	/**
+	 * The regression that matters most. The publisher only started tagging paired
+	 * cameras `kind: 'hotspot'` recently, so every scene already in the database
+	 * has an untagged one - and `isSceneCamera` reads a missing `kind` as
+	 * "scene". A `kind`-based filter keeps exactly the cameras this redaction
+	 * exists to remove, for exactly the scenes that exist today.
+	 */
+	it('drops an untagged camera an internalOnly hotspot links to', () => {
+		const result = redact(buildSettings())
+
+		expect(
+			result.camera?.cameras?.map((camera) => camera.cameraId)
+		).not.toContain('hotspot-camera-1755123456789-a1b2')
+		expect(JSON.stringify(result)).not.toContain('Legacy backstage rig')
+	})
+
+	/**
+	 * Filtering the hotspot array alone is not enough. The linked camera carries
+	 * the viewpoint's pose and name, and `@vctrl/embed` exposes
+	 * `activateCamera(cameraId)` publicly - so leaving the camera behind lets any
+	 * third-party page read the hidden viewpoint and fly a visitor to it.
+	 */
+	it('drops the camera an internalOnly hotspot linked to', () => {
+		const result = redact(buildSettings())
+		const cameraIds = result.camera?.cameras?.map((camera) => camera.cameraId)
+
+		expect(cameraIds).not.toContain('cam-backstage')
+		expect(JSON.stringify(result)).not.toContain('Backstage rig')
+	})
+
+	it('keeps scene cameras, legacy kind-less cameras, and visible hotspot cameras', () => {
+		const result = redact(buildSettings())
+
+		expect(result.camera?.cameras?.map((camera) => camera.cameraId)).toEqual([
+			'cam-scene',
+			'cam-legacy',
+			'cam-public-hotspot'
+		])
+	})
+
+	it('drops an orphaned hotspot camera no surviving hotspot links to', () => {
+		const result = redact(buildSettings())
+
+		expect(
+			result.camera?.cameras?.map((camera) => camera.cameraId)
+		).not.toContain('cam-orphan')
+	})
+
+	it('drops interactions that would activate a removed camera', () => {
+		const result = redact(buildSettings())
+
+		expect(result.interactions?.map((interaction) => interaction.id)).toEqual([
+			'i-public',
+			'i-mixed'
+		])
+	})
+
+	it('keeps the surviving actions of a partially removed interaction', () => {
+		const result = redact(buildSettings())
+		const mixed = result.interactions?.find(
+			(interaction) => interaction.id === 'i-mixed'
+		)
+
+		expect(mixed?.actions).toEqual([
+			{ type: 'set_controls_enabled', enabled: false }
+		])
+	})
+
+	it('clears an active camera selection that pointed at a removed camera', () => {
+		const settings = buildSettings()
+		settings.camera!.activeCameraId = 'cam-backstage'
+
+		expect(redact(settings).camera?.activeCameraId).toBeUndefined()
+	})
+
+	it('keeps an active camera selection that survived', () => {
+		expect(redact(buildSettings()).camera?.activeCameraId).toBe('cam-scene')
+	})
+
+	describe('baked shadow pointer', () => {
+		it('keeps the pointer the asset gate authorized', () => {
+			expect(redact(buildSettings()).shadows?.baked?.assetId).toBe(BAKE_ASSET_ID)
+		})
+
+		/**
+		 * A stale or tampered pointer is unfetchable anyway - the asset gate
+		 * re-derives the servable set server-side - so shipping the id would leak
+		 * an internal identifier for no benefit.
+		 */
+		it('drops a pointer the asset gate refused', () => {
+			expect(redact(buildSettings(), null).shadows?.baked).toBeUndefined()
+			expect(
+				redact(buildSettings(), 'some-other-id').shadows?.baked
+			).toBeUndefined()
+		})
+
+		it('leaves the rest of the shadow settings alone', () => {
+			const settings = buildSettings({
+				shadows: {
+					ao: true,
+					aoIntensity: 1.4,
+					baked: { assetId: 'stale', signature: 'sig' }
+				}
+			})
+
+			const result = redact(settings, null)
+
+			expect(result.shadows?.ao).toBe(true)
+			expect(result.shadows?.aoIntensity).toBe(1.4)
+		})
+	})
+
+	/**
+	 * A hotspot may link any camera the author picks - the publisher's picker
+	 * offers every camera and the server validates only that the id exists. If
+	 * linkage alone promoted a camera to "hotspot camera", one internal hotspot
+	 * pointed at the scene's default view would delete that view from the embed.
+	 * The camera is a scene camera in its own right; only the hotspot hides.
+	 */
+	it('keeps a scene camera an internalOnly hotspot happens to link', () => {
+		const settings = buildSettings({
+			camera: {
+				activeCameraId: 'cam-default',
+				cameras: [{ cameraId: 'cam-default', name: 'Default', kind: 'scene' }]
+			},
+			hotspots: [
+				{
+					id: 'h-note',
+					name: 'Editor note on the default view',
+					worldPosition: [0, 0, 0],
+					linkedCameraId: 'cam-default',
+					visible: true,
+					internalOnly: true,
+					stylePreset: 'dot'
+				}
+			],
+			interactions: []
+		})
+
+		const result = redact(settings, null)
+
+		expect(result.camera?.cameras?.map((camera) => camera.cameraId)).toEqual([
+			'cam-default'
+		])
+		expect(result.camera?.activeCameraId).toBe('cam-default')
+		expect(result.hotspots).toEqual([])
+	})
+
+	it('keeps an untagged ordinary camera an internalOnly hotspot links', () => {
+		const settings = buildSettings({
+			camera: {
+				cameras: [{ cameraId: 'camera-2', name: 'Bookmark' }]
+			},
+			hotspots: [
+				{
+					id: 'h-note',
+					name: 'Note',
+					worldPosition: [0, 0, 0],
+					linkedCameraId: 'camera-2',
+					visible: true,
+					internalOnly: true,
+					stylePreset: 'dot'
+				}
+			],
+			interactions: []
+		})
+
+		expect(
+			redact(settings, null).camera?.cameras?.map((camera) => camera.cameraId)
+		).toEqual(['camera-2'])
+	})
+
+	it('keeps a hotspot camera linked by both a visible and an internal hotspot', () => {
+		const settings = buildSettings({
+			camera: {
+				cameras: [{ cameraId: 'cam-shared', name: 'Shared', kind: 'hotspot' }]
+			},
+			hotspots: [
+				{
+					id: 'h-visible',
+					name: 'Visible',
+					worldPosition: [0, 0, 0],
+					linkedCameraId: 'cam-shared',
+					visible: true,
+					internalOnly: false,
+					stylePreset: 'dot'
+				},
+				{
+					id: 'h-internal',
+					name: 'Internal',
+					worldPosition: [1, 1, 1],
+					linkedCameraId: 'cam-shared',
+					visible: true,
+					internalOnly: true,
+					stylePreset: 'dot'
+				}
+			],
+			interactions: []
+		})
+
+		expect(
+			redact(settings, null).camera?.cameras?.map((camera) => camera.cameraId)
+		).toEqual(['cam-shared'])
+	})
+
+	/**
+	 * Ordinary camera ids are slugified from the user's camera name, so a camera
+	 * simply named "Hotspot Camera 1" gets the id `hotspot-camera-1`. Matching on
+	 * the bare prefix would drop it from the embed while the publisher, the
+	 * dashboard and `/preview` all still showed it.
+	 */
+	it('keeps a camera whose slugified name only looks like a paired id', () => {
+		const settings = buildSettings({
+			camera: {
+				activeCameraId: 'hotspot-camera-1',
+				cameras: [{ cameraId: 'hotspot-camera-1', name: 'Hotspot Camera 1' }]
+			},
+			hotspots: [],
+			interactions: []
+		})
+
+		const result = redact(settings, null)
+
+		expect(result.camera?.cameras?.map((camera) => camera.cameraId)).toEqual([
+			'hotspot-camera-1'
+		])
+		expect(result.camera?.activeCameraId).toBe('hotspot-camera-1')
+	})
+
+	it('drops an unlinked camera carrying a publisher-minted paired id', () => {
+		const settings = buildSettings({
+			camera: {
+				cameras: [
+					{ cameraId: 'cam-main', name: 'Main', kind: 'scene' },
+					{
+						cameraId: 'hotspot-camera-1755123456789-zz99',
+						name: 'Stranded pair'
+					}
+				]
+			},
+			hotspots: [],
+			interactions: []
+		})
+
+		expect(
+			redact(settings, null).camera?.cameras?.map((camera) => camera.cameraId)
+		).toEqual(['cam-main'])
+	})
+
+	it('keeps a minted paired camera a visible hotspot links', () => {
+		const settings = buildSettings({
+			camera: {
+				cameras: [
+					{ cameraId: 'hotspot-camera-1755123456789-aaaa', name: 'Sole detail' }
+				]
+			},
+			hotspots: [
+				{
+					id: 'h-visible',
+					name: 'Sole',
+					worldPosition: [0, 0, 0],
+					linkedCameraId: 'hotspot-camera-1755123456789-aaaa',
+					visible: true,
+					internalOnly: false,
+					stylePreset: 'dot'
+				}
+			],
+			interactions: []
+		})
+
+		expect(
+			redact(settings, null).camera?.cameras?.map((camera) => camera.cameraId)
+		).toEqual(['hotspot-camera-1755123456789-aaaa'])
+	})
+
+	it('passes through a scene with no hotspots, cameras or interactions', () => {
+		const settings = { controls: { autoRotate: true } } as SceneSettings
+
+		expect(redact(settings, null)).toEqual({
+			controls: { autoRotate: true },
+			hotspots: undefined,
+			camera: undefined,
+			interactions: undefined,
+			shadows: undefined
+		})
+	})
+})

--- a/apps/vectreal-platform/tests/integration/embed-asset-authorization.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/embed-asset-authorization.integration.spec.ts
@@ -1,0 +1,386 @@
+/**
+ * Proves, against real rows, that the embed manifest and the embed asset gate
+ * agree about which assets exist.
+ *
+ * They did not. `toAssetRefs` offered every `scene_assets` row while the asset
+ * route served only `scene_published.asset_id` - an id `uploadPublishedGlb`
+ * writes without ever calling `linkSceneAssets`, so it is never in
+ * `scene_assets`. The two sets were disjoint and no embed could load a single
+ * byte. A unit test can assert the policy is self-consistent; only a real
+ * database can show that the rows publishing actually writes produce two sets
+ * that match.
+ *
+ * Opt-in, because it writes to whatever `DATABASE_URL` points at:
+ *
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ *
+ * Every row it creates is namespaced by a fresh uuid and dropped in `afterAll`.
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { PERSISTED_BAKE_FILENAME, SCENE_THUMBNAIL_FILENAME } from '@vctrl/core'
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+	isEmbedServableAssetId,
+	selectEmbedServableAssets
+} from '../../app/lib/domain/scene/embed-asset-policy'
+
+type Schema = typeof import('../../app/db/schema')
+type Manifest =
+	typeof import('../../app/lib/domain/scene/server/scene-manifest.server')
+type PreviewRepo =
+	typeof import('../../app/lib/domain/scene/server/scene-preview-repository.server')
+type SettingsService =
+	typeof import('../../app/lib/domain/scene/server/scene-settings-service.server')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+
+const buildAssetUrl = (assetId: string) => `/api/assets/${assetId}`
+
+describe('embed asset authorization', () => {
+	// Loaded in `beforeAll` rather than at module scope: these modules call
+	// `getDbClient()` on import, which throws without a `DATABASE_URL`.
+	let schema: Schema
+	let buildEmbedSceneManifest: Manifest['buildEmbedSceneManifest']
+	let getPublishedScenePreview: PreviewRepo['getPublishedScenePreview']
+	let toPublishedModelRow: PreviewRepo['toPublishedModelRow']
+	let sceneSettingsService: SettingsService['sceneSettingsService']
+	let db: Db
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+	const assetFolderId = randomUUID()
+
+	const sceneId = randomUUID()
+	const settingsId = randomUUID()
+	const publishedAssetId = randomUUID()
+	const bufferAssetId = randomUUID()
+	const textureAssetId = randomUUID()
+	const bakeAssetId = randomUUID()
+	const thumbnailAssetId = randomUUID()
+
+	beforeAll(async () => {
+		schema = await import('../../app/db/schema')
+		;({ buildEmbedSceneManifest } = await import(
+			'../../app/lib/domain/scene/server/scene-manifest.server'
+		))
+		;({ getPublishedScenePreview, toPublishedModelRow } = await import(
+			'../../app/lib/domain/scene/server/scene-preview-repository.server'
+		))
+		;({ sceneSettingsService } = await import(
+			'../../app/lib/domain/scene/server/scene-settings-service.server'
+		))
+		db = (await import('../../app/db/client')).getDbClient()
+
+		await db.insert(schema.users).values({
+			id: ownerId,
+			email: `owner-${ownerId}@smoke.test`,
+			name: 'Owner'
+		})
+		await db
+			.insert(schema.organizations)
+			.values({ id: organizationId, name: `smoke-${organizationId}`, ownerId })
+		await db.insert(schema.organizationMemberships).values({
+			userId: ownerId,
+			organizationId,
+			role: 'owner'
+		})
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Smoke project',
+			slug: `smoke-${projectId}`
+		})
+		await db
+			.insert(schema.folders)
+			.values({ id: assetFolderId, projectId, name: 'Scene Assets' })
+
+		// The editor assets a save writes, all linked through `scene_assets`.
+		await db.insert(schema.assets).values([
+			{
+				id: bufferAssetId,
+				folderId: assetFolderId,
+				name: 'buffer.bin',
+				type: 'model',
+				filePath: `smoke/${bufferAssetId}.bin`,
+				mimeType: 'application/octet-stream',
+				fileSize: 2902308,
+				ownerId
+			},
+			{
+				id: textureAssetId,
+				folderId: assetFolderId,
+				name: 'Shoe_baseColor.webp',
+				type: 'texture',
+				filePath: `smoke/${textureAssetId}.webp`,
+				mimeType: 'image/webp',
+				fileSize: 84996,
+				ownerId
+			},
+			{
+				id: bakeAssetId,
+				folderId: assetFolderId,
+				name: PERSISTED_BAKE_FILENAME,
+				type: 'texture',
+				filePath: `smoke/${bakeAssetId}.png`,
+				mimeType: 'image/png',
+				fileSize: 27530,
+				ownerId
+			},
+			{
+				id: thumbnailAssetId,
+				folderId: assetFolderId,
+				name: SCENE_THUMBNAIL_FILENAME,
+				type: 'texture',
+				filePath: `smoke/${thumbnailAssetId}.webp`,
+				mimeType: 'image/webp',
+				fileSize: 4096,
+				ownerId
+			},
+			// The published GLB. Deliberately NOT linked into `scene_assets`,
+			// because `uploadPublishedGlb` never links it. This is the exact
+			// production shape that made the two sets disjoint.
+			{
+				id: publishedAssetId,
+				folderId: assetFolderId,
+				name: 'blue-vans-shoe.glb',
+				type: 'model',
+				filePath: `smoke/${publishedAssetId}.glb`,
+				mimeType: 'model/gltf-binary',
+				fileSize: 812345,
+				ownerId
+			}
+		])
+
+		await db.insert(schema.scenes).values({
+			id: sceneId,
+			projectId,
+			folderId: null,
+			name: 'Blue Vans Shoe',
+			status: 'published'
+		})
+		await db.insert(schema.sceneSettings).values({
+			id: settingsId,
+			sceneId,
+			createdBy: ownerId,
+			shadows: { baked: { assetId: bakeAssetId, signature: 'sig-1' } }
+		})
+		await db.insert(schema.sceneAssets).values([
+			{ sceneSettingsId: settingsId, assetId: bufferAssetId },
+			{ sceneSettingsId: settingsId, assetId: textureAssetId },
+			{ sceneSettingsId: settingsId, assetId: bakeAssetId },
+			{ sceneSettingsId: settingsId, assetId: thumbnailAssetId }
+		])
+		await db.insert(schema.scenePublished).values({
+			sceneId,
+			assetId: publishedAssetId,
+			publishedBy: ownerId
+		})
+	})
+
+	afterAll(async () => {
+		// Organizations cascade to projects, folders, scenes and assets.
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, organizationId))
+		await db.delete(schema.users).where(eq(schema.users.id, ownerId))
+	})
+
+	/** What the asset route computes, from the same rows the route reads. */
+	async function routeServableSet() {
+		const preview = await getPublishedScenePreview(projectId, sceneId)
+		expect(preview).not.toBeNull()
+
+		const settingsData =
+			await sceneSettingsService.getSceneSettingsWithAssetRefs(sceneId, {
+				includeGltfJson: false
+			})
+
+		return selectEmbedServableAssets({
+			publishedAssetId: preview!.publishedAssetId,
+			sceneAssets: settingsData?.assets ?? [],
+			bakedShadowAssetId: settingsData?.settings?.shadows?.baked?.assetId
+		})
+	}
+
+	it('reproduces the production shape: the published GLB is not a scene asset', async () => {
+		const settingsData =
+			await sceneSettingsService.getSceneSettingsWithAssetRefs(sceneId, {
+				includeGltfJson: false
+			})
+
+		expect(settingsData?.assets.map((asset) => asset.id)).not.toContain(
+			publishedAssetId
+		)
+	})
+
+	it('serves every asset the embed manifest references', async () => {
+		const preview = await getPublishedScenePreview(projectId, sceneId)
+		const manifest = await buildEmbedSceneManifest(
+			sceneId,
+			toPublishedModelRow(preview!),
+			buildAssetUrl
+		)
+		const servable = await routeServableSet()
+
+		const referenced = [
+			...Object.keys(manifest.assetRefs),
+			preview!.publishedAssetId
+		]
+
+		expect(referenced.length).toBeGreaterThan(0)
+		for (const assetId of referenced) {
+			expect(
+				isEmbedServableAssetId(assetId, servable),
+				`manifest references ${assetId} but the gate refuses it`
+			).toBe(true)
+		}
+	})
+
+	it('refuses every editor asset, which the manifest never references', async () => {
+		const servable = await routeServableSet()
+
+		for (const assetId of [bufferAssetId, textureAssetId, thumbnailAssetId]) {
+			expect(isEmbedServableAssetId(assetId, servable)).toBe(false)
+		}
+	})
+
+	it('references the published GLB and the bake, and no editor assets', async () => {
+		const preview = await getPublishedScenePreview(projectId, sceneId)
+		const manifest = await buildEmbedSceneManifest(
+			sceneId,
+			toPublishedModelRow(preview!),
+			buildAssetUrl
+		)
+
+		expect(manifest.publishedModel).toEqual({
+			url: buildAssetUrl(publishedAssetId),
+			fileName: 'blue-vans-shoe.glb',
+			mimeType: 'model/gltf-binary',
+			byteSize: 812345
+		})
+		expect(Object.keys(manifest.assetRefs)).toEqual([bakeAssetId])
+	})
+
+	it('withholds the editor scene graph and asset rows from an embed', async () => {
+		const preview = await getPublishedScenePreview(projectId, sceneId)
+		const manifest = await buildEmbedSceneManifest(
+			sceneId,
+			toPublishedModelRow(preview!),
+			buildAssetUrl
+		)
+
+		expect(manifest).not.toHaveProperty('gltfJson')
+		expect(manifest).not.toHaveProperty('assets')
+		expect(manifest).not.toHaveProperty('stats')
+	})
+
+	/**
+	 * Filtering the hotspot array alone leaves the linked camera behind, and
+	 * `@vctrl/embed` exposes `activateCamera(cameraId)` to the host page - so a
+	 * third-party site could read the hidden viewpoint's pose out of the manifest
+	 * and fly an anonymous visitor straight to it.
+	 */
+	it('drops internalOnly hotspots and the cameras that would resurrect them', async () => {
+		const publicHotspotId = randomUUID()
+		const internalHotspotId = randomUUID()
+		const legacyInternalHotspotId = randomUUID()
+
+		await db
+			.update(schema.sceneSettings)
+			.set({
+				camera: {
+					activeCameraId: 'cam-backstage',
+					cameras: [
+						{ cameraId: 'cam-scene', name: 'Default', kind: 'scene' },
+						{
+							cameraId: 'cam-sole',
+							name: 'Sole detail',
+							kind: 'hotspot',
+							position: [1, 1, 1]
+						},
+						{
+							cameraId: 'cam-backstage',
+							name: 'Backstage rig',
+							kind: 'hotspot',
+							position: [9, 9, 9]
+						},
+						/*
+						  Untagged, the shape the publisher produced before it started
+						  tagging paired cameras. Every scene already in the database
+						  has one of these, and `isSceneCamera` reads it as a scene
+						  camera - so a `kind`-based filter would leak it.
+						*/
+						{
+							cameraId: 'hotspot-camera-1755123456789-a1b2',
+							name: 'Legacy backstage rig',
+							position: [8, 8, 8]
+						}
+					]
+				},
+				interactions: [
+					{
+						id: 'i-internal',
+						trigger: { source: 'viewer', type: 'viewer_ready' },
+						actions: [{ type: 'activate_camera', cameraId: 'cam-backstage' }]
+					}
+				]
+			})
+			.where(eq(schema.sceneSettings.id, settingsId))
+
+		await db.insert(schema.sceneHotspots).values([
+			{
+				id: publicHotspotId,
+				sceneSettingsId: settingsId,
+				name: 'Sole',
+				linkedCameraId: 'cam-sole',
+				visible: true,
+				internalOnly: false
+			},
+			{
+				id: internalHotspotId,
+				sceneSettingsId: settingsId,
+				name: 'Internal note',
+				linkedCameraId: 'cam-backstage',
+				visible: true,
+				internalOnly: true
+			},
+			{
+				id: legacyInternalHotspotId,
+				sceneSettingsId: settingsId,
+				name: 'Legacy internal note',
+				linkedCameraId: 'hotspot-camera-1755123456789-a1b2',
+				visible: true,
+				internalOnly: true
+			}
+		])
+
+		const preview = await getPublishedScenePreview(projectId, sceneId)
+		const manifest = await buildEmbedSceneManifest(
+			sceneId,
+			toPublishedModelRow(preview!),
+			buildAssetUrl
+		)
+
+		expect(manifest.settings?.hotspots?.map((hotspot) => hotspot.name)).toEqual([
+			'Sole'
+		])
+		expect(
+			manifest.settings?.camera?.cameras?.map((camera) => camera.cameraId)
+		).toEqual(['cam-scene', 'cam-sole'])
+		expect(manifest.settings?.camera?.activeCameraId).toBeUndefined()
+		expect(manifest.settings?.interactions).toEqual([])
+		// Nothing anywhere in the payload should name either hidden viewpoint.
+		expect(JSON.stringify(manifest)).not.toContain('cam-backstage')
+		expect(JSON.stringify(manifest)).not.toContain('hotspot-camera-1755123456789-a1b2')
+		expect(JSON.stringify(manifest)).not.toContain('Legacy backstage rig')
+
+		await db
+			.delete(schema.sceneHotspots)
+			.where(eq(schema.sceneHotspots.sceneSettingsId, settingsId))
+	})
+})

--- a/packages/core/src/types/scene-types.ts
+++ b/packages/core/src/types/scene-types.ts
@@ -470,14 +470,29 @@ export interface ServerScenePayload {
 	assetData: SerializedSceneAssetDataMap | null
 	/** Asset references for manifest-based loading (bytes fetched separately). */
 	assetRefs?: SceneAssetRefMap | null
+	/**
+	 * The published, optimized GLB. Present only on the embed manifest, which
+	 * serves a self-contained model instead of the editor's glTF document plus
+	 * its separate buffers and textures. When this is set, {@link gltfJson} is
+	 * null and {@link assetRefs} carries only assets that live outside the GLB
+	 * (today: the persisted shadow bake).
+	 */
+	publishedModel?: SceneAssetRef | null
 }
 
 /** Resolved scene data contract consumed by loaders and viewer clients. */
 export interface ServerSceneData extends SceneSettings {
 	/** Optional scene metadata payload. */
 	meta?: SceneMetaData
-	/** The GLTF JSON structure. */
-	gltfJson: ExtendedGLTFDocument
+	/**
+	 * The GLTF JSON structure, or null for a scene loaded from a published GLB.
+	 *
+	 * Nullable on purpose. The embed path has no editor document at all, and a
+	 * non-null type here would be a lie that every consumer silently trusts -
+	 * which is how the disjoint-asset-set bug got written in the first place.
+	 * The optimizer and file-reconstruction paths guard on it.
+	 */
+	gltfJson: ExtendedGLTFDocument | null
 	/** Binary asset data keyed by asset identifier. */
 	assetData: SerializedSceneAssetDataMap
 }

--- a/packages/hooks/src/use-load-model/scene-loaders.ts
+++ b/packages/hooks/src/use-load-model/scene-loaders.ts
@@ -3,6 +3,7 @@ import { ModelFileTypes } from '@vctrl/core/model-loader'
 
 import {
 	createStructuredLoadError,
+	isStructuredLoadError,
 	normalizeServerLoadError
 } from './error-helpers'
 import { ingestIntoOptimizer } from './optimizer-ingest'
@@ -10,12 +11,17 @@ import { LoadedModel, ModelSource } from './types'
 import {
 	calculateReferencedBytesFromServerScene,
 	reconstructGltfFiles,
+	resolvePublishedSceneDataContract,
 	resolveServerSceneDataContract
 } from './utils'
 import { fetchManifestAssetData } from './utils/fetch-manifest-assets'
 
 import type { LoadContext } from './load-context'
-import type { ApiEnvelope, ServerScenePayload } from '@vctrl/core'
+import type {
+	ApiEnvelope,
+	SceneAssetRef,
+	ServerScenePayload
+} from '@vctrl/core'
 
 type SceneDataSource = Extract<ModelSource, { kind: 'scene-data' }>
 type ServerSource = Extract<ModelSource, { kind: 'server' }>
@@ -47,11 +53,105 @@ const resolveSceneEndpoint = ({ sceneId, serverOptions }: ServerSource) => ({
  * the dashboard. The default path reconstructs real files so the optimizer can
  * ingest the same bytes the viewer renders.
  */
-export const loadModelFromSceneData = async (
-	{ sceneId, sceneData: payload, parseMode }: SceneDataSource,
-	{ modelLoader, optimizer, publish, onProgress }: LoadContext,
+/**
+ * Key the published GLB borrows inside the asset map while it is fetched.
+ *
+ * Riding along with the real asset refs is what buys byte-weighted progress
+ * across the model and the bake together, one abort controller, and one set of
+ * auth headers. It is removed again before the map becomes `assetData`, so it
+ * never reaches the viewer.
+ */
+const PUBLISHED_MODEL_KEY = '__vctrl_published_model__'
+
+/**
+ * Loads a scene from its published, optimized GLB.
+ *
+ * This is the external embed path. A GLB is self-contained, so there is no
+ * glTF document and no separate buffers or textures - only assets that live
+ * outside the model, which today means the persisted shadow bake.
+ */
+const loadPublishedSceneModel = async (
+	sceneId: string | undefined,
+	payload: ServerScenePayload,
+	publishedModel: SceneAssetRef,
+	{ modelLoader, publish, onProgress }: LoadContext,
 	assetHeaders?: HeadersInit
 ): Promise<LoadedModel> => {
+	const fetched = await fetchManifestAssetData(
+		{ ...(payload.assetRefs ?? {}), [PUBLISHED_MODEL_KEY]: publishedModel },
+		{
+			headers: assetHeaders,
+			onProgress: (fraction) => onProgress(Math.round(fraction * 60))
+		}
+	)
+
+	const modelEntry = fetched[PUBLISHED_MODEL_KEY]
+	delete fetched[PUBLISHED_MODEL_KEY]
+
+	if (!modelEntry) {
+		throw createStructuredLoadError({
+			code: 'missing_assets',
+			message: 'This scene has no published model to load.',
+			recoverable: false,
+			source: 'server-load',
+			context: { sceneId }
+		})
+	}
+
+	const sceneData = resolvePublishedSceneDataContract({
+		...payload,
+		assetData: fetched
+	})
+
+	onProgress(70)
+
+	const modelBytes = toSerializedAssetBytes(modelEntry)
+	const blobBytes = new Uint8Array(modelBytes.byteLength)
+	blobBytes.set(modelBytes)
+	const blob = new Blob([blobBytes], { type: publishedModel.mimeType })
+
+	// The same entry point a dropped `.glb` takes, so the Draco decoder is
+	// attached exactly as it is everywhere else.
+	const result = await modelLoader.loadToThreeJS(
+		new File([blob], publishedModel.fileName, { type: publishedModel.mimeType })
+	)
+
+	const loaded: LoadedModel = {
+		file: {
+			model: result.scene,
+			animations: result.animations,
+			type: ModelFileTypes.glb,
+			name: sceneData.meta?.name || publishedModel.fileName,
+			// Texture bytes are unknowable from outside a GLB; leaving it undefined
+			// is honest, whereas reporting the package size twice is not.
+			sourcePackageBytes: publishedModel.byteSize ?? undefined
+		},
+		sceneId,
+		sceneData
+	}
+
+	publish(loaded)
+	return loaded
+}
+
+export const loadModelFromSceneData = async (
+	source: SceneDataSource,
+	ctx: LoadContext,
+	assetHeaders?: HeadersInit
+): Promise<LoadedModel> => {
+	const { sceneId, sceneData: payload, parseMode } = source
+	const { modelLoader, optimizer, publish, onProgress } = ctx
+
+	if (payload.publishedModel) {
+		return loadPublishedSceneModel(
+			sceneId,
+			payload,
+			payload.publishedModel,
+			ctx,
+			assetHeaders
+		)
+	}
+
 	if (!payload.gltfJson) {
 		throw createStructuredLoadError({
 			code: 'missing_assets',
@@ -174,6 +274,13 @@ export const loadModelFromServer = async (
 	}
 }
 
+/**
+ * Statuses that describe the request itself rather than the manifest's shape.
+ * Falling back to the legacy POST for these only fails a second time, doubling
+ * the requests and flattening a precise auth failure into a generic one.
+ */
+const NON_RECOVERABLE_MANIFEST_STATUSES = new Set([401, 403, 404])
+
 async function fetchManifestPayload(
 	endpoint: string,
 	headers: HeadersInit
@@ -183,17 +290,36 @@ async function fetchManifestPayload(
 			method: 'GET',
 			headers: { Accept: 'application/json', ...headers }
 		})
+
+		if (NON_RECOVERABLE_MANIFEST_STATUSES.has(res.status)) {
+			throw createStructuredLoadError({
+				code: res.status === 404 ? 'not_found' : 'server_load_failed',
+				message: `Server responded with ${res.status} ${res.statusText}`,
+				recoverable: false,
+				source: 'server-load',
+				context: { endpoint, status: res.status }
+			})
+		}
+
 		if (!res.ok) return null
 
 		const envelope = (await res.json()) as ApiEnvelope<ServerScenePayload>
 		const candidate = (envelope.data ?? envelope) as ServerScenePayload
 
 		if (!candidate || typeof candidate !== 'object') return null
+
+		// A published-GLB manifest is complete on its own: no glTF document, and
+		// an empty `assetRefs` when the scene has no shadow bake. Without this
+		// arm the embed manifest would fail the shape check below and the loader
+		// would silently re-acquire the whole editor payload over the legacy POST.
+		if (candidate.publishedModel) return candidate
+
 		if (!candidate.gltfJson) return null
 		if (!candidate.assetRefs && !candidate.assetData) return null
 
 		return candidate
-	} catch {
+	} catch (error) {
+		if (isStructuredLoadError(error)) throw error
 		return null
 	}
 }

--- a/packages/hooks/src/use-load-model/utils/calculate-referenced-bytes.ts
+++ b/packages/hooks/src/use-load-model/utils/calculate-referenced-bytes.ts
@@ -99,6 +99,12 @@ export function calculateReferencedBytesFromServerScene(
 	data: ServerSceneData
 ): ReferencedBytes {
 	const gltfJson = data.gltfJson
+	if (!gltfJson) {
+		// A published GLB is one opaque package: nothing is referenced by URI, so
+		// there is nothing to attribute to buffers or textures.
+		return { sourcePackageBytes: 0, textureBytes: 0 }
+	}
+
 	const assets = Object.values(data.assetData || {}).map((asset) => ({
 		fileName: asset.fileName,
 		size: getSerializedAssetByteSize(asset.data)

--- a/packages/hooks/src/use-load-model/utils/index.ts
+++ b/packages/hooks/src/use-load-model/utils/index.ts
@@ -4,7 +4,10 @@ export {
 	calculateReferencedBytesFromFiles,
 	calculateReferencedBytesFromServerScene
 } from './calculate-referenced-bytes'
-export { resolveServerSceneDataContract } from './resolve-scene-payload'
+export {
+	resolvePublishedSceneDataContract,
+	resolveServerSceneDataContract
+} from './resolve-scene-payload'
 export {
 	fetchManifestAssetData,
 	type FetchManifestAssetsOptions

--- a/packages/hooks/src/use-load-model/utils/reconstruct-files.ts
+++ b/packages/hooks/src/use-load-model/utils/reconstruct-files.ts
@@ -75,6 +75,12 @@ export function reconstructGltfFiles(
 	}
 
 	// Create GLTF file from JSON structure
+	if (!data.gltfJson) {
+		throw new Error(
+			'Cannot reconstruct glTF files: this scene has no glTF document.'
+		)
+	}
+
 	const gltfJsonString = JSON.stringify(data.gltfJson)
 	const gltfBlob = new Blob([gltfJsonString], { type: 'model/gltf+json' })
 

--- a/packages/hooks/src/use-load-model/utils/resolve-scene-payload.ts
+++ b/packages/hooks/src/use-load-model/utils/resolve-scene-payload.ts
@@ -158,3 +158,25 @@ export function resolveServerSceneDataContract(
 		...toSceneSettings(payload)
 	}
 }
+
+/**
+ * Resolves an embed manifest, which carries a published GLB instead of a glTF
+ * document.
+ *
+ * Same settings normalization as {@link resolveServerSceneDataContract}, minus
+ * the referenced-asset cross-check: a GLB is self-contained, so there are no
+ * external URIs to reconcile against the asset map.
+ */
+export function resolvePublishedSceneDataContract(
+	payload: ServerScenePayload
+): ServerSceneData {
+	const assetData = payload.assetData ?? {}
+	validateAssetDataMap(assetData)
+
+	return {
+		meta: payload.meta,
+		gltfJson: null,
+		assetData,
+		...toSceneSettings(payload)
+	}
+}

--- a/packages/hooks/src/use-optimize-model/use-optimize-model.ts
+++ b/packages/hooks/src/use-optimize-model/use-optimize-model.ts
@@ -138,6 +138,16 @@ const useOptimizeModel = () => {
 		async (sceneData: ServerSceneData): Promise<void> => {
 			dispatch({ type: 'LOAD_START' })
 
+			// A scene loaded from a published GLB carries no editor glTF document.
+			// The optimizer works on that document, so there is nothing to ingest -
+			// and the casts below would otherwise turn null into an opaque failure
+			// deep inside glTF-Transform.
+			if (!sceneData.gltfJson) {
+				throw new Error(
+					'Cannot optimize a scene loaded from a published GLB: it has no glTF document.'
+				)
+			}
+
 			try {
 				const optimizer = optimizerRef.current
 


### PR DESCRIPTION
Stacked on #732 — review that first. This branch is cut from it because the redaction below depends on paired cameras carrying `kind: 'hotspot'`, which #732 introduces.

## The bug

An embedded scene could never render, on any site, with any token.

Two places independently decided what an embed may fetch, and they ended up disjoint. `toAssetRefs` offered every `scene_assets` row; the API-key branch of the asset route served exactly one id, `scene_published.asset_id` — which `uploadPublishedGlb` writes without ever calling `linkSceneAssets`, so it is never in `scene_assets` and the manifest never referenced it. Every asset an embed requested 404'd, and `fetchManifestAssetData` aborts the whole load on the first failure.

Measured against production, with a valid token and a permitted referer:

| Request | Before | After |
| --- | --- | --- |
| `GET /embed/<project>/<scene>?token=…` | 200 | 200 |
| `GET /api/scenes/<scene>?preview=1&…` (manifest) | 200 | 200 |
| the assets the manifest points at | **404 ×5** | 200 (one GLB) |

`/preview` was never affected: its session branch authorizes through the `scene_assets` join instead.

## What changed

**One owner for the rule.** Both sides now call `embed-asset-policy`, a pure module, so the two sets cannot drift apart again. The servable set is the published GLB plus the persisted shadow bake. The bake is authorized only when the settings-declared id is *also* a linked row carrying the bake filename — settings are user-writable through the save path, and assets are deduplicated by content hash, so neither signal is an identity on its own.

**Embeds get the optimized GLB.** The embed was loading the editor representation — the glTF document plus source buffers and textures, 3.2 MB for the reported scene — and reassembling it client-side. It now loads the one published GLB through `ModelLoader.loadToThreeJS`, the same entry point a dropped `.glb` takes. No new API in `@vctrl/core`.

**The legacy POST bypass is closed.** `fetchManifestPayload` falls back to `POST get-scene-settings` whenever a manifest fails its shape check, and that action returns the entire editor payload base64-inlined. Dropping `gltfJson` from the embed manifest would have sent every embed down it. The predicate now accepts a published-model manifest, the action refuses API-key callers, and a 401/403/404 manifest throws instead of retrying.

**Two leaks closed.** `internalOnly` hotspots have been shipping to every embed — `getSceneSettings` honors the exclusion behind a `forPublicView` flag no caller has ever passed, and the manifest path never filtered at all. `embed-settings-policy` strips them plus everything that would resurrect them: the paired camera holding the viewpoint's pose, which `@vctrl/embed`'s public `activateCamera` could otherwise fly a visitor to, interactions targeting it, and an active-camera selection pointing at it. Also withheld now: `gltfJson` (the editor scene graph), the raw asset rows (every editor filename and id), and `stats`.

That camera is identified by its `kind` or by the id shape the publisher mints — never by linkage. A hotspot may link any camera the author picks, including the scene's default, so promoting on linkage would delete the scene's opening view from the embed. The id test matches the full minted shape rather than the bare prefix, because ordinary camera ids are slugified from the user's camera name and "Hotspot Camera 1" would otherwise qualify.

## Tests

Nothing caught any of this. The regression test asserts the invariant the two halves violated — *every id the manifest references is one the gate serves* — rather than testing each side alone, which is how they came to disagree while each looked correct. Each new test was confirmed to fail against the pre-fix behavior before being kept.

- `tests/embed-asset-policy.spec.ts` — the manifest/gate invariant and bake authorization
- `tests/embed-settings-policy.spec.ts` — the redaction, including the camera-classification truth table
- `tests/embed-published-load.spec.ts` — the loader branch, and that no path falls back to the POST
- `tests/integration/embed-asset-authorization.integration.spec.ts` — the same invariant against real rows seeded in the exact production shape

## Verification

`typecheck` + `lint` across `vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform`, 584 unit tests, 41 integration tests, and `nx build vectreal-platform` all pass. End-to-end against a local server with a seeded published scene and a real API key: the embed document 200s for an allowed host, 404s without a token, 403s from a host outside the project's allowed domains; the browser makes exactly two requests (manifest + GLB) with no 404s and no POST; editor assets are refused.

## Follow-ups filed separately

Two pre-existing publisher defects surfaced during review and are deliberately out of scope: deleting a hotspot removes whatever camera it links to (including the scene's default), and deleting a camera leaves a dangling `linkedCameraId` that blocks every later save.