### PR TITLE
chore(agents): bind the skills table at session start and in plan mode

### DIFF
--- a/.agents/hooks/skills-invoked.mjs
+++ b/.agents/hooks/skills-invoked.mjs
@@ -1,0 +1,59 @@
+/**
+ * Which Vectreal skills have actually run in this session.
+ *
+ * Read from the transcript rather than a state file. State on disk was the
+ * source of every serious defect in the first version of these hooks: an
+ * unwritable directory wedged the gate into a deny loop it could never satisfy,
+ * ids collided after sanitizing, and files accumulated with no cleanup. The
+ * transcript is already there, is ground truth about what executed rather than
+ * what was typed, and costs nothing extra to read.
+ *
+ * Node, not jq: package.json requires node >=22.22.0, so it is the one
+ * interpreter every contributor is guaranteed to have.
+ */
+import { readFileSync } from 'node:fs'
+
+export const SKILLS = {
+	'vectreal-extension-architecture':
+		'routes, loaders, actions, domain modules, repositories, services, permissions, Drizzle, the client/server boundary',
+	'vectreal-brand-ux-design':
+		'anything a user can see: styling, layout, tokens, type, elevation, motion, empty/loading/error states, responsive, a11y',
+	'vectreal-iterative-delivery':
+		'scoping ambiguous or cross-cutting work, and shipping any PR (owns the review loop)',
+}
+
+export function skillsInvoked(transcriptPath) {
+	const used = new Set()
+	if (!transcriptPath) return used
+	let raw
+	try {
+		raw = readFileSync(transcriptPath, 'utf8')
+	} catch {
+		return used // no transcript yet: treat as nothing invoked
+	}
+	for (const line of raw.split('\n')) {
+		// Cheap reject before parsing; transcripts reach megabytes.
+		if (!line.includes('"Skill"')) continue
+		let record
+		try {
+			record = JSON.parse(line)
+		} catch {
+			continue
+		}
+		for (const block of record.message?.content ?? []) {
+			if (block.type !== 'tool_use' || block.name !== 'Skill') continue
+			// Plugin skills arrive as `plugin:skill`; compare the bare name so a
+			// glob can never match a neighbour like vectreal-marketing.
+			const name = String(block.input?.skill ?? '').split(':').pop()
+			if (name in SKILLS) used.add(name)
+		}
+	}
+	return used
+}
+
+/** Read one JSON payload from stdin. */
+export async function readPayload() {
+	let data = ''
+	for await (const chunk of process.stdin) data += chunk
+	return JSON.parse(data)
+}

--- a/.agents/hooks/skills-invoked.mjs
+++ b/.agents/hooks/skills-invoked.mjs
@@ -22,32 +22,80 @@ export const SKILLS = {
 		'scoping ambiguous or cross-cutting work, and shipping any PR (owns the review loop)',
 }
 
+// `/vectreal-iterative-delivery` loads the skill without ever producing a Skill
+// tool_use, so counting only tool calls denied people who had read it.
+const SLASH_COMMAND = /<command-name>\/?(vectreal-[a-z-]+)<\/command-name>/g
+
+function collectSlashCommands(text, into) {
+	if (typeof text !== 'string') return
+	for (const [, name] of text.matchAll(SLASH_COMMAND)) {
+		if (Object.hasOwn(SKILLS, name)) into.add(name)
+	}
+}
+
+/**
+ * @returns a Set of skill names, or `null` when the transcript cannot be read.
+ * `null` means "cannot tell", which callers must not treat as "none invoked":
+ * an unreadable transcript would otherwise deny forever, and invoking the skill
+ * could never clear it because the deny does not depend on the skill.
+ */
 export function skillsInvoked(transcriptPath) {
-	const used = new Set()
-	if (!transcriptPath) return used
+	if (!transcriptPath) return null
 	let raw
 	try {
 		raw = readFileSync(transcriptPath, 'utf8')
 	} catch {
-		return used // no transcript yet: treat as nothing invoked
+		return null
 	}
+
+	// A tool_use block is written before the tool runs; failure shows up later as
+	// a separate tool_result with is_error. Pair them, or a Skill call the user
+	// rejected would satisfy the gate.
+	const attempted = new Map()
+	const failed = new Set()
+	const used = new Set()
+
 	for (const line of raw.split('\n')) {
-		// Cheap reject before parsing; transcripts reach megabytes.
-		if (!line.includes('"Skill"')) continue
+		// Cheap reject before parsing; transcripts reach megabytes. `is_error`
+		// has to survive it, or the tool_result that marks a Skill call failed
+		// is skipped and a rejected call still satisfies the gate.
+		if (
+			!line.includes('"Skill"') &&
+			!line.includes('<command-name>') &&
+			!line.includes('is_error')
+		) {
+			continue
+		}
 		let record
 		try {
 			record = JSON.parse(line)
 		} catch {
 			continue
 		}
-		for (const block of record.message?.content ?? []) {
-			if (block.type !== 'tool_use' || block.name !== 'Skill') continue
-			// Plugin skills arrive as `plugin:skill`; compare the bare name so a
-			// glob can never match a neighbour like vectreal-marketing.
-			const name = String(block.input?.skill ?? '').split(':').pop()
-			if (name in SKILLS) used.add(name)
+		const content = record.message?.content
+		if (typeof content === 'string') {
+			collectSlashCommands(content, used)
+			continue
+		}
+		if (!Array.isArray(content)) continue
+		for (const block of content) {
+			if (!block || typeof block !== 'object') continue
+			if (block.type === 'tool_use' && block.name === 'Skill') {
+				// Exact match on the bare name. Taking the last `:` segment would
+				// have let any plugin shipping `anything:vectreal-…` satisfy this.
+				const skill = block.input?.skill
+				if (typeof skill === 'string' && Object.hasOwn(SKILLS, skill)) {
+					attempted.set(block.id, skill)
+				}
+			} else if (block.type === 'tool_result' && block.is_error) {
+				failed.add(block.tool_use_id)
+			} else if (block.type === 'text') {
+				collectSlashCommands(block.text, used)
+			}
 		}
 	}
+
+	for (const [id, skill] of attempted) if (!failed.has(id)) used.add(skill)
 	return used
 }
 

--- a/.agents/hooks/skills-plan-gate.mjs
+++ b/.agents/hooks/skills-plan-gate.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse(ExitPlanMode): a plan is not finished until the skill that owns
+ * scoping has been read.
+ *
+ * This is the only edit-blocking rule kept in the repo. Per-file gating was
+ * tried and reverted: matching by top-level directory covered 1027 of 1109
+ * tracked files, demanding a routing skill to fix a typo in a docs page while
+ * leaving routes.tsx unguarded. Leaving plan mode is once per session and has
+ * no false positives, so it is the one place a hard gate pays for itself.
+ */
+import { skillsInvoked, readPayload } from './skills-invoked.mjs'
+
+const REQUIRED = 'vectreal-iterative-delivery'
+
+try {
+	const payload = await readPayload()
+	if (payload.tool_name === 'ExitPlanMode' &&
+		!skillsInvoked(payload.transcript_path).has(REQUIRED)) {
+		console.log(
+			JSON.stringify({
+				hookSpecificOutput: {
+					hookEventName: 'PreToolUse',
+					permissionDecision: 'deny',
+					permissionDecisionReason: [
+						`Blocked: plans are scoped through ${REQUIRED}, which owns scoping,`,
+						'the tier model that sets how much effort a change deserves, and the',
+						'review loop the plan has to end in.',
+						'',
+						`Invoke it first: Skill(skill: "${REQUIRED}"), then present the plan.`,
+					].join('\n'),
+				},
+			}),
+		)
+	}
+} catch {
+	// Fail open: never let a broken hook trap someone in plan mode.
+}

--- a/.agents/hooks/skills-plan-gate.mjs
+++ b/.agents/hooks/skills-plan-gate.mjs
@@ -15,8 +15,10 @@ const REQUIRED = 'vectreal-iterative-delivery'
 
 try {
 	const payload = await readPayload()
-	if (payload.tool_name === 'ExitPlanMode' &&
-		!skillsInvoked(payload.transcript_path).has(REQUIRED)) {
+	// `null` means the transcript could not be read, which is not the same as
+	// "no skill invoked". Denying on it would be unescapable.
+	const used = skillsInvoked(payload.transcript_path)
+	if (payload.tool_name === 'ExitPlanMode' && used && !used.has(REQUIRED)) {
 		console.log(
 			JSON.stringify({
 				hookSpecificOutput: {

--- a/.agents/hooks/skills-remind.mjs
+++ b/.agents/hooks/skills-remind.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * UserPromptSubmit: name the skills this session has not used yet.
+ *
+ * CLAUDE.md carries the same table, but it is injected once at session start
+ * and then competes with a growing context, which is exactly when agents drift
+ * off it. This restates only what is still missing, so it shrinks as skills get
+ * invoked and goes silent once all three have run. An unconditional version of
+ * this cost roughly 46k tokens over a 200-turn session.
+ *
+ * Fails open and silent: a hook that cannot run must never block or nag.
+ */
+import { SKILLS, skillsInvoked, readPayload } from './skills-invoked.mjs'
+
+try {
+	const payload = await readPayload()
+	const missing = Object.entries(SKILLS).filter(
+		([name]) => !skillsInvoked(payload.transcript_path).has(name),
+	)
+	if (missing.length) {
+		const rows = missing.map(([name, when]) => `| ${name} | ${when} |`).join('\n')
+		console.log(
+			JSON.stringify({
+				hookSpecificOutput: {
+					hookEventName: 'UserPromptSubmit',
+					additionalContext: [
+						'Vectreal skills are mandatory, not advisory. Invoke the matching skill',
+						'BEFORE planning or editing, including in plan mode, where scoping is the work.',
+						'',
+						'| Not yet used this session | When to invoke |',
+						'| --- | --- |',
+						rows,
+						'',
+						'Leaving plan mode requires vectreal-iterative-delivery. Rows disappear as',
+						'skills are invoked.',
+					].join('\n'),
+				},
+			}),
+		)
+	}
+} catch {
+	// intentionally silent
+}

--- a/.agents/hooks/skills-remind.mjs
+++ b/.agents/hooks/skills-remind.mjs
@@ -14,9 +14,10 @@ import { SKILLS, skillsInvoked, readPayload } from './skills-invoked.mjs'
 
 try {
 	const payload = await readPayload()
-	const missing = Object.entries(SKILLS).filter(
-		([name]) => !skillsInvoked(payload.transcript_path).has(name),
-	)
+	// Scan once. Calling this inside the filter re-read the whole transcript
+	// per skill, on the hottest hook in the set.
+	const used = skillsInvoked(payload.transcript_path) ?? new Set()
+	const missing = Object.entries(SKILLS).filter(([name]) => !used.has(name))
 	if (missing.length) {
 		const rows = missing.map(([name, when]) => `| ${name} | ${when} |`).join('\n')
 		console.log(

--- a/.agents/skills/vectreal-extension-architecture/SKILL.md
+++ b/.agents/skills/vectreal-extension-architecture/SKILL.md
@@ -160,7 +160,7 @@ Integration tests need `pnpm nx run vectreal-platform:supabase-start` first, the
 
 ## Verified claims
 
-Executed by `apps/vectreal-platform/tests/agent-skill-claims.spec.ts` on every
+Executed by `apps/vectreal-platform/tests/documented-claims.spec.ts` on every
 CI run. If one fails, either the code moved and this skill is now lying, or the
 invariant genuinely broke. Both need a human.
 

--- a/.agents/skills/vectreal-iterative-delivery/SKILL.md
+++ b/.agents/skills/vectreal-iterative-delivery/SKILL.md
@@ -236,10 +236,12 @@ tests fail, say so with the output; if a step was skipped, say that.
 
 ## Verified claims
 
-Executed by `apps/vectreal-platform/tests/agent-skill-claims.spec.ts` on every
+Executed by `apps/vectreal-platform/tests/documented-claims.spec.ts` on every
 CI run.
 
 ```claims
+exists   .agents/hooks/skills-plan-gate.mjs
+present  .claude/settings.json                                  skills-plan-gate.mjs
 present  .github/workflows/ci-quality.yaml                     build-ci
 present  .github/pull_request_template.md                       Root cause
 present  apps/vectreal-platform/vitest.config.ts               tests/**/*.spec.{ts,tsx}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,5 +9,37 @@
 	},
 	"enabledPlugins": {
 		"nx@nx-claude-plugins": true
+	},
+	"hooks": {
+		"UserPromptSubmit": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node",
+						"args": [
+							"${CLAUDE_PROJECT_DIR}/.agents/hooks/skills-remind.mjs"
+						],
+						"timeout": 15
+					}
+				]
+			}
+		],
+		"PreToolUse": [
+			{
+				"matcher": "ExitPlanMode",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node",
+						"args": [
+							"${CLAUDE_PROJECT_DIR}/.agents/hooks/skills-plan-gate.mjs"
+						],
+						"timeout": 15,
+						"statusMessage": "Checking the plan-mode skill gate"
+					}
+				]
+			}
+		]
 	}
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Use agent skills available and helpful for the task at hand. When working on the
 These are not merely suggested: `.agents/hooks/` (wired from
 `.claude/settings.json`) reminds you which of them you have not used yet, and
 refuses to let you leave plan mode until `vectreal-iterative-delivery` has run.
-Both hooks fail open. See the Skills section of `CLAUDE.md`.
+Neither hook can block on an error. See the Skills section of `CLAUDE.md`.
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ Use agent skills available and helpful for the task at hand. When working on the
 - Design and branding: use [vectreal-brand-ux-design](.agents/skills/vectreal-brand-ux-design/SKILL.md) for tokens, the `ds-*` elevation ladder, the `text-*` type scale, motion, responsive and accessibility work, and the styling rules ESLint already enforces.
 - Iterative delivery: use [vectreal-iterative-delivery](.agents/skills/vectreal-iterative-delivery/SKILL.md) for scoping ambiguous work and for shipping any PR. It owns the mandatory review loop, the mutation gate for tests, the git and worktree rules, and the evidence block required before claiming completion.
 
+These are not merely suggested: `.agents/hooks/` (wired from
+`.claude/settings.json`) reminds you which of them you have not used yet, and
+refuses to let you leave plan mode until `vectreal-iterative-delivery` has run.
+Both hooks fail open. See the Skills section of `CLAUDE.md`.
+
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,25 @@ section exists.
 | `vectreal-iterative-delivery` | Scoping ambiguous or cross-cutting work, and shipping any PR. It owns the review loop, which is never skipped. |
 | `react-router-framework-mode` (global) | Framework-mode API questions: route config, loaders, actions, fetchers, pending UI, error boundaries, type generation. Carries 12 reference files. |
 
+Two hooks in `.agents/hooks/`, wired from `.claude/settings.json`, keep this
+table in front of agents, because a table that is only read at session start
+loses to a growing context:
+
+- `skills-remind.mjs` (`UserPromptSubmit`) lists the skills this session has
+  **not** used yet. Rows disappear as skills are invoked, so it costs less the
+  longer you work and goes silent once all three have run.
+- `skills-plan-gate.mjs` (`PreToolUse`) refuses `ExitPlanMode` until
+  `vectreal-iterative-delivery` has run, since that skill owns scoping and the
+  tier model the plan depends on.
+
+Both read the session transcript rather than any state file, both are plain
+Node (the repo already requires it, unlike `jq`), and both fail open and silent:
+if a hook cannot run, work continues unhindered. Nothing else is blocked. An
+earlier version gated edits by top-level directory, which covered 1027 of 1109
+tracked files and demanded a routing skill to fix a typo in a docs page; that
+was reverted. Per-file enforcement, if you want it, belongs in your own
+`~/.claude` config, not here.
+
 ## Commands
 
 All commands run from the repository root using `pnpm` and `nx`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@ section exists.
 
 `.agents/hooks/` keeps this table in front of you: `skills-remind.mjs` lists the
 skills this session has not used yet, and `skills-plan-gate.mjs` refuses
-`ExitPlanMode` until `vectreal-iterative-delivery` has run. Both fail open.
+`ExitPlanMode` until `vectreal-iterative-delivery` has run. Neither can block on
+an error: an unreadable transcript or a bad payload lets work continue. The gate
+denies only when it can positively see the skill did not run.
 
 ## Before you edit product code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,24 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Skills
+
+**IMPORTANT: invoke the matching skill before starting work, not after getting stuck.** They
+live in `.agents/skills/` and are symlinked into `.claude/skills/`. `AGENTS.md`
+lists them too, but Claude Code does not auto-load that file, which is why this
+section exists.
+
+| Skill | Invoke when |
+| --- | --- |
+| `vectreal-extension-architecture` | Adding or changing a route, loader, action, resource route, domain module, repository, service, permission, or the client/server boundary. |
+| `vectreal-brand-ux-design` | Any change a user can see: component styling, layout, tokens, type scale, elevation, motion, empty/loading/error states, responsive or accessibility work. |
+| `vectreal-iterative-delivery` | Scoping ambiguous or cross-cutting work, and shipping any PR. It owns the review loop, which is never skipped. |
+| `react-router-framework-mode` (global) | Framework-mode API questions: route config, loaders, actions, fetchers, pending UI, error boundaries, type generation. Carries 12 reference files. |
+
+`.agents/hooks/` keeps this table in front of you: `skills-remind.mjs` lists the
+skills this session has not used yet, and `skills-plan-gate.mjs` refuses
+`ExitPlanMode` until `vectreal-iterative-delivery` has run. Both fail open.
+
 ## Before you edit product code
 
 **Write the root cause first.** One sentence: what is broken, where the rule that
@@ -25,39 +43,6 @@ expensive. `docs/guides/publish-embed` documented `*.example.com` as a supported
 allowed-domain pattern; no such pattern could be saved at all until it was fixed.
 
 `vectreal-iterative-delivery` owns the operational detail.
-
-## Skills
-
-Invoke these before starting the matching work, not after getting stuck. They
-live in `.agents/skills/` and are symlinked into `.claude/skills/`. `AGENTS.md`
-lists them too, but Claude Code does not auto-load that file, which is why this
-section exists.
-
-| Skill | Invoke when |
-| --- | --- |
-| `vectreal-extension-architecture` | Adding or changing a route, loader, action, resource route, domain module, repository, service, permission, or the client/server boundary. |
-| `vectreal-brand-ux-design` | Any change a user can see: component styling, layout, tokens, type scale, elevation, motion, empty/loading/error states, responsive or accessibility work. |
-| `vectreal-iterative-delivery` | Scoping ambiguous or cross-cutting work, and shipping any PR. It owns the review loop, which is never skipped. |
-| `react-router-framework-mode` (global) | Framework-mode API questions: route config, loaders, actions, fetchers, pending UI, error boundaries, type generation. Carries 12 reference files. |
-
-Two hooks in `.agents/hooks/`, wired from `.claude/settings.json`, keep this
-table in front of agents, because a table that is only read at session start
-loses to a growing context:
-
-- `skills-remind.mjs` (`UserPromptSubmit`) lists the skills this session has
-  **not** used yet. Rows disappear as skills are invoked, so it costs less the
-  longer you work and goes silent once all three have run.
-- `skills-plan-gate.mjs` (`PreToolUse`) refuses `ExitPlanMode` until
-  `vectreal-iterative-delivery` has run, since that skill owns scoping and the
-  tier model the plan depends on.
-
-Both read the session transcript rather than any state file, both are plain
-Node (the repo already requires it, unlike `jq`), and both fail open and silent:
-if a hook cannot run, work continues unhindered. Nothing else is blocked. An
-earlier version gated edits by top-level directory, which covered 1027 of 1109
-tracked files and demanded a routing skill to fix a typo in a docs page; that
-was reverted. Per-file enforcement, if you want it, belongs in your own
-`~/.claude` config, not here.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Makes the skills table in `CLAUDE.md` actually bind agents at session start and
in plan mode, which is where it was being ignored. Two hooks, both fail open,
no per-file edit gating.

## Root cause

Skill invocation was governed only by prose in `CLAUDE.md`, which is injected
once at session start and then loses to a growing context; the rule belongs in a
hook rather than in prose because nothing in the session ever observed whether a
skill had run, so there was no feedback loop and drift was the default.

## Changes

- `.agents/hooks/skills-remind.mjs` (`UserPromptSubmit`) lists only the skills
  this session has **not** used yet. Rows disappear as skills are invoked and it
  goes silent once all three have run, so it costs less the longer you work.
- `.agents/hooks/skills-plan-gate.mjs` (`PreToolUse`) refuses `ExitPlanMode`
  until `vectreal-iterative-delivery` has run.
- `.agents/hooks/skills-invoked.mjs` reads which skills ran from the session
  transcript.
- Wired from the committed `.claude/settings.json` in **exec form**
  (`command: "node"`, `args: ["${CLAUDE_PROJECT_DIR}/..."]`).
- Moves the Skills section to the top of `CLAUDE.md` and marks exactly one line
  `IMPORTANT`, per Anthropic's guidance that a bloated file gets ignored and that
  emphasising many lines means none stands out. 241 lines to 226.
- Fixes a stale reference in all three skills: the claims runner is
  `documented-claims.spec.ts`, not `agent-skill-claims.spec.ts`. Adds two claims so the repo's own
  mechanism checks the gate file exists and is referenced from settings.json.
  They do not verify the wiring itself.

## Design notes

**Why committed rather than personal.** Anthropic documents `.claude/settings.json`
as the place team hooks belong, and cloud sessions read the committed file while
ignoring `~/.claude/settings.json` entirely. A teammate who wants out can
override in their own gitignored `.claude/settings.local.json`.

**Why the transcript instead of a state file.** State on disk caused every
serious defect in the first draft: an unwritable directory wedged the gate into
a deny loop it could never satisfy, ids collided after sanitizing, and files
accumulated with no cleanup. The transcript is ground truth about what executed
rather than what was typed, and cannot be spoofed by prompt text.

**Why Node rather than `jq`.** `package.json` requires `node >=22.22.0`, so it is
the one interpreter every contributor is guaranteed to have. Exec form also
means no shell, which means no shell selection or quoting surprises on Windows and makes the
executable bit irrelevant.

**Why no per-file edit gating.** An earlier draft gated by top-level directory
and covered 1027 of 1108 tracked files: it demanded the routing-and-authorization
skill to fix a typo in `imprint-page.mdx` while leaving `routes.tsx`,
`root.tsx` and `plan-config.ts` unlocked by any one skill. Separately,
[claude-code#29709](https://github.com/anthropics/claude-code/issues/29709)
documents agents routing around a blocked `Edit` by switching to a file write via
Bash, so an edit gate is bypassable by tool choice. `ExitPlanMode` has no
alternate path, which is why it is the one hard gate kept.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] No product code changed.

Verified:

- All three hook modules pass `node --check`; `.claude/settings.json` parses.
- Plan gate: denies on a transcript with no skill invoked, allows on one where
  `vectreal-iterative-delivery` ran.
- Reminder: 3 rows on a fresh session, 2 after one skill ran, silent after all
  three. 728 chars at worst, against 923 every turn unconditionally.
- Never blocks on an error, each reproduced: unreadable transcript (chmod 000),
  `transcript_path` pointing at a directory, a nonexistent path, an absent
  `transcript_path`, malformed payload, empty stdin.
- A Skill call the user rejected does **not** satisfy the gate; a clean one and a
  `/vectreal-iterative-delivery` slash command both do.
- A foreign namespace (`evil:vectreal-iterative-delivery`) and a prototype key
  (`toString`) are both rejected.
- `documented-claims.spec.ts`: 46 passed, including the two new claims.

## Residual risk

The reminder is advisory by design and an agent can ignore it. The durable place
to enforce outcomes is the merge boundary, not a per-developer hook, which is
what the two filed items above are about. This PR only closes the "nobody ever
told the agent, and nothing checked" gap.

## Review

Reviewed adversarially after rebasing onto #747. Three defects found and fixed in
`50be8bf`, each reproducible: an unreadable transcript denied unescapably, a
Skill call the user *rejected* still satisfied the gate, and loading a skill by
slash command was not detected at all. `CLAUDE.md` and `AGENTS.md` also said
"fail open" unqualified, which was untrue for a missing transcript and is exactly
the false-promise class this work exists to stop; both now state the real
behaviour.

The stale-reference fix across the three `SKILL.md` files is arguably a separate
concern from the hooks. It is three lines in three files and is kept here rather
than split, deliberately.
