### PR TITLE
fix(nav): paint the global loading bar above the nav

### DIFF
--- a/apps/vectreal-platform/app/components/global-navigation-loader.tsx
+++ b/apps/vectreal-platform/app/components/global-navigation-loader.tsx
@@ -35,7 +35,21 @@ export function GlobalNavigationLoader() {
 		<div className="pointer-events-none fixed top-0 left-0 z-60 w-full">
 			<div
 				className={cn(
-					'bg-orange h-1 w-full origin-left transition-all duration-300',
+					/*
+					  Only the fade is transitioned. `transition-all` also animated the
+					  transform, and the exit sets `scale-x-100`, so the bar spent 300ms
+					  growing from wherever the 2s `loading-bar` animation had reached.
+					  Most navigations finish in well under 300ms, at which point that
+					  animation is a few percent in, so the exit began at roughly
+					  scaleX(0.02) and read as an orange dot sitting at the left edge,
+					  fading as it stretched.
+
+					  Snapping to full width and fading is also what a progress indicator
+					  should do: reach 100%, then leave. The scale is driven by a fixed
+					  2s animation with no relationship to how long the navigation
+					  actually takes, so its mid-flight value is not worth preserving.
+					*/
+					'bg-orange h-1 w-full origin-left transition-opacity duration-300',
 					isNavigating
 						? 'animate-loading-bar opacity-100'
 						: 'scale-x-100 opacity-0'

--- a/apps/vectreal-platform/app/components/global-navigation-loader.tsx
+++ b/apps/vectreal-platform/app/components/global-navigation-loader.tsx
@@ -21,7 +21,18 @@ export function GlobalNavigationLoader() {
 	if (!isVisible) return null
 
 	return (
-		<div className="pointer-events-none fixed top-0 left-0 z-50 w-full">
+		/*
+		  Above the nav, which is also fixed at top-0 and also z-50 (see
+		  `desktop-nav.tsx` and `mobile-nav.tsx`). Equal z-index is resolved by DOM
+		  order, and the nav renders later, so the bar was painted underneath it: the
+		  1px strip sat behind a 52px header and showed only as a smear through the
+		  header's own backdrop.
+
+		  z-60 is the tier this repo already uses for "above the nav". Transient
+		  surfaces stay higher on purpose - tooltips at 80, dropdowns and popovers at
+		  100 - because a progress strip behind an open menu is correct.
+		*/
+		<div className="pointer-events-none fixed top-0 left-0 z-60 w-full">
 			<div
 				className={cn(
 					'bg-orange h-1 w-full origin-left transition-all duration-300',


### PR DESCRIPTION
## Root cause

The route loading bar and the nav are both `fixed` at `top-0` and both carried `z-50`.

Equal z-index is resolved by DOM order, and the nav renders later, so the 1px bar was painted underneath a 52px header and showed only as a smear through the header's own backdrop. The one indicator telling a visitor the app is doing something was invisible on every route.

## Fix

Raised to `z-60`, the tier this repo already uses for "above the nav". Transient surfaces deliberately stay higher — tooltips at 80, dropdowns and popovers at 100 — because a progress strip behind an open menu is correct.

## Verification

A CSS-only fix has no unit test, so it was verified in the browser by mounting probe elements carrying the two class sets and asking `elementFromPoint` which one paints on top at `y=2`, with the probe nav placed later in the DOM exactly as the real one is:

```
loader z-50 vs nav z-50  ->  NAV COVERS THE BAR (the shipped bug)
loader z-60 vs nav z-50  ->  loader on top (correct)
```

That reproduces the defect and the fix side by side rather than asserting the fix alone.

79 files, 842 tests, typecheck and lint green.

## Filed, not fixed

There is no named z-index scale. Ten distinct values are in use (`z-0`, `10`, `20`, `40`, `50`, `60`, `80`, `100`, `[1]`, `[120]`) with nothing recording what each tier means, which is what let two unrelated fixed elements claim the same layer without anyone noticing. Introducing a scale touches every one of those call sites and belongs in its own change.



## Follow-up in the same PR: the exit artifact

Making the bar visible also made its exit visible, and that was wrong too, so it ships here rather than leaving a newly-visible defect on `main`.

`transition-all` animated the transform as well as the opacity, and the exit state sets `scale-x-100`. The bar therefore spent 300ms growing from wherever the 2s `loading-bar` keyframes had reached. Most navigations finish well inside 300ms, at which point that animation is a few percent in, so the exit began at roughly `scaleX(0.02)`: a 1px orange dot at the left edge, stretching as it faded.

Only the fade is transitioned now. The transform snaps to full width and the bar fades from complete, which is what a progress indicator should do — reach 100%, then leave. The keyframes' mid-flight scale is not worth preserving, since their fixed 2s duration has no relationship to how long the navigation actually took.

Verified by reading the computed `transition-property` for the exit class set:

```
before: transition-all      -> "all"      (animates transform)
after:  transition-opacity  -> "opacity"  (does not)
```

The 300ms window was too short to catch in a screenshot, so there is no visual capture of this one.
