### PR TITLE
fix(embed): allow wildcard storefront domains

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/auth/preview-api-key-auth.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/preview-api-key-auth.server.ts
@@ -7,11 +7,17 @@ import { apiKeyProjects } from '../../../db/schema/auth/api-key-projects'
 import { apiKeys } from '../../../db/schema/auth/api-keys'
 import { projects } from '../../../db/schema/project/projects'
 import {
-	extractHostFromHeader,
-	isAllowedEmbedHost,
-	isLocalhostLike,
-	parseAllowedDomainPatterns
-} from '../embed/embed-domain-policy'
+	decideEmbedAccess,
+	getPreviewTokenFromRequest,
+	type EmbedAccessDecision,
+	type EmbedKeyMatch
+} from '../embed/embed-access-policy'
+
+/**
+ * Lookup and rate limiting for embed access. The decision itself lives in
+ * `embed/embed-access-policy.ts`, which has no database import and is therefore
+ * testable; this module exists to feed it a row and to record the outcome.
+ */
 
 const db = getDbClient()
 
@@ -24,16 +30,6 @@ type AttemptWindow = {
 }
 
 const attemptWindows = new Map<string, AttemptWindow>()
-
-function parseBearerToken(authorizationHeader: string | null): string | null {
-	if (!authorizationHeader) return null
-	const [scheme, token] = authorizationHeader.split(' ')
-	if (!scheme || !token) return null
-	if (scheme.toLowerCase() !== 'bearer') return null
-
-	const trimmed = token.trim()
-	return trimmed.length > 0 ? trimmed : null
-}
 
 function getClientIdentifier(request: Request): string {
 	const forwardedFor = request.headers
@@ -79,85 +75,31 @@ function trackFailedAttempt(clientIdentifier: string) {
 	attemptWindows.set(clientIdentifier, currentWindow)
 }
 
+/** Stays here rather than in the policy module: it needs `node:crypto`. */
 export function hashApiToken(token: string): string {
 	return createHash('sha256').update(token).digest('hex')
 }
 
-export function getPreviewTokenFromRequest(request: Request): string | null {
-	const url = new URL(request.url)
-	const queryToken = url.searchParams.get('token')?.trim()
-	if (queryToken) return queryToken
+export type PreviewApiKeyValidationResult = EmbedAccessDecision
 
-	return parseBearerToken(request.headers.get('authorization'))
-}
-
-export type PreviewApiKeyValidationResult =
-	| {
-			ok: true
-			apiKeyId: string
-			projectId: string
-			userId: string
-	  }
-	| {
-			ok: false
-			error:
-				| 'missing_token'
-				| 'invalid_token'
-				| 'rate_limited'
-				| 'domain_not_allowed'
-	  }
-
-type RequestHostContext = {
-	host: string | null
-	source: 'referer' | 'origin' | 'missing'
-}
-
-function normalizeHost(host: string): string {
-	return host.toLowerCase().trim().replace(/\.+$/, '')
-}
-
-function getRequestHostContext(request: Request): RequestHostContext {
-	const refererHost = extractHostFromHeader(request.headers.get('referer'))
-	if (refererHost) {
-		return { host: refererHost, source: 'referer' }
-	}
-
-	const originHost = extractHostFromHeader(request.headers.get('origin'))
-	if (originHost) {
-		return { host: originHost, source: 'origin' }
-	}
-
-	return { host: null, source: 'missing' }
-}
-
-export async function validatePreviewApiKeyForProject(params: {
-	request: Request
-	projectId: string
-}): Promise<PreviewApiKeyValidationResult> {
-	const { request, projectId } = params
-	const clientIdentifier = getClientIdentifier(request)
-
-	if (isRateLimited(clientIdentifier)) {
-		return { ok: false, error: 'rate_limited' }
-	}
-
-	const token = getPreviewTokenFromRequest(request)
-	if (!token) {
-		trackFailedAttempt(clientIdentifier)
-		return { ok: false, error: 'missing_token' }
-	}
-
-	const hashedToken = hashApiToken(token)
-	const now = new Date()
-
-	// Validate API key and ensure organization matches
+/**
+ * The one live key for this project matching the hash, or null.
+ *
+ * Revoked, deactivated and expired keys are excluded in SQL rather than after
+ * the fact, so a caller cannot forget the check.
+ */
+async function findLiveKeyForProject(
+	hashedToken: string,
+	projectId: string,
+	now: Date
+): Promise<EmbedKeyMatch | null> {
 	const matches = await db
 		.select({
 			apiKeyId: apiKeys.id,
 			projectId: apiKeyProjects.projectId,
 			userId: apiKeys.userId,
-			apiKeyOrgId: apiKeys.organizationId,
-			projectOrgId: projects.organizationId,
+			apiKeyOrganizationId: apiKeys.organizationId,
+			projectOrganizationId: projects.organizationId,
 			allowedEmbedDomains: projects.allowedEmbedDomains
 		})
 		.from(apiKeys)
@@ -174,49 +116,40 @@ export async function validatePreviewApiKeyForProject(params: {
 		)
 		.limit(1)
 
-	if (matches.length === 0) {
-		trackFailedAttempt(clientIdentifier)
-		return { ok: false, error: 'invalid_token' }
+	return matches[0] ?? null
+}
+
+export async function validatePreviewApiKeyForProject(params: {
+	request: Request
+	projectId: string
+}): Promise<PreviewApiKeyValidationResult> {
+	const { request, projectId } = params
+	const clientIdentifier = getClientIdentifier(request)
+
+	if (isRateLimited(clientIdentifier)) {
+		return { ok: false, error: 'rate_limited' }
 	}
 
-	// Extra security: Verify API key's org matches project's org
-	if (matches[0].apiKeyOrgId !== matches[0].projectOrgId) {
+	const token = getPreviewTokenFromRequest(request)
+	const now = new Date()
+
+	// No token means no lookup: an absent token can match no key, and querying
+	// for one would let an unauthenticated caller drive database load.
+	const match = token
+		? await findLiveKeyForProject(hashApiToken(token), projectId, now)
+		: null
+
+	const decision = decideEmbedAccess({ request, token, match })
+
+	if (!decision.ok) {
 		trackFailedAttempt(clientIdentifier)
-		return { ok: false, error: 'invalid_token' }
-	}
-
-	const allowedDomains = parseAllowedDomainPatterns(
-		matches[0].allowedEmbedDomains
-	)
-	const { host: requesterHost, source: requesterHostSource } =
-		getRequestHostContext(request)
-	const applicationHost = normalizeHost(new URL(request.url).hostname)
-
-	const allowByLocalhostFallback =
-		requesterHostSource === 'missing' && isLocalhostLike(applicationHost)
-
-	const allowByInternalHost =
-		requesterHost !== null && requesterHost === applicationHost
-
-	const allowByAllowedDomain =
-		requesterHost !== null && isAllowedEmbedHost(requesterHost, allowedDomains)
-
-	if (
-		!(allowByLocalhostFallback || allowByInternalHost || allowByAllowedDomain)
-	) {
-		trackFailedAttempt(clientIdentifier)
-		return { ok: false, error: 'domain_not_allowed' }
+		return decision
 	}
 
 	await db
 		.update(apiKeys)
 		.set({ lastUsedAt: now })
-		.where(eq(apiKeys.id, matches[0].apiKeyId))
+		.where(eq(apiKeys.id, decision.apiKeyId))
 
-	return {
-		ok: true,
-		apiKeyId: matches[0].apiKeyId,
-		projectId: matches[0].projectId,
-		userId: matches[0].userId
-	}
+	return decision
 }

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.ts
@@ -1,0 +1,161 @@
+import {
+	extractHostFromHeader,
+	isAllowedEmbedHost,
+	isLocalhostLike,
+	normalizeHost,
+	parseAllowedDomainPatterns
+} from './embed-domain-policy'
+
+/**
+ * Decides whether a third-party request may load a published scene.
+ *
+ * This is the security boundary of the product's headline feature, and it lived
+ * inside `preview-api-key-auth.server.ts`, which calls `getDbClient()` at module
+ * scope. Importing it from a test therefore opened a database connection and
+ * threw `Missing DATABASE_URL`, so the decision had no tests at all while the
+ * lookup around it was the only thing standing in the way.
+ *
+ * Splitting decision from lookup is the same move `embed-asset-policy.ts` made
+ * for the asset gate, and for the same reason: the rule can then be tested
+ * directly, against hostile input, without Postgres.
+ *
+ * Deliberately free of Node APIs as well as of the database, so nothing here
+ * needs a `.server` suffix. Token hashing stays behind in the server module
+ * because it needs `node:crypto`.
+ */
+
+export type EmbedAccessFailure =
+	| 'missing_token'
+	| 'invalid_token'
+	| 'rate_limited'
+	| 'domain_not_allowed'
+
+/** The row the key lookup returns, or null when no live key matched. */
+export type EmbedKeyMatch = {
+	apiKeyId: string
+	projectId: string
+	userId: string
+	apiKeyOrganizationId: string
+	projectOrganizationId: string
+	allowedEmbedDomains: string | null
+}
+
+export type EmbedAccessDecision =
+	| { ok: true; apiKeyId: string; projectId: string; userId: string }
+	| { ok: false; error: EmbedAccessFailure }
+
+export type RequestHostContext = {
+	host: string | null
+	source: 'referer' | 'origin' | 'missing'
+}
+
+function parseBearerToken(authorizationHeader: string | null): string | null {
+	if (!authorizationHeader) return null
+	const [scheme, token] = authorizationHeader.split(' ')
+	if (!scheme || !token) return null
+	if (scheme.toLowerCase() !== 'bearer') return null
+
+	const trimmed = token.trim()
+	return trimmed.length > 0 ? trimmed : null
+}
+
+export function getPreviewTokenFromRequest(request: Request): string | null {
+	const url = new URL(request.url)
+	const queryToken = url.searchParams.get('token')?.trim()
+	if (queryToken) return queryToken
+
+	return parseBearerToken(request.headers.get('authorization'))
+}
+
+/**
+ * Which host the request claims to come from.
+ *
+ * `Referer` first, `Origin` second, and `missing` when neither survives. Missing
+ * is a real case rather than an error: `window.open(url, 'noopener,noreferrer')`
+ * strips `Referer`, and so does a `no-referrer` policy on the embedding page.
+ */
+export function resolveRequestHostContext(request: Request): RequestHostContext {
+	const refererHost = extractHostFromHeader(request.headers.get('referer'))
+	if (refererHost) {
+		return { host: refererHost, source: 'referer' }
+	}
+
+	const originHost = extractHostFromHeader(request.headers.get('origin'))
+	if (originHost) {
+		return { host: originHost, source: 'origin' }
+	}
+
+	return { host: null, source: 'missing' }
+}
+
+/**
+ * The host half of the decision, kept as three named conditions because each one
+ * is a separate product rule and reviewers need to see them individually.
+ *
+ * The localhost fallback is why a request with no `Referer` succeeds in local
+ * development and fails in production. The internal-host rule is why opening an
+ * embed URL from Vectreal itself always works and therefore proves nothing about
+ * a customer's allowlist.
+ */
+export function isEmbedRequestHostAllowed(params: {
+	request: Request
+	allowedEmbedDomains: string | null
+}): boolean {
+	const allowedDomains = parseAllowedDomainPatterns(params.allowedEmbedDomains)
+	const { host: requesterHost, source: requesterHostSource } =
+		resolveRequestHostContext(params.request)
+	const applicationHost = normalizeHost(new URL(params.request.url).hostname)
+
+	const allowByLocalhostFallback =
+		requesterHostSource === 'missing' && isLocalhostLike(applicationHost)
+
+	const allowByInternalHost =
+		requesterHost !== null && requesterHost === applicationHost
+
+	const allowByAllowedDomain =
+		requesterHost !== null && isAllowedEmbedHost(requesterHost, allowedDomains)
+
+	return allowByLocalhostFallback || allowByInternalHost || allowByAllowedDomain
+}
+
+/**
+ * The whole decision, given a request and whatever the key lookup found.
+ *
+ * A key that resolves to a different organization than the project reports
+ * `invalid_token`, not a distinct code. Any separate answer would confirm that
+ * the token is real and only mismatched, which is an oracle a caller can walk.
+ */
+export function decideEmbedAccess(params: {
+	request: Request
+	token: string | null
+	match: EmbedKeyMatch | null
+}): EmbedAccessDecision {
+	if (!params.token) {
+		return { ok: false, error: 'missing_token' }
+	}
+
+	const match = params.match
+	if (!match) {
+		return { ok: false, error: 'invalid_token' }
+	}
+
+	if (match.apiKeyOrganizationId !== match.projectOrganizationId) {
+		return { ok: false, error: 'invalid_token' }
+	}
+
+	if (
+		!isEmbedRequestHostAllowed({
+			request: params.request,
+			allowedEmbedDomains: match.allowedEmbedDomains
+		})
+	) {
+		return { ok: false, error: 'domain_not_allowed' }
+	}
+
+	return {
+		ok: true,
+		apiKeyId: match.apiKeyId,
+		projectId: match.projectId,
+		userId: match.userId
+	}
+}

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.ts
@@ -1,6 +1,12 @@
 const LOCALHOST_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
 
-function normalizeHost(host: string): string {
+/**
+ * Exported because the embed access decision needs the identical rule.
+ * `preview-api-key-auth.server.ts` carried its own byte-identical copy, so the
+ * host comparison that decides whether a site may embed was defined twice with
+ * nothing keeping them in step.
+ */
+export function normalizeHost(host: string): string {
 	return host.toLowerCase().trim().replace(/\.+$/, '')
 }
 
@@ -15,7 +21,9 @@ function normalizeHostInput(value: string): string {
 		const parsed = new URL(maybeUrl)
 		return normalizeHost(parsed.hostname)
 	} catch {
-		return normalizeHost(trimmed.replace(/^\*\./, ''))
+		// Genuinely unparseable input only. Callers strip any leading `*.`
+		// before calling, so this never sees a wildcard.
+		return normalizeHost(trimmed)
 	}
 }
 
@@ -52,7 +60,20 @@ export function normalizeDomainPattern(value: string): string | null {
 		return null
 	}
 
-	const hostname = normalizeHostInput(trimmed)
+	/*
+	  Strip the wildcard before parsing rather than letting `new URL` reject it.
+
+	  This used to pass the raw `*.example.com` to `normalizeHostInput` and rely
+	  on `new URL('https://*.example.com')` throwing, so that a catch block could
+	  strip the prefix. URL parsing accepts the asterisk and reports the hostname
+	  verbatim, so that catch was never reached: `isValidHostname` then saw a `*`
+	  label and rejected it. The result was that no wildcard could be saved at
+	  all, while `isAllowedEmbedHost` matched them correctly and the validator's
+	  own error message advertised them as supported. `*.myshopify.com` is the
+	  pattern every Shopify storefront needs.
+	*/
+	const hostPart = hasWildcard ? trimmed.slice(2) : trimmed
+	const hostname = normalizeHostInput(hostPart)
 	if (!isValidHostname(hostname)) {
 		return null
 	}

--- a/apps/vectreal-platform/tests/critical-path.spec.ts
+++ b/apps/vectreal-platform/tests/critical-path.spec.ts
@@ -1,0 +1,173 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The funnel this product exists to serve, and a ratchet that keeps it guarded.
+ *
+ * Publish a scene, mint a key, allow a domain, paste the snippet into a Shopify
+ * storefront, see the model. If any one of those steps is broken the platform
+ * has no reason to exist, and everything else in the repo is decoration. Two of
+ * them have already broken in production while CI was green:
+ *
+ *   - the embed manifest and the asset gate disagreed about which assets an
+ *     embed may fetch, so every embed 404'd (fixed in #734)
+ *   - `*.myshopify.com` could not be saved at all, because the code path that
+ *     implemented wildcards was unreachable (fixed 2026-08-22)
+ *
+ * Both were invisible to tests of either half. Both lived in a module nothing
+ * imported from a spec.
+ *
+ * So this file names the modules that own each step and asserts they are
+ * exercised by tests. `KNOWN_UNGUARDED` pins the steps that are not yet, and the
+ * ratchet only turns one way: a module that gains a spec must be removed from
+ * the set or this fails, and a new unguarded module on the funnel fails
+ * immediately. The gaps stay visible and countable instead of being discovered
+ * by a customer.
+ */
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const APP = 'apps/vectreal-platform'
+
+type FunnelStep = {
+	/** What the user is doing. */
+	step: string
+	/** The module that owns the decision for this step, relative to the app. */
+	module: string
+}
+
+const FUNNEL: FunnelStep[] = [
+	{
+		step: 'save a scene',
+		module: 'app/lib/domain/scene/server/scene-settings.operations.server.ts'
+	},
+	{
+		step: 'publish it, and decide what an embed may fetch',
+		module: 'app/lib/domain/scene/embed-asset-policy.ts'
+	},
+	{
+		step: 'mint an API key scoped to the project',
+		module: 'app/lib/domain/auth/api-key-repository.server.ts'
+	},
+	{
+		step: 'allow the storefront domain',
+		module: 'app/lib/domain/embed/embed-domain-policy.ts'
+	},
+	{
+		step: 'copy a snippet that carries the key',
+		module: 'app/lib/domain/embed/embed-snippet.ts'
+	},
+	{
+		step: 'authorize the third-party request',
+		module: 'app/lib/domain/embed/embed-access-policy.ts'
+	},
+	{
+		step: 'serve the embed manifest',
+		module: 'app/lib/domain/scene/server/scene-manifest.server.ts'
+	}
+]
+
+/*
+  Steps with no test that imports them, each for the same structural reason:
+  the decision is entangled with the database lookup inside a `.server.ts`, so
+  nothing can import it without Postgres. The fix is the one `embed-asset-policy`
+  already demonstrates - lift the decision into a pure module and leave the
+  lookup behind - not a mock.
+
+  Removing an entry is the only way this list is allowed to change.
+*/
+const KNOWN_UNGUARDED = new Set([
+	'app/lib/domain/scene/server/scene-settings.operations.server.ts',
+	'app/lib/domain/auth/api-key-repository.server.ts'
+])
+
+function collectSpecFiles(dir: string): string[] {
+	return readdirSync(dir).flatMap((entry) => {
+		const full = join(dir, entry)
+		if (statSync(full).isDirectory()) return collectSpecFiles(full)
+		return /\.spec\.tsx?$/.test(entry) ? [full] : []
+	})
+}
+
+const SPEC_SOURCES = [
+	join(REPO_ROOT, APP, 'tests'),
+	join(REPO_ROOT, APP, 'app')
+]
+	.filter((dir) => existsSync(dir))
+	.flatMap(collectSpecFiles)
+	/*
+	  Excluding this file is load-bearing. `FUNNEL` names every module as a
+	  string, so a substring search finds all of them here and reports the whole
+	  critical path as covered by the file that is supposed to be checking it.
+	  The first draft did exactly that.
+	*/
+	.filter((file) => !file.endsWith('critical-path.spec.ts'))
+	.map((file) => readFileSync(file, 'utf8'))
+
+/**
+ * A module counts as guarded when a spec actually imports it.
+ *
+ * Two things deliberately do not count. A filename that merely resembles the
+ * module's proves nothing about what is exercised. And `vi.mock('...')` replaces
+ * the module with a stub, so a spec that mocks a module is testing its caller,
+ * not the module - `api-key-repository.server` is mocked by the key route spec
+ * and has no test of its own.
+ */
+function isGuarded(modulePath: string): boolean {
+	const importPath = modulePath.replace(/^app\//, '').replace(/\.tsx?$/, '')
+	const escaped = importPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	const realImport = new RegExp(
+		`(?:from|import\\()\\s*['"][^'"]*${escaped}['"]`
+	)
+	/*
+	  A spec that mocks the module still imports it, to configure the stub. The
+	  key route spec does exactly that, so importing alone would have counted a
+	  module with no test of its own as guarded.
+	*/
+	const mocked = new RegExp(`vi\\.mock\\(\\s*['"][^'"]*${escaped}['"]`)
+	return SPEC_SOURCES.some(
+		(source) => realImport.test(source) && !mocked.test(source)
+	)
+}
+
+describe('critical path', () => {
+	it.each(FUNNEL)('$step: its module exists', ({ module }) => {
+		expect(
+			existsSync(join(REPO_ROOT, APP, module)),
+			`${module} is named as owning "the funnel" but does not exist. If it moved, update FUNNEL; the step still has to be owned by something.`
+		).toBe(true)
+	})
+
+	it.each(FUNNEL.filter(({ module }) => !KNOWN_UNGUARDED.has(module)))(
+		'$step: is exercised by a spec',
+		({ module }) => {
+			expect(
+				isGuarded(module),
+				`No spec imports ${module}, and it is on the critical path. Add one, or add it to KNOWN_UNGUARDED with a reason.`
+			).toBe(true)
+		}
+	)
+
+	/*
+	  The teeth of the ratchet. Once a gap is closed the entry has to go, so the
+	  list cannot quietly describe a past that is no longer true.
+	*/
+	it.each([...KNOWN_UNGUARDED])(
+		'%s is still genuinely unguarded, or should leave KNOWN_UNGUARDED',
+		(module) => {
+			expect(
+				isGuarded(module),
+				`${module} is now imported by a spec. Remove it from KNOWN_UNGUARDED so the gap count stays honest.`
+			).toBe(false)
+		}
+	)
+
+	it('has no stale entries in KNOWN_UNGUARDED', () => {
+		const funnelModules = new Set(FUNNEL.map(({ module }) => module))
+		expect([...KNOWN_UNGUARDED].filter((m) => !funnelModules.has(m))).toEqual(
+			[]
+		)
+	})
+})

--- a/apps/vectreal-platform/tests/embed-access-policy.spec.ts
+++ b/apps/vectreal-platform/tests/embed-access-policy.spec.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	decideEmbedAccess,
+	getPreviewTokenFromRequest,
+	isEmbedRequestHostAllowed,
+	resolveRequestHostContext,
+	type EmbedKeyMatch
+} from '../app/lib/domain/embed/embed-access-policy'
+
+/**
+ * The decision that lets a third-party page load a published scene.
+ *
+ * Until this module was split out of `preview-api-key-auth.server.ts` none of it
+ * could be tested: that file calls `getDbClient()` at module scope, so importing
+ * it threw `Missing DATABASE_URL`. The rule guarding every embed on every
+ * customer site had no test, and the two production failures on this path were
+ * both found by a customer rather than by CI.
+ *
+ * The cases below are written against the allowlist string as an owner actually
+ * saves it, so they exercise the join between this module and
+ * `embed-domain-policy` rather than a hand-built pattern array. That seam is
+ * where the wildcard bug lived.
+ */
+
+const ORG = 'org-1'
+const OTHER_ORG = 'org-2'
+
+function keyMatch(overrides: Partial<EmbedKeyMatch> = {}): EmbedKeyMatch {
+	return {
+		apiKeyId: 'key-1',
+		projectId: 'project-1',
+		userId: 'user-1',
+		apiKeyOrganizationId: ORG,
+		projectOrganizationId: ORG,
+		allowedEmbedDomains: 'store.example.com',
+		...overrides
+	}
+}
+
+function embedRequest({
+	appHost = 'vectreal.com',
+	token = 'vctrl_live',
+	referer,
+	origin,
+	authorization
+}: {
+	appHost?: string
+	token?: string | null
+	referer?: string
+	origin?: string
+	authorization?: string
+} = {}): Request {
+	const url = new URL(`https://${appHost}/embed/project-1/scene-1`)
+	if (token) url.searchParams.set('token', token)
+
+	const headers = new Headers()
+	if (referer) headers.set('referer', referer)
+	if (origin) headers.set('origin', origin)
+	if (authorization) headers.set('authorization', authorization)
+
+	return new Request(url, { headers })
+}
+
+describe('getPreviewTokenFromRequest', () => {
+	it('reads the query parameter', () => {
+		expect(getPreviewTokenFromRequest(embedRequest({ token: 'abc' }))).toBe(
+			'abc'
+		)
+	})
+
+	it('falls back to a bearer header', () => {
+		const request = embedRequest({ token: null, authorization: 'Bearer abc' })
+		expect(getPreviewTokenFromRequest(request)).toBe('abc')
+	})
+
+	it.each([
+		['a non-bearer scheme', 'Basic abc'],
+		['a scheme with no token', 'Bearer'],
+		['an empty token', 'Bearer    ']
+	])('returns null for %s', (_label, authorization) => {
+		const request = embedRequest({ token: null, authorization })
+		expect(getPreviewTokenFromRequest(request)).toBeNull()
+	})
+
+	it('returns null when neither is present', () => {
+		expect(getPreviewTokenFromRequest(embedRequest({ token: null }))).toBeNull()
+	})
+})
+
+describe('resolveRequestHostContext', () => {
+	it('prefers referer over origin', () => {
+		const request = embedRequest({
+			referer: 'https://store.example.com/products/1',
+			origin: 'https://other.example.com'
+		})
+		expect(resolveRequestHostContext(request)).toEqual({
+			host: 'store.example.com',
+			source: 'referer'
+		})
+	})
+
+	it('uses origin when referer is absent', () => {
+		const request = embedRequest({ origin: 'https://store.example.com' })
+		expect(resolveRequestHostContext(request)).toEqual({
+			host: 'store.example.com',
+			source: 'origin'
+		})
+	})
+
+	it('reports missing when a page sends neither', () => {
+		expect(resolveRequestHostContext(embedRequest())).toEqual({
+			host: null,
+			source: 'missing'
+		})
+	})
+})
+
+describe('isEmbedRequestHostAllowed', () => {
+	it('allows a host the owner saved', () => {
+		expect(
+			isEmbedRequestHostAllowed({
+				request: embedRequest({ referer: 'https://store.example.com/p/1' }),
+				allowedEmbedDomains: 'store.example.com'
+			})
+		).toBe(true)
+	})
+
+	it('refuses a host the owner did not save', () => {
+		expect(
+			isEmbedRequestHostAllowed({
+				request: embedRequest({ referer: 'https://evil.example.com/' }),
+				allowedEmbedDomains: 'store.example.com'
+			})
+		).toBe(false)
+	})
+
+	/*
+	  The join with embed-domain-policy. A wildcard has to survive being stored
+	  as text and read back before it can allow anything, which is exactly what
+	  was broken: the matcher understood `*.myshopify.com` and nothing could save
+	  one.
+	*/
+	it('allows a storefront under a saved wildcard', () => {
+		expect(
+			isEmbedRequestHostAllowed({
+				request: embedRequest({
+					referer: 'https://my-store.myshopify.com/products/shoe'
+				}),
+				allowedEmbedDomains: '*.myshopify.com'
+			})
+		).toBe(true)
+	})
+
+	it('refuses a lookalike of a saved wildcard', () => {
+		expect(
+			isEmbedRequestHostAllowed({
+				request: embedRequest({ referer: 'https://evilmyshopify.com/' }),
+				allowedEmbedDomains: '*.myshopify.com'
+			})
+		).toBe(false)
+	})
+
+	it('refuses every third-party host when the allowlist is empty', () => {
+		expect(
+			isEmbedRequestHostAllowed({
+				request: embedRequest({ referer: 'https://store.example.com/' }),
+				allowedEmbedDomains: null
+			})
+		).toBe(false)
+	})
+
+	/*
+	  Why "Test embed URL" in the publisher cannot check a customer's allowlist:
+	  a request from Vectreal itself matches the application host and is allowed
+	  whatever the project says.
+	*/
+	it('allows a request from the application host itself, even with no allowlist', () => {
+		expect(
+			isEmbedRequestHostAllowed({
+				request: embedRequest({
+					appHost: 'vectreal.com',
+					referer: 'https://vectreal.com/publisher/scene-1'
+				}),
+				allowedEmbedDomains: null
+			})
+		).toBe(true)
+	})
+
+	/*
+	  The `noreferrer` trap. Opening the embed URL with 'noopener,noreferrer'
+	  strips Referer, and in production that is refused - so the button that was
+	  meant to prove the embed works reports it as broken.
+	*/
+	it('refuses a request with no referer or origin in production', () => {
+		expect(
+			isEmbedRequestHostAllowed({
+				request: embedRequest({ appHost: 'vectreal.com' }),
+				allowedEmbedDomains: 'store.example.com'
+			})
+		).toBe(false)
+	})
+
+	it('allows the same request against a localhost application host', () => {
+		expect(
+			isEmbedRequestHostAllowed({
+				request: embedRequest({ appHost: 'localhost' }),
+				allowedEmbedDomains: 'store.example.com'
+			})
+		).toBe(true)
+	})
+})
+
+describe('decideEmbedAccess', () => {
+	it('reports missing_token when no token was sent', () => {
+		expect(
+			decideEmbedAccess({
+				request: embedRequest({ token: null }),
+				token: null,
+				match: keyMatch()
+			})
+		).toEqual({ ok: false, error: 'missing_token' })
+	})
+
+	it('reports invalid_token when no live key matched', () => {
+		expect(
+			decideEmbedAccess({
+				request: embedRequest(),
+				token: 'vctrl_live',
+				match: null
+			})
+		).toEqual({ ok: false, error: 'invalid_token' })
+	})
+
+	/*
+	  A real key pointed at another organization's project must be
+	  indistinguishable from a fake one. A distinct code would confirm the token
+	  is genuine, which is an oracle worth walking.
+	*/
+	it('reports invalid_token, not a distinct code, when the key belongs to another organization', () => {
+		expect(
+			decideEmbedAccess({
+				request: embedRequest({ referer: 'https://store.example.com/' }),
+				token: 'vctrl_live',
+				match: keyMatch({ apiKeyOrganizationId: OTHER_ORG })
+			})
+		).toEqual({ ok: false, error: 'invalid_token' })
+	})
+
+	it('reports domain_not_allowed for a live key on an unlisted site', () => {
+		expect(
+			decideEmbedAccess({
+				request: embedRequest({ referer: 'https://evil.example.com/' }),
+				token: 'vctrl_live',
+				match: keyMatch()
+			})
+		).toEqual({ ok: false, error: 'domain_not_allowed' })
+	})
+
+	it('returns the key identity on success', () => {
+		expect(
+			decideEmbedAccess({
+				request: embedRequest({ referer: 'https://store.example.com/p/1' }),
+				token: 'vctrl_live',
+				match: keyMatch()
+			})
+		).toEqual({
+			ok: true,
+			apiKeyId: 'key-1',
+			projectId: 'project-1',
+			userId: 'user-1'
+		})
+	})
+
+	it('lets a Shopify storefront through end to end', () => {
+		expect(
+			decideEmbedAccess({
+				request: embedRequest({
+					referer: 'https://my-store.myshopify.com/products/shoe'
+				}),
+				token: 'vctrl_live',
+				match: keyMatch({ allowedEmbedDomains: '*.myshopify.com' })
+			})
+		).toEqual({
+			ok: true,
+			apiKeyId: 'key-1',
+			projectId: 'project-1',
+			userId: 'user-1'
+		})
+	})
+})

--- a/apps/vectreal-platform/tests/embed-domain-policy.spec.ts
+++ b/apps/vectreal-platform/tests/embed-domain-policy.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	isAllowedEmbedHost,
+	normalizeDomainPattern,
+	parseAllowedDomainPatterns,
+	validateAllowedDomainInput
+} from '../app/lib/domain/embed/embed-domain-policy'
+
+/**
+ * This module decides who may embed a published scene, so it is the security
+ * boundary of the product's headline feature. It had no spec at all.
+ *
+ * The tests below assert the *contract between* the write path
+ * (`normalizeDomainPattern`, which turns what an owner typed into a stored
+ * pattern) and the read path (`isAllowedEmbedHost`, which decides whether a
+ * requesting site matches one). Testing the two halves separately is precisely
+ * what let the wildcard feature ship dead: the matcher handled `*.example.com`
+ * correctly, and nothing in the product could produce one for it to match, so
+ * both halves passed any test written about them alone.
+ *
+ * That is the same shape as the bug that made every embed 404 - two pieces of
+ * code deciding one rule with no shared owner - which is why the invariant, and
+ * not the halves, is what gets pinned here.
+ */
+
+type DomainCase = {
+	/** What the owner types into the project's allowed-domains field. */
+	input: string
+	/** What must be stored. */
+	pattern: string
+	/** Sites that must be able to embed. */
+	allowed: string[]
+	/** Sites that must not. */
+	refused: string[]
+}
+
+const CASES: DomainCase[] = [
+	{
+		input: 'example.com',
+		pattern: 'example.com',
+		allowed: ['example.com', 'EXAMPLE.com', 'example.com.'],
+		refused: ['sub.example.com', 'notexample.com', 'example.com.evil.test']
+	},
+	{
+		/*
+		  The Shopify case. A merchant's storefront is always a subdomain of
+		  myshopify.com, so this is the pattern the product exists to support.
+		*/
+		input: '*.myshopify.com',
+		pattern: '*.myshopify.com',
+		allowed: ['my-store.myshopify.com', 'another.myshopify.com'],
+		refused: [
+			// The apex is Shopify's own marketing site, not a merchant storefront.
+			'myshopify.com',
+			'evilmyshopify.com',
+			'myshopify.com.evil.test'
+		]
+	},
+	{
+		input: 'https://shop.example.com/products/thing?x=1',
+		pattern: 'shop.example.com',
+		allowed: ['shop.example.com'],
+		refused: ['example.com', 'other.example.com']
+	}
+]
+
+describe('embed domain policy', () => {
+	describe.each(CASES)('$input', ({ input, pattern, allowed, refused }) => {
+		it(`normalizes to ${pattern}`, () => {
+			expect(normalizeDomainPattern(input)).toBe(pattern)
+		})
+
+		it('is accepted by the project settings validator', () => {
+			const result = validateAllowedDomainInput(input)
+			expect(result.ok).toBe(true)
+			expect(result.ok && result.patterns).toEqual([pattern])
+		})
+
+		/*
+		  The invariant. A pattern the write path accepts is worthless unless the
+		  read path can match a real host against it, and a host the read path
+		  refuses must stay refused after a round trip through storage.
+		*/
+		it.each(allowed)('lets %s embed, end to end', (host) => {
+			const stored = parseAllowedDomainPatterns(input)
+			expect(isAllowedEmbedHost(host, stored)).toBe(true)
+		})
+
+		it.each(refused)('refuses %s, end to end', (host) => {
+			const stored = parseAllowedDomainPatterns(input)
+			expect(isAllowedEmbedHost(host, stored)).toBe(false)
+		})
+	})
+
+	describe('rejection', () => {
+		it.each([
+			['a bare label', 'localhost-ish'],
+			['a mid-string wildcard', 'foo.*.example.com'],
+			['a trailing wildcard', 'example.*'],
+			['an empty value', '   ']
+		])('rejects %s', (_label, input) => {
+			expect(normalizeDomainPattern(input)).toBeNull()
+		})
+
+		it('reports an invalid entry rather than silently dropping it', () => {
+			const result = validateAllowedDomainInput('example.com\nfoo.*.example.com')
+			expect(result.ok).toBe(false)
+		})
+	})
+
+	describe('an empty allowlist refuses everything', () => {
+		it('refuses any host when no pattern is stored', () => {
+			expect(isAllowedEmbedHost('example.com', [])).toBe(false)
+		})
+	})
+
+	it('deduplicates and accepts a mixed list', () => {
+		const stored = parseAllowedDomainPatterns(
+			'example.com, *.myshopify.com\nexample.com'
+		)
+		expect(stored).toEqual(['example.com', '*.myshopify.com'])
+	})
+})


### PR DESCRIPTION
## What was broken

`*.myshopify.com` could not be saved as an allowed embed domain. Not "was buggy" — structurally impossible, while the validator's own error message advertised wildcards as supported and the matcher handled them correctly.

Every Shopify storefront is a subdomain of `myshopify.com`, so this is the pattern the embed feature exists to serve.

## Root cause

`normalizeDomainPattern` passed the raw pattern to `normalizeHostInput`, which wraps it as a URL and relied on `new URL` **throwing** so a catch block could strip the `*.` prefix:

```ts
try   { return normalizeHost(new URL(`https://${trimmed}`).hostname) }
catch { return normalizeHost(trimmed.replace(/^\*\./, '')) }   // never reached
```

URL parsing accepts the asterisk and returns hostname `*.myshopify.com`. The catch never ran, `isValidHostname` saw a `*` label, and the pattern was rejected. The line implementing the feature was unreachable.

The fix strips the wildcard **before** parsing, so no exception is load-bearing. The broken path is deleted rather than guarded.

## Why three commits ship together

The extraction's test suite depends on the fix: `embed-access-policy.spec.ts` asserts a Shopify storefront is admitted end to end with `*.myshopify.com` stored, which fails without the first commit. Splitting them would mean landing a test that cannot pass.

1. `fix(embed)` — the wildcard fix, plus the first tests this module has ever had
2. `refactor(embed)` — split the access decision out of the key lookup
3. `test(embed)` — the critical-path ratchet

## The decision had no tests, by construction

`validatePreviewApiKeyForProject` decides whether any third-party page may load any published scene. It calls `getDbClient()` at module scope, so importing it from a spec threw `Missing DATABASE_URL`. The security boundary of the headline feature was untestable.

The decision now lives in `embed/embed-access-policy.ts` with no database and no Node import. The server module keeps the lookup, the attempt window, and `lastUsedAt`. Same split `embed-asset-policy.ts` already made for the asset gate. Behaviour is unchanged, and the three host conditions are preserved verbatim as named booleans so the diff is visibly behaviour-preserving.

Also removes a byte-identical private copy of `normalizeHost` that existed in both modules, so the host comparison deciding who may embed was defined twice with nothing keeping them in step.

## The pattern behind both production failures

Two pieces of code deciding one rule with no shared owner:

| Failure | Side A | Side B |
| --- | --- | --- |
| #734 | what the manifest offers | what the asset gate serves |
| this | what can be saved | what can be matched |

Neither is catchable by testing either half. Both tests here are written as the contract **between** the halves.

`critical-path.spec.ts` makes that structural: it names the module owning each funnel step and asserts a spec imports it, with remaining gaps pinned in `KNOWN_UNGUARDED`. The ratchet turns one way only. Two gaps remain, down from three.

## Verification

- 78 files, **803 tests**, typecheck and lint green
- Every guard mutation-tested: dropping the cross-org check fails 1, allowing every host fails 5, dropping the localhost fallback fails 1, preferring Origin over Referer fails 7, reverting the wildcard fix fails 5, weakening the matcher so `evilmyshopify.com` passes fails 2
- The ratchet itself reported the whole critical path as covered twice before the self-reference and `vi.mock` exclusions were added

## Filed, not fixed

The embed rate limiter is keyed on the leftmost `X-Forwarded-For` entry, which the client supplies, and its window is a per-process `Map` across multiple Fly instances. Untouched here as a separate concern.
