### PR TITLE
chore(agents): stop the agent skills from drifting

### DIFF
--- a/.agents/skills/vectreal-brand-ux-design/SKILL.md
+++ b/.agents/skills/vectreal-brand-ux-design/SKILL.md
@@ -1,209 +1,146 @@
 ---
 name: vectreal-brand-ux-design
-description: 'Use when designing or refactoring UI for Vectreal, including visual direction, component styling, interaction design, brand alignment, UX flows, accessibility, and responsive behavior. Triggers: design system, branding, UX philosophy, intentional UI, productive workflows, apple-grade polish, tokens, typography, motion, forms, loading states, UI review.'
+description: 'Use for any change a user can see in Vectreal: component styling, layout, spacing, color, typography, elevation, motion, empty/loading/error states, responsive behavior, accessibility, and marketing UI. Triggers: design, styling, className, Tailwind, token, theme, dark mode, color, typography, type scale, spacing, elevation, surface, card, motion, animation, transition, responsive, mobile, accessibility, focus, contrast, empty state, loading state.'
 ---
 
 # Vectreal Brand UX Design
 
-## Mission
-
-Design purposeful, high-quality interfaces that feel intentional and productive while remaining consistent with Vectreal's token-driven brand system and engineering constraints.
-
-## Non-Negotiables
-
-1. Use token-driven styling first, not arbitrary one-off colors.
-2. Maintain brand direction: DM Sans typography and orange-led accent language.
-3. Every UI decision must serve user task clarity and productivity.
-4. Ensure accessibility and responsiveness are first-class, not post-fix tasks.
-5. Motion must support comprehension and feedback, never decoration-only noise.
-
-## Brand Foundation
-
-1. Typography
-
-- Use DM Sans variable as the base family for consistency and readability.
-- Maintain clear hierarchy via weight, size, spacing, and contrast.
-
-2. Color
-
-- Use semantic tokens from global styles for background/foreground/surfaces/states.
-- Use brand orange accents intentionally for primary actions and highlights.
-- Keep dark/light token behavior coherent; do not hardcode mode-specific hacks unless justified.
-
-3. Visual language
-
-- Keep interfaces modern, confident, and technically clean.
-- Prefer restrained depth, clear spacing, and crisp component boundaries.
-
-## UX Philosophy
-
-1. Intentional and productive
-
-- Prioritize workflows that reduce friction and cognitive overhead.
-- Keep primary actions obvious and progressive disclosure for advanced controls.
-
-2. Purpose over novelty
-
-- Each element must have clear function.
-- Avoid ornamental patterns that do not improve comprehension or throughput.
-
-3. Consistency with room for emphasis
-
-- Reuse established interaction patterns for predictable behavior.
-- Introduce visual emphasis only where hierarchy or decision confidence benefits.
-
-## Apple-Grade Quality Bar (Operationalized)
-
-1. Precision
-
-- Consistent spacing rhythm and alignment across breakpoints.
-- Pixel-level attention to typography, icon sizing, and touch targets.
-
-2. Craft
-
-- Smooth state transitions, clear affordances, and coherent depth hierarchy.
-- Loading/empty/error states feel intentional, not fallback leftovers.
-
-3. Restraint
-
-- Minimal visual noise, strong hierarchy, and concise copy.
-- No over-animation, no excessive gradients/effects that hurt clarity.
-
-4. Performance-aware polish
-
-- Motion and effects must not degrade interaction responsiveness.
-- Prefer lightweight, meaningful animations and proper reduced-motion support.
-
-## Token and Component Rules
-
-1. Token-first styling
-
-- Prefer semantic token usage for surfaces, text, borders, and interactive states.
-- Avoid direct hex literals in feature components when token exists.
-
-2. Shared component system first
-
-- Start from shared UI primitives and extend with variants/composition.
-- Keep local overrides minimal and intentional.
-
-3. Variant discipline
-
-- Use variant APIs for state/intent differences rather than ad-hoc class duplication.
-
-## Interaction and Motion Rules
-
-1. Motion intent
-
-- Use animation to communicate state change, focus shift, and hierarchy.
-
-2. Timing and readability
-
-- Keep micro-interactions quick and clear.
-- Keep larger transitions smooth but bounded; avoid sluggish feel.
-
-3. Accessibility
-
-- Respect reduced-motion preferences.
-- Ensure focus indicators remain visible and consistent.
-
-## Responsive and Accessibility Rules
-
-1. Mobile-first composition
-
-- Build for narrow viewports first, then scale up with clear breakpoint intent.
-
-2. Accessibility baseline
-
-- Keyboard navigable controls.
-- Visible focus rings.
-- Sufficient contrast for text and controls.
-- Semantic structure and meaningful labels for assistive technology.
-
-3. Form ergonomics
-
-- Inputs and controls must have predictable validation and clear error guidance.
-- Preserve context after validation failure and show actionable messages.
-
-## Practical Design Recipes
-
-1. Build a new task-focused dashboard section
-
-- Start with existing layout shell and spacing rhythm.
-- Define one primary action and one clear secondary path.
-- Use cards/surfaces and typographic hierarchy to reduce scan time.
-
-2. Build a high-confidence form flow
-
-- Use shared form primitives and explicit validation messaging.
-- Place primary action consistently and keep supportive hints concise.
-- Provide success/failure feedback immediately and unambiguously.
-
-3. Add loading, empty, and error states
-
-- Loading: indicate structure and expected outcome.
-- Empty: explain what to do next.
-- Error: explain issue and recovery path.
-
-4. Add meaningful motion to a complex panel
-
-- Animate entrance and state transitions to orient user focus.
-- Keep durations tight; avoid chained effects unless they clarify sequence.
-
-## Anti-Patterns and Replacements
-
-1. Anti-pattern: Hardcoded colors in feature modules.
-
-- Replace with semantic or brand token usage from global styles.
-
-2. Anti-pattern: Competing button styles for similar intents.
-
-- Replace with shared variant semantics and consistent CTA hierarchy.
-
-3. Anti-pattern: Motion used as decoration.
-
-- Replace with state-communication motion only.
-
-4. Anti-pattern: Dense UI without hierarchy.
-
-- Replace with spacing rhythm, typographic contrast, and grouped actions.
-
-5. Anti-pattern: Accessibility bolted on at the end.
-
-- Replace with baseline a11y checks during initial implementation.
-
-## Design Review Rubric
-
-1. Purpose
-
-- Is every element serving user task completion?
-
-2. Clarity
-
-- Is information hierarchy instantly scannable?
-
-3. Brand fidelity
-
-- Are typography, color, and component choices aligned to Vectreal system?
-
-4. Interaction quality
-
-- Are states, feedback, and motion coherent and useful?
-
-5. Accessibility
-
-- Keyboard, focus, labels, contrast, and reduced-motion support present?
-
-6. Responsiveness
-
-- Does layout remain productive and readable across mobile and desktop?
-
-## Source-of-Truth References
-
-- shared/components/src/styles/globals.css
-- shared/components/src/ui/
-- apps/vectreal-platform/app/components/
-- apps/vectreal-platform/app/styles/global.module.css
-- apps/vectreal-platform/app/styles/mdx.module.css
-- AGENTS.md
-- .github/copilot-instructions.md
-- CLAUDE.md
+## Tokens: the three that are most often confused
+
+| Want | Use | Never |
+| --- | --- | --- |
+| The brand color | `--orange` (`#fc6c18`), or `bg-orange` / `text-orange` | `--accent`, `--primary` |
+| Brand at partial alpha | `rgb(var(--orange-rgb) / <alpha>)` | `hsl(var(--orange)/…)`, `color-mix` with `--orange` |
+| Hover/focus background for menus, options, ghost controls | `--accent` | a hand-picked gray |
+
+`--accent` is **not** the brand. It is the hover/focus background, near-white in
+light mode and dark gray in dark mode. It used to point at `--orange`, which made
+every dropdown item and ghost hover a solid brand block. `--primary` is not the
+brand either.
+
+`--orange` is a hex, so there is no valid inline alpha form. `hsl(var(--orange)/0.14)`
+was tried once and silently killed a gradient for months; `color-mix` degrades to
+solid brand orange where lightningcss emits its no-alpha fallback. Use
+`--orange-rgb` and keep the two in sync.
+
+Do not declare the same Tailwind theme key in both `:root` and `@theme`. The
+viewer package must not emit global theme tokens.
+
+## Elevation: the `ds-*` ladder
+
+Derived from one `--foreground` mix, so it tracks the theme automatically.
+
+- `ds-raised` (4%) - cards, table containers, anything sitting on the page
+- `ds-overlay` (8%) - popovers, menus, rows hovered on top of raised
+- `ds-sunken` (2.5%) - wells and inputs that should recede
+- `ds-divider` - only where a divider carries meaning, never to draw a box
+- `ds-raised-interactive` / `ds-overlay-interactive` - hover lifts exactly one
+  step. Use these rather than pairing a `ds-*` class with a hand-written hover
+  background: call sites had drifted to 6%, 8%, 12% and 14%, so equivalent rows
+  hovered to different values in the same view.
+
+The ladder self-corrects when it nests: raised inside raised steps up on its own,
+so a `Card` dropped onto a raised panel still has an edge. Same-class nesting
+only.
+
+## Type scale
+
+`text-eyebrow`, `text-display`, `text-headline`, `text-h2`, `text-h3`, `text-h4`,
+`text-stat`, `text-body-lg`, `text-label-xs`. These are the single source of
+truth. Setting `style={{ fontSize: 'var(--text-headline)' }}` gets the size and
+none of the weight, tracking or leading, which is why `text-headline` exists.
+
+## Motion
+
+Durations: `--duration-instant` 80ms, `--duration-fast` 150ms, `--duration-base`
+250ms, `--duration-slow` 400ms, `--duration-cinematic` 700ms.
+Easing: `--ease-out`, `--ease-in-out`, `--ease-spring`.
+
+Motion communicates state change, focus shift, and hierarchy. Respect
+`prefers-reduced-motion`. Do not animate to decorate.
+
+## Rules already enforced by ESLint
+
+`eslint.config.mts` fails the build on these, so read the message rather than
+guessing. Each rule carries a comment explaining the failure it prevents.
+
+1. **Tailwind variants on `ds-*` or `text-*` classes.** They live in
+   `@layer components` and are not registered utilities, so a variant attaches to
+   nothing and Tailwind emits no rule at all. It fails silently. Use an arbitrary
+   utility instead.
+2. **Raw hex in a Tailwind arbitrary value.** Use a token. Where a literal is
+   genuinely correct, such as depicting someone else's interface, hoist it to a
+   named constant with a comment saying why.
+3. **`className` built by template literal or `+`.** Use `cn()`. It merges
+   conflicting Tailwind classes so a caller can override a default, and drops
+   falsy values instead of rendering `undefined` as a class. Pass the parts as
+   separate arguments; pre-joining them inside `cn()` defeats it.
+4. **Inline `<svg>`.** Extract to `shared/components/src/assets/icons` as a named
+   component. A component that exists to draw a graphic rather than an icon
+   disables the rule on the line with a reason.
+
+## Viewport height
+
+Size full-viewport surfaces with `h-dvh` / `min-h-dvh`, or `h-svh` where a shell
+owns the height and scrolls its own content, as `dashboard-layout.tsx` does.
+
+Never Tailwind's screen-height utilities. They compile to `100vh`, the *large*
+viewport, which overhangs persistent mobile browser chrome: bottom-anchored UI
+goes behind the bar and the page is left scrolled with no way back when a canvas
+holds `touch-action: none`. Those class names are deliberately not spelled out
+here, because of the next section.
+
+## Tailwind scans this file
+
+`globals.css` declares `@source '../../../../'`, the repository root. Any string
+anywhere in the repo that looks like a utility, markdown included, is compiled
+into the bundle. Do not write speculative class names in documentation.
+
+## Verify in a browser, not in your head
+
+Design changes close with a screenshot, not a claim. Use the preview tools:
+`preview_start` with `{name: "vectreal-platform"}`, then `read_page`,
+`resize_window` for responsive and dark mode, and `computer` for a screenshot.
+The quality bar for marketing UI is high, and the only way to know a gradient,
+a hover step or a snap point survived is to look at it.
+
+## Anti-patterns
+
+| Anti-pattern | Replacement |
+| --- | --- |
+| `--accent` or `--primary` used to mean "brand" | `--orange` / `bg-orange` / `text-orange` |
+| Alpha applied to `--orange` inline | `rgb(var(--orange-rgb) / <alpha>)` |
+| Hand-written hover background beside a `ds-*` class | `ds-raised-interactive` / `ds-overlay-interactive` |
+| Font size set inline from a `--text-*` token | The matching `text-*` class |
+| Loading, empty and error states added last | Designed with the happy path |
+| Accessibility retrofitted after review | Keyboard, focus ring, contrast, labels from the start |
+
+## Source of truth
+
+- `shared/components/src/styles/globals.css` (read the comments; several record
+  an afternoon someone already lost)
+- `shared/components/src/ui/`
+- `eslint.config.mts`, the `no-restricted-syntax` block
+- `apps/vectreal-platform/app/components/`
+
+## Verified claims
+
+Executed by `apps/vectreal-platform/tests/agent-skill-claims.spec.ts` on every
+CI run. The `absent` line is the load-bearing one: it fails the build the day
+someone points `--accent` back at the brand.
+
+```claims
+present  shared/components/src/styles/globals.css                              --orange: #fc6c18
+present  shared/components/src/styles/globals.css                              --orange-rgb: 252 108 24
+absent   shared/components/src/styles/globals.css                              --accent: var(--orange)
+present  shared/components/src/styles/globals.css                              --duration-fast: 150ms
+present  shared/components/src/styles/globals.css                              --duration-cinematic: 700ms
+present  shared/components/src/styles/globals.css                              .ds-raised-interactive
+present  shared/components/src/styles/globals.css                              .ds-overlay-interactive
+present  shared/components/src/styles/globals.css                              .ds-divider
+present  shared/components/src/styles/globals.css                              .text-headline
+present  shared/components/src/styles/globals.css                              @source '../../../../'
+present  eslint.config.mts                                                     Build className with cn()
+present  eslint.config.mts                                                     Inline SVG
+present  apps/vectreal-platform/app/routes/layouts/dashboard-layout.tsx        h-svh
+```

--- a/.agents/skills/vectreal-extension-architecture/SKILL.md
+++ b/.agents/skills/vectreal-extension-architecture/SKILL.md
@@ -1,185 +1,185 @@
 ---
 name: vectreal-extension-architecture
-description: 'Use when extending Vectreal platform architecture, adding routes/loaders/actions, introducing domain modules, changing DB access patterns, or refactoring client/server boundaries in React Router v7 framework mode. Triggers: architecture, layout tree, route structure, modularization, separation of concerns, DRY, clean code, server/client split, loader action, Drizzle repository, RLS, Nx conventions.'
+description: 'Use when extending the Vectreal platform: adding or changing routes, loaders, actions, resource routes, domain modules, repositories, services, permissions, or the client/server boundary in React Router v7 framework mode. Triggers: route, loader, action, fetcher, resource route, API endpoint, authorization, permission, role check, Drizzle, repository, service, .server.ts, RLS, client/server split, Nx target.'
 ---
 
 # Vectreal Extension Architecture
 
-## Mission
+## Authorization: read this before writing any access check
 
-Build new features in ways that preserve Vectreal's layout semantics, domain modularity, and framework-mode data flow without introducing unnecessary abstraction overhead.
+**Postgres RLS is inert for application traffic.** `app/db/client.ts` connects
+with a plain `DATABASE_URL` and never issues `set local role`, so `auth.uid()`
+is null on every app query and every policy is bypassed.
 
-## Non-Negotiables
+The policies are real. They are declared with `pgPolicy` across
+`app/db/schema/**` and built from predicate helpers in `app/db/schema/rls.ts`:
+`isUserSelf`, `isOrganizationMember`, `isOrganizationAdmin`, `canAccessProject`.
+Those names read exactly like the authorization helpers you are looking for,
+which is the trap. They compile to SQL that never runs for a request. Calling one
+from application code produces a check that always passes.
 
-1. Keep route and file structure aligned with layout semantics and user journey.
-2. Use React Router v7 framework mode patterns (loaders, actions, Route.LoaderArgs, Route.ActionArgs, Route.ComponentProps).
-3. Separate server-only code into .server.ts modules and never import server modules into client runtime.
-4. Keep data access in domain repositories/services, not directly in route UI modules.
-5. Use canonical identifiers from prd documents for plans, entitlements, billing states, consent, and analytics events.
-6. Run tasks through Nx via pnpm nx; do not call underlying tooling directly.
+An access check written against RLS is therefore not an access check. The single
+authorization mechanism that runs is the role table in
+`app/lib/domain/dashboard/dashboard-operations.ts`.
 
-## Architectural Principles
+Server side, resolve the actor and assert:
 
-1. Layout-driven tree semantics
+```ts
+const membership = await resolveSceneMembership(user.id, sceneId)  // .server.ts
+assertDashboardPermission('scene:delete', membership)
+```
 
-- Route composition must reflect UX and access boundaries first, file placement second.
-- Nested layouts must represent real shared concerns (auth shell, dashboard shell, docs shell), not convenience wrappers.
-- Prefer explicit route tree clarity over clever dynamic routing.
+`resolveProjectMembership`, `resolveSceneMembership` and
+`resolveSceneFolderMembership` live in `dashboard-permissions.server.ts`
+alongside `assertDashboardPermission`.
 
-2. Modularization without overhead
+Client side, `dashboard-operations.ts` is pure and client-safe, so components
+call `canPerformDashboardOperation` directly to gate affordances. Loaders ship a
+`DashboardCapabilityMap` built by `buildDashboardCapabilities`
+(`dashboard-capabilities.ts`).
 
-- Organize by domain responsibility, not arbitrary technical layering.
-- Extract modules when they reduce duplication or isolate volatile logic.
-- Avoid speculative abstraction: no new shared layers unless at least two concrete callers benefit now.
+Adding an operation means adding it to the `DashboardOperation` union **and** to
+`DASHBOARD_OPERATION_ROLES`. That map is a total `Record`, so a missing rule is a
+compile error rather than a silent allow. Never hand-roll a role comparison.
 
-3. Clean code and DRY by intent
+**Report a non-member as 404, not 403,** on anything keyed by an id the actor
+may not know. A 403 confirms the id exists, which turns the endpoint into an id
+oracle. This is not yet uniform in the repo: `ApiResponse.forbidden` has 16 call
+sites, correctly for CSRF and cross-origin rejection (which reveal no id) and
+questionably on a few scene routes. Follow the rule on new code; do not copy the
+nearest existing example.
 
-- DRY means deduplicating business meaning, not forcing all similar code into generic helpers.
-- Keep orchestrators explicit when domain workflows differ.
-- Favor small, composable functions with clear names over generic utility buckets.
+## Non-negotiables
 
-4. Strict client/server boundary
+1. Server-only modules end in `.server.ts` and are never imported from a client
+   component, a shared hook, or anything that reaches the browser bundle.
+2. Drizzle queries live in repository modules. Cross-repository workflows live
+   in services. Route modules stay thin: parse, authorize, call, respond.
+3. Route composition follows access and layout boundaries first, file
+   convenience second. Routes are declared in `app/routes.tsx`, not file-based.
+4. Plan, entitlement, billing-state and consent identifiers come from
+   `app/constants/plan-config.ts` (consent: `app/lib/consent/consent-cookie.ts`).
+   Add to the owning type first so every missing case fails to compile.
+5. Run every task through `pnpm nx`. Never call `eslint`, `tsc` or `vitest`
+   directly.
+6. Migrations come only from `pnpm nx run vectreal-platform:drizzle-generate`
+   after a schema edit. Hand-authoring one desynchronizes the meta snapshot.
 
-- Server concerns: auth, db, secrets, stripe/webhooks, RLS-sensitive queries, request validation.
-- Client concerns: rendering, interaction state, optimistic UX, purely visual transforms.
-- Crossing boundary must happen through loaders/actions/API routes only.
+## Framework-mode traps that have cost real time here
 
-## Route and Layout Workflow
+**`fetcher.state === 'idle'` does not mean "finished".** It is also the state
+before any request is dispatched. If dispatch happens in an effect, it never runs
+during SSR, so a `loading` flag derived from `state` is false in the server HTML
+and any "no results" branch behind it gets baked into the response. Derive
+loaded-ness from the data instead:
 
-1. Start from route intent
+```ts
+const hasLoaded = fetcher.data !== undefined
+```
 
-- Identify destination layout and access level first.
-- Place route module where tree semantics remain obvious to future maintainers.
+This shipped three separate symptom fixes before the cause was found. When you
+patch the same defect at a third call site, stop and find the cause.
 
-2. Implement loader/action contract
+**StrictMode double-invokes mount effects**, not update effects. A ref guard
+around a load-once or submit-once effect exists for that reason alone. Say so in
+a comment, or the next reader deletes it.
 
-- Use typed args from generated +types.
-- Loader returns data for read path; action handles mutation path.
-- Keep parsing/validation close to action entry or delegated to domain parser module.
+**A route module cannot be imported by a test.** `getDbClient()` runs at module
+scope and throws `Missing DATABASE_URL`. Put logic a test needs to reach in a
+pure module with no db import and no `.server` suffix, and have the route call
+it. `app/lib/domain/scene/scene-route-params.ts` is the pattern.
 
-3. Compose UI from stable boundaries
+## Recipe: a new resource route
 
-- Route module orchestrates calls to domain functions and UI composition.
-- Reusable UI belongs in shared/components or app/components based on scope.
+1. Register it in `app/routes.tsx` under the API block:
+   `route('api/projects/:projectId/api-keys', './routes/api/projects.$projectId.api-keys.ts')`
+2. Loader: `getAuthUser` or `loadAuthenticatedUser` → `resolveProjectMembership`
+   → `canPerformDashboardOperation` / `assertDashboardPermission`.
+3. Action: `ensureValidCsrfFormData` (`app/lib/http/csrf.server.ts`) before any
+   mutation.
+4. Respond through `ApiResponse.*` from `@shared/utils`. The envelope is
+   `{ success: true, data }` or `{ success: false, error, quota? }`.
+5. Merge auth headers with `append`, not `set`. Supabase can rotate more than one
+   cookie in a single response and `set` drops all but the last.
 
-## Domain and Data Workflow
+## Recipe: a dashboard mutation
 
-1. Put queries in repository modules
+Create, rename, move and delete for projects, folders and scenes already have a
+home: `POST /api/dashboard/mutations`. The contract is in
+`dashboard-mutations.ts`, execution in `dashboard-mutations.server.ts`, the
+client hook is `useDashboardMutations`. The server recomputes the required tier
+itself, so nothing client-supplied is trusted. Destructive confirmations come
+from `planDeleteConfirmation` rendered by `ConfirmDestructiveDialog`.
 
-- Repositories own Drizzle query shape and joins.
-- Reuse RLS helpers where access checks are required.
+Do not add a parallel endpoint for a fifth verb on these entities. Extend the
+contract.
 
-2. Put workflow rules in service modules
+## Project manifests
 
-- Services orchestrate cross-repository behavior and external integrations.
-- Services expose explicit domain operations, not low-level transport details.
+Every project's `package.json` must declare what its own source imports, at the
+installed version. pnpm resolves an undeclared import by walking up to the root
+`node_modules`, so a wrong manifest still builds, which is how `@vctrl/core` came
+to publish `three@^0.177.0` while the repo built against 0.185.1.
 
-3. Keep route modules thin
+`@nx/dependency-checks` enforces this and `--fix` writes the correction,
+including `catalog:`. Trust it over hand-editing. A package that deliberately
+bundles a dependency declares that as an `ignoredDependencies` entry in
+`eslint.config.mts` with a reason.
 
-- Route modules should validate input, call domain operations, and produce HTTP/UI responses.
+## Anti-patterns
 
-## React Router v7 Framework Mode Rules
+| Anti-pattern | Replacement |
+| --- | --- |
+| Access check that relies on RLS, `auth.uid()`, or a hand-written role comparison | `assertDashboardPermission` against the operation table |
+| 403 for a resource the actor cannot see | 404, so ids cannot be enumerated |
+| Drizzle query inside a route module | Repository function, called through a service when it spans repositories |
+| Shared abstraction created for one current caller | Explicit local code until a second caller exists |
+| `loading` derived from `fetcher.state` | `hasLoaded` derived from `fetcher.data !== undefined` |
+| Logic a test needs, placed in a route or `.server.ts` module | Pure module with no db import |
+| New endpoint for an entity `/api/dashboard/mutations` already owns | Extend the mutation contract |
 
-1. Prefer loader/action over ad-hoc client fetch for route-owned data.
-2. Keep mutation operations in actions or API route actions.
-3. Use generated route types; avoid hand-rolled duplicate route typing.
-4. Use scoped error boundaries per layout tier when behavior differs between public/auth/dashboard contexts.
+## Gates
 
-## Client and Server Separation Rules
+```bash
+pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform
+```
 
-1. Server-only files
+Unit tests: `npx vitest run --root .` (or `pnpm nx test vectreal-platform`).
+Integration tests need `pnpm nx run vectreal-platform:supabase-start` first, then
+`pnpm nx run vectreal-platform:test-integration`.
 
-- Use .server.ts naming for server-only modules.
-- Never import .server.ts into client components, shared client hooks, or browser bundles.
+## Source of truth
 
-2. API routes
+- `CLAUDE.md`
+- `apps/vectreal-platform/app/routes.tsx`
+- `apps/vectreal-platform/app/lib/domain/dashboard/dashboard-operations.ts`
+- `apps/vectreal-platform/app/lib/domain/dashboard/dashboard-permissions.server.ts`
+- `apps/vectreal-platform/app/constants/plan-config.ts`
+- `apps/vectreal-platform/app/db/client.ts` (read it before trusting any claim
+  about RLS)
 
-- Keep API route modules server-only and response-focused.
-- Centralize auth and CSRF checks with existing helpers.
+## Verified claims
 
-3. Sessions and secrets
+Executed by `apps/vectreal-platform/tests/agent-skill-claims.spec.ts` on every
+CI run. If one fails, either the code moved and this skill is now lying, or the
+invariant genuinely broke. Both need a human.
 
-- Cookie/session/secret handling stays server-side only.
-
-## Identifier Discipline
-
-1. Do not invent new literal identifiers for:
-
-- Plans
-- Entitlements
-- Billing states
-- Consent categories
-- Analytics event names
-
-2. If a new identifier is required, add it to the owning type in `app/constants/plan-config.ts` (or `app/lib/consent/consent-cookie.ts` for consent) first, so every missing case becomes a compile error, then code against it.
-
-## Nx and Execution Discipline
-
-1. Run lint/test/build/typecheck/migrations through Nx using pnpm nx.
-2. Prefer nx run and nx affected workflows consistent with repository conventions.
-3. Do not bypass Nx cache/task graph by calling underlying toolchains directly.
-
-## Anti-Patterns and Replacements
-
-1. Anti-pattern: Direct Drizzle queries in route UI module.
-
-- Replace with repository function in domain layer and call through service when needed.
-
-2. Anti-pattern: Shared abstraction created for a single current caller.
-
-- Replace with local explicit code; extract only with proven second use-case.
-
-3. Anti-pattern: Client component importing server utility.
-
-- Replace with loader/action mediated data flow.
-
-4. Anti-pattern: Route tree flattened for convenience.
-
-- Replace with nested layout structure that matches true semantic shells.
-
-5. Anti-pattern: Hardcoded plan/entitlement/consent identifiers in ad-hoc strings.
-
-- Replace with the canonical constants and maps exported from `app/constants/plan-config.ts`.
-
-## Practical Extension Recipes
-
-1. Add a new authenticated dashboard feature
-
-- Add/adjust route in route tree under dashboard layout.
-- Add loader for read data and action for mutations.
-- Place domain queries in repository, orchestrate with service, keep route thin.
-- Reuse shared UI primitives and existing error boundary semantics.
-
-2. Add a new API mutation endpoint
-
-- Create server route action under routes/api.
-- Validate payload and auth/CSRF up front.
-- Call service operation; return consistent JSON shape.
-
-3. Add a new domain capability with DB persistence
-
-- Add schema/type updates where required.
-- Add repository methods for data access.
-- Add service methods for business logic.
-- Wire through route action/loader.
-
-## Review Checklist
-
-1. Does the route placement reflect layout semantics and access boundaries?
-2. Are loader/action typed and used instead of ad-hoc client fetch for route-owned data?
-3. Is server-only code isolated in .server.ts?
-4. Are DB queries in repositories and workflows in services?
-5. Are plan/entitlement/consent identifiers canonical and unchanged?
-6. Were commands run via pnpm nx only?
-7. Did this change avoid unnecessary new abstraction layers?
-
-## Source-of-Truth References
-
-- AGENTS.md
-- .github/copilot-instructions.md
-- CLAUDE.md
-- apps/vectreal-platform/app/routes.tsx
-- apps/vectreal-platform/app/db/schema/rls.ts
-- apps/vectreal-platform/app/constants/plan-config.ts
-- apps/vectreal-platform/app/constants/product-copy.ts
-- apps/vectreal-platform/app/lib/domain/dashboard/dashboard-operations.ts
+```claims
+absent   apps/vectreal-platform/app/db/client.ts                                            set local role
+present  apps/vectreal-platform/app/db/client.ts                                            Missing DATABASE_URL
+present  apps/vectreal-platform/app/db/schema/rls.ts                                        isOrganizationMember
+present  apps/vectreal-platform/app/db/schema/rls.ts                                        canAccessProject
+present  apps/vectreal-platform/app/lib/domain/dashboard/dashboard-permissions.server.ts    assertDashboardPermission
+present  apps/vectreal-platform/app/lib/domain/dashboard/dashboard-permissions.server.ts    resolveProjectMembership
+present  apps/vectreal-platform/app/lib/domain/dashboard/dashboard-permissions.server.ts    resolveSceneMembership
+present  apps/vectreal-platform/app/lib/domain/dashboard/dashboard-permissions.server.ts    resolveSceneFolderMembership
+present  apps/vectreal-platform/app/lib/domain/dashboard/dashboard-operations.ts            canPerformDashboardOperation
+present  apps/vectreal-platform/app/lib/domain/dashboard/dashboard-operations.ts            DASHBOARD_OPERATION_ROLES
+present  apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.ts          buildDashboardCapabilities
+present  apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.ts          DashboardCapabilityMap
+present  apps/vectreal-platform/app/lib/http/csrf.server.ts                                 ensureValidCsrfFormData
+present  shared/utils/src/lib/api.utils.ts                                                  success: true, data
+exists   apps/vectreal-platform/app/lib/domain/scene/scene-route-params.ts
+present  apps/vectreal-platform/app/routes.tsx                                              api/dashboard/mutations
+present  eslint.config.mts                                                                  dependency-checks
+```

--- a/.agents/skills/vectreal-iterative-delivery/SKILL.md
+++ b/.agents/skills/vectreal-iterative-delivery/SKILL.md
@@ -1,155 +1,218 @@
 ---
 name: vectreal-iterative-delivery
-description: 'Use when requests are ambiguous or cross-cutting and require iterative execution with explicit alignment gates. Triggers: ambiguous scope, architecture+UX+infra changes, phased rollout, verification-first development, uncertainty reduction, autonomous review loops.'
+description: 'Use when scoping ambiguous or cross-cutting Vectreal work, and when shipping any PR. Owns the mandatory review loop, the mutation gate for tests, and the git and worktree rules. Triggers: plan, scope, phased rollout, ship, PR, pull request, review, code review, verify, test coverage, commit, branch, worktree, done, ready to merge.'
 ---
 
 # Vectreal Iterative Delivery
 
-## Mission
+## Two dials, not one tradeoff
 
-Reduce ambiguity to near-zero before coding, then deliver in short verified loops that optimize correctness, DX, UX, and operational overhead.
+How to **cut** work and how much **effort** to spend on it are separate
+decisions. Conflating them produces both failure modes: sprawling tasks that
+need seven review rounds, and days spent perfecting something nobody depends on.
 
-## Core Loop
+**Cut by concern. Always.** One concern per task, per PR, per subagent. Review
+rounds track the number of concerns in a diff, not its size. Measured on this
+workstream:
 
-1. Discovery
+| PR | Concerns | Files | Review rounds |
+| --- | --- | --- | --- |
+| #736 eslint rules | 1 | 7 | 1 |
+| #732 hotspot fixes + module split + comparison | 3 | 20 | 3 |
+| #734 server manifest + client loader | 2 | 20 | 5 |
+| #735 route + hook + panel + dialog + key options + snippet | 6 | 14 | 7 |
+| embed domain policy | 1 | 2 | 0 |
 
-- Map current behavior and failure surfaces before proposing fixes.
-- Identify unknowns explicitly and convert each into a concrete question.
-- Validate assumptions against repository conventions, the plan/entitlement types in `app/constants/plan-config.ts`, and existing architecture patterns.
+Twenty files with two concerns cost more rounds than seven files with one.
+Splitting is close to free; mixing is not.
 
-2. Alignment
+**Spend by tier.** Distance from the funnel sets depth, and only depth.
 
-- Summarize intended outcomes, non-goals, and ownership boundaries (app vs package vs infra).
-- Confirm acceptance criteria and rollout order before implementation.
-- Resolve conflicts (security vs speed, UX vs scope, local unblock vs long-term architecture).
+| Tier | What | Depth |
+| --- | --- | --- |
+| 1 | On the funnel: save a scene, publish it, mint a key, allow a domain, copy the snippet, authorize the request, serve the manifest and assets | Full loop. Mutation gate. A test of the invariant *between* contract halves, not each half. Integration coverage. |
+| 2 | Supports the funnel: dashboard, billing, auth UI, publisher | One review pass. Escalate to the loop only if it finds something. |
+| 3 | Off the funnel: marketing, docs, tooling, skills, this file | Gates green and one read-through. No loop. |
 
-3. Design
+`apps/vectreal-platform/tests/critical-path.spec.ts` holds the funnel as data and
+fails when a step loses its guard. It is the tier-1 list.
 
-- Plan by phase with dependencies and explicit verification checkpoints.
-- Prefer minimal viable slice first, then progressive hardening.
-- Keep public APIs stable unless change is deliberate and documented.
+So the grid is:
 
-4. Implementation
+|  | Narrow scope | Wide scope |
+| --- | --- | --- |
+| **Deep** | Tier 1, correct | #735: seven rounds for one feature |
+| **Shallow** | Tier 3, correct | how the wildcard bug shipped |
 
-- Execute one vertical slice at a time (code + tests/checks + docs where needed).
-- Preserve existing behavior outside target scope.
-- Use Nx project targets for workflows and automation.
+Hyperfixation is not caused by narrow scope. It is deep effort spent on a tier-3
+concern. On 2026-08-22 three agent skill files were rewritten and verified with
+tier-1 rigour while a tier-1 bug (`*.myshopify.com` could not be saved at all)
+sat filed and untouched from the day before. Narrow was right; deep was wrong.
 
-5. Verification
+**Drift triggers.** Both are checkable mid-task:
 
-- Run project-level checks through Nx only.
-- Validate runtime behavior in the exact user surfaces being fixed.
-- Confirm no plan/entitlement/consent identifier drift.
-- Run explicit negative-path checks (error, empty, timeout, retry, permission, offline where relevant).
-- Verify diagnostics state (type, lint, editor warnings for touched files) before closing the loop.
+1. **One PR, one sentence, no "and".** If the description needs a conjunction it
+   is two PRs. #735's needed five.
+2. **If the diff touches a file the scope line did not name**, stop. Either
+   rename the scope out loud, or file the finding and leave the file alone.
 
-6. Autonomous Review
+## The loop, which is never skipped
 
-- Perform self-review for regressions, error paths, and maintainability.
-- Identify residual risks and classify follow-up work separately from done work.
+Findings are not the deliverable. **A clean review round is.**
 
-7. Plan Alignment
+1. **Review** - several subagents in parallel, each on one distinct dimension.
+2. **Map** - one subagent consolidates into a fix spec: dedupe, decide, and name
+   the single owner of each rule.
+3. **Fix** - subagents implement the spec on disjoint files so they cannot
+   collide.
+4. **Verify** - the Nx gates below, plus live verification in the surface that
+   changed.
+5. **Repeat from 1** until a round comes back with nothing.
 
-- Report deltas from original plan, not full restatements.
-- Re-open ambiguity only where evidence indicates mismatch.
-- Iterate until acceptance criteria are objectively met.
+**Phases are barriers.** Readers and writers never run at the same time. Every
+agent in a phase finishes before the next starts. A reviewer reading a tree a
+fixer is mid-edit reports against a state that never existed. Parallelism lives
+inside a phase, never across one.
 
-## Iteration Contract (Mandatory)
+Serial single-resource work stays with the main agent: the browser pane, the dev
+server, the local database. Only reading, mapping and editing fan out.
 
-Every implementation loop must include all four phases in order:
+Subagent reports are evidence, not verdicts. They are confidently wrong often
+enough that a finding gets checked against the code before it becomes a fix.
 
-1. Implementation
-2. Verification
-3. Autonomous review
-4. Plan alignment
+## The mutation gate
 
-No phase may be skipped. If time or scope is constrained, reduce slice size, not gate coverage.
+**For every guard you add, mutate the production line and confirm a test goes
+red.** Run this while implementing, not after review asks for it.
 
-## Exhaustive Verification Checklist (Per Loop)
+This is the single highest-value habit here. On PR #735 the review loop ran seven
+rounds; three separate rounds found a test of mine that could not fail, and one
+was directly beneath a comment I had written warning about that exact failure
+mode. The mutation check catches all of them in seconds and takes rounds off the
+loop.
 
-Before closing a loop, check all applicable items:
+Named failure modes it catches:
 
-1. Build and type checks for touched projects via Nx.
-2. Tests for touched projects via Nx.
-3. Runtime happy-path validation in each modified surface.
-4. Runtime failure-path validation in each modified surface.
-5. Diagnostics clean for touched files (including editor warnings).
-6. Import/order/style rules satisfied in touched files.
-7. Canonical plan/entitlement/consent identifiers unchanged unless explicitly intended.
-8. Security/infra blast radius reviewed for infra/auth/config changes.
-9. User-facing recovery paths verified (retry/fallback/actionable copy).
-10. Residual risks and follow-ups documented.
+- **The tautological assertion.** A regex capture group that can never match what
+  it claims (`[^"]*` will not contain a quote), or asserting attribute names
+  while the payload injects sibling elements. Parse with `DOMParser` and assert
+  an exact element list rather than pattern-matching a string.
+- **The untested guard.** Delete the guard; if the suite is still green, the test
+  was never testing it.
+- **The test that pins the bug.** Write the failing test first when fixing a
+  defect, and watch it fail for the stated reason before fixing.
 
-If any applicable item fails, continue iterating; do not report completion.
+## Stop symptom-patching
 
-## Sub-Agent Coverage Policy
+When you fix what looks like the same defect at a **third** call site, stop and
+find the cause. "Zero results means confirmed empty" was patched in three places
+before round six found the real cause: a `loading` flag derived from
+`fetcher.state`, which reads `idle` before dispatch too, and dispatch is an effect
+that never runs during SSR, so both empty-state claims were baked into the server
+HTML.
 
-Use a sub-agent in iterative loops when it can reduce blind spots or speed up coverage.
+Two patches of one symptom is a coincidence. Three is a missing root cause.
 
-Required triggers:
+## Scope discipline
 
-1. Cross-cutting changes across app + package + infra.
-2. Searching for dispersed call sites, configs, or invariants across the workspace.
-3. Validation sweeps where independent read-only confirmation improves confidence.
+Out-of-scope findings become a catalogue row (Notion **Vectreal Work Items**) or
+a GitHub issue. They never become lines in the diff and never become a report
+handed back for triage. Say plainly in the PR what was filed rather than fixed,
+and why.
 
-Execution rule:
+Deliver the whole scope that was asked for. If part is blocked, finish everything
+else in full and say what was left out. Scaling the work down is the user's call.
 
-- After each substantial implementation slice, run at least one focused sub-agent pass for exploration or verification when any required trigger applies.
-- Treat sub-agent output as additional evidence, then still perform final local verification gates.
+## Git rules
 
-## Loop Evidence Block (Required)
+- **Never write git history unless asked.** Commit, push, merge, rebase and tag
+  all count. A plan that authorizes PRs for named phases authorizes those phases
+  and nothing else.
+- **No self-attribution anywhere.** Not in commit messages, not in PR titles or
+  bodies, not in branch names. Branches take a conventional prefix describing the
+  change: `feat/`, `fix/`, `chore/`, `test/`, `docs/`, `refactor/`, `perf/`,
+  `ci/`. A `PreToolUse` hook blocks the common cases, but the hook is a backstop,
+  not the rule.
+- **Use `git -C <path>` on every git call. Never `cd`.** A `git checkout -b` that
+  ran in a worktree while the edits sat in the main repo put a commit on an
+  unrelated branch, and it was caught only because `gh pr create` failed.
+- **Conventional Commits** for messages. Versioning is Release Please; never
+  `nx release`.
 
-Any completion/update that claims a loop or phase is done must include a compact evidence block.
+## Worktree rules
 
-Required fields:
+Worktrees keep pre-bump `node_modules` that disagree with `pnpm-lock.yaml`.
+Reinstall before trusting any test result on a dependency-regression bug.
 
-1. Commands run (Nx commands only).
-2. Touched surfaces validated (route/page/hook/module names).
-3. Failure paths tested (what failed path was exercised and outcome).
-4. Diagnostics status for touched files.
-5. Residual risks and follow-ups.
+## Merge-order and staleness
 
-If evidence is incomplete, report as in-progress instead of done.
+- To test whether a branch still holds unique work, use `git merge-tree
+  --write-tree` plus GitHub's merged-PR head-ref list. `git diff main...branch`
+  is three-dot and measures from the merge base, so it reports every
+  squash-merged branch as full of unique work.
+- Stacked PRs: merge the base, rebase the child, then merge the child. Merging
+  both back to back conflicts.
 
-## Required Gates
+## Gates
 
-1. Ambiguity gate
+```bash
+pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform
+```
 
-- No coding begins until unresolved questions are listed and either answered or intentionally deferred.
+```bash
+npx vitest run --root .
+```
 
-2. Safety gate
+Integration tests need `pnpm nx run vectreal-platform:supabase-start` first, then
+`pnpm nx run vectreal-platform:test-integration`.
 
-- Security-sensitive or infrastructure-changing work requires explicit blast-radius acknowledgment and rollback approach.
+CI runs `build-ci`, not `build`, plus job-level env vars, so `nx build` passing
+locally is not the gate.
 
-3. Verification gate
+**`nx run-many -p <name>` exits 0 when the name matches nothing.** It prints
+"No tasks were run" and succeeds, so a typo turns a gate into a no-op that reads
+as a pass. The project names are `vectreal-platform`, `shared/components`,
+`shared/utils`, `vctrl/core`, `vctrl/hooks`, `vctrl/viewer`, `vctrl/embed`,
+`storybook`, `terraform`. Note the slashes: `shared-components` is not a project
+and silently covers nothing. Check the task count in the summary against the
+number of projects times targets.
 
-- Each phase closes only after command-level validation and behavior confirmation.
-- Each iteration closes only after the Exhaustive Verification Checklist is satisfied for all applicable items.
+After the PR is open, verify the PR and not just the working tree: the diff
+contains only the files this step names, and CI is green on the actual PR head.
 
-4. UX/DX gate
+## Evidence block
 
-- User-facing failure states must have actionable feedback and retry/recovery paths.
-- Developer workflows must be one-command where practical and documented in-repo.
+Any claim that a phase is done carries:
 
-## Ownership Heuristic
+1. Commands run, with their result.
+2. Surfaces validated, including the failure path exercised.
+3. What was filed rather than fixed.
+4. Residual risk.
 
-- Package layer: normalize technical error signals and event contracts.
-- App layer: map signals to user messaging, recovery UX, and route-specific fallback UI.
-- Infra layer: local bootstrap reliability, least-privilege defaults, and reproducible targets.
+If the evidence is incomplete, report in progress. Report outcomes faithfully: if
+tests fail, say so with the output; if a step was skipped, say that.
 
-## Anti-Patterns
+## Anti-patterns
 
-- Jumping to implementation while ambiguity is still implicit.
-- Solving with broad refactors when a focused vertical slice is sufficient.
-- Reporting success based on type-check alone without runtime failure-path validation.
-- Introducing new identifiers that conflict with the canonical values in `app/constants/plan-config.ts`.
+| Anti-pattern | Replacement |
+| --- | --- |
+| Review round skipped because the change looks small | Run the loop; #735's worst defect was in a 3-line hook |
+| Test written after the guard, never mutated | Mutate the line, watch it go red |
+| Third patch of one symptom | Find the cause |
+| Reviewers and fixers running concurrently | Phase barrier |
+| Subagent finding applied without checking the code | Verify, then fix |
+| Success reported from a passing type-check | Runtime failure-path check in the changed surface |
+| Out-of-scope fix folded into the diff | Catalogue row, named in the PR |
 
-## Done Criteria
+## Verified claims
 
-A phase is done only when all are true:
+Executed by `apps/vectreal-platform/tests/agent-skill-claims.spec.ts` on every
+CI run.
 
-1. Code changes are merged for the scoped slice.
-2. Relevant Nx checks pass.
-3. Runtime path works for success and failure states.
-4. Docs/config updates reflect the new workflow.
-5. Residual risks and next steps are explicit.
+```claims
+present  .github/workflows/ci-quality.yaml                     build-ci
+present  apps/vectreal-platform/vitest.config.ts               tests/**/*.spec.{ts,tsx}
+exists   apps/vectreal-platform/vitest.integration.config.ts
+exists   .agents/skills/vectreal-extension-architecture/SKILL.md
+exists   .agents/skills/vectreal-brand-ux-design/SKILL.md
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@ Use agent skills available and helpful for the task at hand. When working on the
 
 ## Project Skills
 
-- Architecture extensions: use [vectreal-extension-architecture](.agents/skills/vectreal-extension-architecture/SKILL.md) for route/layout semantics, modularization, client/server boundaries, Drizzle access patterns, and React Router framework-mode conventions.
-- Design and branding: use [vectreal-brand-ux-design](.agents/skills/vectreal-brand-ux-design/SKILL.md) for token-based styling, brand alignment, intentional UX flows, accessibility, responsive behavior, and high-polish UI execution.
-- Iterative delivery: use [vectreal-iterative-delivery](.agents/skills/vectreal-iterative-delivery/SKILL.md) for ambiguity elimination, phased implementation, mandatory implementation→verification→autonomous review→plan alignment loops, exhaustive per-iteration validation, sub-agent-assisted coverage when changes are cross-cutting, and required loop evidence blocks before claiming completion.
+- Architecture extensions: use [vectreal-extension-architecture](.agents/skills/vectreal-extension-architecture/SKILL.md) for routes, loaders, actions, resource routes, domain modules, repositories, services, the client/server boundary, and authorization. Read its first section before writing any access check: RLS is inert for app traffic, so the role table in `dashboard-operations.ts` is the only authorization that runs.
+- Design and branding: use [vectreal-brand-ux-design](.agents/skills/vectreal-brand-ux-design/SKILL.md) for tokens, the `ds-*` elevation ladder, the `text-*` type scale, motion, responsive and accessibility work, and the styling rules ESLint already enforces.
+- Iterative delivery: use [vectreal-iterative-delivery](.agents/skills/vectreal-iterative-delivery/SKILL.md) for scoping ambiguous work and for shipping any PR. It owns the mandatory review loop, the mutation gate for tests, the git and worktree rules, and the evidence block required before claiming completion.
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Skills
+
+Invoke these before starting the matching work, not after getting stuck. They
+live in `.agents/skills/` and are symlinked into `.claude/skills/`. `AGENTS.md`
+lists them too, but Claude Code does not auto-load that file, which is why this
+section exists.
+
+| Skill | Invoke when |
+| --- | --- |
+| `vectreal-extension-architecture` | Adding or changing a route, loader, action, resource route, domain module, repository, service, permission, or the client/server boundary. |
+| `vectreal-brand-ux-design` | Any change a user can see: component styling, layout, tokens, type scale, elevation, motion, empty/loading/error states, responsive or accessibility work. |
+| `vectreal-iterative-delivery` | Scoping ambiguous or cross-cutting work, and shipping any PR. It owns the review loop, which is never skipped. |
+| `react-router-framework-mode` (global) | Framework-mode API questions: route config, loaders, actions, fetchers, pending UI, error boundaries, type generation. Carries 12 reference files. |
+
 ## Commands
 
 All commands run from the repository root using `pnpm` and `nx`.

--- a/apps/vectreal-platform/tests/agent-skill-claims.spec.ts
+++ b/apps/vectreal-platform/tests/agent-skill-claims.spec.ts
@@ -1,0 +1,123 @@
+import { readFileSync, existsSync, readdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Executes the factual claims the agent skills make about this repository.
+ *
+ * The skills in `.agents/skills/` tell an agent which function to call, which
+ * token holds the brand colour, and which invariants hold. Those are assertions
+ * about code, written in prose, in a file no compiler reads. They rot silently,
+ * and a rotted one is worse than no skill at all: on 2026-08-22 the architecture
+ * skill still said "reuse RLS helpers where access checks are required", in a
+ * codebase where `db/client.ts` never issues `set local role`, so every policy is
+ * bypassed and that advice generates security holes.
+ *
+ * So each SKILL.md carries a fenced ```claims block, and this spec runs it. The
+ * claim and the prose that depends on it live in the same file, which is the
+ * point: they cannot drift apart, because there is only one artifact. Renaming
+ * `assertDashboardPermission` fails here and names the skill that has to change.
+ *
+ * Grammar, one claim per line:
+ *
+ *     exists   <path>
+ *     present  <path>  <literal, rest of line>
+ *     absent   <path>  <literal, rest of line>
+ *
+ * Paths are relative to the repository root. Literals are matched verbatim, not
+ * as patterns, so a claim cannot accidentally widen into something that always
+ * passes.
+ */
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const SKILLS_DIR = join(REPO_ROOT, '.agents/skills')
+
+type Claim = {
+	op: 'exists' | 'present' | 'absent'
+	path: string
+	literal: string
+	line: number
+}
+
+function parseClaims(markdown: string): Claim[] {
+	const claims: Claim[] = []
+	const lines = markdown.split('\n')
+	let inBlock = false
+
+	lines.forEach((raw, index) => {
+		const line = raw.trim()
+
+		if (line.startsWith('```claims')) {
+			inBlock = true
+			return
+		}
+		if (inBlock && line.startsWith('```')) {
+			inBlock = false
+			return
+		}
+		if (!inBlock || line === '' || line.startsWith('#')) return
+
+		const [op, path, ...rest] = line.split(/\s+/)
+		if (op !== 'exists' && op !== 'present' && op !== 'absent') {
+			throw new Error(`Unknown claim op "${op}" on line ${index + 1}`)
+		}
+		claims.push({ op, path, literal: rest.join(' '), line: index + 1 })
+	})
+
+	return claims
+}
+
+const skillNames = readdirSync(SKILLS_DIR).filter((name) =>
+	existsSync(join(SKILLS_DIR, name, 'SKILL.md'))
+)
+
+describe('agent skill claims', () => {
+	it('finds the skills directory and at least one skill', () => {
+		expect(skillNames.length).toBeGreaterThan(0)
+	})
+
+	describe.each(skillNames)('%s', (skillName) => {
+		const skillPath = join(SKILLS_DIR, skillName, 'SKILL.md')
+		const markdown = readFileSync(skillPath, 'utf8')
+		const claims = parseClaims(markdown)
+
+		/*
+		  Without this, a skill whose claims block was deleted or renamed would
+		  pass by asserting nothing at all - which is the exact failure mode the
+		  delivery skill calls "the tautological assertion".
+		*/
+		it('declares at least one checkable claim', () => {
+			expect(claims.length).toBeGreaterThan(0)
+		})
+
+		it.each(claims.map((claim) => [`${claim.op} ${claim.path} ${claim.literal}`.trim(), claim] as const))(
+			'%s',
+			(_label, claim) => {
+				const target = join(REPO_ROOT, claim.path)
+
+				expect(
+					existsSync(target),
+					`${skillName}/SKILL.md line ${claim.line}: ${claim.path} does not exist`
+				).toBe(true)
+
+				if (claim.op === 'exists') return
+
+				const contents = readFileSync(target, 'utf8')
+
+				if (claim.op === 'present') {
+					expect(
+						contents.includes(claim.literal),
+						`${skillName}/SKILL.md line ${claim.line} claims ${claim.path} contains "${claim.literal}". It does not. Fix the code or fix the skill.`
+					).toBe(true)
+				} else {
+					expect(
+						contents.includes(claim.literal),
+						`${skillName}/SKILL.md line ${claim.line} claims ${claim.path} does NOT contain "${claim.literal}". It does. The skill's reasoning may no longer hold.`
+					).toBe(false)
+				}
+			}
+		)
+	})
+})


### PR DESCRIPTION
## Why the skills never fired

The three project skills existed, were invocable, and had never been used in a session. Two causes, both invisible from the code:

1. **Only `AGENTS.md` pointed at them.** Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md`, so the pointer lived in a file the agent never read. `CLAUDE.md` now carries a Skills table naming each skill and when to invoke it.
2. **`skillOverrides` had muted `react-router-framework-mode` to `"name-only"`**, which loads the name without the description so nothing can decide to invoke it. That lives in the gitignored `.claude/settings.local.json`, so the mute was invisible to the repo and to review, and worktrees keep their own copy. Cleared locally; nothing to commit, but the failure mode is worth knowing.

## One of them was giving out security-defect advice

The architecture skill said to *"reuse RLS helpers where access checks are required"*.

`db/client.ts` connects with a plain `DATABASE_URL` and never issues `set local role`, so `auth.uid()` is null and every policy is bypassed. The predicate helpers in `db/schema/rls.ts` are named `isOrganizationMember` and `canAccessProject`, which is what makes the trap convincing: they read exactly like the authorization helpers you are looking for, and they compile to SQL that never runs. The role table in `dashboard-operations.ts` is the only authorization that executes.

The brand skill had the mirror problem: an *"orange-led accent language"*, where `--accent` is the near-white hover token and `globals.css` carries a comment about the time it did point at `--orange` and turned every dropdown item into a brand block. It now documents the `ds-*` elevation ladder, the `text-*` scale, and the styling rules ESLint already enforces, rather than restating values that drift.

## The mechanism

Roughly 500 lines of unfalsifiable prose out, 390 lines of checkable specifics in.

Each skill now carries a fenced ` ```claims ` block, and `agent-skill-claims.spec.ts` executes it:

```
absent   apps/vectreal-platform/app/db/client.ts   set local role
present  .../dashboard-permissions.server.ts       assertDashboardPermission
absent   shared/components/src/styles/globals.css  --accent: var(--orange)
```

The claim and the prose that depends on it live in **one artifact**, so they cannot drift apart. Rename `assertDashboardPermission` and CI fails naming the skill that now lies. That `absent` line fails the build the day someone points `--accent` back at the brand.

39 claims. Grammar is `exists` / `present` / `absent`, matched verbatim rather than as patterns so a claim cannot widen into something that always passes.

## Verification

- 76 files, **777 tests**, typecheck and lint green
- Mutation-tested three ways: a false claim, a violated `absent` invariant, and a deleted claims block each turn the suite red
- The vacuity guard is deliberate — a skill whose claims block was deleted would otherwise pass by asserting nothing

## Limits, stated plainly

This verifies that identifiers exist and invariants hold as string checks. It does not verify the advice is good. `absent "set local role"` in one file is not a proof that RLS is inert. It raises the floor.

## Merge order

Independent of #737 and file-disjoint, so either can land first. One prose line in the delivery skill references `tests/critical-path.spec.ts`, which arrives in #737, so merging that one first avoids a briefly stale reference.
