### PR TITLE
refactor(api-keys): give "is this key live" a single owner

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
@@ -40,6 +40,11 @@ import { createCheckboxColumn, SortableHeader } from './data-table'
 import { SceneThumbnail } from './scene-thumbnail'
 import { StatusBreakdown, type SceneStatusCounts } from './status-breakdown'
 import { useIsClientMounted } from '../../hooks/use-is-client-mounted'
+import {
+	resolveApiKeyState,
+	type ApiKeyLifecycleRow,
+	type ApiKeyState
+} from '../../lib/domain/auth/api-key-lifecycle'
 
 import type { LegacyColumnDef as ColumnDef } from '@tanstack/react-table/legacy'
 
@@ -581,8 +586,16 @@ const ApiKeyActionsCell = memo(function ApiKeyActionsCell({
 							<Pencil className="mr-2 h-4 w-4" />
 							Edit
 						</DropdownMenuItem>
+						{/*
+						  Only an already-revoked key hides the action. An expired key
+						  keeps it on purpose: revoking one is how an owner records that
+						  it is dead deliberately rather than by lapsing, and it is the
+						  step before deleting it.
+						*/}
 						<DropdownMenuItem
-							disabled={Boolean(row.revokedAt)}
+							disabled={
+								resolveApiKeyState(toLifecycleRow(row), new Date()) === 'revoked'
+							}
 							onClick={() => onRevoke(row.id)}
 							className={DESTRUCTIVE_MENU_ITEM}
 						>
@@ -720,24 +733,43 @@ interface ApiKeyColumnsOptions {
 	onRevoke: (keyId: string) => void
 }
 
-function getApiKeyStatus(row: ApiKeyRow): {
-	label: string
-	variant: 'default' | 'secondary' | 'destructive' | 'outline'
-	icon: 'revoked' | 'expired' | 'active' | 'inactive'
-} {
-	if (row.revokedAt) {
-		return { label: 'Revoked', variant: 'destructive', icon: 'revoked' }
+/**
+ * A table row in the shape `api-key-lifecycle` reads.
+ *
+ * The dates are re-wrapped rather than passed through: loader data reaches this
+ * file after serialization, and `formatRelativeTime` below has always guarded
+ * the same way.
+ */
+function toLifecycleRow(row: ApiKeyRow): ApiKeyLifecycleRow {
+	return {
+		active: row.active,
+		expiresAt: row.expiresAt ? new Date(row.expiresAt) : null,
+		revokedAt: row.revokedAt ? new Date(row.revokedAt) : null
 	}
+}
 
-	if (row.expiresAt && new Date(row.expiresAt) < new Date()) {
-		return { label: 'Expired', variant: 'outline', icon: 'expired' }
+/**
+ * How each lifecycle state is presented. A total `Record`, so a new state is a
+ * compile error here rather than a row that silently renders as Inactive.
+ */
+const API_KEY_STATUS_PRESENTATION: Record<
+	ApiKeyState,
+	{
+		label: string
+		variant: 'default' | 'secondary' | 'destructive' | 'outline'
+		Icon: typeof XCircle
 	}
+> = {
+	revoked: { label: 'Revoked', variant: 'destructive', Icon: XCircle },
+	expired: { label: 'Expired', variant: 'outline', Icon: Clock },
+	active: { label: 'Active', variant: 'default', Icon: CheckCircle2 },
+	inactive: { label: 'Inactive', variant: 'secondary', Icon: Ban }
+}
 
-	if (row.active) {
-		return { label: 'Active', variant: 'default', icon: 'active' }
-	}
-
-	return { label: 'Inactive', variant: 'secondary', icon: 'inactive' }
+function getApiKeyStatus(row: ApiKeyRow) {
+	return API_KEY_STATUS_PRESENTATION[
+		resolveApiKeyState(toLifecycleRow(row), new Date())
+	]
 }
 
 function formatRelativeTime(date: Date | null): string {
@@ -857,20 +889,12 @@ export function createApiKeyColumns(
 			),
 			accessorFn: (row) => getApiKeyStatus(row).label,
 			cell: ({ row }) => {
-				const status = getApiKeyStatus(row.original)
-				const StatusIcon =
-					status.icon === 'revoked'
-						? XCircle
-						: status.icon === 'expired'
-							? Clock
-							: status.icon === 'active'
-								? CheckCircle2
-								: Ban
+				const { label, variant, Icon } = getApiKeyStatus(row.original)
 
 				return (
-					<Badge variant={status.variant} className="gap-1">
-						<StatusIcon className="size-3" />
-						{status.label}
+					<Badge variant={variant} className="gap-1">
+						<Icon className="size-3" />
+						{label}
 					</Badge>
 				)
 			}

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-lifecycle.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-lifecycle.ts
@@ -1,0 +1,73 @@
+/**
+ * The single source of truth for "is this API key usable, and if not, why".
+ *
+ * Four places answered that question independently before this module existed,
+ * and they disagreed in two ways that reached production:
+ *
+ *   - `active` is `boolean | null`. The authorization query requires
+ *     `active = true`, so a null-`active` row is refused. `toEmbedApiKeyOptions`
+ *     asked `active === false`, so the same row was offered in the embed panel's
+ *     key picker as usable and then 404'd at the embed.
+ *   - The query treats a key as live while `expires_at > now`, so a key at
+ *     exactly its expiry instant is dead. `getApiKeyStatus` asked `< now` and
+ *     labelled that same key Active in the dashboard table.
+ *
+ * Neither was visible to a test of either side on its own, which is why
+ * `tests/api-key-lifecycle.spec.ts` asserts this module against the query's
+ * predicate rather than against itself.
+ *
+ * Deliberately pure - no database import and no `.server` suffix - so a spec can
+ * import it and so components can gate affordances with the same rule the server
+ * enforces, following `embed-key-options.ts` and `embed-access-policy.ts`.
+ */
+
+export type ApiKeyState = 'active' | 'expired' | 'revoked' | 'inactive'
+
+/** The minimum of an `api_keys` row this module reads. */
+export interface ApiKeyLifecycleRow {
+	active: boolean | null
+	expiresAt: Date | null
+	revokedAt: Date | null
+}
+
+/**
+ * Which state an API key is in.
+ *
+ * The order is the reporting priority, not a set of independent tests: a revoked
+ * key that has also expired reports `revoked`, because that is the fact its
+ * owner acted on. Only `active` means the key authorizes anything, so every
+ * other branch is a reason a request will be refused.
+ */
+export function resolveApiKeyState(
+	row: ApiKeyLifecycleRow,
+	now: Date
+): ApiKeyState {
+	if (row.revokedAt !== null) {
+		return 'revoked'
+	}
+
+	// `<=` and not `<`: the query keeps a key live while `expires_at > now`, so
+	// the expiry instant itself is already dead.
+	if (row.expiresAt !== null && row.expiresAt.getTime() <= now.getTime()) {
+		return 'expired'
+	}
+
+	// `!== true` and not `=== false`: the column is nullable, and the query
+	// requires `active = true`, under which null is refused like false.
+	if (row.active !== true) {
+		return 'inactive'
+	}
+
+	return 'active'
+}
+
+/**
+ * Whether this key authorizes a request.
+ *
+ * Equivalent by construction to the `WHERE` clause in `findLiveKeyForProject`
+ * (`preview-api-key-auth.server.ts`), which cannot call this function because it
+ * runs in Postgres. The spec pins the two together instead.
+ */
+export function isApiKeyLive(row: ApiKeyLifecycleRow, now: Date): boolean {
+	return resolveApiKeyState(row, now) === 'active'
+}

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
@@ -14,19 +14,32 @@ import {
 } from '../billing/entitlement-service.server'
 import { QuotaExceededError } from '../billing/quota-exceeded-error'
 import { checkQuota } from '../billing/usage-service.server'
+import { type DashboardOperation } from '../dashboard/dashboard-operations'
 import { assertDashboardPermission } from '../dashboard/dashboard-permissions.server'
 
 const db = getDbClient()
 
 type DbClient = typeof db
 
+/** The operations this module is allowed to assert. */
+type ApiKeyOperation = Extract<DashboardOperation, `api-key:${string}`>
+
 /**
- * Verify user is an admin or owner of the organization
+ * Verify the actor may perform `operation` in this organization.
+ *
+ * The operation is a parameter rather than a constant because this function
+ * used to assert `api-key:create` for create, update *and* revoke. That was
+ * inert only because the three role lists happen to be identical: the moment
+ * one of them tightened, `dashboard-operations.ts` would have described a rule
+ * this path does not enforce, and that table is the only authorization that
+ * runs in this app - `db/client.ts` connects without `set local role`, so every
+ * RLS policy is bypassed.
  */
 async function verifyOrganizationAdminAccess(
 	dbClient: DbClient,
 	organizationId: string,
-	userId: string
+	userId: string,
+	operation: ApiKeyOperation
 ): Promise<typeof organizationMemberships.$inferSelect> {
 	const membership = await dbClient
 		.select()
@@ -43,7 +56,7 @@ async function verifyOrganizationAdminAccess(
 		throw new Error('User does not have access to this organization')
 	}
 
-	assertDashboardPermission('api-key:create', { role: membership[0].role })
+	assertDashboardPermission(operation, { role: membership[0].role })
 
 	return membership[0]
 }
@@ -247,7 +260,12 @@ export async function createApiKey(
 		params
 
 	// Verify user is admin/owner of organization
-	await verifyOrganizationAdminAccess(db, organizationId, userId)
+	await verifyOrganizationAdminAccess(
+		db,
+		organizationId,
+		userId,
+		'api-key:create'
+	)
 
 	const quotaCheck = await checkQuota(organizationId, 'api_keys_per_org')
 	if (quotaCheck.outcome === 'hard_limit_exceeded') {
@@ -352,8 +370,12 @@ export async function updateApiKey(
 		throw new Error('API key not found or access denied')
 	}
 
-	// Verify user is admin/owner
-	await verifyOrganizationAdminAccess(db, existingKey.organization.id, userId)
+	await verifyOrganizationAdminAccess(
+		db,
+		existingKey.organization.id,
+		userId,
+		'api-key:update'
+	)
 
 	// If projectIds provided, verify they belong to organization
 	if (projectIds && projectIds.length > 0) {
@@ -409,8 +431,12 @@ export async function revokeApiKey(
 		throw new Error('API key not found or access denied')
 	}
 
-	// Verify user is admin/owner
-	await verifyOrganizationAdminAccess(db, existingKey.organization.id, userId)
+	await verifyOrganizationAdminAccess(
+		db,
+		existingKey.organization.id,
+		userId,
+		'api-key:revoke'
+	)
 
 	// Set revokedAt timestamp
 	await db

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-key-options.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-key-options.ts
@@ -4,7 +4,12 @@
  * Pure - no database import and no `.server` suffix - so the rules below are
  * testable directly rather than only through a route, and so the client can
  * import the option type without pulling the db client in.
+ *
+ * Whether a key still works is not decided here. `api-key-lifecycle.ts` owns
+ * that, and this module only shapes its answer for the picker.
  */
+
+import { resolveApiKeyState } from '../auth/api-key-lifecycle'
 
 /** One row in the embed panel's key picker. Never carries a key's plaintext. */
 export interface EmbedApiKeyOption {
@@ -14,7 +19,16 @@ export interface EmbedApiKeyOption {
 	keyPreview: string
 	expiresAt: string | null
 	lastUsedAt: string | null
+	/** Revoked, or otherwise unusable for a reason the owner caused. */
 	revoked: boolean
+	/**
+	 * Aged out, and not revoked.
+	 *
+	 * Mutually exclusive with `revoked` rather than independent of it: these are
+	 * two views of one state, and a revoked key reports only that it was revoked,
+	 * which is the fact its owner acted on. Read them in that order, as
+	 * `embed-key-field.tsx` does.
+	 */
 	expired: boolean
 }
 
@@ -49,18 +63,26 @@ export function toEmbedApiKeyOptions(
 ): EmbedApiKeyOption[] {
 	return keys
 		.filter((key) => key.projects.some((project) => project.id === projectId))
-		.map((key) => ({
-			id: key.apiKey.id,
-			name: key.apiKey.name,
-			keyPreview: key.apiKey.keyPreview,
-			expiresAt: key.apiKey.expiresAt?.toISOString() ?? null,
-			lastUsedAt: key.apiKey.lastUsedAt?.toISOString() ?? null,
-			revoked: key.apiKey.revokedAt !== null || key.apiKey.active === false,
-			expired:
-				key.apiKey.expiresAt !== null &&
-				key.apiKey.expiresAt.getTime() <= now.getTime(),
-			createdAt: key.apiKey.createdAt.getTime()
-		}))
+		.map((key) => {
+			const state = resolveApiKeyState(key.apiKey, now)
+
+			return {
+				id: key.apiKey.id,
+				name: key.apiKey.name,
+				keyPreview: key.apiKey.keyPreview,
+				expiresAt: key.apiKey.expiresAt?.toISOString() ?? null,
+				lastUsedAt: key.apiKey.lastUsedAt?.toISOString() ?? null,
+				/*
+				  `inactive` counts as revoked here on purpose. The picker's job is to
+				  say whether a key still works, and both states mean it does not.
+				  This used to ask `active === false`, which let a null-`active` row
+				  read as usable in the picker and then 404 at the embed.
+				*/
+				revoked: state === 'revoked' || state === 'inactive',
+				expired: state === 'expired',
+				createdAt: key.apiKey.createdAt.getTime()
+			}
+		})
 		.sort((a, b) => {
 			const byUsable =
 				Number(a.revoked || a.expired) - Number(b.revoked || b.expired)

--- a/apps/vectreal-platform/tests/api-key-lifecycle.spec.ts
+++ b/apps/vectreal-platform/tests/api-key-lifecycle.spec.ts
@@ -1,0 +1,211 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	isApiKeyLive,
+	resolveApiKeyState,
+	type ApiKeyLifecycleRow
+} from '../app/lib/domain/auth/api-key-lifecycle'
+
+/**
+ * The contract between the two halves that decide whether an API key works.
+ *
+ * `findLiveKeyForProject` decides it in Postgres; `isApiKeyLive` decides it in
+ * TypeScript for every surface that cannot run SQL. Testing either one alone
+ * proves nothing, because the bug this file exists to prevent is the two of them
+ * disagreeing - which they did, in two places, until 2026-08-22.
+ *
+ * So the SQL predicate is transcribed here as data, the transcription is checked
+ * against the real query text, and the module is checked against the
+ * transcription over every combination of the three columns involved.
+ */
+
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const AUTH_MODULE = join(
+	APP_ROOT,
+	'app/lib/domain/auth/preview-api-key-auth.server.ts'
+)
+
+const authSource = readFileSync(AUTH_MODULE, 'utf8')
+
+/**
+ * The lifecycle half of `findLiveKeyForProject`'s `WHERE` clause.
+ *
+ * `sql` is the literal Drizzle expression, so editing the query without editing
+ * this file fails below rather than silently drifting. `holds` is its meaning.
+ */
+const LIFECYCLE_SQL_CLAUSES: Array<{
+	sql: string
+	holds: (row: ApiKeyLifecycleRow, now: Date) => boolean
+}> = [
+	{
+		sql: 'eq(apiKeys.active, true)',
+		holds: (row) => row.active === true
+	},
+	{
+		sql: 'isNull(apiKeys.revokedAt)',
+		holds: (row) => row.revokedAt === null
+	},
+	{
+		sql: 'or(isNull(apiKeys.expiresAt), gt(apiKeys.expiresAt, now))',
+		holds: (row, now) =>
+			row.expiresAt === null || row.expiresAt.getTime() > now.getTime()
+	}
+]
+
+/** The identity half. Not lifecycle, but it has to be accounted for below. */
+const IDENTITY_SQL_CLAUSES = [
+	'eq(apiKeys.hashedKey, hashedToken)',
+	'eq(apiKeyProjects.projectId, projectId)'
+]
+
+function extractWhereClause(source: string): string {
+	/*
+	  Anchored on the function rather than taking the file's first `.where(`.
+	  There is a second one further down, on the `lastUsedAt` update, and adding
+	  any query above this one would otherwise make the assertion below fail
+	  while pointing at the wrong statement.
+	*/
+	const fn = source.indexOf('async function findLiveKeyForProject')
+	expect(fn, 'findLiveKeyForProject has been renamed or moved').toBeGreaterThan(
+		-1
+	)
+
+	const start = source.indexOf('.where(', fn)
+	const end = source.indexOf('.limit(', start)
+	expect(start, 'findLiveKeyForProject no longer has a .where(').toBeGreaterThan(
+		-1
+	)
+	expect(end, 'findLiveKeyForProject no longer has a .limit(').toBeGreaterThan(
+		start
+	)
+
+	return source.slice(start, end).replace(/\s+/g, '')
+}
+
+const NOW = new Date('2026-08-22T12:00:00.000Z')
+const PAST = new Date('2026-08-21T12:00:00.000Z')
+const FUTURE = new Date('2026-08-23T12:00:00.000Z')
+/** The expiry instant itself. The query calls this dead; the table used to call it Active. */
+const EXACTLY_NOW = new Date(NOW.getTime())
+
+const ACTIVE_VALUES: Array<boolean | null> = [true, false, null]
+const REVOKED_VALUES: Array<Date | null> = [null, PAST]
+const EXPIRY_VALUES: Array<Date | null> = [null, PAST, EXACTLY_NOW, FUTURE]
+
+const ALL_ROWS: ApiKeyLifecycleRow[] = ACTIVE_VALUES.flatMap((active) =>
+	REVOKED_VALUES.flatMap((revokedAt) =>
+		EXPIRY_VALUES.map((expiresAt) => ({ active, expiresAt, revokedAt }))
+	)
+)
+
+function describeRow(row: ApiKeyLifecycleRow): string {
+	const expiry =
+		row.expiresAt === null
+			? 'no expiry'
+			: row.expiresAt.getTime() === NOW.getTime()
+				? 'expiring exactly now'
+				: row.expiresAt < NOW
+					? 'expired'
+					: 'expiring later'
+
+	return `active=${String(row.active)}, ${row.revokedAt ? 'revoked' : 'not revoked'}, ${expiry}`
+}
+
+describe('api key lifecycle', () => {
+	describe('the transcription of the query still matches the query', () => {
+		it.each(LIFECYCLE_SQL_CLAUSES.map((clause) => clause.sql))(
+			'%s is still in findLiveKeyForProject',
+			(sql) => {
+				expect(
+					authSource.replace(/\s+/g, '').includes(sql.replace(/\s+/g, '')),
+					`findLiveKeyForProject no longer contains ${sql}. If the query changed, change LIFECYCLE_SQL_CLAUSES and api-key-lifecycle.ts with it.`
+				).toBe(true)
+			}
+		)
+
+		/*
+		  The teeth. The check above passes just as well when a fourth condition
+		  has been added to the query and nothing here knows about it, which is
+		  exactly how the two halves drifted apart last time.
+		*/
+		it('has no lifecycle condition the transcription does not cover', () => {
+			const expected = `.where(and(${[
+				...IDENTITY_SQL_CLAUSES,
+				...LIFECYCLE_SQL_CLAUSES.map((clause) => clause.sql)
+			].join(',')}))`.replace(/\s+/g, '')
+
+			expect(
+				extractWhereClause(authSource),
+				'The WHERE clause of findLiveKeyForProject is not the set of conditions this spec transcribes. A condition was added, removed or reordered; api-key-lifecycle.ts has to answer for it.'
+			).toBe(expected)
+		})
+	})
+
+	describe('isApiKeyLive agrees with the query on every row shape', () => {
+		it.each(ALL_ROWS.map((row) => [describeRow(row), row] as const))(
+			'%s',
+			(_label, row) => {
+				const sqlWouldSelect = LIFECYCLE_SQL_CLAUSES.every((clause) =>
+					clause.holds(row, NOW)
+				)
+
+				expect(isApiKeyLive(row, NOW)).toBe(sqlWouldSelect)
+			}
+		)
+	})
+
+	describe('resolveApiKeyState', () => {
+		it('reports revoked ahead of every other reason', () => {
+			expect(
+				resolveApiKeyState(
+					{ active: false, expiresAt: PAST, revokedAt: PAST },
+					NOW
+				)
+			).toBe('revoked')
+		})
+
+		it('treats a null active column as inactive, not as usable', () => {
+			// The regression: `active === false` let a null-active key through the
+			// embed panel's picker, and the query then refused it.
+			expect(
+				resolveApiKeyState(
+					{ active: null, expiresAt: null, revokedAt: null },
+					NOW
+				)
+			).toBe('inactive')
+			expect(
+				isApiKeyLive({ active: null, expiresAt: null, revokedAt: null }, NOW)
+			).toBe(false)
+		})
+
+		it('treats the expiry instant itself as expired', () => {
+			// The regression: `< now` labelled this Active in the dashboard while
+			// the query, using `expires_at > now`, refused it.
+			expect(
+				resolveApiKeyState(
+					{ active: true, expiresAt: EXACTLY_NOW, revokedAt: null },
+					NOW
+				)
+			).toBe('expired')
+		})
+
+		it('reports active only when nothing is wrong', () => {
+			expect(
+				resolveApiKeyState(
+					{ active: true, expiresAt: FUTURE, revokedAt: null },
+					NOW
+				)
+			).toBe('active')
+			expect(
+				resolveApiKeyState(
+					{ active: true, expiresAt: null, revokedAt: null },
+					NOW
+				)
+			).toBe('active')
+		})
+	})
+})

--- a/apps/vectreal-platform/tests/embed-key-options.spec.ts
+++ b/apps/vectreal-platform/tests/embed-key-options.spec.ts
@@ -57,11 +57,18 @@ describe('toEmbedApiKeyOptions', () => {
 		])
 	})
 
-	it('marks a revoked key by either signal the schema uses', () => {
+	it('marks a revoked key by every signal the schema allows', () => {
 		const options = toEmbedApiKeyOptions(
 			[
 				makeKey({ id: 'timestamp', revokedAt: new Date('2026-05-01') }),
 				makeKey({ id: 'flag', active: false }),
+				/*
+				  `active` is nullable, and the embed query requires `active = true`,
+				  so a null-`active` key authorizes nothing. This asked
+				  `active === false` until 2026-08-22, which offered exactly this key
+				  in the picker as usable and then 404'd at the embed.
+				*/
+				makeKey({ id: 'null-flag', active: null }),
 				makeKey({ id: 'live' })
 			],
 			PROJECT_ID,
@@ -71,7 +78,12 @@ describe('toEmbedApiKeyOptions', () => {
 		const revoked = Object.fromEntries(
 			options.map((option) => [option.id, option.revoked])
 		)
-		expect(revoked).toEqual({ timestamp: true, flag: true, live: false })
+		expect(revoked).toEqual({
+			timestamp: true,
+			flag: true,
+			'null-flag': true,
+			live: false
+		})
 	})
 
 	it('treats expiry as of the given instant, boundary inclusive', () => {


### PR DESCRIPTION
## Summary

Four separate places decided whether an API key is still usable, and two of them
disagreed with the query that actually authorizes embed requests. This gives the
rule one owner and pins it to that query with a test.

First of four PRs in the API key security chain. It is a prerequisite for rotate
and delete, which need a trustworthy answer to "is this key live" before they
can refuse to rotate a revoked key.

## Root cause

Four call sites re-derived key liveness from raw columns because no module owned
the predicate, so the fix belongs in one pure module that both the UI and the
domain read - not in a guard added at each site.

## Changes

- New pure `app/lib/domain/auth/api-key-lifecycle.ts`: `resolveApiKeyState` and
  `isApiKeyLive`. No database import and no `.server` suffix, so a spec can
  import it and components can gate affordances with the same rule the server
  enforces.
- `embed-key-options.ts` and `table-columns.tsx` derive from it instead of
  re-deriving. The status presentation became a total `Record<ApiKeyState, ...>`,
  so a new state is a compile error rather than a row that silently renders as
  Inactive.
- `verifyOrganizationAdminAccess` takes the operation as a parameter instead of
  hardcoding `api-key:create` for create, update and revoke alike.

### Two disagreements this fixes, both live in production

- **`active` is nullable.** The query requires `active = true`, so a
  null-`active` row is refused. `toEmbedApiKeyOptions` asked `active === false`,
  so that same key was offered in the embed panel's key picker as usable and
  then 404'd at the embed.
- **The expiry instant itself.** The query keeps a key live while
  `expires_at > now`. `getApiKeyStatus` asked `< now`, so a key at exactly its
  expiry read **Active** in the dashboard table while every request using it was
  refused.

Neither was visible to a test of either half on its own. `tests/api-key-lifecycle.spec.ts`
transcribes the SQL clauses as data, asserts by exact match that the
transcription still matches the real query text, and then checks the module
against it across all 24 combinations of the three columns.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

Gates: `typecheck,lint` over `vctrl/core`, `vctrl/hooks`, `vctrl/viewer`,
`vectreal-platform` (8 tasks, matching 4 projects x 2 targets). 879 unit tests
across 80 files.

**Mutation gate, 5 for 5.** Each mutation was applied to the production line and
a test confirmed red, then restored and confirmed byte-identical:

| Mutation | Tests red |
| --- | --- |
| drop `isNull(apiKeys.revokedAt)` from the query | 2 |
| `row.active !== true` to `=== false` | 3 |
| expiry `<=` to `<` | 2 |
| revert the picker to `state === 'revoked'` only | 1 |
| drop the clause again, after anchoring the extractor | 2 |

Not verified in a browser, deliberately: no styling, layout or affordance
changes here, and the badge renders with the same variant and icon as before.
The visible surface lands in PR 2 (rotate and delete) and closes with a
screenshot there.

Integration tests not run - this PR changes no database behavior.

## Notes

Two things the review loop raised and this PR handles rather than hides:

- `EmbedApiKeyOption.expired` is now mutually exclusive with `revoked` rather
  than independent of it. Both consumers already read them in that order, so
  nothing observable changes, but the field is now documented to say so.
- The plan for this PR said to disable Revoke on any non-active key. That is a
  regression, not a fix: revoking an expired key is how an owner records that it
  is dead deliberately rather than by lapsing, and it is the step before
  deleting. The `disabled` prop is behavior-identical to before, just routed
  through the owner so it cannot drift.
