### PR TITLE
fix(docs): repair the docs page header

### DIFF
--- a/apps/vectreal-platform/app/components/docs/docs-mobile-navigation.tsx
+++ b/apps/vectreal-platform/app/components/docs/docs-mobile-navigation.tsx
@@ -7,7 +7,6 @@ import {
 	SheetTitle,
 	SheetTrigger
 } from '@shared/components/ui/sheet'
-import { BookText } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import { DocsPageToc } from './docs-page-toc'
@@ -39,10 +38,7 @@ export function DocsMobileNavigation({
 				<SheetTrigger asChild>{children}</SheetTrigger>
 				<SheetContent side="left" className="w-[90vw] max-w-sm">
 					<SheetHeader>
-						<SheetTitle className="flex items-center gap-2">
-							<BookText className="h-4 w-4" aria-hidden="true" />
-							Documentation
-						</SheetTitle>
+						<SheetTitle>Documentation</SheetTitle>
 						<SheetDescription>
 							Navigate pages and jump to sections.
 						</SheetDescription>

--- a/apps/vectreal-platform/app/routes/layouts/docs-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/docs-layout.tsx
@@ -132,7 +132,7 @@ export default function DocsLayout() {
 							<BreadcrumbItem>
 								<BreadcrumbLink asChild>
 									<span>
-										<Link className="max-md:hidden" to="/docs" viewTransition>
+										<Link className="max-lg:hidden" to="/docs" viewTransition>
 											Docs
 										</Link>
 

--- a/apps/vectreal-platform/app/styles/mdx.module.css
+++ b/apps/vectreal-platform/app/styles/mdx.module.css
@@ -32,6 +32,35 @@
 	  `@layer components` and is not a Tailwind utility, so `@apply` cannot
 	  reach it. Same for every `.text-*` and `.ds-*` in the design system.
 	*/
+	/*
+	  `rehype-autolink-headings` appends `<a class="heading-anchor">#</a>` to every
+	  heading (see the plugin config in vite.config.ts). Nothing styled it, so a
+	  literal orange "#" rendered beside every title on every docs, legal and
+	  newsroom page.
+
+	  `:global` is required. The class name is injected by the rehype plugin at
+	  build time and never passes through this CSS module, so a bare
+	  `.heading-anchor` would be mangled into a name that matches nothing.
+
+	  Revealed on hover rather than deleted, because it is the permalink affordance.
+	  No focus rule: the plugin sets `tabIndex: -1` and `aria-hidden`, so the anchor
+	  is out of both the tab order and the accessibility tree, and a `:focus-visible`
+	  rule here would be dead code.
+	*/
+	:global(.heading-anchor) {
+		@apply ml-2 no-underline;
+		color: var(--color-orange);
+		opacity: 0;
+		transition: opacity var(--duration-fast) var(--ease-out);
+	}
+
+	h1:hover :global(.heading-anchor),
+	h2:hover :global(.heading-anchor),
+	h3:hover :global(.heading-anchor),
+	h4:hover :global(.heading-anchor) {
+		opacity: 1;
+	}
+
 	h1 {
 		@apply max-w-4xl text-balance;
 		font-size: var(--text-headline);


### PR DESCRIPTION
## Root cause

Two defects on every docs page, both the same shape: one half of a pair was written and the other was left out.

**The duplicate breadcrumb.** The desktop link carried `max-md:hidden`, while `DocsMobileNavigation` gates itself on `lg:hidden`. Between 768px and 1024px both rendered, stacked, and the two-line bar overlapped the heading below it. The sidebar appears at `lg`, so `lg` is the breakpoint the link should have used from the start. Fixing it also restores the gap to the heading, because the bar is back to one line and the article's existing top margin was sized for that.

**The visible `#`.** `rehype-autolink-headings` appends `<a class="heading-anchor">#</a>` to every heading, and **no stylesheet ever defined that class**, so a literal orange `#` rendered beside every title on every docs, legal and newsroom page.

## Before / after

| | Before | After |
| --- | --- | --- |
| Breadcrumb | `Docs` and `☰ Docs` stacked, overlapping the title | one entry |
| Heading | `Uploading Models#` in orange, always | `Uploading Models`, anchor on hover |
| Mobile sheet header | book glyph beside the word "Documentation" | title alone |

## Notes on the anchor rule

`:global` is required. The class is injected by the rehype plugin at build time and never passes through the CSS module, so a bare `.heading-anchor` would be mangled into a name matching nothing.

It goes in the block shared by `.root`, `.docsContent` and `.newsroomContent`, so the legal and newsroom pages are fixed by the same rule rather than by a second copy that can drift.

No focus rule: the plugin sets `tabIndex: -1` and `aria-hidden`, so the anchor is out of both the tab order and the accessibility tree, and a `:focus-visible` rule would be dead code. That the permalink is mouse-only is a separate question, left alone here.

## The book icon

Removed from the mobile sheet header. It labelled the panel a second time next to the word "Documentation". It was the only reason for the lucide import and for the flex row on `SheetTitle`, so both went with it.

## Verification

Verified in the browser at 800px, which is inside the range where the duplicate appeared:

- one breadcrumb entry, correct spacing to the heading
- anchor computes `opacity: 0` at rest, reveals on hover, `href="#uploading-models"` intact
- breadcrumb link now resolves to `max-lg:hidden`
- mobile sheet opens with the title alone

79 files, **842 tests**, typecheck and lint green.

## Unrelated, spotted while verifying

`docs/getting-started/installation` states that internal packages resolve through TypeScript path mappings rather than pnpm workspace links. `CLAUDE.md` says the opposite, and `pnpm-workspace.yaml` lists every project. Filed rather than fixed here.
