### PR TITLE
feat(embed): build the snippet from a real key instead of a placeholder

### DIFF
--- a/apps/vectreal-platform/app/components/embed/embed-created-key-dialog.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-created-key-dialog.tsx
@@ -1,0 +1,107 @@
+import { Button } from '@shared/components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@shared/components/ui/dialog'
+import { Check, Copy } from 'lucide-react'
+import { useState, type FC } from 'react'
+import { toast } from 'sonner'
+
+import { EMBED_COPY } from '../../lib/domain/embed/embed-snippet'
+
+interface EmbedCreatedKeyDialogProps {
+	plaintext: string | null
+	onDismiss: () => void
+}
+
+/**
+ * The one and only view of a freshly minted key.
+ *
+ * A modal rather than a notice inside the panel, because the panel is not a
+ * stable place to put a secret that cannot be re-read. In the publisher it
+ * lives inside a `type="single"` accordion: opening any other section
+ * unmounts it, taking the key with it. The user would not have "left the
+ * page" - they would have clicked a heading - and the key would be gone for
+ * good. A modal blocks the accordion underneath until it is dismissed.
+ *
+ * `api-keys-new.tsx` has its own version of this for the same event. The two
+ * differ in what they tell the user to do next, which is why this is not that
+ * one lifted out; the shared shell is worth extracting once a third appears.
+ */
+export const EmbedCreatedKeyDialog: FC<EmbedCreatedKeyDialogProps> = ({
+	plaintext,
+	onDismiss
+}) => {
+	const [copied, setCopied] = useState(false)
+
+	const handleCopy = async () => {
+		if (!plaintext || !navigator?.clipboard) {
+			toast.error(EMBED_COPY.clipboardUnavailable)
+			return
+		}
+
+		try {
+			await navigator.clipboard.writeText(plaintext)
+			setCopied(true)
+			toast.success(EMBED_COPY.copyKeySuccess)
+		} catch (error) {
+			console.error('Failed to copy the API key:', error)
+			toast.error(EMBED_COPY.copyKeyFailure)
+		}
+	}
+
+	const handleDismiss = () => {
+		if (
+			!copied &&
+			!window.confirm(EMBED_COPY.createKeyDismissWithoutCopyConfirm)
+		) {
+			return
+		}
+
+		setCopied(false)
+		onDismiss()
+	}
+
+	return (
+		<Dialog
+			open={plaintext !== null}
+			onOpenChange={(open) => !open && handleDismiss()}
+		>
+			{/* Escape is disabled so the one dismissal path runs the copy check. */}
+			<DialogContent onEscapeKeyDown={(event) => event.preventDefault()}>
+				<DialogHeader>
+					<DialogTitle>{EMBED_COPY.createKeyDialogTitle}</DialogTitle>
+					<DialogDescription>{EMBED_COPY.createKeyOnce}</DialogDescription>
+				</DialogHeader>
+
+				{/*
+				  `ph-no-capture` keeps the key out of PostHog session replay. Replay
+				  masks input values by default but not ordinary DOM text, and this
+				  app sets no `maskTextSelector`, so an unmarked block renders the
+				  live key straight into any recording.
+				*/}
+				<div className="ph-no-capture bg-muted rounded-xl p-3 font-mono text-xs break-all">
+					{plaintext}
+				</div>
+
+				<DialogFooter className="gap-2 sm:justify-between">
+					<Button variant="secondary" onClick={handleCopy}>
+						{copied ? (
+							<Check className="mr-1 h-3.5 w-3.5" />
+						) : (
+							<Copy className="mr-1 h-3.5 w-3.5" />
+						)}
+						{copied ? EMBED_COPY.copied : EMBED_COPY.copyKey}
+					</Button>
+					<Button onClick={handleDismiss}>
+						{EMBED_COPY.createKeyDialogDismiss}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/vectreal-platform/app/components/embed/embed-created-key-dialog.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-created-key-dialog.tsx
@@ -15,6 +15,7 @@ import { EMBED_COPY } from '../../lib/domain/embed/embed-snippet'
 
 interface EmbedCreatedKeyDialogProps {
 	plaintext: string | null
+	expiresAt: string | null
 	onDismiss: () => void
 }
 
@@ -34,6 +35,7 @@ interface EmbedCreatedKeyDialogProps {
  */
 export const EmbedCreatedKeyDialog: FC<EmbedCreatedKeyDialogProps> = ({
 	plaintext,
+	expiresAt,
 	onDismiss
 }) => {
 	const [copied, setCopied] = useState(false)
@@ -87,6 +89,19 @@ export const EmbedCreatedKeyDialog: FC<EmbedCreatedKeyDialogProps> = ({
 				<div className="ph-no-capture bg-muted rounded-xl p-3 font-mono text-xs break-all">
 					{plaintext}
 				</div>
+
+				{/*
+				  Said here rather than left to be discovered. This key is about to
+				  be pasted into a production storefront, and an embed that stops
+				  working in three months with no warning is the expensive version
+				  of this conversation.
+				*/}
+				{expiresAt && (
+					<p className="text-muted-foreground text-xs">
+						{EMBED_COPY.createKeyExpiresPrefix}{' '}
+						{new Date(expiresAt).toLocaleDateString()}
+					</p>
+				)}
 
 				<DialogFooter className="gap-2 sm:justify-between">
 					<Button variant="secondary" onClick={handleCopy}>

--- a/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
@@ -8,9 +8,10 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@shared/components/ui/select'
-import { Copy, Eye, EyeOff, KeyRound, Plus } from 'lucide-react'
+import { Eye, EyeOff, KeyRound, Plus } from 'lucide-react'
 import { useState, type FC } from 'react'
 
+import { EmbedCreatedKeyDialog } from './embed-created-key-dialog'
 import {
 	matchesKeyPreview,
 	type EmbedApiKeyOption
@@ -20,7 +21,6 @@ import { InfoTooltip } from '../info-tooltip'
 import { InlineNotice } from '../layout-components'
 
 import type { EmbedApiKeysApi } from './use-embed-api-keys'
-import type { ClipboardCopyApi } from '../../hooks/use-clipboard-copy'
 
 /** `name ...ab3x (expired)` - enough to recognize a key you saved elsewhere. */
 function describeKey(option: EmbedApiKeyOption): string {
@@ -35,13 +35,11 @@ function describeKey(option: EmbedApiKeyOption): string {
 
 interface EmbedKeyFieldProps {
 	api: EmbedApiKeysApi
-	clipboard: ClipboardCopyApi
 }
 
-export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api, clipboard }) => {
+export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api }) => {
 	const [revealed, setRevealed] = useState(false)
 
-	const createdPlaintext = api.createdPlaintext
 	const selectedKey = api.keys.find((key) => key.id === api.selectedKeyId)
 	const previewMismatch = Boolean(
 		selectedKey &&
@@ -62,7 +60,7 @@ export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api, clipboard }) => {
 				<InfoTooltip content={EMBED_COPY.tokenHelp} />
 			</div>
 
-			<div className="flex items-center gap-2">
+			<div className="ph-no-capture flex items-center gap-2">
 				<Input
 					id="embed-token"
 					type={revealed ? 'text' : 'password'}
@@ -150,29 +148,10 @@ export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api, clipboard }) => {
 				</InlineNotice>
 			)}
 
-			{createdPlaintext && (
-				<InlineNotice>
-					<div className="flex items-start justify-between gap-2">
-						<span>{EMBED_COPY.createKeyOnce}</span>
-						<Button
-							variant="secondary"
-							size="sm"
-							onClick={() =>
-								clipboard.copy('key', createdPlaintext, {
-									success: EMBED_COPY.copyKeySuccess,
-									failure: EMBED_COPY.copyKeyFailure,
-									unavailable: EMBED_COPY.clipboardUnavailable
-								})
-							}
-						>
-							<Copy className="mr-1 h-3 w-3" />
-							{clipboard.copiedId === 'key'
-								? EMBED_COPY.copied
-								: EMBED_COPY.copyKey}
-						</Button>
-					</div>
-				</InlineNotice>
-			)}
+			<EmbedCreatedKeyDialog
+				plaintext={api.createdPlaintext}
+				onDismiss={api.dismissCreatedKey}
+			/>
 		</div>
 	)
 }

--- a/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
@@ -135,12 +135,13 @@ export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api }) => {
 			</div>
 
 			{/*
-			  Not just "no keys yet": a failed load also reports zero keys, and a
-			  member who may open this panel but may not read keys would otherwise
-			  be told the project has none directly above the 403 saying they are
-			  not allowed to know.
+			  Only once an answer is in. Zero keys is what a project with none, a
+			  request still in flight, a request never dispatched, and a refused
+			  request all look like from here - and a member who may open this
+			  panel but may not read keys would otherwise be told the project has
+			  none, directly above the 403 saying they are not allowed to know.
 			*/}
-			{api.keys.length === 0 && !api.loading && !api.loadError && (
+			{api.keys.length === 0 && api.hasLoaded && !api.loadError && (
 				<p className="text-muted-foreground text-xs">
 					{EMBED_COPY.keyPickerEmpty}
 				</p>

--- a/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
@@ -126,7 +126,8 @@ export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api }) => {
 						) : (
 							<>
 								<Plus className="mr-1 h-3.5 w-3.5" />
-								<KeyRound className="h-3.5 w-3.5" />
+								<KeyRound className="mr-1 h-3.5 w-3.5" />
+								{EMBED_COPY.createKeyShort}
 							</>
 						)}
 					</Button>
@@ -156,6 +157,7 @@ export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api }) => {
 
 			<EmbedCreatedKeyDialog
 				plaintext={api.createdPlaintext}
+				expiresAt={api.createdKeyExpiresAt}
 				onDismiss={api.dismissCreatedKey}
 			/>
 		</div>

--- a/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
@@ -133,7 +133,13 @@ export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api }) => {
 				)}
 			</div>
 
-			{api.keys.length === 0 && !api.loading && (
+			{/*
+			  Not just "no keys yet": a failed load also reports zero keys, and a
+			  member who may open this panel but may not read keys would otherwise
+			  be told the project has none directly above the 403 saying they are
+			  not allowed to know.
+			*/}
+			{api.keys.length === 0 && !api.loading && !api.loadError && (
 				<p className="text-muted-foreground text-xs">
 					{EMBED_COPY.keyPickerEmpty}
 				</p>

--- a/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-key-field.tsx
@@ -1,0 +1,178 @@
+import { Button } from '@shared/components/ui/button'
+import { Input } from '@shared/components/ui/input'
+import { Label } from '@shared/components/ui/label'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@shared/components/ui/select'
+import { Copy, Eye, EyeOff, KeyRound, Plus } from 'lucide-react'
+import { useState, type FC } from 'react'
+
+import {
+	matchesKeyPreview,
+	type EmbedApiKeyOption
+} from '../../lib/domain/embed/embed-key-options'
+import { EMBED_COPY } from '../../lib/domain/embed/embed-snippet'
+import { InfoTooltip } from '../info-tooltip'
+import { InlineNotice } from '../layout-components'
+
+import type { EmbedApiKeysApi } from './use-embed-api-keys'
+import type { ClipboardCopyApi } from '../../hooks/use-clipboard-copy'
+
+/** `name ...ab3x (expired)` - enough to recognize a key you saved elsewhere. */
+function describeKey(option: EmbedApiKeyOption): string {
+	const suffix = option.revoked
+		? ` (${EMBED_COPY.keyRevokedSuffix})`
+		: option.expired
+			? ` (${EMBED_COPY.keyExpiredSuffix})`
+			: ''
+
+	return `${option.name} ...${option.keyPreview}${suffix}`
+}
+
+interface EmbedKeyFieldProps {
+	api: EmbedApiKeysApi
+	clipboard: ClipboardCopyApi
+}
+
+export const EmbedKeyField: FC<EmbedKeyFieldProps> = ({ api, clipboard }) => {
+	const [revealed, setRevealed] = useState(false)
+
+	const createdPlaintext = api.createdPlaintext
+	const selectedKey = api.keys.find((key) => key.id === api.selectedKeyId)
+	const previewMismatch = Boolean(
+		selectedKey &&
+			api.token.trim() &&
+			!matchesKeyPreview(api.token, selectedKey.keyPreview)
+	)
+
+	return (
+		<div className="space-y-2">
+			{!api.token && (
+				<InlineNotice>{EMBED_COPY.tokenMissingNotice}</InlineNotice>
+			)}
+
+			<div className="flex items-center gap-2">
+				<Label htmlFor="embed-token" className="text-sm">
+					{EMBED_COPY.tokenLabel}
+				</Label>
+				<InfoTooltip content={EMBED_COPY.tokenHelp} />
+			</div>
+
+			<div className="flex items-center gap-2">
+				<Input
+					id="embed-token"
+					type={revealed ? 'text' : 'password'}
+					autoComplete="off"
+					spellCheck={false}
+					value={api.token}
+					onChange={(event) => api.setToken(event.target.value)}
+					placeholder={EMBED_COPY.tokenPlaceholder}
+				/>
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={() => setRevealed((current) => !current)}
+					title={revealed ? EMBED_COPY.tokenHide : EMBED_COPY.tokenReveal}
+					aria-label={revealed ? EMBED_COPY.tokenHide : EMBED_COPY.tokenReveal}
+				>
+					{revealed ? (
+						<EyeOff className="h-3.5 w-3.5" />
+					) : (
+						<Eye className="h-3.5 w-3.5" />
+					)}
+				</Button>
+			</div>
+
+			{previewMismatch && (
+				<p className="text-warning-foreground text-xs">
+					{EMBED_COPY.tokenMismatch}
+				</p>
+			)}
+
+			<div className="flex items-center gap-2">
+				<Label className="text-sm">{EMBED_COPY.keyPickerLabel}</Label>
+				<InfoTooltip content={EMBED_COPY.keyPickerHint} />
+			</div>
+
+			<div className="flex items-center gap-2">
+				<Select
+					value={api.selectedKeyId}
+					onValueChange={api.selectKey}
+					disabled={api.keys.length === 0}
+				>
+					<SelectTrigger className="flex-1">
+						<SelectValue placeholder={EMBED_COPY.keyPickerPlaceholder} />
+					</SelectTrigger>
+					<SelectContent>
+						{api.keys.map((option) => (
+							<SelectItem key={option.id} value={option.id}>
+								{describeKey(option)}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				{api.canCreateKey && (
+					<Button
+						variant="secondary"
+						size="sm"
+						onClick={api.createKey}
+						disabled={api.creating}
+						title={EMBED_COPY.createKey}
+					>
+						{api.creating ? (
+							EMBED_COPY.createKeyPending
+						) : (
+							<>
+								<Plus className="mr-1 h-3.5 w-3.5" />
+								<KeyRound className="h-3.5 w-3.5" />
+							</>
+						)}
+					</Button>
+				)}
+			</div>
+
+			{api.keys.length === 0 && !api.loading && (
+				<p className="text-muted-foreground text-xs">
+					{EMBED_COPY.keyPickerEmpty}
+				</p>
+			)}
+
+			{api.loadError && (
+				<InlineNotice tone="error">{api.loadError}</InlineNotice>
+			)}
+			{api.createError && (
+				<InlineNotice tone="error">
+					{EMBED_COPY.createKeyFailure} {api.createError}
+				</InlineNotice>
+			)}
+
+			{createdPlaintext && (
+				<InlineNotice>
+					<div className="flex items-start justify-between gap-2">
+						<span>{EMBED_COPY.createKeyOnce}</span>
+						<Button
+							variant="secondary"
+							size="sm"
+							onClick={() =>
+								clipboard.copy('key', createdPlaintext, {
+									success: EMBED_COPY.copyKeySuccess,
+									failure: EMBED_COPY.copyKeyFailure,
+									unavailable: EMBED_COPY.clipboardUnavailable
+								})
+							}
+						>
+							<Copy className="mr-1 h-3 w-3" />
+							{clipboard.copiedId === 'key'
+								? EMBED_COPY.copied
+								: EMBED_COPY.copyKey}
+						</Button>
+					</div>
+				</InlineNotice>
+			)}
+		</div>
+	)
+}

--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
@@ -51,6 +51,17 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 	const clipboard = useClipboardCopy()
 	const keysApi = useEmbedApiKeys({ projectId, enabled: canEmbed })
 
+	/*
+	  A snippet without a token is not a partial snippet, it is a broken one:
+	  `buildEmbedUrl` omits the parameter rather than failing, so the result
+	  looks finished and 404s on every site. Handing that to someone who scrolled
+	  past the notice and clicked Copy puts them exactly where this whole change
+	  started, so the copy actions wait for a key the same way the test button
+	  already did.
+	*/
+	const hasToken = Boolean(keysApi.token.trim())
+	const canCopySnippet = canEmbed && hasToken
+
 	const embedUrl = useMemo(() => {
 		if (!canEmbed || !origin) return ''
 
@@ -154,9 +165,9 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 								{EMBED_COPY.editProject}
 							</Link>
 						</div>
-						{keysApi.allowedDomains.length === 0 ? (
+						{keysApi.allowedDomains.length === 0 && !keysApi.loadError ? (
 							<InlineNotice>{EMBED_COPY.allowedDomainsEmpty}</InlineNotice>
-						) : (
+						) : keysApi.allowedDomains.length === 0 ? null : (
 							<div className="flex flex-wrap gap-1">
 								{keysApi.allowedDomains.map((domain) => (
 									<code
@@ -210,7 +221,8 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 						variant="secondary"
 						size="sm"
 						onClick={handleCopyUrl}
-						disabled={!canEmbed}
+						disabled={!canCopySnippet}
+						title={hasToken ? undefined : EMBED_COPY.copyNeedsToken}
 					>
 						<Link2 className="mr-2 h-3.5 w-3.5" />
 						{clipboard.copiedId === 'url'
@@ -316,7 +328,8 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 									failure: EMBED_COPY.copyEmbedFailure
 								})
 							}
-							disabled={!canEmbed}
+							disabled={!canCopySnippet}
+							title={hasToken ? undefined : EMBED_COPY.copyNeedsToken}
 						>
 							<Copy className="mr-1 h-3 w-3" />
 							{clipboard.copiedId === 'embed'
@@ -347,7 +360,8 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 									failure: EMBED_COPY.copySdkFailure
 								})
 							}
-							disabled={!canEmbed}
+							disabled={!canCopySnippet}
+							title={hasToken ? undefined : EMBED_COPY.copyNeedsToken}
 						>
 							<Copy className="mr-1 h-3 w-3" />
 							{clipboard.copiedId === 'sdk'

--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
@@ -139,7 +139,7 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 
 			{canEmbed && (
 				<>
-					<EmbedKeyField api={keysApi} clipboard={clipboard} />
+					<EmbedKeyField api={keysApi} />
 
 					<div className="space-y-1">
 						<div className="flex items-center gap-2">
@@ -201,6 +201,7 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 				<Label className="text-sm">{EMBED_COPY.previewUrlLabel}</Label>
 				<div className="flex items-center gap-2">
 					<Input
+						className="ph-no-capture"
 						readOnly
 						value={embedUrl}
 						placeholder={EMBED_COPY.previewUrlPlaceholder}
@@ -322,7 +323,7 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 								? EMBED_COPY.copied
 								: EMBED_COPY.copyEmbed}
 						</Button>
-						<div className="bg-muted no-scrollbar relative overflow-x-auto rounded-2xl p-3 font-mono text-xs">
+						<div className="ph-no-capture bg-muted no-scrollbar relative overflow-x-auto rounded-2xl p-3 font-mono text-xs">
 							<pre>{embedCode}</pre>
 						</div>
 					</div>
@@ -353,7 +354,7 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 								? EMBED_COPY.copied
 								: EMBED_COPY.copySdk}
 						</Button>
-						<div className="bg-muted no-scrollbar relative overflow-x-auto rounded-2xl p-3 font-mono text-xs">
+						<div className="ph-no-capture bg-muted no-scrollbar relative overflow-x-auto rounded-2xl p-3 font-mono text-xs">
 							<pre>{sdkCode}</pre>
 						</div>
 					</div>

--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
@@ -9,16 +9,19 @@ import {
 } from '@shared/components/ui/tabs'
 import { cn } from '@shared/utils'
 import { Copy, ExternalLink, Link2 } from 'lucide-react'
-import { useMemo, useState, type FC } from 'react'
+import { useEffect, useMemo, useState, type FC } from 'react'
+import { Link } from 'react-router'
 import { toast } from 'sonner'
 
+import { EmbedKeyField } from './embed-key-field'
+import { useEmbedApiKeys } from './use-embed-api-keys'
+import { useClipboardCopy } from '../../hooks/use-clipboard-copy'
 import {
-	addPreviewTokenPlaceholder,
-	buildEmbedPath,
+	buildEmbedUrl,
+	buildInternalPreviewPath,
 	buildResponsiveEmbedSnippet,
 	buildSdkEmbedSnippet,
 	EMBED_COPY,
-	PREVIEW_API_KEY_PLACEHOLDER,
 	toAbsoluteEmbedUrl
 } from '../../lib/domain/embed/embed-snippet'
 import { InfoTooltip } from '../info-tooltip'
@@ -37,127 +40,95 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 }) => {
 	const [width, setWidth] = useState('100%')
 	const [height, setHeight] = useState('400px')
-	const [copiedUrl, setCopiedUrl] = useState(false)
-	const [copiedCode, setCopiedCode] = useState(false)
-	const [copiedSdk, setCopiedSdk] = useState(false)
+
+	// Read after mount rather than during render: the server has no `window`, so
+	// deriving the URL inline renders one thing on the server and another on the
+	// client, which is a hydration mismatch on a form value.
+	const [origin, setOrigin] = useState('')
+	useEffect(() => setOrigin(window.location.origin), [])
+
 	const canEmbed = Boolean(sceneId && projectId)
+	const clipboard = useClipboardCopy()
+	const keysApi = useEmbedApiKeys({ projectId, enabled: canEmbed })
 
-	const previewPath = canEmbed
-		? buildEmbedPath({
-				projectId: projectId as string,
-				sceneId: sceneId as string
-			})
-		: ''
-	const previewPathWithTokenPlaceholder = previewPath
-		? addPreviewTokenPlaceholder(previewPath)
-		: ''
+	const embedUrl = useMemo(() => {
+		if (!canEmbed || !origin) return ''
 
-	const absolutePreviewUrl = useMemo(() => {
-		if (!previewPathWithTokenPlaceholder || typeof window === 'undefined') {
-			return previewPathWithTokenPlaceholder
-		}
+		return buildEmbedUrl({
+			origin,
+			projectId: projectId as string,
+			sceneId: sceneId as string,
+			token: keysApi.token
+		})
+	}, [canEmbed, origin, projectId, sceneId, keysApi.token])
+
+	const internalPreviewUrl = useMemo(() => {
+		if (!canEmbed || !origin) return ''
 
 		return toAbsoluteEmbedUrl(
-			previewPathWithTokenPlaceholder,
-			window.location.origin
+			buildInternalPreviewPath({
+				projectId: projectId as string,
+				sceneId: sceneId as string
+			}),
+			origin
 		)
-	}, [previewPathWithTokenPlaceholder])
+	}, [canEmbed, origin, projectId, sceneId])
 
-	const absolutePreviewUrlNoToken = useMemo(() => {
-		if (!previewPath || typeof window === 'undefined') return ''
-		return toAbsoluteEmbedUrl(previewPath, window.location.origin)
-	}, [previewPath])
+	const embedCode = embedUrl
+		? buildResponsiveEmbedSnippet({ src: embedUrl, width, height })
+		: EMBED_COPY.embedCodeUnavailable
 
-	const generateEmbedCode = () => {
-		if (!absolutePreviewUrl) {
-			return EMBED_COPY.embedCodeUnavailable
-		}
+	const sdkCode = embedUrl
+		? buildSdkEmbedSnippet({ src: embedUrl, width, height })
+		: EMBED_COPY.sdkCodeUnavailable
 
-		return buildResponsiveEmbedSnippet({
-			src: absolutePreviewUrl,
-			width,
-			height
-		})
-	}
-
-	const generateSdkCode = () => {
-		if (!absolutePreviewUrl) {
-			return EMBED_COPY.sdkCodeUnavailable
-		}
-
-		return buildSdkEmbedSnippet({
-			src: absolutePreviewUrl,
-			width,
-			height
-		})
-	}
-
-	const handleCopyCode = async () => {
+	const copySnippet = (
+		id: 'embed' | 'sdk',
+		value: string,
+		messages: { success: string; failure: string }
+	) => {
 		if (!canEmbed) {
 			toast.error(EMBED_COPY.missingSceneForEmbed)
 			return
 		}
-		if (!navigator?.clipboard) {
-			toast.error(EMBED_COPY.clipboardUnavailable)
-			return
-		}
 
-		try {
-			await navigator.clipboard.writeText(generateEmbedCode())
-			setCopiedCode(true)
-			window.setTimeout(() => setCopiedCode(false), 1500)
-			toast.success(EMBED_COPY.copyEmbedSuccess)
-		} catch (error) {
-			console.error('Failed to copy embed code:', error)
-			toast.error(EMBED_COPY.copyEmbedFailure)
-		}
+		void clipboard.copy(id, value, {
+			...messages,
+			unavailable: EMBED_COPY.clipboardUnavailable
+		})
 	}
 
-	const handleCopySdk = async () => {
-		if (!canEmbed) {
-			toast.error(EMBED_COPY.missingSceneForEmbed)
-			return
-		}
-		if (!navigator?.clipboard) {
-			toast.error(EMBED_COPY.clipboardUnavailable)
-			return
-		}
-
-		try {
-			await navigator.clipboard.writeText(generateSdkCode())
-			setCopiedSdk(true)
-			window.setTimeout(() => setCopiedSdk(false), 1500)
-			toast.success(EMBED_COPY.copySdkSuccess)
-		} catch (error) {
-			console.error('Failed to copy SDK snippet:', error)
-			toast.error(EMBED_COPY.copySdkFailure)
-		}
-	}
-
-	const handleCopyUrl = async () => {
+	const handleCopyUrl = () => {
 		if (!canEmbed) {
 			toast.error(EMBED_COPY.missingSceneForUrl)
 			return
 		}
-		if (!navigator?.clipboard) {
-			toast.error(EMBED_COPY.clipboardUnavailable)
-			return
-		}
 
-		try {
-			await navigator.clipboard.writeText(absolutePreviewUrl)
-			setCopiedUrl(true)
-			window.setTimeout(() => setCopiedUrl(false), 1500)
-			toast.success(EMBED_COPY.copyUrlSuccess)
-		} catch (error) {
-			console.error('Failed to copy preview URL:', error)
-			toast.error(EMBED_COPY.copyUrlFailure)
-		}
+		void clipboard.copy('url', embedUrl, {
+			success: EMBED_COPY.copyUrlSuccess,
+			failure: EMBED_COPY.copyUrlFailure,
+			unavailable: EMBED_COPY.clipboardUnavailable
+		})
 	}
 
-	const handleOpenPreview = () => {
-		if (!absolutePreviewUrlNoToken) return
-		window.open(absolutePreviewUrlNoToken, '_blank', 'noopener,noreferrer')
+	const copyIdentifier = (id: 'project-id' | 'scene-id', value: string) => {
+		void clipboard.copy(id, value, {
+			success: EMBED_COPY.copyIdSuccess,
+			failure: EMBED_COPY.copyUrlFailure,
+			unavailable: EMBED_COPY.clipboardUnavailable
+		})
+	}
+
+	/*
+	  `noopener` without `noreferrer`, deliberately. `noreferrer` strips the
+	  `Referer` header, and `validatePreviewApiKeyForProject` then sees no
+	  requester host at all: off a localhost-like instance that falls straight
+	  through to `domain_not_allowed`, so the button meant to prove the embed
+	  works would 403 on every production scene that is in fact fine.
+	*/
+	const openInNewTab = (url: string) => {
+		if (!url) return
+		window.open(url, '_blank', 'noopener')
 	}
 
 	return (
@@ -165,16 +136,40 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 			{!canEmbed && (
 				<InlineNotice>{EMBED_COPY.unavailableUntilSaved}</InlineNotice>
 			)}
+
 			{canEmbed && (
-				<InlineNotice>
-					{EMBED_COPY.draftWarningPrefix}
-					<code className="mx-1">{PREVIEW_API_KEY_PLACEHOLDER}</code>
-					{EMBED_COPY.draftWarningSuffix}
-					<div className="text-label-xs mt-1 opacity-80">
-						Tip: create separate keys per environment and restrict keys to only
-						the projects each embed needs.
+				<>
+					<EmbedKeyField api={keysApi} clipboard={clipboard} />
+
+					<div className="space-y-1">
+						<div className="flex items-center gap-2">
+							<Label className="text-sm">
+								{EMBED_COPY.allowedDomainsLabel}
+							</Label>
+							<InfoTooltip content={EMBED_COPY.allowedDomainsHelp} />
+							<Link
+								to={`/dashboard/projects/${projectId}/edit`}
+								className="text-label-xs text-muted-foreground hover:text-foreground ml-auto underline"
+							>
+								{EMBED_COPY.editProject}
+							</Link>
+						</div>
+						{keysApi.allowedDomains.length === 0 ? (
+							<InlineNotice>{EMBED_COPY.allowedDomainsEmpty}</InlineNotice>
+						) : (
+							<div className="flex flex-wrap gap-1">
+								{keysApi.allowedDomains.map((domain) => (
+									<code
+										key={domain}
+										className="bg-muted rounded-md px-2 py-0.5 font-mono text-xs"
+									>
+										{domain}
+									</code>
+								))}
+							</div>
+						)}
 					</div>
-				</InlineNotice>
+				</>
 			)}
 
 			<div className="grid grid-cols-2 gap-4">
@@ -207,7 +202,7 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 				<div className="flex items-center gap-2">
 					<Input
 						readOnly
-						value={absolutePreviewUrl}
+						value={embedUrl}
 						placeholder={EMBED_COPY.previewUrlPlaceholder}
 					/>
 					<Button
@@ -217,19 +212,80 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 						disabled={!canEmbed}
 					>
 						<Link2 className="mr-2 h-3.5 w-3.5" />
-						{copiedUrl ? EMBED_COPY.copied : EMBED_COPY.copyUrl}
+						{clipboard.copiedId === 'url'
+							? EMBED_COPY.copied
+							: EMBED_COPY.copyUrl}
 					</Button>
+				</div>
+				<div className="flex items-center gap-2">
 					<Button
 						variant="ghost"
 						size="sm"
-						onClick={handleOpenPreview}
+						onClick={() => openInNewTab(internalPreviewUrl)}
 						disabled={!canEmbed}
-						title={EMBED_COPY.openPreview}
 					>
-						<ExternalLink className="h-3.5 w-3.5" />
+						<ExternalLink className="mr-1 h-3.5 w-3.5" />
+						{EMBED_COPY.openPreview}
 					</Button>
+					<InfoTooltip content={EMBED_COPY.openPreviewHelp} />
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => openInNewTab(embedUrl)}
+						disabled={!canEmbed || !keysApi.token.trim()}
+					>
+						<ExternalLink className="mr-1 h-3.5 w-3.5" />
+						{EMBED_COPY.testEmbedUrl}
+					</Button>
+					<InfoTooltip content={EMBED_COPY.testEmbedUrlHelp} />
 				</div>
 			</div>
+
+			{canEmbed && (
+				<div className="space-y-1">
+					<Label className="text-sm">{EMBED_COPY.identifiersLabel}</Label>
+					<div className="grid gap-1">
+						{(
+							[
+								{
+									id: 'project-id' as const,
+									label: EMBED_COPY.projectIdLabel,
+									value: projectId as string
+								},
+								{
+									id: 'scene-id' as const,
+									label: EMBED_COPY.sceneIdLabel,
+									value: sceneId as string
+								}
+							] satisfies Array<{
+								id: 'project-id' | 'scene-id'
+								label: string
+								value: string
+							}>
+						).map((identifier) => (
+							<div key={identifier.id} className="flex items-center gap-2">
+								<span className="text-muted-foreground w-20 shrink-0 text-xs">
+									{identifier.label}
+								</span>
+								<code className="bg-muted min-w-0 flex-1 truncate rounded-md px-2 py-1 font-mono text-xs">
+									{identifier.value}
+								</code>
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => copyIdentifier(identifier.id, identifier.value)}
+									aria-label={identifier.label}
+								>
+									<Copy className="h-3 w-3" />
+									{clipboard.copiedId === identifier.id && (
+										<span className="ml-1 text-xs">{EMBED_COPY.copied}</span>
+									)}
+								</Button>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
 
 			<Tabs defaultValue="html">
 				<TabsList className="w-full">
@@ -253,14 +309,21 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 							variant="secondary"
 							className="bg-muted/50 absolute top-2 right-2 z-10 backdrop-blur-sm"
 							size="sm"
-							onClick={handleCopyCode}
+							onClick={() =>
+								copySnippet('embed', embedCode, {
+									success: EMBED_COPY.copyEmbedSuccess,
+									failure: EMBED_COPY.copyEmbedFailure
+								})
+							}
 							disabled={!canEmbed}
 						>
 							<Copy className="mr-1 h-3 w-3" />
-							{copiedCode ? EMBED_COPY.copied : EMBED_COPY.copyEmbed}
+							{clipboard.copiedId === 'embed'
+								? EMBED_COPY.copied
+								: EMBED_COPY.copyEmbed}
 						</Button>
 						<div className="bg-muted no-scrollbar relative overflow-x-auto rounded-2xl p-3 font-mono text-xs">
-							<pre>{generateEmbedCode()}</pre>
+							<pre>{embedCode}</pre>
 						</div>
 					</div>
 				</TabsContent>
@@ -277,14 +340,21 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 							variant="secondary"
 							className="bg-muted/50 absolute top-2 right-2 z-10 backdrop-blur-sm"
 							size="sm"
-							onClick={handleCopySdk}
+							onClick={() =>
+								copySnippet('sdk', sdkCode, {
+									success: EMBED_COPY.copySdkSuccess,
+									failure: EMBED_COPY.copySdkFailure
+								})
+							}
 							disabled={!canEmbed}
 						>
 							<Copy className="mr-1 h-3 w-3" />
-							{copiedSdk ? EMBED_COPY.copied : EMBED_COPY.copySdk}
+							{clipboard.copiedId === 'sdk'
+								? EMBED_COPY.copied
+								: EMBED_COPY.copySdk}
 						</Button>
 						<div className="bg-muted no-scrollbar relative overflow-x-auto rounded-2xl p-3 font-mono text-xs">
-							<pre>{generateSdkCode()}</pre>
+							<pre>{sdkCode}</pre>
 						</div>
 					</div>
 				</TabsContent>

--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
@@ -166,13 +166,15 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 							</Link>
 						</div>
 						{/*
-						  Silent unless the list is known to be empty. Both a load in
-						  flight and a refused one report zero domains, and this notice
-						  states as fact that the project refuses every third-party site
-						  - which is alarming, actionable, and wrong in both cases.
+						  Silent unless the list is known to be empty. A load in flight,
+						  a load never dispatched (this panel is server-rendered, and the
+						  request goes out from an effect) and a refused load all report
+						  zero domains, and this notice states as fact that the project
+						  refuses every third-party site - alarming, actionable, and
+						  wrong in all three.
 						*/}
 						{keysApi.allowedDomains.length === 0 ? (
-							!keysApi.loading && !keysApi.loadError ? (
+							keysApi.hasLoaded && !keysApi.loadError ? (
 								<InlineNotice>{EMBED_COPY.allowedDomainsEmpty}</InlineNotice>
 							) : null
 						) : (

--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
@@ -165,9 +165,17 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 								{EMBED_COPY.editProject}
 							</Link>
 						</div>
-						{keysApi.allowedDomains.length === 0 && !keysApi.loadError ? (
-							<InlineNotice>{EMBED_COPY.allowedDomainsEmpty}</InlineNotice>
-						) : keysApi.allowedDomains.length === 0 ? null : (
+						{/*
+						  Silent unless the list is known to be empty. Both a load in
+						  flight and a refused one report zero domains, and this notice
+						  states as fact that the project refuses every third-party site
+						  - which is alarming, actionable, and wrong in both cases.
+						*/}
+						{keysApi.allowedDomains.length === 0 ? (
+							!keysApi.loading && !keysApi.loadError ? (
+								<InlineNotice>{EMBED_COPY.allowedDomainsEmpty}</InlineNotice>
+							) : null
+						) : (
 							<div className="flex flex-wrap gap-1">
 								{keysApi.allowedDomains.map((domain) => (
 									<code

--- a/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
+++ b/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
@@ -45,6 +45,8 @@ export interface EmbedApiKeysApi {
 	selectKey: (keyId: string) => void
 	/** Set once, when a key is minted here. The only time a key is readable. */
 	createdPlaintext: string | null
+	/** Expiry of that key, so the dialog can say when the embed will stop. */
+	createdKeyExpiresAt: string | null
 	/** Closes the one-time key dialog. The value is unrecoverable afterwards. */
 	dismissCreatedKey: () => void
 	createKey: () => void
@@ -82,6 +84,9 @@ export function useEmbedApiKeys(params: {
 	const [token, setToken] = useState('')
 	const [selectedKeyId, setSelectedKeyId] = useState('')
 	const [createdPlaintext, setCreatedPlaintext] = useState<string | null>(null)
+	const [createdKeyExpiresAt, setCreatedKeyExpiresAt] = useState<string | null>(
+		null
+	)
 
 	const requestedEndpointRef = useRef<string | null>(null)
 	const handledCreateRef = useRef<unknown>(null)
@@ -127,6 +132,7 @@ export function useEmbedApiKeys(params: {
 
 		const { key, plaintext } = createFetcher.data.data
 		setCreatedPlaintext(plaintext)
+		setCreatedKeyExpiresAt(key.expiresAt)
 		setToken(plaintext)
 		setSelectedKeyId(key.id)
 		listFetcher.load(endpoint)
@@ -164,6 +170,7 @@ export function useEmbedApiKeys(params: {
 		selectedKeyId,
 		selectKey,
 		createdPlaintext,
+		createdKeyExpiresAt,
 		dismissCreatedKey,
 		createKey,
 		creating: createFetcher.state !== 'idle',

--- a/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
+++ b/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
@@ -36,7 +36,20 @@ export interface EmbedApiKeysApi {
 	keys: EmbedApiKeyOption[]
 	allowedDomains: string[]
 	canCreateKey: boolean
-	loading: boolean
+	/**
+	 * Whether an answer has actually come back.
+	 *
+	 * Not the inverse of a spinner. `listFetcher.state` is `'idle'` both after a
+	 * request finishes *and* before one is ever dispatched, and the request is
+	 * dispatched from an effect - which never runs on the server. So a
+	 * state-derived "loading" flag reads `false` during server rendering, and
+	 * every empty-state message gated on it renders into the SSR'd HTML as a
+	 * confident statement of fact about data nobody has fetched yet.
+	 *
+	 * Presence of `data` is the honest signal: it is set once, by a response,
+	 * success or failure alike.
+	 */
+	hasLoaded: boolean
 	loadError: string | null
 	/** Held in React state only: never persisted, never sent to analytics. */
 	token: string
@@ -160,7 +173,7 @@ export function useEmbedApiKeys(params: {
 		keys: payload?.keys ?? EMPTY_KEYS,
 		allowedDomains: payload?.allowedDomains ?? EMPTY_DOMAINS,
 		canCreateKey: payload?.canCreateKey ?? false,
-		loading: listFetcher.state !== 'idle',
+		hasLoaded: listFetcher.data !== undefined,
 		loadError:
 			listFetcher.data && !listFetcher.data.success
 				? (listFetcher.data.error ?? 'Could not load API keys.')

--- a/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
+++ b/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
@@ -27,6 +27,8 @@ export interface EmbedApiKeysApi {
 	selectKey: (keyId: string) => void
 	/** Set once, when a key is minted here. The only time a key is readable. */
 	createdPlaintext: string | null
+	/** Closes the one-time key dialog. The value is unrecoverable afterwards. */
+	dismissCreatedKey: () => void
 	createKey: () => void
 	creating: boolean
 	createError: string | null
@@ -104,6 +106,10 @@ export function useEmbedApiKeys(params: {
 		setSelectedKeyId(keyId)
 	}, [])
 
+	const dismissCreatedKey = useCallback(() => {
+		setCreatedPlaintext(null)
+	}, [])
+
 	const payload = listFetcher.data?.success ? listFetcher.data.data : null
 
 	return {
@@ -120,6 +126,7 @@ export function useEmbedApiKeys(params: {
 		selectedKeyId,
 		selectKey,
 		createdPlaintext,
+		dismissCreatedKey,
 		createKey,
 		creating: createFetcher.state !== 'idle',
 		createError:

--- a/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
+++ b/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai'
+import { useSetAtom } from 'jotai/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useFetcher } from 'react-router'
 import { useAuthenticityToken } from 'remix-utils/csrf/react'

--- a/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
+++ b/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
@@ -1,7 +1,14 @@
+import { useSetAtom } from 'jotai'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useFetcher } from 'react-router'
 import { useAuthenticityToken } from 'remix-utils/csrf/react'
 
+import {
+	buildUpgradeModalState,
+	upgradeModalAtom
+} from '../../lib/stores/upgrade-modal-store'
+
+import type { Plan } from '../../constants/plan-config'
 import type { EmbedApiKeyOption } from '../../lib/domain/embed/embed-key-options'
 import type {
 	EmbedApiKeyCreatedPayload,
@@ -10,9 +17,20 @@ import type {
 
 /**
  * `ApiResponse.success` wraps the payload; `ApiResponse.error` returns a bare
- * `{ success: false, error }`.
+ * `{ success: false, error }`. `ApiResponse.quotaExceeded` adds `quota`, which
+ * is what the upgrade modal needs to name the limit that was hit.
  */
-type Envelope<T> = { success: true; data: T } | { success: false; error?: string }
+interface QuotaEnvelope {
+	limitKey: string
+	currentValue: number
+	limit: number | null
+	plan: Plan
+	upgradeTo?: Plan | null
+}
+
+type Envelope<T> =
+	| { success: true; data: T }
+	| { success: false; error?: string; quota?: QuotaEnvelope }
 
 export interface EmbedApiKeysApi {
 	keys: EmbedApiKeyOption[]
@@ -59,6 +77,7 @@ export function useEmbedApiKeys(params: {
 	const listFetcher = useFetcher<Envelope<EmbedApiKeysPayload>>()
 	const createFetcher = useFetcher<Envelope<EmbedApiKeyCreatedPayload>>()
 	const csrfToken = useAuthenticityToken()
+	const setUpgradeModal = useSetAtom(upgradeModalAtom)
 
 	const [token, setToken] = useState('')
 	const [selectedKeyId, setSelectedKeyId] = useState('')
@@ -85,14 +104,33 @@ export function useEmbedApiKeys(params: {
 		if (handledCreateRef.current === createFetcher.data) return
 		handledCreateRef.current = createFetcher.data
 
-		if (!createFetcher.data.success || !endpoint) return
+		if (!createFetcher.data.success) {
+			// The org is out of API keys on its plan. The route forwards what the
+			// upgrade prompt needs, so route it there rather than leaving the user
+			// with an error string and no way forward - this is what the full
+			// create-key form does for the same error.
+			const { quota, error } = createFetcher.data
+			if (quota) {
+				setUpgradeModal(
+					buildUpgradeModalState({
+						reason: 'quota_exceeded',
+						message: error ?? 'API key limit reached for your plan.',
+						...quota,
+						actionAttempted: 'api_key_create'
+					})
+				)
+			}
+			return
+		}
+
+		if (!endpoint) return
 
 		const { key, plaintext } = createFetcher.data.data
 		setCreatedPlaintext(plaintext)
 		setToken(plaintext)
 		setSelectedKeyId(key.id)
 		listFetcher.load(endpoint)
-	}, [createFetcher.state, createFetcher.data, endpoint])
+	}, [createFetcher.state, createFetcher.data, endpoint, setUpgradeModal])
 
 	const createKey = useCallback(() => {
 		if (!endpoint) return
@@ -130,7 +168,9 @@ export function useEmbedApiKeys(params: {
 		createKey,
 		creating: createFetcher.state !== 'idle',
 		createError:
-			createFetcher.data && !createFetcher.data.success
+			createFetcher.data &&
+			!createFetcher.data.success &&
+			!createFetcher.data.quota
 				? (createFetcher.data.error ?? null)
 				: null
 	}

--- a/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
+++ b/apps/vectreal-platform/app/components/embed/use-embed-api-keys.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useFetcher } from 'react-router'
+import { useAuthenticityToken } from 'remix-utils/csrf/react'
+
+import type { EmbedApiKeyOption } from '../../lib/domain/embed/embed-key-options'
+import type {
+	EmbedApiKeyCreatedPayload,
+	EmbedApiKeysPayload
+} from '../../routes/api/projects.$projectId.api-keys'
+
+/**
+ * `ApiResponse.success` wraps the payload; `ApiResponse.error` returns a bare
+ * `{ success: false, error }`.
+ */
+type Envelope<T> = { success: true; data: T } | { success: false; error?: string }
+
+export interface EmbedApiKeysApi {
+	keys: EmbedApiKeyOption[]
+	allowedDomains: string[]
+	canCreateKey: boolean
+	loading: boolean
+	loadError: string | null
+	/** Held in React state only: never persisted, never sent to analytics. */
+	token: string
+	setToken: (value: string) => void
+	selectedKeyId: string
+	selectKey: (keyId: string) => void
+	/** Set once, when a key is minted here. The only time a key is readable. */
+	createdPlaintext: string | null
+	createKey: () => void
+	creating: boolean
+	createError: string | null
+}
+
+const EMPTY_KEYS: EmbedApiKeyOption[] = []
+const EMPTY_DOMAINS: string[] = []
+
+/**
+ * The embed panel's API key state.
+ *
+ * Lives outside the panel because it is most of what the panel does: two
+ * fetchers, the token the snippet is built from, and the one-shot plaintext a
+ * freshly created key returns. Leaving it inline made the panel a component
+ * with more state than markup.
+ *
+ * The token deliberately has no persistence. Writing it to `localStorage` would
+ * leave a working embed credential in the browser of anyone who opens this
+ * panel on a shared machine, and it is cheap to paste again.
+ */
+export function useEmbedApiKeys(params: {
+	projectId?: string
+	enabled: boolean
+}): EmbedApiKeysApi {
+	const { projectId, enabled } = params
+	const endpoint = projectId ? `/api/projects/${projectId}/api-keys` : null
+
+	const listFetcher = useFetcher<Envelope<EmbedApiKeysPayload>>()
+	const createFetcher = useFetcher<Envelope<EmbedApiKeyCreatedPayload>>()
+	const csrfToken = useAuthenticityToken()
+
+	const [token, setToken] = useState('')
+	const [selectedKeyId, setSelectedKeyId] = useState('')
+	const [createdPlaintext, setCreatedPlaintext] = useState<string | null>(null)
+
+	const requestedEndpointRef = useRef<string | null>(null)
+	const handledCreateRef = useRef<unknown>(null)
+
+	useEffect(() => {
+		if (!enabled || !endpoint) return
+		if (requestedEndpointRef.current === endpoint) return
+
+		requestedEndpointRef.current = endpoint
+		listFetcher.load(endpoint)
+		// `listFetcher` is deliberately not a dependency: it is a new object every
+		// render, so depending on it re-fires the request on each one. The ref is
+		// what makes this run once per endpoint.
+	}, [enabled, endpoint])
+
+	// A newly minted key is the one the user wants selected and pasted, and the
+	// list it has to appear in was fetched before it existed.
+	useEffect(() => {
+		if (createFetcher.state !== 'idle' || !createFetcher.data) return
+		if (handledCreateRef.current === createFetcher.data) return
+		handledCreateRef.current = createFetcher.data
+
+		if (!createFetcher.data.success || !endpoint) return
+
+		const { key, plaintext } = createFetcher.data.data
+		setCreatedPlaintext(plaintext)
+		setToken(plaintext)
+		setSelectedKeyId(key.id)
+		listFetcher.load(endpoint)
+	}, [createFetcher.state, createFetcher.data, endpoint])
+
+	const createKey = useCallback(() => {
+		if (!endpoint) return
+		createFetcher.submit(
+			{ intent: 'create', csrf: csrfToken },
+			{ method: 'post', action: endpoint }
+		)
+	}, [createFetcher, csrfToken, endpoint])
+
+	const selectKey = useCallback((keyId: string) => {
+		setSelectedKeyId(keyId)
+	}, [])
+
+	const payload = listFetcher.data?.success ? listFetcher.data.data : null
+
+	return {
+		keys: payload?.keys ?? EMPTY_KEYS,
+		allowedDomains: payload?.allowedDomains ?? EMPTY_DOMAINS,
+		canCreateKey: payload?.canCreateKey ?? false,
+		loading: listFetcher.state !== 'idle',
+		loadError:
+			listFetcher.data && !listFetcher.data.success
+				? (listFetcher.data.error ?? 'Could not load API keys.')
+				: null,
+		token,
+		setToken,
+		selectedKeyId,
+		selectKey,
+		createdPlaintext,
+		createKey,
+		creating: createFetcher.state !== 'idle',
+		createError:
+			createFetcher.data && !createFetcher.data.success
+				? (createFetcher.data.error ?? null)
+				: null
+	}
+}

--- a/apps/vectreal-platform/app/hooks/use-clipboard-copy.ts
+++ b/apps/vectreal-platform/app/hooks/use-clipboard-copy.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+const CONFIRMATION_MS = 1500
+
+export interface ClipboardCopyApi {
+	copy: (
+		id: string,
+		value: string,
+		messages: { success: string; failure: string; unavailable: string }
+	) => Promise<void>
+	/** Id of the button that most recently copied, for its "Copied" label. */
+	copiedId: string | null
+}
+
+/**
+ * Copy-to-clipboard with a short per-button confirmation.
+ *
+ * One `copiedId` rather than a boolean per button: the embed panel has six copy
+ * affordances, and each one carrying its own `useState` plus `setTimeout` was
+ * how the three that existed before drifted into three slightly different
+ * versions of the same handler.
+ */
+export function useClipboardCopy(): ClipboardCopyApi {
+	const [copiedId, setCopiedId] = useState<string | null>(null)
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+	useEffect(
+		() => () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current)
+		},
+		[]
+	)
+
+	const copy = useCallback(
+		async (
+			id: string,
+			value: string,
+			messages: { success: string; failure: string; unavailable: string }
+		) => {
+			if (!navigator?.clipboard) {
+				toast.error(messages.unavailable)
+				return
+			}
+
+			try {
+				await navigator.clipboard.writeText(value)
+				setCopiedId(id)
+				if (timeoutRef.current) clearTimeout(timeoutRef.current)
+				timeoutRef.current = setTimeout(() => setCopiedId(null), CONFIRMATION_MS)
+				toast.success(messages.success)
+			} catch (error) {
+				console.error('Failed to copy to clipboard:', error)
+				toast.error(messages.failure)
+			}
+		},
+		[]
+	)
+
+	return { copy, copiedId }
+}

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-key-options.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-key-options.ts
@@ -1,0 +1,87 @@
+/**
+ * Shaping API keys for the embed panel's key picker.
+ *
+ * Pure - no database import and no `.server` suffix - so the rules below are
+ * testable directly rather than only through a route, and so the client can
+ * import the option type without pulling the db client in.
+ */
+
+/** One row in the embed panel's key picker. Never carries a key's plaintext. */
+export interface EmbedApiKeyOption {
+	id: string
+	name: string
+	/** Last four characters of the key. The only part ever stored in the clear. */
+	keyPreview: string
+	expiresAt: string | null
+	lastUsedAt: string | null
+	revoked: boolean
+	expired: boolean
+}
+
+/** Minimum of `ApiKeyWithDetails` this module reads. */
+export interface EmbedApiKeySource {
+	apiKey: {
+		id: string
+		name: string
+		keyPreview: string
+		active: boolean | null
+		expiresAt: Date | null
+		revokedAt: Date | null
+		lastUsedAt: Date | null
+		createdAt: Date
+	}
+	projects: Array<{ id: string }>
+}
+
+/**
+ * The keys scoped to one project, usable ones first.
+ *
+ * Revoked and expired keys are kept rather than filtered out. They are the
+ * answer to the question that brings someone to this panel - an embed that
+ * worked yesterday and 404s today usually names a key in its URL that has since
+ * been revoked or aged out, and a picker that hides those leaves the owner
+ * comparing a working key against an empty list.
+ */
+export function toEmbedApiKeyOptions(
+	keys: EmbedApiKeySource[],
+	projectId: string,
+	now: Date
+): EmbedApiKeyOption[] {
+	return keys
+		.filter((key) => key.projects.some((project) => project.id === projectId))
+		.map((key) => ({
+			id: key.apiKey.id,
+			name: key.apiKey.name,
+			keyPreview: key.apiKey.keyPreview,
+			expiresAt: key.apiKey.expiresAt?.toISOString() ?? null,
+			lastUsedAt: key.apiKey.lastUsedAt?.toISOString() ?? null,
+			revoked: key.apiKey.revokedAt !== null || key.apiKey.active === false,
+			expired:
+				key.apiKey.expiresAt !== null &&
+				key.apiKey.expiresAt.getTime() <= now.getTime(),
+			createdAt: key.apiKey.createdAt.getTime()
+		}))
+		.sort((a, b) => {
+			const byUsable =
+				Number(a.revoked || a.expired) - Number(b.revoked || b.expired)
+			return byUsable !== 0 ? byUsable : b.createdAt - a.createdAt
+		})
+		.map(({ createdAt: _createdAt, ...option }) => option)
+}
+
+/**
+ * Whether a pasted token could be the selected key.
+ *
+ * Only the last four characters are stored in the clear, so this is the whole
+ * check that is available: it catches pasting the wrong key of several, and
+ * cannot confirm the right one. Advisory, never a gate - a false negative here
+ * must not stop someone shipping a key that works.
+ */
+export function matchesKeyPreview(token: string, keyPreview: string): boolean {
+	const trimmed = token.trim()
+	if (trimmed.length < keyPreview.length) {
+		return false
+	}
+
+	return trimmed.slice(-keyPreview.length) === keyPreview
+}

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
@@ -22,6 +22,8 @@ export const EMBED_COPY = {
 		'The snippet below carries this key. A key cannot be read back after it is created, so paste the one you saved or create a new key for this project.',
 	tokenMissingNotice:
 		'Add an API key to generate a snippet that works. Without one the embed answers "not found" on every site.',
+	copyNeedsToken:
+		'Add an API key first - a snippet without one answers "not found" on every site.',
 	tokenReveal: 'Show key',
 	tokenHide: 'Hide key',
 	tokenMismatch:
@@ -34,6 +36,7 @@ export const EMBED_COPY = {
 	keyRevokedSuffix: 'revoked',
 	keyExpiredSuffix: 'expired',
 	createKey: 'Create a key for this project',
+	createKeyShort: 'Create key',
 	createKeyPending: 'Creating...',
 	createKeyFailure: 'Could not create an API key.',
 	createKeyDialogTitle: 'API key created',
@@ -42,6 +45,7 @@ export const EMBED_COPY = {
 	createKeyDialogDismiss: 'Done',
 	createKeyDismissWithoutCopyConfirm:
 		'You have not copied the key. It cannot be shown again. Close anyway?',
+	createKeyExpiresPrefix: 'This key stops working on',
 	copyKey: 'Copy key',
 	copyKeySuccess: 'API key copied.',
 	copyKeyFailure: 'Failed to copy the API key.',

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
@@ -36,8 +36,12 @@ export const EMBED_COPY = {
 	createKey: 'Create a key for this project',
 	createKeyPending: 'Creating...',
 	createKeyFailure: 'Could not create an API key.',
+	createKeyDialogTitle: 'API key created',
 	createKeyOnce:
-		'This is the only time the full key is shown. Copy it, or copy the snippet below, before you leave this page.',
+		'This is the only time the full key is shown. It is stored hashed, so it cannot be read back. Copy it now, or copy the finished snippet behind this dialog.',
+	createKeyDialogDismiss: 'Done',
+	createKeyDismissWithoutCopyConfirm:
+		'You have not copied the key. It cannot be shown again. Close anyway?',
 	copyKey: 'Copy key',
 	copyKeySuccess: 'API key copied.',
 	copyKeyFailure: 'Failed to copy the API key.',
@@ -167,12 +171,32 @@ export function escapeHtmlAttributeValue(value: string): string {
 		.replace(/'/g, '&#39;')
 }
 
+/**
+ * Every value either builder interpolates, escaped.
+ *
+ * `width` and `height` are free text from the panel's own inputs and land in a
+ * quoted `style` attribute, so a value ending in a quote breaks out of it
+ * exactly the way the old `?token=` placeholder broke out of `src`. Escaping
+ * rather than validating: the only caller is the panel, the only author is the
+ * scene's owner, and the goal is a snippet that parses - not a policy about
+ * which CSS lengths are allowed, which would silently discard `calc(...)`.
+ */
+function escapeSnippetValues(options: EmbedSnippetOptions): {
+	width: string
+	height: string
+	src: string
+} {
+	return {
+		width: escapeHtmlAttributeValue(options.width?.trim() || DEFAULT_WIDTH),
+		height: escapeHtmlAttributeValue(options.height?.trim() || DEFAULT_HEIGHT),
+		src: escapeHtmlAttributeValue(options.src)
+	}
+}
+
 export function buildResponsiveEmbedSnippet(
 	options: EmbedSnippetOptions
 ): string {
-	const width = options.width?.trim() || DEFAULT_WIDTH
-	const height = options.height?.trim() || DEFAULT_HEIGHT
-	const src = escapeHtmlAttributeValue(options.src)
+	const { width, height, src } = escapeSnippetValues(options)
 
 	return `<div style="width: ${width}; max-width: 100%; height: ${height};">
   <iframe
@@ -185,9 +209,7 @@ export function buildResponsiveEmbedSnippet(
 }
 
 export function buildSdkEmbedSnippet(options: EmbedSnippetOptions): string {
-	const width = options.width?.trim() || DEFAULT_WIDTH
-	const height = options.height?.trim() || DEFAULT_HEIGHT
-	const src = escapeHtmlAttributeValue(options.src)
+	const { width, height, src } = escapeSnippetValues(options)
 
 	return `<!-- 1. Include the SDK (or: npm install @vctrl/embed) -->
 <script src="${EMBED_SDK_CDN_URL}"></script>

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
@@ -1,5 +1,3 @@
-export const PREVIEW_API_KEY_PLACEHOLDER = 'YOUR_PREVIEW_API_KEY'
-
 /**
  * CDN URL for the `@vctrl/embed` UMD build used by the generated SDK snippet.
  *
@@ -18,11 +16,42 @@ export const EMBED_SDK_CDN_URL =
 export const EMBED_COPY = {
 	unavailableUntilSaved:
 		'Embedding is unavailable until this scene is saved and linked to a project.',
-	draftWarningPrefix:
-		'External embeds stay protected. Publish first, then replace',
-	draftWarningSuffix:
-		'with a valid preview API key token. Signed-in dashboard users can preview via session auth.',
-	previewUrlLabel: 'Embed Preview URL',
+	tokenLabel: 'API key',
+	tokenPlaceholder: 'vctrl_...',
+	tokenHelp:
+		'The snippet below carries this key. A key cannot be read back after it is created, so paste the one you saved or create a new key for this project.',
+	tokenMissingNotice:
+		'Add an API key to generate a snippet that works. Without one the embed answers "not found" on every site.',
+	tokenReveal: 'Show key',
+	tokenHide: 'Hide key',
+	tokenMismatch:
+		'This does not look like the selected key: the last four characters do not match.',
+	keyPickerLabel: 'Key for this project',
+	keyPickerPlaceholder: 'Which key are you using?',
+	keyPickerEmpty: 'No API keys are scoped to this project yet.',
+	keyPickerHint:
+		'Picking a key here only labels the field below - the full value was shown once, when the key was created.',
+	keyRevokedSuffix: 'revoked',
+	keyExpiredSuffix: 'expired',
+	createKey: 'Create a key for this project',
+	createKeyPending: 'Creating...',
+	createKeyFailure: 'Could not create an API key.',
+	createKeyOnce:
+		'This is the only time the full key is shown. Copy it, or copy the snippet below, before you leave this page.',
+	copyKey: 'Copy key',
+	copyKeySuccess: 'API key copied.',
+	copyKeyFailure: 'Failed to copy the API key.',
+	allowedDomainsLabel: 'Allowed domains',
+	allowedDomainsEmpty:
+		'This project allows no domains, so every third-party site is refused - even with a valid key. Add the site you are embedding on before you ship.',
+	allowedDomainsHelp:
+		'Only these sites may load the embed. Vectreal itself is always permitted, which is why the test button below cannot check this list for you.',
+	editProject: 'Project settings',
+	identifiersLabel: 'Identifiers',
+	projectIdLabel: 'Project ID',
+	sceneIdLabel: 'Scene ID',
+	copyIdSuccess: 'Copied.',
+	previewUrlLabel: 'Embed URL',
 	previewUrlPlaceholder: 'Save scene to generate URL',
 	embedCodeLabel: 'Embed Code',
 	embedCodeHelp:
@@ -38,15 +67,20 @@ export const EMBED_COPY = {
 	copyEmbedFailure: 'Failed to copy embed code.',
 	copySdkSuccess: 'SDK snippet copied.',
 	copySdkFailure: 'Failed to copy SDK snippet.',
-	copyUrlSuccess: 'Preview URL copied.',
-	copyUrlFailure: 'Failed to copy preview URL.',
+	copyUrlSuccess: 'Embed URL copied.',
+	copyUrlFailure: 'Failed to copy embed URL.',
 	clipboardUnavailable: 'Clipboard is not available in this browser.',
 	missingSceneForEmbed: 'Save this scene first to generate an embed snippet.',
-	missingSceneForUrl: 'Save this scene first to generate a preview URL.',
+	missingSceneForUrl: 'Save this scene first to generate an embed URL.',
 	embedCodeUnavailable:
 		'<!-- Save this scene before generating an embed snippet -->',
 	sdkCodeUnavailable: '// Save this scene before generating an SDK snippet',
 	openPreview: 'Open preview',
+	openPreviewHelp:
+		'Opens the internal preview, which authenticates with your dashboard session. It always works for you, and so proves nothing about the embed.',
+	testEmbedUrl: 'Test embed URL',
+	testEmbedUrlHelp:
+		'Opens the real embed URL carrying the key above. This checks the key and the published scene, but not the domain list: a request from this site is always permitted, so a visitor on your own site can still be refused. Needs a key.',
 	tabHtml: 'HTML',
 	tabSdk: 'SDK'
 } as const
@@ -76,14 +110,61 @@ export function buildInternalPreviewPath(params: {
 	return `/preview/${params.projectId}/${params.sceneId}`
 }
 
-export function addPreviewTokenPlaceholder(previewPath: string): string {
-	const url = new URL(previewPath, 'http://localhost')
-	url.searchParams.set('token', PREVIEW_API_KEY_PLACEHOLDER)
-	return `${url.pathname}${url.search}`
-}
-
 export function toAbsoluteEmbedUrl(path: string, origin: string): string {
 	return new URL(path, origin).toString()
+}
+
+/**
+ * The embed URL a visitor loads, token included.
+ *
+ * Built through `URLSearchParams` rather than string concatenation so the token
+ * is percent-encoded. The panel used to emit a literal `YOUR_PREVIEW_API_KEY`
+ * for the user to substitute by hand inside an HTML attribute, and the obvious
+ * substitution - pasting a quoted key - closed the attribute early:
+ *
+ *     src="https://vectreal.com/embed/p/s?token="vctrl_abc"   style="..."
+ *
+ * The browser then requested `?token=`, and an empty token is a 404. Nothing
+ * about that failure points at the quoting, which is why the placeholder is
+ * gone and the real token is interpolated here instead.
+ */
+export function buildEmbedUrl(params: {
+	origin: string
+	projectId: string
+	sceneId: string
+	token?: string
+}): string {
+	const url = new URL(
+		buildEmbedPath({ projectId: params.projectId, sceneId: params.sceneId }),
+		params.origin
+	)
+
+	const token = params.token?.trim()
+	if (token) {
+		url.searchParams.set('token', token)
+	}
+
+	return url.toString()
+}
+
+/**
+ * Escapes a value for interpolation into a quoted HTML attribute.
+ *
+ * `&` has to go first, or the escapes emitted below get double-escaped. Both
+ * quote characters are covered so the result is safe in either quoting style
+ * rather than only in the one the snippet builders happen to use today.
+ *
+ * A multi-parameter embed URL is the case that needs this: `URLSearchParams`
+ * percent-encodes the values but joins them with a bare `&`, which is invalid
+ * inside an attribute and silently truncates the URL in strict parsers.
+ */
+export function escapeHtmlAttributeValue(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
 }
 
 export function buildResponsiveEmbedSnippet(
@@ -91,10 +172,11 @@ export function buildResponsiveEmbedSnippet(
 ): string {
 	const width = options.width?.trim() || DEFAULT_WIDTH
 	const height = options.height?.trim() || DEFAULT_HEIGHT
+	const src = escapeHtmlAttributeValue(options.src)
 
 	return `<div style="width: ${width}; max-width: 100%; height: ${height};">
   <iframe
-    src="${options.src}"
+    src="${src}"
     style="width: 100%; height: 100%; border: 0;"
     allow="autoplay; xr-spatial-tracking"
     allowfullscreen
@@ -105,6 +187,7 @@ export function buildResponsiveEmbedSnippet(
 export function buildSdkEmbedSnippet(options: EmbedSnippetOptions): string {
 	const width = options.width?.trim() || DEFAULT_WIDTH
 	const height = options.height?.trim() || DEFAULT_HEIGHT
+	const src = escapeHtmlAttributeValue(options.src)
 
 	return `<!-- 1. Include the SDK (or: npm install @vctrl/embed) -->
 <script src="${EMBED_SDK_CDN_URL}"></script>
@@ -113,7 +196,7 @@ export function buildSdkEmbedSnippet(options: EmbedSnippetOptions): string {
 <div style="width: ${width}; max-width: 100%; height: ${height};">
   <iframe
     id="vectreal-scene"
-    src="${options.src}"
+    src="${src}"
     style="width: 100%; height: 100%; border: 0;"
     allow="autoplay; xr-spatial-tracking"
     allowfullscreen

--- a/apps/vectreal-platform/app/routes.tsx
+++ b/apps/vectreal-platform/app/routes.tsx
@@ -27,6 +27,10 @@ export default [
 	route('api/scenes/:sceneId?', './routes/api/scenes.$sceneId.ts'),
 	route('api/scene-location-options', './routes/api/scene-location-options.ts'),
 	route('api/dashboard/mutations', './routes/api/dashboard.mutations.ts'),
+	route(
+		'api/projects/:projectId/api-keys',
+		'./routes/api/projects.$projectId.api-keys.ts'
+	),
 
 	// Auth api
 	route('auth/session', './routes/api/auth/session.ts'),

--- a/apps/vectreal-platform/app/routes/api/projects.$projectId.api-keys.ts
+++ b/apps/vectreal-platform/app/routes/api/projects.$projectId.api-keys.ts
@@ -33,6 +33,27 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router'
 /** Matches the 90-day default the full API key form offers. */
 const DEFAULT_EXPIRY_DAYS = 90
 
+/**
+ * Re-attaches the auth headers to a response that could not carry them.
+ *
+ * `getAuthUser` returns a `Set-Cookie` whenever Supabase rotates the session,
+ * and dropping it leaves the browser holding a token the server has already
+ * replaced. Most `ApiResponse` statics take `options.headers`, but
+ * `badRequest` and `quotaExceeded` do not, so the error paths need this.
+ * `dashboard.mutations.ts` carries the same helper for the same reason.
+ */
+function withHeaders(response: Response, headers: Headers): Response {
+	const merged = new Headers(response.headers)
+	headers.forEach((value, key) => {
+		merged.append(key, value)
+	})
+
+	return new Response(response.body, {
+		status: response.status,
+		headers: merged
+	})
+}
+
 export interface EmbedApiKeysPayload {
 	projectId: string
 	projectName: string
@@ -122,16 +143,16 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		return csrfCheck
 	}
 
-	if (formData.get('intent') !== 'create') {
-		return ApiResponse.badRequest('Unsupported intent')
-	}
-
 	const access = await resolveProjectAccess(request, params.projectId)
 	if ('error' in access) {
 		return access.error
 	}
 
 	const { userId, headers, membership } = access
+
+	if (formData.get('intent') !== 'create') {
+		return withHeaders(ApiResponse.badRequest('Unsupported intent'), headers)
+	}
 
 	if (!canPerformDashboardOperation('api-key:create', membership)) {
 		return ApiResponse.forbidden(
@@ -174,17 +195,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		return ApiResponse.created(payload, { headers })
 	} catch (error) {
 		if (error instanceof QuotaExceededError) {
-			return ApiResponse.quotaExceeded(error.message, {
-				limitKey: error.limitKey,
-				currentValue: error.currentValue,
-				limit: error.limit,
-				plan: error.plan,
-				upgradeTo: error.upgradeTo
-			})
+			return withHeaders(
+				ApiResponse.quotaExceeded(error.message, {
+					limitKey: error.limitKey,
+					currentValue: error.currentValue,
+					limit: error.limit,
+					plan: error.plan,
+					upgradeTo: error.upgradeTo
+				}),
+				headers
+			)
 		}
 
-		return ApiResponse.badRequest(
-			error instanceof Error ? error.message : 'Could not create an API key'
+		return withHeaders(
+			ApiResponse.badRequest(
+				error instanceof Error ? error.message : 'Could not create an API key'
+			),
+			headers
 		)
 	}
 }

--- a/apps/vectreal-platform/app/routes/api/projects.$projectId.api-keys.ts
+++ b/apps/vectreal-platform/app/routes/api/projects.$projectId.api-keys.ts
@@ -1,0 +1,190 @@
+/**
+ * The embed panel's view of one project's API keys.
+ *
+ * The panel is mounted from two places with very different data plumbing - the
+ * dashboard scene route's loader already holds the project row, while the
+ * publisher would need a four-file thread-through to reach it - so the panel
+ * fetches for itself against this route rather than either mount site growing
+ * props it cannot supply.
+ *
+ * No plaintext key is ever read back here. `createApiKey` returns one exactly
+ * once, on creation, and that response is the only place it appears.
+ */
+
+import { ApiResponse } from '@shared/utils'
+
+import {
+	createApiKey,
+	getAllUserApiKeys
+} from '../../lib/domain/auth/api-key-repository.server'
+import { QuotaExceededError } from '../../lib/domain/billing/quota-exceeded-error'
+import { canPerformDashboardOperation } from '../../lib/domain/dashboard/dashboard-operations'
+import { resolveProjectMembership } from '../../lib/domain/dashboard/dashboard-permissions.server'
+import { parseAllowedDomainPatterns } from '../../lib/domain/embed/embed-domain-policy'
+import { toEmbedApiKeyOptions } from '../../lib/domain/embed/embed-key-options'
+import { getProject } from '../../lib/domain/project/project-repository.server'
+import { getAuthUser } from '../../lib/http/auth.server'
+import { ensureValidCsrfFormData } from '../../lib/http/csrf.server'
+import { ensurePost } from '../../lib/http/requests.server'
+
+import type { EmbedApiKeyOption } from '../../lib/domain/embed/embed-key-options'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router'
+
+/** Matches the 90-day default the full API key form offers. */
+const DEFAULT_EXPIRY_DAYS = 90
+
+export interface EmbedApiKeysPayload {
+	projectId: string
+	projectName: string
+	allowedDomains: string[]
+	keys: EmbedApiKeyOption[]
+	canCreateKey: boolean
+}
+
+export interface EmbedApiKeyCreatedPayload {
+	key: EmbedApiKeyOption
+	/** The only time this value is ever sent. Not persisted in the clear. */
+	plaintext: string
+}
+
+async function resolveProjectAccess(request: Request, projectId?: string) {
+	if (!projectId) {
+		return { error: ApiResponse.badRequest('Missing project id') } as const
+	}
+
+	const authResult = await getAuthUser(request)
+	if (authResult instanceof Response) {
+		return { error: authResult } as const
+	}
+
+	const headers = new Headers(authResult.headers)
+	const membership = await resolveProjectMembership(
+		projectId,
+		authResult.user.id
+	)
+
+	// A project the actor is not a member of is reported as missing rather than
+	// forbidden, so this route cannot be used to probe which ids exist.
+	if (!membership) {
+		return {
+			error: ApiResponse.notFound('Project not found', { headers })
+		} as const
+	}
+
+	return { userId: authResult.user.id, headers, membership } as const
+}
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+	const access = await resolveProjectAccess(request, params.projectId)
+	if ('error' in access) {
+		return access.error
+	}
+
+	const { userId, headers, membership } = access
+
+	if (!canPerformDashboardOperation('api-key:read', membership)) {
+		return ApiResponse.forbidden(
+			'You do not have permission to view API keys',
+			{ headers }
+		)
+	}
+
+	const [project, allKeys] = await Promise.all([
+		getProject(membership.projectId, userId),
+		getAllUserApiKeys(userId)
+	])
+
+	if (!project) {
+		return ApiResponse.notFound('Project not found', { headers })
+	}
+
+	const payload: EmbedApiKeysPayload = {
+		projectId: project.id,
+		projectName: project.name,
+		allowedDomains: parseAllowedDomainPatterns(project.allowedEmbedDomains),
+		keys: toEmbedApiKeyOptions(allKeys, project.id, new Date()),
+		canCreateKey: canPerformDashboardOperation('api-key:create', membership)
+	}
+
+	return ApiResponse.success(payload, 200, { headers })
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+	const methodCheck = ensurePost(request)
+	if (methodCheck) {
+		return methodCheck
+	}
+
+	const formData = await request.formData()
+
+	const csrfCheck = await ensureValidCsrfFormData(request, formData)
+	if (csrfCheck) {
+		return csrfCheck
+	}
+
+	if (formData.get('intent') !== 'create') {
+		return ApiResponse.badRequest('Unsupported intent')
+	}
+
+	const access = await resolveProjectAccess(request, params.projectId)
+	if ('error' in access) {
+		return access.error
+	}
+
+	const { userId, headers, membership } = access
+
+	if (!canPerformDashboardOperation('api-key:create', membership)) {
+		return ApiResponse.forbidden(
+			'You do not have permission to create API keys',
+			{ headers }
+		)
+	}
+
+	const project = await getProject(membership.projectId, userId)
+	if (!project) {
+		return ApiResponse.notFound('Project not found', { headers })
+	}
+
+	const expiresAt = new Date()
+	expiresAt.setDate(expiresAt.getDate() + DEFAULT_EXPIRY_DAYS)
+
+	try {
+		// `createApiKey` re-checks admin access and the per-org quota itself; the
+		// check above is what turns a thrown error into a 403 the panel can render.
+		const created = await createApiKey({
+			userId,
+			organizationId: membership.organizationId,
+			name: `Embed key for ${project.name}`,
+			description: 'Created from the scene embed panel.',
+			projectIds: [project.id],
+			expiresAt
+		})
+
+		const [option] = toEmbedApiKeyOptions(
+			[{ apiKey: created.apiKey, projects: [{ id: project.id }] }],
+			project.id,
+			new Date()
+		)
+
+		const payload: EmbedApiKeyCreatedPayload = {
+			key: option,
+			plaintext: created.plaintext
+		}
+
+		return ApiResponse.created(payload, { headers })
+	} catch (error) {
+		if (error instanceof QuotaExceededError) {
+			return ApiResponse.quotaExceeded(error.message, {
+				limitKey: error.limitKey,
+				currentValue: error.currentValue,
+				limit: error.limit,
+				plan: error.plan,
+				upgradeTo: error.upgradeTo
+			})
+		}
+
+		return ApiResponse.badRequest(
+			error instanceof Error ? error.message : 'Could not create an API key'
+		)
+	}
+}

--- a/apps/vectreal-platform/app/routes/docs/getting-started/first-model.mdx
+++ b/apps/vectreal-platform/app/routes/docs/getting-started/first-model.mdx
@@ -80,7 +80,7 @@ The snippet looks like:
 ```html
 <div style="width: 100%; max-width: 100%; height: 400px;">
   <iframe
-    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
     style="width: 100%; height: 100%; border: 0;"
     allow="autoplay; xr-spatial-tracking"
     allowfullscreen

--- a/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
@@ -38,7 +38,7 @@ Or include the UMD build from an npm CDN before your page code. The entry point 
 <div style="width: 100%; height: 400px;">
   <iframe
     id="vectreal-scene"
-    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
     style="width: 100%; height: 100%; border: 0;"
     allow="autoplay; xr-spatial-tracking"
     allowfullscreen
@@ -265,7 +265,7 @@ If you prefer zero dependencies, you can implement the protocol directly. Both s
 ## Security
 
 - **Origin validation** - the bridge accepts messages only from the first origin that successfully contacts it. The SDK uses `new URL(iframe.src).origin` as `targetOrigin` automatically; never `'*'`.
-- **Token privacy** - keep `YOUR_PREVIEW_API_KEY` server-side or in environment variables. Tokens are validated against the project's allowed domain list on every request.
+- **Token privacy** - keep the key server-side or in environment variables. Tokens are validated against the project's allowed domain list on every request.
 - **Domain allowlist** - configure which external origins can load your preview at [Dashboard → Projects](/dashboard/projects). Requests from unlisted domains receive `403 Forbidden`.
 
 ---

--- a/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
@@ -24,24 +24,32 @@ External iframe embeds require a **preview API key** scoped to the project that 
 
 ### Creating a key
 
+The quickest route is the **Embed** section of a published scene: paste a key you already saved, or click **Create a key for this project** to mint one scoped to that project alone. The snippet below it is then already correct, and there is nothing left to substitute by hand.
+
+To create a key with your own name, description or expiry instead:
+
 1. Go to [Dashboard → API Keys](/dashboard/api-keys).
 2. Click **New API Key**.
 3. Select the project(s) the key should have access to.
 4. Copy the key - it is shown only once.
+
+> A key is stored hashed, so it cannot be read back later. The **Embed** panel's key picker shows each key's name and last four characters, which is enough to tell which of your saved keys a project expects, but not enough to recover one you did not save.
 
 ### Using the key
 
 Pass the key as the `token` query parameter in the embed URL:
 
 ```
-/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY
+/embed/<projectId>/<sceneId>?token=vctrl_your_key_here
 ```
 
 Or as a `Bearer` token in the `Authorization` header for API requests:
 
 ```http
-Authorization: Bearer YOUR_PREVIEW_API_KEY
+Authorization: Bearer vctrl_your_key_here
 ```
+
+> **Do not paste a quoted key into the snippet.** `?token="vctrl_..."` closes the `src` attribute at the first quote, so the browser requests an empty token and the embed answers `404` with nothing to indicate why. Copy the snippet from the **Embed** panel with the key already filled in, rather than editing the URL in place.
 
 ---
 
@@ -76,7 +84,7 @@ The hosted preview iframe can also be controlled from the parent page over `post
 ```html
 <div style="width: 100%; max-width: 100%; height: 400px;">
   <iframe
-    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
     style="width: 100%; height: 100%; border: 0;"
     allow="autoplay; xr-spatial-tracking"
     allowfullscreen
@@ -89,7 +97,7 @@ The hosted preview iframe can also be controlled from the parent page over `post
 ```html
 <div style="position:relative;padding-top:56.25%;width:100%">
   <iframe
-    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
     style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
     allow="autoplay; xr-spatial-tracking"
     allowfullscreen
@@ -144,7 +152,7 @@ each carrying only its own field (`zoom` or `pan`), so a partial payload is norm
 <div style="position:relative;padding-top:56.25%;width:100%">
   <iframe
     id="vectreal-preview"
-    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=YOUR_PREVIEW_API_KEY"
+    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
     style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
     allow="autoplay; xr-spatial-tracking"
     loading="lazy"

--- a/apps/vectreal-platform/tests/embed-api-keys-route.spec.ts
+++ b/apps/vectreal-platform/tests/embed-api-keys-route.spec.ts
@@ -1,0 +1,323 @@
+/**
+ * The route's guards, with the database mocked out.
+ *
+ * `embed-key-options.spec.ts` proves the shaping rules answer correctly. This
+ * one proves the route *asks* them, and asserts the two properties that have no
+ * other home: that a non-member is told the project does not exist rather than
+ * that they may not see it, and that the rotated session cookie survives every
+ * response - including the two `ApiResponse` statics that take no headers.
+ *
+ * `dashboard-mutations-execution.spec.ts` is the template for the mocking.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const PROJECT_ID = 'project-1'
+const ORG_ID = 'org-1'
+
+vi.mock('../app/db/client', () => ({ getDbClient: () => ({}) }))
+
+vi.mock('../app/lib/domain/auth/api-key-repository.server', () => ({
+	createApiKey: vi.fn(),
+	getAllUserApiKeys: vi.fn(async () => [])
+}))
+
+vi.mock('../app/lib/domain/dashboard/dashboard-permissions.server', () => ({
+	resolveProjectMembership: vi.fn()
+}))
+
+vi.mock('../app/lib/domain/project/project-repository.server', () => ({
+	getProject: vi.fn()
+}))
+
+vi.mock('../app/lib/http/auth.server', () => ({ getAuthUser: vi.fn() }))
+
+vi.mock('../app/lib/http/csrf.server', () => ({
+	ensureValidCsrfFormData: vi.fn(async () => null)
+}))
+
+import {
+	createApiKey,
+	getAllUserApiKeys
+} from '../app/lib/domain/auth/api-key-repository.server'
+import { QuotaExceededError } from '../app/lib/domain/billing/quota-exceeded-error'
+import { resolveProjectMembership } from '../app/lib/domain/dashboard/dashboard-permissions.server'
+import { getProject } from '../app/lib/domain/project/project-repository.server'
+import { getAuthUser } from '../app/lib/http/auth.server'
+import { action, loader } from '../app/routes/api/projects.$projectId.api-keys'
+
+import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router'
+
+/** Route handlers take a router context this spec has no use for. */
+const routeArgs = (request: Request) =>
+	({ request, params: { projectId: PROJECT_ID } }) as unknown as LoaderFunctionArgs &
+		ActionFunctionArgs
+
+
+/** The rotated Supabase cookie every response has to carry back. */
+const SESSION_COOKIE = 'sb-access-token=rotated; Path=/'
+
+function authenticateAs(role: 'owner' | 'admin' | 'member' | null) {
+	vi.mocked(getAuthUser).mockResolvedValue({
+		user: { id: 'user-1' },
+		headers: new Headers({ 'Set-Cookie': SESSION_COOKIE })
+	} as unknown as Awaited<ReturnType<typeof getAuthUser>>)
+
+	vi.mocked(resolveProjectMembership).mockResolvedValue(
+		role
+			? {
+					organizationId: ORG_ID,
+					projectId: PROJECT_ID,
+					role,
+					isResourceOwner: false
+				}
+			: null
+	)
+
+	vi.mocked(getProject).mockResolvedValue({
+		id: PROJECT_ID,
+		organizationId: ORG_ID,
+		name: 'Storefront',
+		slug: 'storefront',
+		// Exact hosts only: `parseAllowedDomainPatterns` silently discards every
+		// `*.` pattern today (filed separately), and encoding that here would
+		// make the eventual fix look like a regression in this spec.
+		allowedEmbedDomains: 'shop.example.com\nstore.example.com'
+	})
+}
+
+const loadKeys = () =>
+	loader(
+		routeArgs(
+			new Request(`https://vectreal.com/api/projects/${PROJECT_ID}/api-keys`)
+		)
+	)
+
+function createRequest() {
+	const body = new FormData()
+	body.set('intent', 'create')
+	body.set('csrf', 'token')
+
+	return new Request(
+		`https://vectreal.com/api/projects/${PROJECT_ID}/api-keys`,
+		{ method: 'POST', body }
+	)
+}
+
+const submitCreate = () => action(routeArgs(createRequest()))
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	vi.mocked(getAllUserApiKeys).mockResolvedValue([])
+})
+
+describe('loader', () => {
+	it('serves a member of the project their keys and domains', async () => {
+		authenticateAs('admin')
+		const response = (await loadKeys()) as Response
+
+		expect(response.status).toBe(200)
+		await expect(response.json()).resolves.toMatchObject({
+			success: true,
+			data: {
+				projectId: PROJECT_ID,
+				projectName: 'Storefront',
+				allowedDomains: ['shop.example.com', 'store.example.com'],
+				canCreateKey: true
+			}
+		})
+	})
+
+	it('reports a project the actor cannot see as missing, not forbidden', async () => {
+		/*
+		  404, not 403. A 403 would confirm the id names a real project, which
+		  turns this route into a way to enumerate them.
+		*/
+		authenticateAs(null)
+		const response = (await loadKeys()) as Response
+
+		expect(response.status).toBe(404)
+		expect(vi.mocked(getAllUserApiKeys)).not.toHaveBeenCalled()
+	})
+
+	it('refuses a member who may open the panel but may not read keys', async () => {
+		authenticateAs('member')
+		const response = (await loadKeys()) as Response
+
+		expect(response.status).toBe(403)
+		expect(vi.mocked(getAllUserApiKeys)).not.toHaveBeenCalled()
+	})
+
+	it('drops keys scoped to a different project', async () => {
+		authenticateAs('owner')
+		vi.mocked(getAllUserApiKeys).mockResolvedValue([
+			{
+				apiKey: {
+					id: 'mine',
+					name: 'mine',
+					keyPreview: 'ab3x',
+					active: true,
+					expiresAt: null,
+					revokedAt: null,
+					lastUsedAt: null,
+					createdAt: new Date('2026-01-01')
+				},
+				projects: [{ id: PROJECT_ID }]
+			},
+			{
+				apiKey: {
+					id: 'theirs',
+					name: 'theirs',
+					keyPreview: '9zQ1',
+					active: true,
+					expiresAt: null,
+					revokedAt: null,
+					lastUsedAt: null,
+					createdAt: new Date('2026-01-01')
+				},
+				projects: [{ id: 'project-2' }]
+			}
+		] as unknown as Awaited<ReturnType<typeof getAllUserApiKeys>>)
+
+		const body = await ((await loadKeys()) as Response).json()
+
+		expect(body.data.keys.map((key: { id: string }) => key.id)).toEqual(['mine'])
+	})
+})
+
+describe('action', () => {
+	it('rejects a method other than POST before reading anything', async () => {
+		const response = (await action(
+			routeArgs(new Request('https://vectreal.com/x', { method: 'GET' }))
+		)) as Response
+
+		expect(response.status).toBe(405)
+		expect(vi.mocked(getAuthUser)).not.toHaveBeenCalled()
+	})
+
+	it('scopes a created key to this project alone', async () => {
+		authenticateAs('admin')
+		vi.mocked(createApiKey).mockResolvedValue({
+			apiKey: {
+				id: 'new-key',
+				name: 'Embed key for Storefront',
+				keyPreview: 'ab3x',
+				active: true,
+				expiresAt: new Date('2026-11-20'),
+				revokedAt: null,
+				lastUsedAt: null,
+				createdAt: new Date('2026-08-22')
+			},
+			plaintext: 'vctrl_secretab3x'
+		} as unknown as Awaited<ReturnType<typeof createApiKey>>)
+
+		const response = (await submitCreate()) as Response
+		const body = await response.json()
+
+		expect(response.status).toBe(201)
+		expect(vi.mocked(createApiKey).mock.calls[0][0]).toMatchObject({
+			organizationId: ORG_ID,
+			projectIds: [PROJECT_ID]
+		})
+		expect(body.data.plaintext).toBe('vctrl_secretab3x')
+		expect(body.data.key.keyPreview).toBe('ab3x')
+	})
+
+	it('refuses a member and never reaches the repository', async () => {
+		authenticateAs('member')
+		const response = (await submitCreate()) as Response
+
+		expect(response.status).toBe(403)
+		expect(vi.mocked(createApiKey)).not.toHaveBeenCalled()
+	})
+
+	it('forwards the quota envelope so the panel can offer an upgrade', async () => {
+		authenticateAs('owner')
+		vi.mocked(createApiKey).mockRejectedValue(
+			new QuotaExceededError({
+				limitKey: 'api_keys_per_org',
+				currentValue: 3,
+				limit: 3,
+				plan: 'free',
+				upgradeTo: 'pro',
+				message: 'API key limit reached for your plan.'
+			})
+		)
+
+		const response = (await submitCreate()) as Response
+
+		expect(response.status).toBe(403)
+		await expect(response.json()).resolves.toMatchObject({
+			success: false,
+			quota: { limitKey: 'api_keys_per_org', plan: 'free', upgradeTo: 'pro' }
+		})
+	})
+})
+
+describe('the rotated session cookie survives every response', () => {
+	/*
+	  `ApiResponse.badRequest` and `.quotaExceeded` are the only two statics that
+	  accept no headers, so both need the local `withHeaders` wrapper. Dropping it
+	  loses a rotated Supabase cookie and silently desynchronizes the session -
+	  a failure with no symptom at the point it happens.
+	*/
+	it.each([
+		['success', 'admin' as const, 'ok' as const],
+		['quota refusal', 'owner' as const, 'quota' as const],
+		['repository failure', 'owner' as const, 'error' as const],
+		['unsupported intent', 'admin' as const, 'intent' as const]
+	])('carries it on a %s', async (_label, role, outcome) => {
+		authenticateAs(role)
+
+		if (outcome === 'quota') {
+			vi.mocked(createApiKey).mockRejectedValue(
+				new QuotaExceededError({
+					limitKey: 'api_keys_per_org',
+					currentValue: 3,
+					limit: 3,
+					plan: 'free',
+					upgradeTo: 'pro',
+					message: 'limit'
+				})
+			)
+		} else if (outcome === 'error') {
+			vi.mocked(createApiKey).mockRejectedValue(new Error('database is down'))
+		} else {
+			vi.mocked(createApiKey).mockResolvedValue({
+				apiKey: {
+					id: 'k',
+					name: 'k',
+					keyPreview: 'ab3x',
+					active: true,
+					expiresAt: null,
+					revokedAt: null,
+					lastUsedAt: null,
+					createdAt: new Date('2026-08-22')
+				},
+				plaintext: 'vctrl_x'
+			} as unknown as Awaited<ReturnType<typeof createApiKey>>)
+		}
+
+		const body = new FormData()
+		body.set('intent', outcome === 'intent' ? 'destroy' : 'create')
+		body.set('csrf', 'token')
+
+		const response = (await action(
+			routeArgs(
+				new Request(
+					`https://vectreal.com/api/projects/${PROJECT_ID}/api-keys`,
+					{ method: 'POST', body }
+				)
+			)
+		)) as Response
+
+		expect(response.headers.get('Set-Cookie')).toBe(SESSION_COOKIE)
+	})
+
+	it('carries it on the loader too', async () => {
+		authenticateAs('admin')
+		const response = (await loadKeys()) as Response
+
+		expect(response.headers.get('Set-Cookie')).toBe(SESSION_COOKIE)
+	})
+})

--- a/apps/vectreal-platform/tests/embed-created-key-dialog.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-created-key-dialog.spec.tsx
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { EmbedCreatedKeyDialog } from '../app/components/embed/embed-created-key-dialog'
 
 const PLAINTEXT = 'vctrl_secretvalueab3x'
+const EXPIRES_AT = '2026-11-20T00:00:00.000Z'
 
 const writeText = vi.fn(async () => undefined)
 
@@ -33,13 +34,43 @@ const confirmWith = (answer: boolean) =>
 
 describe('EmbedCreatedKeyDialog', () => {
 	it('shows nothing until a key exists', () => {
-		render(<EmbedCreatedKeyDialog plaintext={null} onDismiss={vi.fn()} />)
+		render(<EmbedCreatedKeyDialog plaintext={null} expiresAt={EXPIRES_AT} onDismiss={vi.fn()} />)
 
 		expect(screen.queryByText(PLAINTEXT)).toBeNull()
 	})
 
+	it('says when the key stops working', () => {
+		/*
+		  This value is about to be pasted into a production storefront. An embed
+		  that dies in three months with no warning is the expensive version of
+		  this conversation, so the expiry is stated at the one moment the user is
+		  definitely looking.
+		*/
+		render(
+			<EmbedCreatedKeyDialog
+				plaintext={PLAINTEXT}
+				expiresAt={EXPIRES_AT}
+				onDismiss={vi.fn()}
+			/>
+		)
+
+		expect(screen.getByText(/stops working on/i)).not.toBeNull()
+	})
+
+	it('says nothing about expiry for a key that never expires', () => {
+		render(
+			<EmbedCreatedKeyDialog
+				plaintext={PLAINTEXT}
+				expiresAt={null}
+				onDismiss={vi.fn()}
+			/>
+		)
+
+		expect(screen.queryByText(/stops working on/i)).toBeNull()
+	})
+
 	it('renders the key so it can be read and copied', async () => {
-		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={vi.fn()} />)
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} expiresAt={EXPIRES_AT} onDismiss={vi.fn()} />)
 
 		expect(screen.getByText(PLAINTEXT)).not.toBeNull()
 
@@ -53,7 +84,7 @@ describe('EmbedCreatedKeyDialog', () => {
 		  sets no `maskTextSelector` - so without this class the live key would be
 		  readable in any recording of this dialog.
 		*/
-		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={vi.fn()} />)
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} expiresAt={EXPIRES_AT} onDismiss={vi.fn()} />)
 
 		expect(screen.getByText(PLAINTEXT).closest('.ph-no-capture')).not.toBeNull()
 	})
@@ -61,7 +92,7 @@ describe('EmbedCreatedKeyDialog', () => {
 	it('asks before closing when the key has not been copied', () => {
 		const confirm = confirmWith(false)
 		const onDismiss = vi.fn()
-		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />)
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} expiresAt={EXPIRES_AT} onDismiss={onDismiss} />)
 
 		fireEvent.click(screen.getByRole('button', { name: /^done$/i }))
 
@@ -72,7 +103,7 @@ describe('EmbedCreatedKeyDialog', () => {
 	it('closes when the user confirms they accept losing it', () => {
 		confirmWith(true)
 		const onDismiss = vi.fn()
-		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />)
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} expiresAt={EXPIRES_AT} onDismiss={onDismiss} />)
 
 		fireEvent.click(screen.getByRole('button', { name: /^done$/i }))
 
@@ -82,7 +113,7 @@ describe('EmbedCreatedKeyDialog', () => {
 	it('closes without asking once the key has been copied', async () => {
 		const confirm = confirmWith(false)
 		const onDismiss = vi.fn()
-		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />)
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} expiresAt={EXPIRES_AT} onDismiss={onDismiss} />)
 
 		fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
 		await screen.findByRole('button', { name: /^copied$/i })
@@ -96,7 +127,7 @@ describe('EmbedCreatedKeyDialog', () => {
 	it('does not let Escape bypass the question', () => {
 		const confirm = confirmWith(false)
 		const onDismiss = vi.fn()
-		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />)
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} expiresAt={EXPIRES_AT} onDismiss={onDismiss} />)
 
 		fireEvent.keyDown(document.activeElement ?? document.body, {
 			key: 'Escape',
@@ -116,16 +147,16 @@ describe('EmbedCreatedKeyDialog', () => {
 		const confirm = confirmWith(true)
 		const onDismiss = vi.fn()
 		const { rerender } = render(
-			<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />
+			<EmbedCreatedKeyDialog plaintext={PLAINTEXT} expiresAt={EXPIRES_AT} onDismiss={onDismiss} />
 		)
 
 		fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
 		await screen.findByRole('button', { name: /^copied$/i })
 		fireEvent.click(screen.getByRole('button', { name: /^done$/i }))
 
-		rerender(<EmbedCreatedKeyDialog plaintext={null} onDismiss={onDismiss} />)
+		rerender(<EmbedCreatedKeyDialog plaintext={null} expiresAt={EXPIRES_AT} onDismiss={onDismiss} />)
 		rerender(
-			<EmbedCreatedKeyDialog plaintext="vctrl_second9zQ1" onDismiss={onDismiss} />
+			<EmbedCreatedKeyDialog plaintext="vctrl_second9zQ1" expiresAt={EXPIRES_AT} onDismiss={onDismiss} />
 		)
 
 		confirm.mockClear()

--- a/apps/vectreal-platform/tests/embed-created-key-dialog.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-created-key-dialog.spec.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+/**
+ * The guard on an unrecoverable value.
+ *
+ * A key is stored hashed, so the plaintext this dialog shows exists nowhere
+ * else and cannot be fetched again. Everything asserted here is about not
+ * losing it: that dismissing without copying asks first, that Escape cannot
+ * slip past that question, and that a later key does not inherit the previous
+ * one's "copied" state and skip the check.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EmbedCreatedKeyDialog } from '../app/components/embed/embed-created-key-dialog'
+
+const PLAINTEXT = 'vctrl_secretvalueab3x'
+
+const writeText = vi.fn(async () => undefined)
+
+beforeEach(() => {
+	vi.stubGlobal('navigator', { clipboard: { writeText } })
+	writeText.mockClear()
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.restoreAllMocks()
+})
+
+const confirmWith = (answer: boolean) =>
+	vi.spyOn(window, 'confirm').mockReturnValue(answer)
+
+describe('EmbedCreatedKeyDialog', () => {
+	it('shows nothing until a key exists', () => {
+		render(<EmbedCreatedKeyDialog plaintext={null} onDismiss={vi.fn()} />)
+
+		expect(screen.queryByText(PLAINTEXT)).toBeNull()
+	})
+
+	it('renders the key so it can be read and copied', async () => {
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={vi.fn()} />)
+
+		expect(screen.getByText(PLAINTEXT)).not.toBeNull()
+
+		fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+		await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(PLAINTEXT))
+	})
+
+	it('keeps the key out of session replay', () => {
+		/*
+		  Replay masks input values by default but not text nodes, and this app
+		  sets no `maskTextSelector` - so without this class the live key would be
+		  readable in any recording of this dialog.
+		*/
+		const { container } = render(
+			<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={vi.fn()} />
+		)
+		const block = screen.getByText(PLAINTEXT)
+
+		expect(block.closest('.ph-no-capture')).not.toBeNull()
+		expect(container).toBeDefined()
+	})
+
+	it('asks before closing when the key has not been copied', () => {
+		const confirm = confirmWith(false)
+		const onDismiss = vi.fn()
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />)
+
+		fireEvent.click(screen.getByRole('button', { name: /^done$/i }))
+
+		expect(confirm).toHaveBeenCalled()
+		expect(onDismiss).not.toHaveBeenCalled()
+	})
+
+	it('closes when the user confirms they accept losing it', () => {
+		confirmWith(true)
+		const onDismiss = vi.fn()
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />)
+
+		fireEvent.click(screen.getByRole('button', { name: /^done$/i }))
+
+		expect(onDismiss).toHaveBeenCalledTimes(1)
+	})
+
+	it('closes without asking once the key has been copied', async () => {
+		const confirm = confirmWith(false)
+		const onDismiss = vi.fn()
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />)
+
+		fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+		await screen.findByRole('button', { name: /^copied$/i })
+
+		fireEvent.click(screen.getByRole('button', { name: /^done$/i }))
+
+		expect(confirm).not.toHaveBeenCalled()
+		expect(onDismiss).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not let Escape bypass the question', () => {
+		const confirm = confirmWith(false)
+		const onDismiss = vi.fn()
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />)
+
+		fireEvent.keyDown(document.activeElement ?? document.body, {
+			key: 'Escape',
+			code: 'Escape'
+		})
+
+		expect(onDismiss).not.toHaveBeenCalled()
+		expect(confirm).not.toHaveBeenCalled()
+		expect(screen.getByText(PLAINTEXT)).not.toBeNull()
+	})
+
+	it('re-arms the question for the next key', async () => {
+		/*
+		  `copied` is what suppresses the confirmation. If it survived a dismissal,
+		  the second key a user creates would close silently on the first click.
+		*/
+		const confirm = confirmWith(true)
+		const onDismiss = vi.fn()
+		const { rerender } = render(
+			<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={onDismiss} />
+		)
+
+		fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+		await screen.findByRole('button', { name: /^copied$/i })
+		fireEvent.click(screen.getByRole('button', { name: /^done$/i }))
+
+		rerender(<EmbedCreatedKeyDialog plaintext={null} onDismiss={onDismiss} />)
+		rerender(
+			<EmbedCreatedKeyDialog plaintext="vctrl_second9zQ1" onDismiss={onDismiss} />
+		)
+
+		confirm.mockClear()
+		fireEvent.click(screen.getByRole('button', { name: /^done$/i }))
+
+		expect(confirm).toHaveBeenCalled()
+	})
+})

--- a/apps/vectreal-platform/tests/embed-created-key-dialog.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-created-key-dialog.spec.tsx
@@ -53,13 +53,9 @@ describe('EmbedCreatedKeyDialog', () => {
 		  sets no `maskTextSelector` - so without this class the live key would be
 		  readable in any recording of this dialog.
 		*/
-		const { container } = render(
-			<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={vi.fn()} />
-		)
-		const block = screen.getByText(PLAINTEXT)
+		render(<EmbedCreatedKeyDialog plaintext={PLAINTEXT} onDismiss={vi.fn()} />)
 
-		expect(block.closest('.ph-no-capture')).not.toBeNull()
-		expect(container).toBeDefined()
+		expect(screen.getByText(PLAINTEXT).closest('.ph-no-capture')).not.toBeNull()
 	})
 
 	it('asks before closing when the key has not been copied', () => {

--- a/apps/vectreal-platform/tests/embed-key-field.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-key-field.spec.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+/**
+ * The key picker's empty message, on the same terms as its sibling.
+ *
+ * This exact guard - zero results read as "confirmed empty" rather than "not
+ * known yet" - was found four times in this change, in two mirrored call sites.
+ * The panel's copy of it is covered by `embed-options-panel.spec.ts`; this is
+ * the other half, so a fifth instance cannot land in whichever one nobody
+ * tested.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EmbedKeyField } from '../app/components/embed/embed-key-field'
+import { EMBED_COPY } from '../app/lib/domain/embed/embed-snippet'
+
+import type { EmbedApiKeysApi } from '../app/components/embed/use-embed-api-keys'
+
+let api: EmbedApiKeysApi
+
+beforeEach(() => {
+	api = {
+		keys: [],
+		allowedDomains: [],
+		canCreateKey: true,
+		hasLoaded: true,
+		loadError: null,
+		token: '',
+		setToken: vi.fn(),
+		selectedKeyId: '',
+		selectKey: vi.fn(),
+		createdPlaintext: null,
+		createdKeyExpiresAt: null,
+		dismissCreatedKey: vi.fn(),
+		createKey: vi.fn(),
+		creating: false,
+		createError: null
+	}
+})
+
+const emptyMessage = () => screen.queryByText(EMBED_COPY.keyPickerEmpty)
+
+describe('the key picker empty message', () => {
+	it('appears once the project is known to have no keys', () => {
+		render(<EmbedKeyField api={api} />)
+
+		expect(emptyMessage()).not.toBeNull()
+	})
+
+	it('says nothing before an answer has arrived', () => {
+		render(<EmbedKeyField api={{ ...api, hasLoaded: false }} />)
+
+		expect(emptyMessage()).toBeNull()
+	})
+
+	it('says nothing when the keys could not be read', () => {
+		render(
+			<EmbedKeyField
+				api={{
+					...api,
+					loadError: 'You do not have permission to view API keys'
+				}}
+			/>
+		)
+
+		expect(emptyMessage()).toBeNull()
+		expect(
+			screen.getByText('You do not have permission to view API keys')
+		).not.toBeNull()
+	})
+})

--- a/apps/vectreal-platform/tests/embed-key-options.spec.ts
+++ b/apps/vectreal-platform/tests/embed-key-options.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	matchesKeyPreview,
+	toEmbedApiKeyOptions,
+	type EmbedApiKeySource
+} from '../app/lib/domain/embed/embed-key-options'
+
+const PROJECT_ID = 'project-a'
+const NOW = new Date('2026-08-22T12:00:00.000Z')
+
+function makeKey(
+	overrides: Partial<EmbedApiKeySource['apiKey']> & { id: string },
+	projectIds: string[] = [PROJECT_ID]
+): EmbedApiKeySource {
+	return {
+		apiKey: {
+			name: `key ${overrides.id}`,
+			keyPreview: 'ab3x',
+			active: true,
+			expiresAt: null,
+			revokedAt: null,
+			lastUsedAt: null,
+			createdAt: new Date('2026-01-01T00:00:00.000Z'),
+			...overrides
+		},
+		projects: projectIds.map((id) => ({ id }))
+	}
+}
+
+describe('toEmbedApiKeyOptions', () => {
+	it('keeps only the keys scoped to the project', () => {
+		const options = toEmbedApiKeyOptions(
+			[
+				makeKey({ id: 'mine' }),
+				makeKey({ id: 'other' }, ['project-b']),
+				makeKey({ id: 'both' }, ['project-b', PROJECT_ID])
+			],
+			PROJECT_ID,
+			NOW
+		)
+
+		expect(options.map((option) => option.id)).toEqual(['mine', 'both'])
+	})
+
+	it('never carries anything beyond the four-character preview', () => {
+		const [option] = toEmbedApiKeyOptions([makeKey({ id: 'k' })], PROJECT_ID, NOW)
+
+		expect(Object.keys(option).sort()).toEqual([
+			'expired',
+			'expiresAt',
+			'id',
+			'keyPreview',
+			'lastUsedAt',
+			'name',
+			'revoked'
+		])
+	})
+
+	it('marks a revoked key by either signal the schema uses', () => {
+		const options = toEmbedApiKeyOptions(
+			[
+				makeKey({ id: 'timestamp', revokedAt: new Date('2026-05-01') }),
+				makeKey({ id: 'flag', active: false }),
+				makeKey({ id: 'live' })
+			],
+			PROJECT_ID,
+			NOW
+		)
+
+		const revoked = Object.fromEntries(
+			options.map((option) => [option.id, option.revoked])
+		)
+		expect(revoked).toEqual({ timestamp: true, flag: true, live: false })
+	})
+
+	it('treats expiry as of the given instant, boundary inclusive', () => {
+		const options = toEmbedApiKeyOptions(
+			[
+				makeKey({ id: 'past', expiresAt: new Date('2026-08-22T11:59:59.000Z') }),
+				makeKey({ id: 'exactly', expiresAt: NOW }),
+				makeKey({ id: 'future', expiresAt: new Date('2026-08-22T12:00:01.000Z') }),
+				makeKey({ id: 'never', expiresAt: null })
+			],
+			PROJECT_ID,
+			NOW
+		)
+
+		const expired = Object.fromEntries(
+			options.map((option) => [option.id, option.expired])
+		)
+		expect(expired).toEqual({
+			past: true,
+			exactly: true,
+			future: false,
+			never: false
+		})
+	})
+
+	it('lists usable keys before unusable ones, newest first within each group', () => {
+		const options = toEmbedApiKeyOptions(
+			[
+				makeKey({ id: 'old-usable', createdAt: new Date('2026-01-01') }),
+				makeKey({
+					id: 'new-revoked',
+					createdAt: new Date('2026-08-01'),
+					revokedAt: new Date('2026-08-02')
+				}),
+				makeKey({ id: 'new-usable', createdAt: new Date('2026-07-01') }),
+				makeKey({
+					id: 'old-expired',
+					createdAt: new Date('2025-01-01'),
+					expiresAt: new Date('2025-06-01')
+				})
+			],
+			PROJECT_ID,
+			NOW
+		)
+
+		expect(options.map((option) => option.id)).toEqual([
+			'new-usable',
+			'old-usable',
+			'new-revoked',
+			'old-expired'
+		])
+	})
+
+	it('serializes timestamps so the payload survives the JSON boundary', () => {
+		const [option] = toEmbedApiKeyOptions(
+			[
+				makeKey({
+					id: 'k',
+					expiresAt: new Date('2026-11-20T00:00:00.000Z'),
+					lastUsedAt: new Date('2026-08-01T09:30:00.000Z')
+				})
+			],
+			PROJECT_ID,
+			NOW
+		)
+
+		expect(option.expiresAt).toBe('2026-11-20T00:00:00.000Z')
+		expect(option.lastUsedAt).toBe('2026-08-01T09:30:00.000Z')
+	})
+})
+
+describe('matchesKeyPreview', () => {
+	it('matches on the last four characters, ignoring pasted whitespace', () => {
+		expect(matchesKeyPreview('vctrl_longvalueab3x', 'ab3x')).toBe(true)
+		expect(matchesKeyPreview('  vctrl_longvalueab3x \n', 'ab3x')).toBe(true)
+	})
+
+	it('rejects a different key and a value too short to hold the preview', () => {
+		expect(matchesKeyPreview('vctrl_longvalue9zQ1', 'ab3x')).toBe(false)
+		expect(matchesKeyPreview('ab', 'ab3x')).toBe(false)
+		expect(matchesKeyPreview('', 'ab3x')).toBe(false)
+	})
+
+	it('is case sensitive, because the preview is a base62 slice', () => {
+		expect(matchesKeyPreview('vctrl_valueAB3X', 'ab3x')).toBe(false)
+	})
+})

--- a/apps/vectreal-platform/tests/embed-options-panel.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-options-panel.spec.tsx
@@ -9,7 +9,7 @@
  */
 
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { EmbedOptionsPanel } from '../app/components/embed/embed-options-panel'
 import { EMBED_COPY } from '../app/lib/domain/embed/embed-snippet'
@@ -17,15 +17,28 @@ import { EMBED_COPY } from '../app/lib/domain/embed/embed-snippet'
 const load = vi.fn()
 
 let token = ''
+let loading = false
 let loadError: string | null = null
 let allowedDomains: string[] = ['shop.example.com']
+
+/*
+  Reset between tests. These are module-level so the mock factory can read them,
+  which means a test that forgets to set one silently inherits the previous
+  test's value and can pass for the wrong reason.
+*/
+beforeEach(() => {
+	token = ''
+	loading = false
+	loadError = null
+	allowedDomains = ['shop.example.com']
+})
 
 vi.mock('../app/components/embed/use-embed-api-keys', () => ({
 	useEmbedApiKeys: () => ({
 		keys: [],
 		allowedDomains,
 		canCreateKey: true,
-		loading: false,
+		loading,
 		loadError,
 		token,
 		setToken: vi.fn(),
@@ -75,7 +88,6 @@ function renderPanel() {
 
 describe('the copy actions wait for a key', () => {
 	it('refuses to copy anything while there is no token', () => {
-		token = ''
 		renderPanel()
 
 		expect(button(EMBED_COPY.testEmbedUrl)).toHaveProperty('disabled', true)
@@ -105,12 +117,22 @@ describe('the copy actions wait for a key', () => {
 
 describe('the allowed-domains readout', () => {
 	it('says the project allows none only when it actually knows that', () => {
-		token = ''
 		allowedDomains = []
-		loadError = null
 		renderPanel()
 
 		expect(screen.getByText(EMBED_COPY.allowedDomainsEmpty)).not.toBeNull()
+	})
+
+	it('claims nothing while the list is still loading', () => {
+		/*
+		  The window this notice was wrong in on every single mount: a request in
+		  flight reports zero domains, exactly like a project that really has none.
+		*/
+		allowedDomains = []
+		loading = true
+		renderPanel()
+
+		expect(screen.queryByText(EMBED_COPY.allowedDomainsEmpty)).toBeNull()
 	})
 
 	it('claims nothing about domains it could not load', () => {
@@ -119,7 +141,6 @@ describe('the allowed-domains readout', () => {
 		  keys that their project allows none - directly under the notice saying
 		  they are not allowed to know - is a false statement, not an empty state.
 		*/
-		token = ''
 		allowedDomains = []
 		loadError = 'You do not have permission to view API keys'
 		renderPanel()

--- a/apps/vectreal-platform/tests/embed-options-panel.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-options-panel.spec.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * The panel's refusal to hand out a broken snippet.
+ *
+ * `buildEmbedUrl` omits the token parameter rather than failing when there is
+ * no key, so a tokenless snippet is not a partial one - it is a finished-looking
+ * string that answers 404 on every site. That is the original bug's outcome
+ * reached by a different route: skipping a step rather than mis-editing one.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EmbedOptionsPanel } from '../app/components/embed/embed-options-panel'
+import { EMBED_COPY } from '../app/lib/domain/embed/embed-snippet'
+
+const load = vi.fn()
+
+let token = ''
+let loadError: string | null = null
+let allowedDomains: string[] = ['shop.example.com']
+
+vi.mock('../app/components/embed/use-embed-api-keys', () => ({
+	useEmbedApiKeys: () => ({
+		keys: [],
+		allowedDomains,
+		canCreateKey: true,
+		loading: false,
+		loadError,
+		token,
+		setToken: vi.fn(),
+		selectedKeyId: '',
+		selectKey: vi.fn(),
+		createdPlaintext: null,
+		createdKeyExpiresAt: null,
+		dismissCreatedKey: vi.fn(),
+		createKey: vi.fn(),
+		creating: false,
+		createError: null
+	})
+}))
+
+vi.mock('react-router', () => ({
+	Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+	useFetcher: () => ({ load, state: 'idle', data: undefined })
+}))
+
+const PROJECT_ID = 'project-1'
+const SCENE_ID = 'scene-1'
+
+const button = (name: string) =>
+	screen.getByRole('button', { name: new RegExp(name, 'i') })
+
+/**
+ * Every copy action, including the one in the tab that is not mounted yet.
+ *
+ * Radix unmounts inactive tab content, so `Copy SDK` does not exist in the DOM
+ * until its tab is selected - asserting on it without switching would be
+ * asserting on nothing.
+ */
+const copyButtons = () => {
+	const visible = [button(EMBED_COPY.copyUrl), button(EMBED_COPY.copyEmbed)]
+
+	fireEvent.mouseDown(screen.getByRole('tab', { name: EMBED_COPY.tabSdk }))
+	visible.push(button(EMBED_COPY.copySdk))
+
+	return visible
+}
+
+function renderPanel() {
+	return render(
+		<EmbedOptionsPanel projectId={PROJECT_ID} sceneId={SCENE_ID} />
+	)
+}
+
+describe('the copy actions wait for a key', () => {
+	it('refuses to copy anything while there is no token', () => {
+		token = ''
+		renderPanel()
+
+		expect(button(EMBED_COPY.testEmbedUrl)).toHaveProperty('disabled', true)
+
+		for (const copy of copyButtons()) {
+			expect(copy).toHaveProperty('disabled', true)
+		}
+	})
+
+	it('releases every copy action once a token is present', () => {
+		token = 'vctrl_realkeyab3x'
+		renderPanel()
+
+		for (const copy of copyButtons()) {
+			expect(copy).toHaveProperty('disabled', false)
+		}
+	})
+
+	it('puts the token into the snippet it offers', () => {
+		token = 'vctrl_realkeyab3x'
+		const { container } = renderPanel()
+
+		const snippet = container.querySelector('pre')?.textContent ?? ''
+		expect(snippet).toContain('token=vctrl_realkeyab3x')
+	})
+})
+
+describe('the allowed-domains readout', () => {
+	it('says the project allows none only when it actually knows that', () => {
+		token = ''
+		allowedDomains = []
+		loadError = null
+		renderPanel()
+
+		expect(screen.getByText(EMBED_COPY.allowedDomainsEmpty)).not.toBeNull()
+	})
+
+	it('claims nothing about domains it could not load', () => {
+		/*
+		  A failed load reports zero domains. Telling a member who may not read
+		  keys that their project allows none - directly under the notice saying
+		  they are not allowed to know - is a false statement, not an empty state.
+		*/
+		token = ''
+		allowedDomains = []
+		loadError = 'You do not have permission to view API keys'
+		renderPanel()
+
+		expect(screen.queryByText(EMBED_COPY.allowedDomainsEmpty)).toBeNull()
+	})
+})

--- a/apps/vectreal-platform/tests/embed-options-panel.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-options-panel.spec.tsx
@@ -17,7 +17,7 @@ import { EMBED_COPY } from '../app/lib/domain/embed/embed-snippet'
 const load = vi.fn()
 
 let token = ''
-let loading = false
+let hasLoaded = true
 let loadError: string | null = null
 let allowedDomains: string[] = ['shop.example.com']
 
@@ -28,7 +28,7 @@ let allowedDomains: string[] = ['shop.example.com']
 */
 beforeEach(() => {
 	token = ''
-	loading = false
+	hasLoaded = true
 	loadError = null
 	allowedDomains = ['shop.example.com']
 })
@@ -38,7 +38,7 @@ vi.mock('../app/components/embed/use-embed-api-keys', () => ({
 		keys: [],
 		allowedDomains,
 		canCreateKey: true,
-		loading,
+		hasLoaded,
 		loadError,
 		token,
 		setToken: vi.fn(),
@@ -123,13 +123,14 @@ describe('the allowed-domains readout', () => {
 		expect(screen.getByText(EMBED_COPY.allowedDomainsEmpty)).not.toBeNull()
 	})
 
-	it('claims nothing while the list is still loading', () => {
+	it('claims nothing before an answer has arrived', () => {
 		/*
-		  The window this notice was wrong in on every single mount: a request in
-		  flight reports zero domains, exactly like a project that really has none.
+		  The window this notice was wrong in on every render, server included: a
+		  request in flight - or not yet dispatched - reports zero domains, exactly
+		  like a project that really has none.
 		*/
 		allowedDomains = []
-		loading = true
+		hasLoaded = false
 		renderPanel()
 
 		expect(screen.queryByText(EMBED_COPY.allowedDomainsEmpty)).toBeNull()

--- a/apps/vectreal-platform/tests/embed-snippet.spec.ts
+++ b/apps/vectreal-platform/tests/embed-snippet.spec.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	buildEmbedPath,
+	buildEmbedUrl,
+	buildInternalPreviewPath,
+	buildResponsiveEmbedSnippet,
+	buildSdkEmbedSnippet,
+	EMBED_COPY,
+	escapeHtmlAttributeValue
+} from '../app/lib/domain/embed/embed-snippet'
+
+const ORIGIN = 'https://vectreal.com'
+const PROJECT_ID = '08db6be1-f87b-4278-abfc-d80ef549e3a7'
+const SCENE_ID = '1ee4f724-2ee5-4162-9804-2de08bcb0eca'
+
+/** The `src` attribute value of the first iframe in a snippet. */
+function readSrcAttribute(snippet: string): string {
+	const match = snippet.match(/<iframe[\s\S]*?\ssrc="([^"]*)"/)
+	expect(match, 'snippet has an iframe src').not.toBeNull()
+	return match![1]
+}
+
+/** Reverses `escapeHtmlAttributeValue`, the way a browser's parser would. */
+function decodeHtmlEntities(value: string): string {
+	return value
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&amp;/g, '&')
+}
+
+describe('buildEmbedUrl', () => {
+	it('omits the token parameter entirely when there is no token', () => {
+		const url = buildEmbedUrl({
+			origin: ORIGIN,
+			projectId: PROJECT_ID,
+			sceneId: SCENE_ID
+		})
+
+		expect(url).toBe(`${ORIGIN}${buildEmbedPath({ projectId: PROJECT_ID, sceneId: SCENE_ID })}`)
+		expect(new URL(url).searchParams.has('token')).toBe(false)
+	})
+
+	it('treats a whitespace-only token as absent', () => {
+		const url = buildEmbedUrl({
+			origin: ORIGIN,
+			projectId: PROJECT_ID,
+			sceneId: SCENE_ID,
+			token: '   '
+		})
+
+		expect(new URL(url).searchParams.has('token')).toBe(false)
+	})
+
+	it('trims a pasted token rather than encoding the whitespace', () => {
+		const url = buildEmbedUrl({
+			origin: ORIGIN,
+			projectId: PROJECT_ID,
+			sceneId: SCENE_ID,
+			token: '  vctrl_abc123  '
+		})
+
+		expect(new URL(url).searchParams.get('token')).toBe('vctrl_abc123')
+	})
+})
+
+describe('token round trip through a generated snippet', () => {
+	/*
+	  The reported bug: the panel emitted `?token=YOUR_PREVIEW_API_KEY` inside an
+	  HTML attribute and told the user to substitute it. Pasting a quoted key
+	  closed the attribute early, the browser requested `?token=`, and an empty
+	  token is a 404. Asserting a golden string would not have caught it - the
+	  golden string was correct. What has to hold is that the token the panel was
+	  given is the token a parser reads back out.
+	*/
+	const HOSTILE_TOKENS = [
+		'vctrl_N3wIdPytooD26cwRCsRqm8zMZrLrjXWG',
+		'vctrl_with+plus/and=equals',
+		'vctrl_with&ampersand',
+		'vctrl_with"double"quotes',
+		"vctrl_with'single'quotes",
+		'vctrl_with<angle>brackets',
+		'vctrl_with spaces'
+	]
+
+	for (const builder of [buildResponsiveEmbedSnippet, buildSdkEmbedSnippet]) {
+		describe(builder.name, () => {
+			for (const token of HOSTILE_TOKENS) {
+				it(`survives ${JSON.stringify(token)}`, () => {
+					const src = buildEmbedUrl({
+						origin: ORIGIN,
+						projectId: PROJECT_ID,
+						sceneId: SCENE_ID,
+						token
+					})
+
+					const parsed = new URL(
+						decodeHtmlEntities(readSrcAttribute(builder({ src })))
+					)
+
+					expect(parsed.searchParams.get('token')).toBe(token)
+					expect(parsed.pathname).toBe(
+						buildEmbedPath({ projectId: PROJECT_ID, sceneId: SCENE_ID })
+					)
+				})
+			}
+		})
+	}
+
+	it('escapes the separator between parameters, not just the values', () => {
+		const src = `${ORIGIN}/embed/p/s?token=abc&camera=front&autoRotate=1`
+		const snippet = buildResponsiveEmbedSnippet({ src })
+
+		expect(snippet).toContain('&amp;camera=front')
+		expect(snippet).not.toMatch(/src="[^"]*[^;]&camera/)
+
+		const parsed = new URL(decodeHtmlEntities(readSrcAttribute(snippet)))
+		expect(parsed.searchParams.get('camera')).toBe('front')
+		expect(parsed.searchParams.get('autoRotate')).toBe('1')
+	})
+
+	it('leaves no attribute-closing quote in the emitted src', () => {
+		const src = buildEmbedUrl({
+			origin: ORIGIN,
+			projectId: PROJECT_ID,
+			sceneId: SCENE_ID,
+			token: 'vctrl_"injected" style="display:none'
+		})
+
+		expect(readSrcAttribute(buildResponsiveEmbedSnippet({ src }))).not.toContain(
+			'"'
+		)
+	})
+})
+
+describe('escapeHtmlAttributeValue', () => {
+	it('escapes ampersands once, not twice', () => {
+		expect(escapeHtmlAttributeValue('a&b')).toBe('a&amp;b')
+		expect(escapeHtmlAttributeValue('a<b')).toBe('a&lt;b')
+		expect(escapeHtmlAttributeValue('a"b')).toBe('a&quot;b')
+	})
+
+	it('is reversible for a value carrying every escaped character', () => {
+		const raw = `&<>"'`
+		expect(decodeHtmlEntities(escapeHtmlAttributeValue(raw))).toBe(raw)
+	})
+})
+
+describe('no hand-substituted placeholder survives anywhere', () => {
+	/*
+	  A placeholder inside an HTML attribute that the user is told to replace by
+	  hand *is* the bug, so nothing this module emits may contain one.
+	*/
+	const PLACEHOLDER = /YOUR_[A-Z_]*KEY|<projectId>|<sceneId>/
+
+	it('is absent from the generated snippets', () => {
+		const src = buildEmbedUrl({
+			origin: ORIGIN,
+			projectId: PROJECT_ID,
+			sceneId: SCENE_ID,
+			token: 'vctrl_real'
+		})
+
+		expect(buildResponsiveEmbedSnippet({ src })).not.toMatch(PLACEHOLDER)
+		expect(buildSdkEmbedSnippet({ src })).not.toMatch(PLACEHOLDER)
+	})
+
+	it('is absent from every string of panel copy', () => {
+		for (const [key, value] of Object.entries(EMBED_COPY)) {
+			expect(value, `EMBED_COPY.${key}`).not.toMatch(PLACEHOLDER)
+		}
+	})
+})
+
+describe('the two link targets stay distinct', () => {
+	/*
+	  "Open preview" used to open the token-authenticated `/embed` URL with no
+	  token, so it 404'd every time. The panel now opens `/preview` there, which
+	  is session-authenticated, and offers `/embed` separately as the visitor's
+	  view. The bug returns the moment these two agree.
+	*/
+	it('preview is session-authenticated and carries no token', () => {
+		const preview = buildInternalPreviewPath({
+			projectId: PROJECT_ID,
+			sceneId: SCENE_ID
+		})
+
+		expect(preview).toBe(`/preview/${PROJECT_ID}/${SCENE_ID}`)
+		expect(preview).not.toContain('token')
+		expect(preview).not.toBe(
+			buildEmbedPath({ projectId: PROJECT_ID, sceneId: SCENE_ID })
+		)
+	})
+})

--- a/apps/vectreal-platform/tests/embed-snippet.spec.ts
+++ b/apps/vectreal-platform/tests/embed-snippet.spec.ts
@@ -144,7 +144,9 @@ describe('the width and height fields cannot break the snippet', () => {
 		'100%"><script>alert(1)</script><div style="',
 		'100%" onmouseover="alert(1)',
 		'400px"><img src=x onerror=alert(1)>',
-		"100%' onload='alert(1)"
+		// Injects the tag the snippet legitimately contains: caught by counting
+		// elements, invisible to a `querySelector('iframe')` check.
+		'100%"><iframe src="https://evil.example"></iframe><div style="'
 	]
 
 	/**

--- a/apps/vectreal-platform/tests/embed-snippet.spec.ts
+++ b/apps/vectreal-platform/tests/embed-snippet.spec.ts
@@ -147,6 +147,21 @@ describe('the width and height fields cannot break the snippet', () => {
 		"100%' onload='alert(1)"
 	]
 
+	/**
+	 * Every element the snippet produces, in tree order.
+	 *
+	 * The whole document, not `body`: a parser hoists a leading `<script>` into
+	 * `<head>`, so scoping this to the body would stop looking exactly where an
+	 * injected element could land unseen.
+	 */
+	const STRUCTURAL = new Set(['html', 'head', 'body'])
+	const elementsOf = (snippet: string) =>
+		Array.from(
+			new DOMParser().parseFromString(snippet, 'text/html').querySelectorAll('*')
+		)
+			.map((element) => element.tagName.toLowerCase())
+			.filter((tag) => !STRUCTURAL.has(tag))
+
 	for (const value of HOSTILE) {
 		it(`survives a width of ${JSON.stringify(value)}`, () => {
 			const snippet = buildResponsiveEmbedSnippet({
@@ -155,11 +170,22 @@ describe('the width and height fields cannot break the snippet', () => {
 			})
 			const doc = new DOMParser().parseFromString(snippet, 'text/html')
 
-			expect(doc.querySelector('script')).toBeNull()
-			expect(doc.querySelector('img')).toBeNull()
+			/*
+			  The whole element list, not a hunt for specific tags. Payloads break
+			  out in ways that move different counters - one opens a sibling
+			  `<script>`, one nests an `<img>` inside the wrapper without changing
+			  any `div` or `script` count, one adds only an attribute and changes
+			  no element at all. Pinning the exact set the builder is supposed to
+			  emit catches every shape, including ones nobody thought to list.
 
-			const wrapper = doc.body.firstElementChild as HTMLElement
-			expect(wrapper.tagName).toBe('DIV')
+			  Deliberately not asserting the absence of the string `alert(1)`:
+			  escaping leaves it sitting inertly inside the `style` value, so a
+			  correctly escaped snippet still contains those characters. What
+			  matters is that the parser reads them as text, not as markup.
+			*/
+			expect(elementsOf(snippet)).toEqual(['div', 'iframe'])
+
+			const wrapper = doc.querySelector('div') as HTMLElement
 			expect(wrapper.getAttributeNames()).toEqual(['style'])
 			expect(wrapper.style.width).toBe('')
 		})
@@ -171,9 +197,22 @@ describe('the width and height fields cannot break the snippet', () => {
 			})
 			const doc = new DOMParser().parseFromString(snippet, 'text/html')
 
-			expect(doc.querySelector('img')).toBeNull()
+			/*
+			  Counting, not absence. This snippet ships two legitimate `<script>`
+			  tags, so `querySelector('script')` is useless here - and asserting
+			  only the wrapper's attribute list is worse than useless, because a
+			  payload that breaks out opens *sibling* elements rather than adding
+			  attributes, leaving that assertion green with `alert(1)` live in the
+			  document.
+			*/
+			expect(elementsOf(snippet)).toEqual([
+				'script',
+				'div',
+				'iframe',
+				'script'
+			])
 			expect(
-				doc.querySelectorAll('div')[0].getAttributeNames()
+				(doc.querySelector('div') as HTMLElement).getAttributeNames()
 			).toEqual(['style'])
 		})
 	}

--- a/apps/vectreal-platform/tests/embed-snippet.spec.ts
+++ b/apps/vectreal-platform/tests/embed-snippet.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -14,21 +15,26 @@ const ORIGIN = 'https://vectreal.com'
 const PROJECT_ID = '08db6be1-f87b-4278-abfc-d80ef549e3a7'
 const SCENE_ID = '1ee4f724-2ee5-4162-9804-2de08bcb0eca'
 
-/** The `src` attribute value of the first iframe in a snippet. */
-function readSrcAttribute(snippet: string): string {
-	const match = snippet.match(/<iframe[\s\S]*?\ssrc="([^"]*)"/)
-	expect(match, 'snippet has an iframe src').not.toBeNull()
-	return match![1]
+/**
+ * The iframe a real HTML parser finds in a snippet.
+ *
+ * Deliberately `DOMParser` rather than a regex over the string: the question
+ * these tests exist to answer is what a *browser* reads back out of the
+ * generated markup, and the reported bug was precisely that the markup parsed
+ * differently than it looked. A regex capturing `[^"]*` cannot contain a quote
+ * by construction, so any assertion made through one holds whether or not the
+ * escaping works.
+ */
+function parseIframe(snippet: string): HTMLIFrameElement {
+	const doc = new DOMParser().parseFromString(snippet, 'text/html')
+	const iframe = doc.querySelector('iframe')
+	expect(iframe, 'snippet parses to markup containing an iframe').not.toBeNull()
+	return iframe as HTMLIFrameElement
 }
 
-/** Reverses `escapeHtmlAttributeValue`, the way a browser's parser would. */
-function decodeHtmlEntities(value: string): string {
-	return value
-		.replace(/&lt;/g, '<')
-		.replace(/&gt;/g, '>')
-		.replace(/&quot;/g, '"')
-		.replace(/&#39;/g, "'")
-		.replace(/&amp;/g, '&')
+/** The `src` a browser resolves, entity references already decoded for us. */
+function readParsedSrc(snippet: string): string {
+	return parseIframe(snippet).getAttribute('src') ?? ''
 }
 
 describe('buildEmbedUrl', () => {
@@ -96,9 +102,7 @@ describe('token round trip through a generated snippet', () => {
 						token
 					})
 
-					const parsed = new URL(
-						decodeHtmlEntities(readSrcAttribute(builder({ src })))
-					)
+					const parsed = new URL(readParsedSrc(builder({ src })))
 
 					expect(parsed.searchParams.get('token')).toBe(token)
 					expect(parsed.pathname).toBe(
@@ -114,24 +118,77 @@ describe('token round trip through a generated snippet', () => {
 		const snippet = buildResponsiveEmbedSnippet({ src })
 
 		expect(snippet).toContain('&amp;camera=front')
-		expect(snippet).not.toMatch(/src="[^"]*[^;]&camera/)
 
-		const parsed = new URL(decodeHtmlEntities(readSrcAttribute(snippet)))
+		const parsed = new URL(readParsedSrc(snippet))
 		expect(parsed.searchParams.get('camera')).toBe('front')
 		expect(parsed.searchParams.get('autoRotate')).toBe('1')
 	})
 
-	it('leaves no attribute-closing quote in the emitted src', () => {
-		const src = buildEmbedUrl({
-			origin: ORIGIN,
-			projectId: PROJECT_ID,
-			sceneId: SCENE_ID,
-			token: 'vctrl_"injected" style="display:none'
+	it('cannot be made to inject an attribute through the src', () => {
+		const src = `${ORIGIN}/embed/p/s?token=vctrl_" onload="alert(1)`
+		const iframe = parseIframe(buildResponsiveEmbedSnippet({ src }))
+
+		expect(iframe.getAttribute('src')).toBe(src)
+		expect(iframe.getAttribute('onload')).toBeNull()
+	})
+})
+
+describe('the width and height fields cannot break the snippet', () => {
+	/*
+	  Both are free text in the panel and land in a quoted `style` attribute, so
+	  they are the same breakout the token placeholder was - one field over. A
+	  parser is what settles it: the wrapper keeps exactly one attribute, and no
+	  element appears that the builder did not write.
+	*/
+	const HOSTILE = [
+		'100%"><script>alert(1)</script><div style="',
+		'100%" onmouseover="alert(1)',
+		'400px"><img src=x onerror=alert(1)>',
+		"100%' onload='alert(1)"
+	]
+
+	for (const value of HOSTILE) {
+		it(`survives a width of ${JSON.stringify(value)}`, () => {
+			const snippet = buildResponsiveEmbedSnippet({
+				src: `${ORIGIN}/embed/p/s`,
+				width: value
+			})
+			const doc = new DOMParser().parseFromString(snippet, 'text/html')
+
+			expect(doc.querySelector('script')).toBeNull()
+			expect(doc.querySelector('img')).toBeNull()
+
+			const wrapper = doc.body.firstElementChild as HTMLElement
+			expect(wrapper.tagName).toBe('DIV')
+			expect(wrapper.getAttributeNames()).toEqual(['style'])
+			expect(wrapper.style.width).toBe('')
 		})
 
-		expect(readSrcAttribute(buildResponsiveEmbedSnippet({ src }))).not.toContain(
-			'"'
-		)
+		it(`survives a height of ${JSON.stringify(value)}`, () => {
+			const snippet = buildSdkEmbedSnippet({
+				src: `${ORIGIN}/embed/p/s`,
+				height: value
+			})
+			const doc = new DOMParser().parseFromString(snippet, 'text/html')
+
+			expect(doc.querySelector('img')).toBeNull()
+			expect(
+				doc.querySelectorAll('div')[0].getAttributeNames()
+			).toEqual(['style'])
+		})
+	}
+
+	it('still passes an ordinary CSS length through untouched', () => {
+		const snippet = buildResponsiveEmbedSnippet({
+			src: `${ORIGIN}/embed/p/s`,
+			width: 'calc(100% - 20px)',
+			height: '640px'
+		})
+		const wrapper = new DOMParser().parseFromString(snippet, 'text/html').body
+			.firstElementChild as HTMLElement
+
+		expect(wrapper.style.width).toBe('calc(100% - 20px)')
+		expect(wrapper.style.height).toBe('640px')
 	})
 })
 
@@ -142,9 +199,14 @@ describe('escapeHtmlAttributeValue', () => {
 		expect(escapeHtmlAttributeValue('a"b')).toBe('a&quot;b')
 	})
 
-	it('is reversible for a value carrying every escaped character', () => {
+	it('round-trips every escaped character through a real parser', () => {
 		const raw = `&<>"'`
-		expect(decodeHtmlEntities(escapeHtmlAttributeValue(raw))).toBe(raw)
+		const doc = new DOMParser().parseFromString(
+			`<i data-v="${escapeHtmlAttributeValue(raw)}"></i>`,
+			'text/html'
+		)
+
+		expect(doc.querySelector('i')?.getAttribute('data-v')).toBe(raw)
 	})
 })
 

--- a/apps/vectreal-platform/tests/use-embed-api-keys.spec.tsx
+++ b/apps/vectreal-platform/tests/use-embed-api-keys.spec.tsx
@@ -40,10 +40,7 @@ vi.mock('remix-utils/csrf/react', () => ({
 	useAuthenticityToken: () => 'csrf-token'
 }))
 
-vi.mock('jotai', () => ({
-	atom: vi.fn(),
-	useSetAtom: () => setUpgradeModal
-}))
+vi.mock('jotai/react', () => ({ useSetAtom: () => setUpgradeModal }))
 
 let callIndex = 0
 
@@ -185,23 +182,32 @@ describe('creating a key', () => {
 		expect(load).toHaveBeenCalledTimes(2)
 	})
 
-	it('applies one response once, however often the effect re-runs', () => {
-		const created = {
+	it('applies a second key, rather than blocking everything after the first', () => {
+		/*
+		  The mount-time test above proves the identity guard *checks*. This one
+		  proves it does not over-block: `if (handledCreateRef.current) return`
+		  would swallow every key after the first, and three rerenders with
+		  unchanged props - which is what stood here - cannot tell the difference,
+		  because an unchanged dependency array never re-runs the effect either way.
+		*/
+		const response = (id: string, plaintext: string) => ({
 			success: true,
-			data: {
-				key: { id: 'new', name: 'Embed key', keyPreview: 'ab3x' },
-				plaintext: 'vctrl_secretab3x'
-			}
-		}
+			data: { key: { id, name: 'Embed key', keyPreview: 'ab3x' }, plaintext }
+		})
 		const probe = mount({ projectId: 'p1', enabled: true })
 
-		fetchers[1] = { state: 'idle', data: created }
+		fetchers[1] = { state: 'idle', data: response('first', 'vctrl_firstab3x') }
 		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
-		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
+		expect(probe.latest().token).toBe('vctrl_firstab3x')
+
+		act(() => probe.latest().dismissCreatedKey())
+
+		fetchers[1] = { state: 'idle', data: response('second', 'vctrl_second9zQ1') }
 		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
 
-		// One refresh for the create, on top of the initial load.
-		expect(load).toHaveBeenCalledTimes(2)
+		expect(probe.latest().token).toBe('vctrl_second9zQ1')
+		expect(probe.latest().selectedKeyId).toBe('second')
+		expect(probe.latest().createdPlaintext).toBe('vctrl_second9zQ1')
 	})
 
 	it('applies a response already present at mount exactly once', () => {

--- a/apps/vectreal-platform/tests/use-embed-api-keys.spec.tsx
+++ b/apps/vectreal-platform/tests/use-embed-api-keys.spec.tsx
@@ -116,6 +116,29 @@ describe('loading the key list', () => {
 		])
 	})
 
+	it('reports nothing known before a response arrives', () => {
+		/*
+		  The state that produced this: `listFetcher.state` is `'idle'` both after
+		  a request settles and before one is dispatched, and dispatch happens in
+		  an effect - which never runs during server rendering. A flag derived
+		  from `state` therefore says "not loading" in the SSR'd HTML, and every
+		  empty-state message gated on it renders as fact about unfetched data.
+		*/
+		const probe = mount({ projectId: 'p1', enabled: true })
+
+		expect(probe.latest().hasLoaded).toBe(false)
+		expect(probe.latest().keys).toEqual([])
+		expect(probe.latest().allowedDomains).toEqual([])
+		expect(probe.latest().loadError).toBeNull()
+	})
+
+	it('knows an answer arrived, including a refusal', () => {
+		fetchers[0] = { state: 'idle', data: { success: false, error: 'nope' } }
+		expect(mount({ projectId: 'p1', enabled: true }).latest().hasLoaded).toBe(
+			true
+		)
+	})
+
 	it('surfaces a refusal instead of reporting an empty project', () => {
 		fetchers[0] = {
 			state: 'idle',
@@ -148,6 +171,7 @@ describe('loading the key list', () => {
 		expect(api.keys).toHaveLength(1)
 		expect(api.allowedDomains).toEqual(['shop.example.com'])
 		expect(api.canCreateKey).toBe(true)
+		expect(api.hasLoaded).toBe(true)
 		expect(api.loadError).toBeNull()
 	})
 })

--- a/apps/vectreal-platform/tests/use-embed-api-keys.spec.tsx
+++ b/apps/vectreal-platform/tests/use-embed-api-keys.spec.tsx
@@ -1,0 +1,310 @@
+// @vitest-environment jsdom
+/**
+ * The panel's fetch and create state.
+ *
+ * Two guards carry this hook, and both are the kind a later "simplification"
+ * removes without anything going red: the ref that stops the key request
+ * re-firing on every render, and the one that stops a create response being
+ * applied twice. The rest is envelope reading - the difference between an
+ * error surfacing and being swallowed.
+ */
+
+import { act, render } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useEmbedApiKeys } from '../app/components/embed/use-embed-api-keys'
+
+import type { EmbedApiKeysApi } from '../app/components/embed/use-embed-api-keys'
+
+const { load, submit, setUpgradeModal, fetchers } = vi.hoisted(() => ({
+	load: vi.fn(),
+	submit: vi.fn(),
+	setUpgradeModal: vi.fn(),
+	fetchers: [] as Array<{ state: string; data: unknown }>
+}))
+
+vi.mock('react-router', () => ({
+	// Two `useFetcher()` calls per render, in a fixed order: list, then create.
+	// A fresh object each time, which is exactly the identity churn the ref
+	// guard in the hook exists to survive.
+	useFetcher: vi.fn(() => {
+		const index = callIndex++ % 2
+		return index === 0
+			? { load, state: fetchers[0].state, data: fetchers[0].data }
+			: { submit, state: fetchers[1].state, data: fetchers[1].data }
+	})
+}))
+
+vi.mock('remix-utils/csrf/react', () => ({
+	useAuthenticityToken: () => 'csrf-token'
+}))
+
+vi.mock('jotai', () => ({
+	atom: vi.fn(),
+	useSetAtom: () => setUpgradeModal
+}))
+
+let callIndex = 0
+
+/*
+  Mounted under `StrictMode` deliberately. Both refs in this hook exist only to
+  survive StrictMode's double-invoked effects - the dependency arrays already
+  stop a plain re-render from re-firing anything - so a test that renders
+  normally passes just as happily with both guards deleted. Rendering the way
+  the app renders is what gives these assertions teeth.
+*/
+function mount(props: { projectId?: string; enabled: boolean }) {
+	const seen: EmbedApiKeysApi[] = []
+
+	function Probe(inner: typeof props) {
+		seen.push(useEmbedApiKeys(inner))
+		return null
+	}
+
+	const utils = render(
+		<StrictMode>
+			<Probe {...props} />
+		</StrictMode>
+	)
+
+	return {
+		latest: () => seen[seen.length - 1],
+		rerender: (next: typeof props) =>
+			utils.rerender(
+				<StrictMode>
+					<Probe {...next} />
+				</StrictMode>
+			)
+	}
+}
+
+beforeEach(() => {
+	callIndex = 0
+	load.mockClear()
+	submit.mockClear()
+	setUpgradeModal.mockClear()
+	fetchers[0] = { state: 'idle', data: undefined }
+	fetchers[1] = { state: 'idle', data: undefined }
+})
+
+describe('loading the key list', () => {
+	it('requests once, and not again on re-render or a repeated effect', () => {
+		const probe = mount({ projectId: 'p1', enabled: true })
+
+		expect(load).toHaveBeenCalledTimes(1)
+		expect(load).toHaveBeenCalledWith('/api/projects/p1/api-keys')
+
+		probe.rerender({ projectId: 'p1', enabled: true })
+		probe.rerender({ projectId: 'p1', enabled: true })
+
+		expect(load).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not request until the scene has a project', () => {
+		const probe = mount({ projectId: undefined, enabled: false })
+		expect(load).not.toHaveBeenCalled()
+
+		probe.rerender({ projectId: 'p1', enabled: true })
+		expect(load).toHaveBeenCalledTimes(1)
+	})
+
+	it('requests again when the project changes', () => {
+		const probe = mount({ projectId: 'p1', enabled: true })
+		probe.rerender({ projectId: 'p2', enabled: true })
+
+		expect(load.mock.calls.map(([url]) => url)).toEqual([
+			'/api/projects/p1/api-keys',
+			'/api/projects/p2/api-keys'
+		])
+	})
+
+	it('surfaces a refusal instead of reporting an empty project', () => {
+		fetchers[0] = {
+			state: 'idle',
+			data: { success: false, error: 'You do not have permission to view API keys' }
+		}
+		const probe = mount({ projectId: 'p1', enabled: true })
+
+		expect(probe.latest().keys).toEqual([])
+		expect(probe.latest().loadError).toBe(
+			'You do not have permission to view API keys'
+		)
+	})
+
+	it('reads the payload through the success envelope', () => {
+		fetchers[0] = {
+			state: 'idle',
+			data: {
+				success: true,
+				data: {
+					projectId: 'p1',
+					projectName: 'Storefront',
+					allowedDomains: ['shop.example.com'],
+					keys: [{ id: 'k1', name: 'live', keyPreview: 'ab3x' }],
+					canCreateKey: true
+				}
+			}
+		}
+		const api = mount({ projectId: 'p1', enabled: true }).latest()
+
+		expect(api.keys).toHaveLength(1)
+		expect(api.allowedDomains).toEqual(['shop.example.com'])
+		expect(api.canCreateKey).toBe(true)
+		expect(api.loadError).toBeNull()
+	})
+})
+
+describe('creating a key', () => {
+	it('posts the intent and the CSRF token to this project', () => {
+		mount({ projectId: 'p1', enabled: true }).latest().createKey()
+
+		expect(submit).toHaveBeenCalledWith(
+			{ intent: 'create', csrf: 'csrf-token' },
+			{ method: 'post', action: '/api/projects/p1/api-keys' }
+		)
+	})
+
+	it('fills the token, selects the key, and refreshes the list', () => {
+		const created = {
+			success: true,
+			data: {
+				key: { id: 'new', name: 'Embed key', keyPreview: 'ab3x' },
+				plaintext: 'vctrl_secretab3x'
+			}
+		}
+		const probe = mount({ projectId: 'p1', enabled: true })
+		expect(load).toHaveBeenCalledTimes(1)
+
+		fetchers[1] = { state: 'idle', data: created }
+		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
+
+		expect(probe.latest().token).toBe('vctrl_secretab3x')
+		expect(probe.latest().createdPlaintext).toBe('vctrl_secretab3x')
+		expect(probe.latest().selectedKeyId).toBe('new')
+		expect(load).toHaveBeenCalledTimes(2)
+	})
+
+	it('applies one response once, however often the effect re-runs', () => {
+		const created = {
+			success: true,
+			data: {
+				key: { id: 'new', name: 'Embed key', keyPreview: 'ab3x' },
+				plaintext: 'vctrl_secretab3x'
+			}
+		}
+		const probe = mount({ projectId: 'p1', enabled: true })
+
+		fetchers[1] = { state: 'idle', data: created }
+		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
+		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
+		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
+
+		// One refresh for the create, on top of the initial load.
+		expect(load).toHaveBeenCalledTimes(2)
+	})
+
+	it('applies a response already present at mount exactly once', () => {
+		/*
+		  The case the identity guard is actually for. A dependency array already
+		  stops an unchanged response being re-applied on update, so the guard only
+		  earns its place when the effect runs twice against the same data - which
+		  is what a mount does under StrictMode, and what a remount does when the
+		  publisher's accordion closes and reopens with the fetcher still holding
+		  its result. Applying twice would fire a second list refresh.
+		*/
+		fetchers[1] = {
+			state: 'idle',
+			data: {
+				success: true,
+				data: {
+					key: { id: 'new', name: 'Embed key', keyPreview: 'ab3x' },
+					plaintext: 'vctrl_secretab3x'
+				}
+			}
+		}
+
+		const probe = mount({ projectId: 'p1', enabled: true })
+
+		expect(probe.latest().token).toBe('vctrl_secretab3x')
+		// The initial list load, plus exactly one refresh for the create.
+		expect(load).toHaveBeenCalledTimes(2)
+	})
+
+	it('opens the upgrade prompt once for a refusal present at mount', () => {
+		fetchers[1] = {
+			state: 'idle',
+			data: {
+				success: false,
+				error: 'API key limit reached for your plan.',
+				quota: {
+					limitKey: 'api_keys_per_org',
+					currentValue: 3,
+					limit: 3,
+					plan: 'free',
+					upgradeTo: 'pro'
+				}
+			}
+		}
+
+		mount({ projectId: 'p1', enabled: true })
+
+		expect(setUpgradeModal).toHaveBeenCalledTimes(1)
+	})
+
+	it('forgets the plaintext once dismissed', () => {
+		const probe = mount({ projectId: 'p1', enabled: true })
+		fetchers[1] = {
+			state: 'idle',
+			data: {
+				success: true,
+				data: {
+					key: { id: 'new', name: 'k', keyPreview: 'ab3x' },
+					plaintext: 'vctrl_secretab3x'
+				}
+			}
+		}
+		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
+
+		act(() => probe.latest().dismissCreatedKey())
+
+		expect(probe.latest().createdPlaintext).toBeNull()
+		// The token stays: the user still needs it to build a snippet.
+		expect(probe.latest().token).toBe('vctrl_secretab3x')
+	})
+
+	it('opens the upgrade prompt on a quota refusal rather than a bare error', () => {
+		const probe = mount({ projectId: 'p1', enabled: true })
+		fetchers[1] = {
+			state: 'idle',
+			data: {
+				success: false,
+				error: 'API key limit reached for your plan.',
+				quota: {
+					limitKey: 'api_keys_per_org',
+					currentValue: 3,
+					limit: 3,
+					plan: 'free',
+					upgradeTo: 'pro'
+				}
+			}
+		}
+		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
+
+		expect(setUpgradeModal).toHaveBeenCalledTimes(1)
+		// The modal is the message, so the inline notice must not double it.
+		expect(probe.latest().createError).toBeNull()
+	})
+
+	it('still shows an inline error when there is no upgrade to offer', () => {
+		const probe = mount({ projectId: 'p1', enabled: true })
+		fetchers[1] = {
+			state: 'idle',
+			data: { success: false, error: 'Could not create an API key' }
+		}
+		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
+
+		expect(setUpgradeModal).not.toHaveBeenCalled()
+		expect(probe.latest().createError).toBe('Could not create an API key')
+	})
+})


### PR DESCRIPTION
Step 2 of the `/embed` fix. Independent of [#734](https://github.com/Vectreal/vectreal-platform/pull/734) — no file overlap, lands in either order.

## The bug

The panel emitted `?token=YOUR_PREVIEW_API_KEY` inside an HTML attribute and asked the user to substitute it by hand. The obvious substitution — pasting a quoted key — closed the `src` attribute at the first quote:

```
src="https://vectreal.com/embed/p/s?token="vctrl_abc"   style="..."
```

The browser then requested `?token=`, and an empty token is a 404 with nothing to indicate why. This is what the reported Shopify snippet did.

A placeholder inside a quoted attribute that the user is asked to replace **is** the bug, so it is gone rather than reworded.

## What the panel does now

| | |
|---|---|
| **Key picker** | The keys scoped to this project — name, last four characters, status. Revoked and expired keys are listed, not hidden: an embed that worked yesterday and 404s today usually names a key that has since been revoked, and hiding those leaves the owner comparing a working key against an empty list. |
| **Token field** | What the snippet is built from. React state only — not localStorage, not sessionStorage, never an analytics capture. |
| **Create a key for this project** | Mints one scoped to that project alone and fills the field in-session. Plaintext appears exactly once, as on the full API keys form. |
| **Allowed domains** | Read-only, with a link to project settings. An empty list refuses every third-party page with 403 even with a perfect key — the docs said so and the UI was silent. |
| **Identifiers** | Copyable project and scene ids, which previously appeared only inside a URL. |

## Correctness

`buildEmbedUrl` builds through `URLSearchParams`, and both snippet builders escape the `src` they interpolate. A multi-parameter URL previously emitted a bare `&` into an attribute, which is invalid HTML.

**"Open preview"** opened the token-authenticated `/embed` URL with no token, so it 404'd every time. It now opens the session-authenticated `/preview`.

**"Test embed URL"** is new: it opens the real embed URL with `noopener` and deliberately *not* `noreferrer`. `noreferrer` strips the `Referer`, the domain check then reads no requester host, and off any non-localhost instance that falls straight through to `domain_not_allowed` — so the button meant to prove the embed works would 403 on scenes that are fine. Its tooltip also says what it *cannot* check: `allowByInternalHost` permits any request from vectreal.com regardless of the domain list, so this button never exercises the allowlist.

## New resource route

`api/projects/:projectId/api-keys` backs the panel. Both mount sites pass only ids — the dashboard scene loader has the project row, the publisher would need a four-file thread-through — so the panel fetches for itself rather than either site growing props it cannot supply. A project the actor cannot see is reported as missing rather than forbidden, so the route cannot enumerate ids.

## Tests

`tests/embed-snippet.spec.ts` asserts the round trip rather than a golden string: a golden string was *correct* under the old code, which is why nothing caught this. Seven hostile tokens through both snippet builders, the `&` separator case, and a guard that no placeholder survives in any emitted snippet or any string of panel copy.

`tests/embed-key-options.spec.ts` covers project scoping, both revocation signals the schema uses, the expiry boundary, ordering, and that the payload carries nothing beyond the four-character preview.

Both were checked for teeth by reverting each fix and confirming the relevant test goes red.

## Gates

- `nx typecheck vectreal-platform` — pass
- `nx lint vectreal-platform` — pass
- 530 unit tests — pass

## Still open

Step 3 (key reveal / rotate / editable expiry / delete) is what makes the picker able to *fill* the token rather than only label it. Until then the picker tells you which saved key a project expects; it cannot recover one you did not save.