### PR TITLE
chore(process): require a root cause before editing product code

### DIFF
--- a/.agents/skills/vectreal-iterative-delivery/SKILL.md
+++ b/.agents/skills/vectreal-iterative-delivery/SKILL.md
@@ -5,6 +5,36 @@ description: 'Use when scoping ambiguous or cross-cutting Vectreal work, and whe
 
 # Vectreal Iterative Delivery
 
+## Investigate before editing
+
+Before the first edit to product code, write the root cause: what is broken,
+where the rule governing it lives, and why the fix belongs there rather than at
+the call site. It goes in the PR body under "Root cause".
+
+This is deliberately aimed at the artifact rather than at a planning mode. A mode
+binds one tool; a written root cause binds every contributor and can be checked
+in review.
+
+**Code is truth. Documentation is a hypothesis.** Verify any claim a doc makes
+before planning on it. `publish-embed.mdx` listed `*.example.com` as a supported
+allowed-domain pattern from the day the feature was written, and no wildcard
+could be saved at all, so a plan built on that page was wrong before it started.
+Stale docs are worse than absent docs because they read as authoritative.
+
+**Two triggers.**
+
+1. If the root cause will not fit in one sentence, you do not understand it yet.
+   Keep investigating. This is the depth control: cost scales with the real
+   difficulty of the problem, not with a fixed ceremony.
+2. If the fix adds a check rather than removing a cause, go one level deeper. The
+   wildcard fix is the positive case: the `try`/`catch` was being used as a branch
+   for a case that never throws, so the branch was deleted rather than
+   special-cased around.
+
+**What this is not.** It is not a licence to investigate indefinitely. The
+statement is the deliverable, and for most changes it is one line written in
+seconds.
+
 ## Two dials, not one tradeoff
 
 How to **cut** work and how much **effort** to spend on it are separate
@@ -211,6 +241,7 @@ CI run.
 
 ```claims
 present  .github/workflows/ci-quality.yaml                     build-ci
+present  .github/pull_request_template.md                       Root cause
 present  apps/vectreal-platform/vitest.config.ts               tests/**/*.spec.{ts,tsx}
 exists   apps/vectreal-platform/vitest.integration.config.ts
 exists   .agents/skills/vectreal-extension-architecture/SKILL.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,16 @@
 
 Closes #<!-- issue number -->
 
+## Root cause
+
+<!--
+  Required for any change to product code. One sentence: what is broken, where
+  the rule governing it lives, and why the fix belongs there rather than at the
+  call site. If it will not fit in a sentence, investigate further before
+  editing. If the fix adds a check rather than removing a cause, go one level
+  deeper. For docs, tooling or a pure addition, write "n/a" and why.
+-->
+
 ## Changes
 
 <!-- Bullet list of the key changes made. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,30 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Before you edit product code
+
+**Write the root cause first.** One sentence: what is broken, where the rule that
+governs it lives, and why the fix belongs there rather than at the call site. It
+goes in the PR body under "Root cause", so it binds contributors and agents
+alike rather than depending on a tool's planning mode.
+
+The rule is cheap when the answer is obvious ("the word is misspelled") and
+expensive only when the problem is. Two triggers keep it calibrated:
+
+1. **If you cannot write it in one sentence, you do not understand it yet.**
+   Keep investigating rather than starting to edit.
+2. **If the fix adds a check rather than removing a cause, go one level deeper.**
+   A guard placed around a broken path preserves the break.
+
+**Code is truth. Documentation is a hypothesis.** Any claim taken from a doc into
+a plan gets verified against the code before the plan is final. Docs that
+describe behavior go stale silently and read as authoritative, which poisons a
+plan before implementation starts and surfaces mid-session where it is most
+expensive. `docs/guides/publish-embed` documented `*.example.com` as a supported
+allowed-domain pattern; no such pattern could be saved at all until it was fixed.
+
+`vectreal-iterative-delivery` owns the operational detail.
+
 ## Skills
 
 Invoke these before starting the matching work, not after getting stuck. They


### PR DESCRIPTION
## Root cause

Nothing required an author to state what they had investigated before the first edit, so two distinct failures kept recurring: fixes applied at the call site instead of at the rule, and plans built on documentation that no longer matched the code. The requirement belongs in the instruction files and the PR template, because that is what every contributor and every agent reads, rather than in a planning mode that binds one tool.

## What changes

A required **Root cause** section in the PR template: one sentence saying what is broken, where the rule governing it lives, and why the fix belongs there rather than at the call site.

Aimed at the artifact, not at a mode. Plan mode is a Claude Code feature; a human contributor and other agents cannot use it, and it cannot be checked in review. A written root cause binds everyone and is visible in the diff.

## Why this is a hard rule without an exemption list

The cost scales with the real difficulty of the problem, so the exemption is built into the price rather than into the rule:

- typo in a doc: *"the word is misspelled"*, five seconds
- the wildcard domain bug in #737: twenty minutes, and worth every one

Two triggers keep it calibrated:

1. **If the root cause will not fit in one sentence, it is not understood yet.** Keep investigating rather than starting to edit. This is the depth control.
2. **If the fix adds a check rather than removing a cause, go one level deeper.** A guard placed around a broken path preserves the break. #737 is the positive case: a `try`/`catch` used as a branch for a case that never throws was deleted, not special-cased around.

## Code is truth, docs are a hypothesis

The second clause is about sources, and there is a live example on the critical path.

`docs/guides/publish-embed` has documented this row since the feature was written:

| `*.example.com` | All subdomains of `example.com` |

No wildcard pattern could be saved at all until #737 landed, about an hour ago. Any plan built on that page was wrong before implementation started, and the mismatch would only surface mid-session where it is most expensive to absorb. Stale docs are worse than absent docs, because they read as authoritative and an agent will take them as ground truth.

Any claim taken from a doc into a plan now gets verified against the code first.

## Ownership

Stated once in `CLAUDE.md`; the operational detail lives in `vectreal-iterative-delivery`, which owns process. The skill's claims block pins the PR template heading, so the rule cannot quietly lose its enforcement point.

## Verification

- 79 files, **843 tests**, typecheck and lint green on top of current `main`
- Mutation-tested: renaming the template heading to "Rationale" fails the claim with `claims .github/pull_request_template.md contains "Root cause". It does not.`
- The claim path was initially written `PULL_REQUEST_TEMPLATE.md`, which resolves on a case-insensitive macOS filesystem and would have failed on Linux CI. Corrected to the tracked lowercase name before pushing.
