### PR TITLE
refactor(ui): name the app's stacking layers as z-index tiers

### DIFF
--- a/.agents/skills/vectreal-brand-ux-design/SKILL.md
+++ b/.agents/skills/vectreal-brand-ux-design/SKILL.md
@@ -50,6 +50,31 @@ only.
 truth. Setting `style={{ fontSize: 'var(--text-headline)' }}` gets the size and
 none of the weight, tracking or leading, which is why `text-headline` exists.
 
+## Stacking: the `--z-index-*` tiers
+
+Named tiers in `globals.css`, each with a comment saying what belongs there.
+They generate the matching utilities, so a call site names a layer instead of
+picking a number.
+
+| Tier | Value | What sits there |
+| --- | --- | --- |
+| `z-page-chrome` | 20 | Chrome owned by one route: the docs breadcrumb bar, the internal preview overlay, a sticky summary card |
+| `z-nav` | 50 | Site chrome fixed for the whole session: desktop and mobile nav, consent banner |
+| `z-overlay` | 50 | Radix's portal layer: dialog, alert dialog, sheet, drawer, menus, popovers, hover cards |
+| `z-above-nav` | 60 | Must cover the nav: the route loading bar, an embed viewer gone fullscreen |
+| `z-tooltip` | 80 | Tooltips, above the overlay layer so they still show inside a dialog |
+| `z-overlay-raised` | 100 | One overlay that has to clear another |
+| `z-select` | 120 | The select listbox, top of the ladder |
+
+The nav and the overlay layer tie at 50 deliberately. Both land in the root
+stacking context, and Radix portals its overlays to the end of the document
+body, so the tie resolves in their favor. That is also why the publisher shell
+keeps every surface of its own below 50, in its own ladder in
+`shell-layout.ts`: at or above it they paint over confirmation modals.
+
+Below 50 is component-local ordering and stays a plain number. Giving it a tier
+name would claim a relationship with the site chrome that it does not have.
+
 ## Motion
 
 Durations: `--duration-instant` 80ms, `--duration-fast` 150ms, `--duration-base`
@@ -78,6 +103,15 @@ guessing. Each rule carries a comment explaining the failure it prevents.
 4. **Inline `<svg>`.** Extract to `shared/components/src/assets/icons` as a named
    component. A component that exists to draw a graphic rather than an icon
    disables the rule on the line with a reason.
+5. **A z-index at or above 50, and every escape hatch below it.** 50 is where
+   the site nav and Radix's portal layer live, in the root stacking context, so
+   a number there is competing with them and needs a tier name. Tailwind v4
+   spells the escape hatch three ways and all three are rejected: the bracket,
+   the `z-` custom-property shorthand in parentheses, and a leading `!`.
+   This is the rule the route loading bar needed: it and the header were both
+   fixed to the top of the viewport at 50, nothing recorded that they
+   overlapped, and DOM order decided the bar painted underneath, on every
+   navigation.
 
 ## Viewport height
 
@@ -87,14 +121,23 @@ owns the height and scrolls its own content, as `dashboard-layout.tsx` does.
 Never Tailwind's screen-height utilities. They compile to `100vh`, the *large*
 viewport, which overhangs persistent mobile browser chrome: bottom-anchored UI
 goes behind the bar and the page is left scrolled with no way back when a canvas
-holds `touch-action: none`. Those class names are deliberately not spelled out
-here, because of the next section.
+holds `touch-action: none`.
 
-## Tailwind scans this file
+## Tailwind scans more than markup
 
-`globals.css` declares `@source '../../../../'`, the repository root. Any string
-anywhere in the repo that looks like a utility, markdown included, is compiled
-into the bundle. Do not write speculative class names in documentation.
+`globals.css` declares `@source '../../../../'`, the repository root, so any
+string that looks like a utility is compiled into the bundle whether or not it
+was ever meant to render.
+
+Specs, config files and markdown are excluded, so prose in this file and in a
+README costs nothing. Comments and strings inside `.ts` and `.tsx` are still
+scanned, and cannot be excluded, because those files also hold the real markup.
+A JSDoc example, a commented-out block of JSX, and plain English both ways: the
+word "ordinal" in a sentence about clip ids compiles to Tailwind's `ordinal`
+utility. Roughly fifteen rules in the bundle today come from comments alone.
+
+So the rule survives where it still bites: do not name a utility in a code
+comment unless the file actually uses it.
 
 ## Verify in a browser, not in your head
 
@@ -125,7 +168,7 @@ a hover step or a snap point survived is to look at it.
 
 ## Verified claims
 
-Executed by `apps/vectreal-platform/tests/agent-skill-claims.spec.ts` on every
+Executed by `apps/vectreal-platform/tests/documented-claims.spec.ts` on every
 CI run. The `absent` line is the load-bearing one: it fails the build the day
 someone points `--accent` back at the brand.
 
@@ -140,6 +183,14 @@ present  shared/components/src/styles/globals.css                              .
 present  shared/components/src/styles/globals.css                              .ds-divider
 present  shared/components/src/styles/globals.css                              .text-headline
 present  shared/components/src/styles/globals.css                              @source '../../../../'
+present  shared/components/src/styles/globals.css                              @source not '../../../../**/*.md'
+present  shared/utils/src/lib/styling.utils.ts                                 extendTailwindMerge
+present  shared/components/src/styles/globals.css                              --z-index-nav: 50
+present  shared/components/src/styles/globals.css                              --z-index-overlay: 50
+present  shared/components/src/styles/globals.css                              --z-index-above-nav: 60
+present  shared/components/src/styles/globals.css                              --z-index-select: 120
+present  eslint.config.mts                                                     z-index outside the named scale
+exists   apps/vectreal-platform/tests/documented-claims.spec.ts
 present  eslint.config.mts                                                     Build className with cn()
 present  eslint.config.mts                                                     Inline SVG
 present  apps/vectreal-platform/app/routes/layouts/dashboard-layout.tsx        h-svh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,15 @@ Components are in `shared/components/src/ui/` (shadcn-based, Radix UI primitives
 - **Versioning**: Managed by Release Please. Do not use `nx release`. Internal deps use `workspace:*`; shared third-party versions use `catalog:` and are declared in `pnpm-workspace.yaml`.
 - **Docs pages**: MDX files in `app/routes/docs/`. Adding a new page also requires a route in `app/routes.tsx` and an entry in the `docsPages` array in `app/lib/docs/docs-manifest.ts`, which is what `DocsTreeNav` renders.
 - **Server-only modules**: Files that must not be bundled client-side are named `*.server.ts`.
-- **Viewport height**: Size full-viewport surfaces with `h-dvh` / `min-h-dvh`, or `h-svh` where a shell owns the height and scrolls its own content, as `dashboard-layout.tsx` does. Never Tailwind's `screen` height utilities: they compile to `100vh`, the *large* viewport, which overhangs persistent mobile browser chrome, pushing bottom-anchored UI behind the bar and leaving the page scrolled with no way back when a canvas holds `touch-action: none`. (Spelling those class names out here would be self-defeating: the Tailwind scanner reads this file and would re-emit the very utilities the codebase dropped.)
+- **Stacking**: App-global layers are named tiers in `globals.css`
+  (`--z-index-page-chrome`, `-nav`, `-overlay`, `-above-nav`, `-tooltip`,
+  `-overlay-raised`, `-select`), each carrying a comment about what belongs
+  there. Use the tier utility rather than a number: ESLint rejects a bare
+  z-index at or above 50, and any arbitrary bracket value, because 50 is where
+  the site nav and Radix's portal layer already sit in the root stacking
+  context. Ordering siblings inside one component's own stacking context stays
+  a plain low number.
+- **Viewport height**: Size full-viewport surfaces with `h-dvh` / `min-h-dvh`, or `h-svh` where a shell owns the height and scrolls its own content, as `dashboard-layout.tsx` does. Never Tailwind's `screen` height utilities: they compile to `100vh`, the *large* viewport, which overhangs persistent mobile browser chrome, pushing bottom-anchored UI behind the bar and leaving the page scrolled with no way back when a canvas holds `touch-action: none`. (The class names are left unspelled from when this file was scanned by Tailwind and naming them re-emitted them; markdown is excluded now, but the same hazard is live in any `.ts` or `.tsx` comment.)
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/apps/vectreal-platform/app/components/consent/consent-banner.tsx
+++ b/apps/vectreal-platform/app/components/consent/consent-banner.tsx
@@ -26,7 +26,7 @@ export function ConsentBanner() {
 					animate={{ y: 0, opacity: 1 }}
 					exit={{ y: 80, opacity: 0 }}
 					transition={{ duration: 0.25, ease: 'easeOut' }}
-					className="ds-overlay fixed right-0 bottom-0 left-0 z-50 border-t px-4 py-4 shadow-lg backdrop-blur-sm sm:px-6"
+					className="ds-overlay fixed right-0 bottom-0 left-0 z-nav border-t px-4 py-4 shadow-lg backdrop-blur-sm sm:px-6"
 					role="dialog"
 					aria-modal="false"
 					aria-label="Cookie consent"

--- a/apps/vectreal-platform/app/components/global-navigation-loader.tsx
+++ b/apps/vectreal-platform/app/components/global-navigation-loader.tsx
@@ -22,17 +22,19 @@ export function GlobalNavigationLoader() {
 
 	return (
 		/*
-		  Above the nav, which is also fixed at top-0 and also z-50 (see
-		  `desktop-nav.tsx` and `mobile-nav.tsx`). Equal z-index is resolved by DOM
-		  order, and the nav renders later, so the bar was painted underneath it: the
-		  1px strip sat behind a 52px header and showed only as a smear through the
-		  header's own backdrop.
+		  Above the nav, which is also fixed to the top of the viewport and also on
+		  the nav tier (see `desktop-nav.tsx` and `mobile-nav.tsx`). An equal
+		  z-index is resolved by DOM order, and the nav renders later, so the bar
+		  was painted underneath it: the 1px strip sat behind a 52px header and
+		  showed only as a smear through the header's own backdrop.
 
-		  z-60 is the tier this repo already uses for "above the nav". Transient
-		  surfaces stay higher on purpose - tooltips at 80, dropdowns and popovers at
-		  100 - because a progress strip behind an open menu is correct.
+		  `z-above-nav` is the tier for exactly this, defined in `globals.css`
+		  beside the rest of the ladder. Tooltips and everything above them stay
+		  higher, so a transient surface is never cut by a progress strip. The base
+		  overlay layer ties with the nav underneath, which costs it the one pixel
+		  the bar occupies.
 		*/
-		<div className="pointer-events-none fixed top-0 left-0 z-60 w-full">
+		<div className="pointer-events-none fixed top-0 left-0 z-above-nav w-full">
 			<div
 				className={cn(
 					/*

--- a/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-embed-client.tsx
+++ b/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-embed-client.tsx
@@ -370,7 +370,7 @@ export default function MockShopEmbedClient({
 										'md:hover:bg-muted/50 md:cursor-pointer md:hover:scale-[1.015]',
 									interactiveMode &&
 										!isMobileViewport &&
-										'fixed inset-0 z-50 aspect-auto rounded-none md:relative md:inset-auto md:z-auto md:aspect-4/3 md:rounded-2xl',
+										'fixed inset-0 z-above-nav aspect-auto rounded-none md:relative md:inset-auto md:z-auto md:aspect-4/3 md:rounded-2xl',
 									shouldUseMobileOverlay && 'pointer-events-none opacity-0'
 								)}
 							>
@@ -436,7 +436,7 @@ export default function MockShopEmbedClient({
 			{shouldUseMobileOverlay &&
 				typeof document !== 'undefined' &&
 				createPortal(
-					<div className="fixed inset-0 z-60 bg-black/95">
+					<div className="fixed inset-0 z-above-nav bg-black/95">
 						<div className="relative h-[100dvh] w-full overflow-hidden">
 							{viewerFrame}
 							<div

--- a/apps/vectreal-platform/app/components/navigation/desktop-nav.tsx
+++ b/apps/vectreal-platform/app/components/navigation/desktop-nav.tsx
@@ -30,7 +30,7 @@ function DesktopNav({
 	return (
 		<nav
 			className={cn(
-				'fixed top-0 right-0 left-0 z-50 items-center justify-center p-4',
+				'fixed top-0 right-0 left-0 z-nav items-center justify-center p-4',
 				className
 			)}
 			aria-label="Main navigation"

--- a/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
+++ b/apps/vectreal-platform/app/components/navigation/mobile-nav.tsx
@@ -100,7 +100,7 @@ function MobileNav({
 		<>
 			<nav
 				className={cn(
-					'fixed top-0 right-0 left-0 z-50 items-center justify-between p-2',
+					'fixed top-0 right-0 left-0 z-nav items-center justify-between p-2',
 					className
 				)}
 				aria-label="Main navigation"

--- a/apps/vectreal-platform/app/components/publisher/optimization/optimize-button.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/optimize-button.tsx
@@ -106,7 +106,7 @@ export const OptimizeButton: FC<OptimizeButtonProps> = ({
 							<ChevronDownIcon className="h-4 w-4" />
 						</Button>
 					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" sideOffset={6} className="z-100">
+					<DropdownMenuContent align="end" sideOffset={6} className="z-overlay-raised">
 						<DropdownMenuItem onClick={onStackOptimize}>
 							<SparklesIcon className="h-4 w-4" />
 							Optimize Further

--- a/apps/vectreal-platform/app/components/publisher/shell/shell-layout.ts
+++ b/apps/vectreal-platform/app/components/publisher/shell/shell-layout.ts
@@ -3,11 +3,16 @@
  *
  * ## Stacking
  *
- * **Everything here must stay below `z-50`.** Radix portals its overlays
- * (dialog, alert-dialog, sheet, drawer) to the document body at `z-50`, and the
- * publisher's surfaces are ordinary in-page elements in the same root stacking
- * context. Anything at or above 50 paints over confirmation modals and their
- * backdrops, which is how the sidebars at `z-[70]` ended up covering them.
+ * **Everything here must stay below the overlay tier.** Radix portals its
+ * overlays (dialog, alert-dialog, sheet, drawer) to the document body at
+ * `--z-index-overlay`, which is 50, and the publisher's surfaces are ordinary
+ * in-page elements in the same root stacking context. Anything at or above 50
+ * paints over confirmation modals and their backdrops, which is how the
+ * sidebars, then sitting at 70, ended up covering them.
+ *
+ * These stay literal rather than joining the tier scale in `globals.css`: the
+ * scale names layers the whole app shares, and this is one surface ordering its
+ * own parts underneath all of them.
  *
  * Within the shell the order is bottom-up by how much a surface should
  * interrupt: the card sits under the tools it sits beside, sidebars cover the
@@ -26,7 +31,7 @@ export const PUBLISHER_LAYER = {
 	/** Sliding panels: publish sidebar, compose sidebar, optimization drawer. */
 	sidebar: 'z-40',
 	/** Header row. Above the sidebars so its location dropdown is never clipped. */
-	header: 'z-[45]'
+	header: 'z-45'
 } as const
 
 /**

--- a/apps/vectreal-platform/app/components/publisher/sidebars/preset-button-group.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/preset-button-group.tsx
@@ -66,7 +66,7 @@ export const PresetButtonGroup = memo(
 					<Button
 						variant="secondary"
 						size="sm"
-						className="z-100 w-full px-3 py-1"
+						className="w-full px-3 py-1"
 						onClick={toggleSlider}
 					>
 						<span className="text-muted-foreground flex items-center text-xs font-medium">

--- a/apps/vectreal-platform/app/components/scene-embed/preview-chrome/preview-chrome.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/preview-chrome/preview-chrome.tsx
@@ -57,7 +57,7 @@ const PreviewChrome = ({
 	const offset = prefersReducedMotion ? 0 : 8
 
 	return (
-		<div className="pointer-events-none absolute inset-0 z-50">
+		<div className="pointer-events-none absolute inset-0 z-page-chrome">
 			<AnimatePresence initial={false}>
 				{isVisible ? (
 					<motion.div

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-info-popover.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-info-popover.tsx
@@ -21,7 +21,7 @@ const SceneEmbedInfoPopover = ({
 	title,
 	description
 }: SceneEmbedInfoPopoverProps) => (
-	<InfoPopover className="z-100">
+	<InfoPopover>
 		<InfoPopoverTrigger />
 		<InfoPopoverContent>
 			<InfoPopoverCloseButton />

--- a/apps/vectreal-platform/app/routes/dashboard-page/billing-upgrade.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/billing-upgrade.tsx
@@ -283,7 +283,7 @@ function BillingUpgradeContent({
 					</div>
 				)}
 
-				<Card className="border-primary/20 bg-muted/75 sticky top-0 left-0 z-50 w-full py-0 shadow-lg backdrop-blur-md">
+				<Card className="border-primary/20 bg-muted/75 sticky top-0 left-0 z-page-chrome w-full py-0 shadow-lg backdrop-blur-md">
 					<CardContent className="space-y-3 p-4">
 						{checkoutError && (
 							<div className="bg-destructive/5 border-destructive/20 flex items-start gap-2 rounded-lg border p-3">

--- a/apps/vectreal-platform/app/routes/layouts/docs-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/docs-layout.tsx
@@ -126,7 +126,7 @@ export default function DocsLayout() {
 			</aside>
 
 			<main className="min-w-0 flex-1 lg:px-8">
-				<div className="ds-overlay fixed top-12 left-0 z-20 mb-4 flex w-dvw items-center justify-between gap-3 px-4 py-1 md:top-16">
+				<div className="ds-overlay fixed top-12 left-0 z-page-chrome mb-4 flex w-dvw items-center justify-between gap-3 px-4 py-1 md:top-16">
 					<Breadcrumb aria-label="Docs breadcrumb">
 						<BreadcrumbList>
 							<BreadcrumbItem>

--- a/apps/vectreal-platform/tests/eslint-house-rules.spec.ts
+++ b/apps/vectreal-platform/tests/eslint-house-rules.spec.ts
@@ -89,6 +89,123 @@ describe('className must be built with cn()', () => {
 	})
 })
 
+describe('z-index must come from the named scale', () => {
+	it('rejects a bare value at the chrome tier', async () => {
+		const messages = await messagesFor(
+			'export const A = () => <div className="fixed top-0 z-50" />\n'
+		)
+
+		expect(messages).toHaveLength(1)
+		expect(messages[0].message).toContain('z-page-chrome')
+	})
+
+	it('rejects an arbitrary value at any height', async () => {
+		const messages = await messagesFor(
+			'export const A = () => <div className="z-[45]" />\n'
+		)
+
+		expect(messages).toHaveLength(1)
+	})
+
+	it('rejects the escape hatches Tailwind spells differently', async () => {
+		/*
+		  Three spellings of the same hole. `z-(--x)` is the one most likely to be
+		  reached for here, because the tiers are real custom properties and this
+		  codebase already writes `origin-(--radix-...)` everywhere; a leading `!`
+		  is the worst, since it makes the resulting conflict harder to unpick.
+		*/
+		const messages = await messagesFor(
+			'export const A = () => (\n' +
+				'\t<div className="fixed !z-50">\n' +
+				'\t\t<span className="z-(--anything)" />\n' +
+				'\t\t<span className="md:!z-60" />\n' +
+				'\t</div>\n)\n'
+		)
+
+		expect(messages).toHaveLength(3)
+	})
+
+	it('rejects a value carried by a variant', async () => {
+		/*
+		  One message per string, not per class: the selector matches the `Literal`
+		  node, so a second offender in the same attribute is already covered by
+		  the first report. Separate elements to see both.
+		*/
+		const messages = await messagesFor(
+			'export const A = () => (\n' +
+				'\t<div className="md:z-60">\n' +
+				'\t\t<span className="group-data-[state=open]:z-70" />\n' +
+				'\t</div>\n)\n'
+		)
+
+		expect(messages).toHaveLength(2)
+	})
+
+	it('rejects one parked in a lookup table', async () => {
+		/*
+		  The shape `PUBLISHER_LAYER` has. Nothing about it looks like a class
+		  until it reaches a `className`, by which point the number is three files
+		  away from the element it stacks against.
+		*/
+		const messages = await messagesFor(
+			"export const LAYER = { header: 'z-90' } as const\n"
+		)
+
+		expect(messages).toHaveLength(1)
+	})
+
+	it('rejects one written as a template literal', async () => {
+		/*
+		  The `cn()` rules above only reach a template literal used as a className
+		  or passed to `cn()`. A backtick string in a `const` evades both, and the
+		  `Literal` selector does not match template nodes at all.
+		*/
+		const messages = await messagesFor('export const LAYER = `z-90`\n')
+
+		expect(messages).toHaveLength(1)
+	})
+
+	it('accepts a tier name and local ordering below the chrome', async () => {
+		const messages = await messagesFor(
+			'export const A = () => (\n' +
+				'\t<div className="fixed z-nav">\n' +
+				'\t\t<span className="relative z-10" />\n' +
+				'\t\t<span className="absolute z-45" />\n' +
+				'\t\t<span className="!z-tooltip" />\n' +
+				'\t</div>\n)\n'
+		)
+
+		expect(messages).toEqual([])
+	})
+
+	it('leaves other utilities whose names end in z- alone', async () => {
+		/*
+		  `translate-z-*` and `rotate-z-*` are unrelated axes. The selector anchors
+		  on whitespace, a variant colon, or the start of the string precisely so
+		  the hyphen in front of these keeps them out.
+		*/
+		const messages = await messagesFor(
+			'export const A = () => <div className="translate-z-50 md:rotate-z-70" />\n'
+		)
+
+		expect(messages).toEqual([])
+	})
+
+	it('does not reach a negative value or a concatenated one', async () => {
+		/*
+		  Both gaps are deliberate and pinned here so they stay decisions. A
+		  negative z-index paints behind its stacking context and cannot compete
+		  with the chrome the rule protects; a concatenated one would need constant
+		  folding to see, which the sibling cn() rules do not do either.
+		*/
+		const messages = await messagesFor(
+			'export const A = "-z-50"\n' + "export const B = 'z-' + '90'\n"
+		)
+
+		expect(messages).toEqual([])
+	})
+})
+
 describe('SVG must live in an icon component', () => {
 	const INLINE_SVG =
 		'export const A = () => (\n' +

--- a/apps/vectreal-platform/tests/z-index-tiers.spec.ts
+++ b/apps/vectreal-platform/tests/z-index-tiers.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * The stacking tiers, pinned between the stylesheet that defines them and the
+ * `cn()` config that has to know their names.
+ *
+ * Two files have to agree and nothing else makes them: `globals.css` declares
+ * `--z-index-*` and generates the utilities, while `styling.utils.ts` lists the
+ * same names so tailwind-merge can resolve a conflict between two of them.
+ * A tier added to one and not the other fails silently - the utility works, and
+ * only an override stops taking effect, in whichever component happened to
+ * accept a `className`.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { cn, Z_INDEX_TIERS } from '@shared/utils'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const GLOBALS = join(REPO_ROOT, 'shared/components/src/styles/globals.css')
+
+function tiersDeclaredInStylesheet() {
+	const css = readFileSync(GLOBALS, 'utf8')
+	return [...css.matchAll(/^\t--z-index-([a-z-]+):\s*(\d+);$/gm)].map(
+		([, name, value]) => ({ name, value: Number(value) })
+	)
+}
+
+describe('z-index tiers', () => {
+	const declared = tiersDeclaredInStylesheet()
+
+	it('finds the tier block in globals.css', () => {
+		expect(declared.length).toBeGreaterThan(0)
+	})
+
+	it('lists exactly the tiers the stylesheet declares', () => {
+		expect([...Z_INDEX_TIERS].sort()).toEqual(
+			declared.map((tier) => tier.name).sort()
+		)
+	})
+
+	it('lets a caller override a component default', () => {
+		/*
+		  The regression this pins. Without the tiers registered, both classes
+		  survive and the stylesheet's alphabetical order decides, so `z-overlay`
+		  beats the `z-above-nav` a caller asked for.
+		*/
+		expect(cn('z-overlay', 'z-above-nav')).toBe('z-above-nav')
+		expect(cn('z-overlay', 'z-overlay-raised')).toBe('z-overlay-raised')
+		expect(cn('z-page-chrome', 'z-nav')).toBe('z-nav')
+	})
+
+	it('resolves a tier against a bare number in both directions', () => {
+		expect(cn('z-nav', 'z-10')).toBe('z-10')
+		expect(cn('z-10', 'z-nav')).toBe('z-nav')
+	})
+
+	it('leaves other class groups alone', () => {
+		expect(cn('translate-z-50', 'rotate-z-90')).toBe(
+			'translate-z-50 rotate-z-90'
+		)
+		expect(cn('p-2', 'p-4')).toBe('p-4')
+	})
+})

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -228,6 +228,64 @@ export default defineConfig(tseslint.configs.recommended, [
 				},
 				{
 					/*
+					  A z-index outside the named scale.
+
+					  The tiers live in `globals.css` as `--z-index-*` and compile to
+					  `z-page-chrome`, `z-nav`, `z-overlay`, `z-above-nav`, `z-tooltip`,
+					  `z-overlay-raised` and `z-select`, each with a comment saying what
+					  belongs there.
+
+					  The line sits at 50 because 50 is where the app's chrome starts:
+					  the site nav and Radix's portal layer both live there, in the root
+					  stacking context, so any new number at or above it is competing
+					  with them and needs a name. That is not hypothetical. The nav and
+					  the route loading bar were both fixed to the top of the viewport
+					  at 50, nothing recorded that they overlapped, and DOM order quietly
+					  decided the loading bar painted underneath the header.
+
+					  Below 50 is left alone on purpose. Ordering siblings inside one
+					  component's own stacking context is local, and a plain z-10 says
+					  that more honestly than a tier name would.
+
+					  Every escape hatch is rejected whatever its value, because an
+					  escape hatch is exactly how 45, 70, 100 and 120 each arrived
+					  without anyone choosing them together. Tailwind v4 spells one
+					  three ways and the rule has to know all three: the bracket, the
+					  `z-(--custom-property)` shorthand this codebase already uses
+					  freely for Radix's popper variables, and a leading `!`, which is
+					  the worst of them because it makes a stacking conflict harder to
+					  unpick rather than easier.
+
+					  Two forms are deliberately not matched, rather than overlooked.
+					  A negative z-index paints behind its stacking context and so
+					  cannot compete with the chrome this rule protects. And a value
+					  assembled by concatenation, `'z-' + n`, would need constant
+					  folding to see; the sibling `cn()` rules have the same limit, and
+					  `eslint-house-rules.spec.ts` pins both so the gap stays a decision
+					  rather than a surprise.
+					*/
+					selector:
+						'Literal[value=/(^|[\\s:\'"])!?z-(\\[|\\(|[5-9][0-9]|[1-9][0-9]{2,})/]',
+					message:
+						'z-index outside the named scale. Use a tier from globals.css (z-page-chrome, z-nav, z-overlay, z-above-nav, z-tooltip, z-overlay-raised, z-select), or stay below 50 if this is ordering siblings inside one component. Anything at or above 50 shares the root stacking context with the site nav and Radix overlays, so it needs a name rather than a number.'
+				},
+				{
+					/*
+					  The same value written in a backtick string.
+
+					  The two `cn()` rules above only reach a template literal used
+					  directly as a className or passed to `cn()`, so a class string
+					  parked in a `const` or in a lookup table - which is exactly the
+					  shape `PUBLISHER_LAYER` has - would slip past both of them and
+					  past the `Literal` selector, which does not match template nodes.
+					*/
+					selector:
+						'TemplateElement[value.raw=/(^|[\\s:\'"])!?z-(\\[|\\(|[5-9][0-9]|[1-9][0-9]{2,})/]',
+					message:
+						'z-index outside the named scale, written as a template literal. Use a tier from globals.css (z-page-chrome, z-nav, z-overlay, z-above-nav, z-tooltip, z-overlay-raised, z-select), or stay below 50 if this is ordering siblings inside one component.'
+				},
+				{
+					/*
 					  An SVG pasted into a feature component.
 
 					  Icons belong in `shared/components/src/assets/icons` as named

--- a/shared/components/src/styles/globals.css
+++ b/shared/components/src/styles/globals.css
@@ -1,5 +1,39 @@
 /* Design system - token-based light/dark themes */
 @source '../../../../';
+/*
+  Three kinds of file that never render markup, all of which were being compiled
+  into the bundle anyway.
+
+  A spec asserts on class strings deliberately built to be wrong:
+  `eslint-house-rules.spec.ts` names the exact z-index values the house rules
+  reject, so every one of them shipped. A config file documents them: the `ds-*`
+  rule in `eslint.config.mts` names a replacement utility in its message, and
+  the scanner compiled that prose into a perfectly valid `hover:` color-mix
+  rule for a variant nothing in the app uses. Markdown explains them: a `cn()`
+  example in `shared/utils/README.md` shipped a bare `ring-2`, and the motion
+  table in the brand skill pulled three `--duration-*` tokens into `:root` that
+  nothing references.
+
+  `.mdx` is deliberately still scanned. Those are the docs pages, and they do
+  render.
+
+  The scanner cannot tell a fixture or an example from a component, and asking
+  every future comment and README to avoid naming a utility is a rule nobody can
+  follow for long, so the file kinds that never render are excluded instead.
+
+  That does not close the hole, only the part of it that can be closed. Comments
+  inside `.ts` and `.tsx` are still scanned, because those files also hold the
+  real markup, and about fifteen rules in the bundle come from JSDoc examples,
+  commented-out JSX, and one sentence containing the word "ordinal". Naming a
+  utility in a comment is still a cost; it is just a cost no glob can refund.
+
+  One trap for whoever extends this: `.claude/skills/` symlinks to
+  `.agents/skills/`, so a skill file is walked under both paths and an exclusion
+  naming only one of them removes nothing.
+*/
+@source not '../../../../**/*.spec.{ts,tsx}';
+@source not '../../../../**/*.config.{ts,cts,mts,js,cjs,mjs}';
+@source not '../../../../**/*.md';
 
 @import 'tailwindcss';
 @import 'tw-animate-css';
@@ -338,6 +372,77 @@
 	--color-error-bg: var(--error-bg);
 	--color-error-border: var(--error-border);
 	--color-error-foreground: var(--error-foreground);
+}
+
+/*
+  Stacking tiers.
+
+  A plain `@theme` rather than the `inline` one above, so every tier lands in
+  `:root` as a real custom property as well as generating its utility. Raw CSS
+  and inline styles can then read `var(--z-index-nav)` without restating the
+  number.
+
+  The values are exactly what the app already computed to. The names are the new
+  part. Ten different z-indexes were in use with nothing recording what any of
+  them meant, so two unrelated fixed elements both picked 50 and DOM order
+  decided which one painted: the nav and the route loading bar were both pinned
+  to the top of the viewport, and the loading bar lost, on every navigation.
+
+  Only app-global stacking belongs here. Ordering two siblings inside a single
+  component's own stacking context is local, and stays a plain `z-0` / `z-10`;
+  giving it a tier name would claim a relationship with the site chrome that it
+  does not have. ESLint draws that line at 50, because 50 is where the chrome
+  starts.
+*/
+@theme {
+	/*
+	  Chrome belonging to one route rather than to the site: the docs breadcrumb
+	  bar, the internal preview overlay, the sticky summary card in the billing
+	  upgrade flow. Below the nav on purpose, which stays reachable over it.
+	*/
+	--z-index-page-chrome: 20;
+
+	/*
+	  Site chrome fixed to the viewport for the whole session: the desktop and
+	  mobile nav, and the consent banner anchored opposite it.
+	*/
+	--z-index-nav: 50;
+
+	/*
+	  Radix's portal layer: dialog, alert dialog, sheet, drawer, and the menu,
+	  popover and hover-card surfaces that default to it.
+
+	  Ties with the nav, and does so knowingly. Both are 50 and both land in the
+	  root stacking context, but Radix portals this one to the end of `<body>`,
+	  so the tie resolves in its favor. That is also why the publisher shell
+	  keeps every surface of its own below 50: at or above it they paint over
+	  confirmation modals and their backdrops, which is how sidebars once covered
+	  the dialog asking whether to discard a scene.
+	*/
+	--z-index-overlay: 50;
+
+	/*
+	  Must cover the nav: the route loading bar, and an embed viewer that has
+	  gone fullscreen.
+	*/
+	--z-index-above-nav: 60;
+
+	/* Tooltips, above the overlay layer so they still show inside a dialog. */
+	--z-index-tooltip: 80;
+
+	/*
+	  One overlay that has to clear another. Only the publisher's optimize menu
+	  reaches for it, because it opens from inside the optimization drawer.
+	  Anything portaled to the body already clears the page it opened from, so
+	  use `--z-index-overlay` first and step up only if you can see it clipped.
+	*/
+	--z-index-overlay-raised: 100;
+
+	/*
+	  The select listbox, top of the ladder. A select is the one overlay that
+	  routinely opens from inside another one.
+	*/
+	--z-index-select: 120;
 }
 
 @layer base {

--- a/shared/components/src/ui/alert-dialog.tsx
+++ b/shared/components/src/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ function AlertDialogOverlay({
 		<AlertDialogPrimitive.Overlay
 			data-slot="alert-dialog-overlay"
 			className={cn(
-				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-overlay bg-black/50',
 				className
 			)}
 			{...props}
@@ -67,7 +67,7 @@ function AlertDialogContent({
 			<AlertDialogPrimitive.Content
 				data-slot="alert-dialog-content"
 				className={cn(
-					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-lg duration-200 sm:max-w-lg',
+					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-overlay grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-lg duration-200 sm:max-w-lg',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/context-menu.tsx
+++ b/shared/components/src/ui/context-menu.tsx
@@ -84,7 +84,7 @@ function ContextMenuSubContent({
 		<ContextMenuPrimitive.SubContent
 			data-slot="context-menu-sub-content"
 			className={cn(
-				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
+				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
 				className
 			)}
 			{...props}
@@ -101,7 +101,7 @@ function ContextMenuContent({
 			<ContextMenuPrimitive.Content
 				data-slot="context-menu-content"
 				className={cn(
-					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md p-1 shadow-md',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md p-1 shadow-md',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/dialog.tsx
+++ b/shared/components/src/ui/dialog.tsx
@@ -37,7 +37,7 @@ function DialogOverlay({
 		<DialogPrimitive.Overlay
 			data-slot="dialog-overlay"
 			className={cn(
-				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-overlay bg-black/50',
 				className
 			)}
 			{...props}
@@ -73,7 +73,7 @@ function DialogContent({
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
-					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-lg duration-200 sm:max-w-lg',
+					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-overlay grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-lg duration-200 sm:max-w-lg',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/drawer.tsx
+++ b/shared/components/src/ui/drawer.tsx
@@ -37,7 +37,7 @@ function DrawerOverlay({
 		<DrawerPrimitive.Overlay
 			data-slot="drawer-overlay"
 			className={cn(
-				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-overlay bg-black/50',
 				className
 			)}
 			{...props}
@@ -60,7 +60,7 @@ function DrawerContent({
 			<DrawerPrimitive.Content
 				data-slot="drawer-content"
 				className={cn(
-					'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+					'group/drawer-content bg-background fixed z-overlay flex h-auto flex-col',
 					'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
 					'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
 					'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',

--- a/shared/components/src/ui/dropdown-menu.tsx
+++ b/shared/components/src/ui/dropdown-menu.tsx
@@ -41,7 +41,7 @@ function DropdownMenuContent({
 				data-slot="dropdown-menu-content"
 				sideOffset={sideOffset}
 				className={cn(
-					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl! p-1 shadow-md',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl! p-1 shadow-md',
 					className
 				)}
 				{...props}
@@ -229,7 +229,7 @@ function DropdownMenuSubContent({
 		<DropdownMenuPrimitive.SubContent
 			data-slot="dropdown-menu-sub-content"
 			className={cn(
-				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
+				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/hover-card.tsx
+++ b/shared/components/src/ui/hover-card.tsx
@@ -42,7 +42,7 @@ function HoverCardContent({
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(
-					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-xl! p-4 shadow-md outline-hidden',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay w-64 origin-(--radix-hover-card-content-transform-origin) rounded-xl! p-4 shadow-md outline-hidden',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/menubar.tsx
+++ b/shared/components/src/ui/menubar.tsx
@@ -76,7 +76,7 @@ function MenubarContent({
 				alignOffset={alignOffset}
 				sideOffset={sideOffset}
 				className={cn(
-					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md p-1 shadow-md',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md p-1 shadow-md',
 					className
 				)}
 				{...props}
@@ -245,7 +245,7 @@ function MenubarSubContent({
 		<MenubarPrimitive.SubContent
 			data-slot="menubar-sub-content"
 			className={cn(
-				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
+				'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md p-1 shadow-lg',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/navigation-menu.tsx
+++ b/shared/components/src/ui/navigation-menu.tsx
@@ -105,7 +105,7 @@ function NavigationMenuViewport({
 	return (
 		<div
 			className={cn(
-				'absolute top-full left-0 isolate z-50 flex justify-center'
+				'absolute top-full left-0 isolate z-overlay flex justify-center'
 			)}
 		>
 			<NavigationMenuPrimitive.Viewport
@@ -144,7 +144,7 @@ function NavigationMenuIndicator({
 		<NavigationMenuPrimitive.Indicator
 			data-slot="navigation-menu-indicator"
 			className={cn(
-				'data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden',
+				'data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-1 flex h-1.5 items-end justify-center overflow-hidden',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/popover.tsx
+++ b/shared/components/src/ui/popover.tsx
@@ -29,7 +29,7 @@ function PopoverContent({
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(
-					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-xl! p-4 shadow-md outline-hidden',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay w-72 origin-(--radix-popover-content-transform-origin) rounded-xl! p-4 shadow-md outline-hidden',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/select.tsx
+++ b/shared/components/src/ui/select.tsx
@@ -63,7 +63,7 @@ function SelectContent({
 					// control radius; dropping the panel to match it left the content
 					// and its own `rounded-lg` items on the same arc, with no step
 					// between the container and the things inside it.
-					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-[120] max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border shadow-md',
+					'ds-overlay text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-select max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border shadow-md',
 					position === 'popper' &&
 						'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
 					className

--- a/shared/components/src/ui/sheet.tsx
+++ b/shared/components/src/ui/sheet.tsx
@@ -35,7 +35,7 @@ function SheetOverlay({
 		<SheetPrimitive.Overlay
 			data-slot="sheet-overlay"
 			className={cn(
-				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-overlay bg-black/50',
 				className
 			)}
 			{...props}
@@ -57,7 +57,7 @@ function SheetContent({
 			<SheetPrimitive.Content
 				data-slot="sheet-content"
 				className={cn(
-					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-overlay flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
 					side === 'right' &&
 						'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
 					side === 'left' &&

--- a/shared/components/src/ui/tooltip.tsx
+++ b/shared/components/src/ui/tooltip.tsx
@@ -43,13 +43,20 @@ function TooltipContent({
 				data-slot="tooltip-content"
 				sideOffset={sideOffset}
 				className={cn(
-					'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-80 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-xl px-3 py-1.5 text-xs text-balance',
+					'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-tooltip w-fit origin-(--radix-tooltip-content-transform-origin) rounded-xl px-3 py-1.5 text-xs text-balance',
 					className
 				)}
 				{...props}
 			>
 				{children}
-				<TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+				{/*
+				  Local ordering against the text beside it, not a tier. Radix copies
+				  the computed z-index off this content node onto the wrapper it
+				  portals, so `z-tooltip` above is what stacks the tooltip, and that
+				  wrapper is the stacking context the arrow is sealed inside. Any
+				  positive value here does the same job.
+				*/}
+				<TooltipPrimitive.Arrow className="bg-primary fill-primary z-10 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
 			</TooltipPrimitive.Content>
 		</TooltipPrimitive.Portal>
 	)

--- a/shared/utils/src/lib/styling.utils.ts
+++ b/shared/utils/src/lib/styling.utils.ts
@@ -1,6 +1,36 @@
 import { type ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { extendTailwindMerge } from 'tailwind-merge'
+
+/**
+ * The stacking tiers declared as `--z-index-*` in `globals.css`.
+ *
+ * tailwind-merge validates the z-index group as `z-<number>`, so a tier name is
+ * invisible to it: `cn('z-overlay', 'z-above-nav')` kept both classes and left
+ * the winner to whichever rule sorted last in the stylesheet. That order is
+ * alphabetical, so a caller passing `z-above-nav` to a component defaulting to
+ * `z-overlay` was silently overridden by the default - the exact failure `cn()`
+ * exists to prevent, on the one scale where losing is invisible until something
+ * paints in the wrong layer.
+ *
+ * `z-index-tiers.spec.ts` pins this list against the stylesheet, because the
+ * names living in two files is the obvious way for it to rot.
+ */
+const Z_INDEX_TIERS = [
+	'page-chrome',
+	'nav',
+	'overlay',
+	'above-nav',
+	'tooltip',
+	'overlay-raised',
+	'select'
+]
+
+const twMerge = extendTailwindMerge({
+	extend: { classGroups: { z: [{ z: Z_INDEX_TIERS }] } }
+})
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs))
 }
+
+export { Z_INDEX_TIERS }


### PR DESCRIPTION
## Summary

Names the app's stacking layers as `--z-index-*` tiers in `globals.css` and migrates every call site onto them, so a fixed element declares which layer it belongs to instead of picking a number.

## Root cause

App-global stacking had no rule anywhere: every call site restated a bare number, so nothing recorded what a layer meant or who was already on it, which is how the nav and the route loading bar both ended up fixed to the top of the viewport at 50 with DOM order silently deciding the winner (#742); the rule belongs in the token set in `globals.css` beside the other design tokens, because that is the one place a layer can be defined once and read by every call site.

## Changes

**Seven named tiers**, in a plain `@theme` block rather than the `inline` one, so each lands in `:root` as a real custom property *and* generates its utility. Every tier carries a comment saying what belongs there.

| Tier | Value | What sits there |
| --- | --- | --- |
| `z-page-chrome` | 20 | docs breadcrumb bar, internal preview overlay, billing sticky card |
| `z-nav` | 50 | desktop and mobile nav, consent banner |
| `z-overlay` | 50 | Radix's portal layer: dialog, sheet, drawer, menus, popovers |
| `z-above-nav` | 60 | route loading bar, an embed viewer gone fullscreen |
| `z-tooltip` | 80 | tooltips |
| `z-overlay-raised` | 100 | one overlay clearing another |
| `z-select` | 120 | the select listbox |

- **Values are what the app already computed**, so the tiering is behavior-preserving. Four sites moved deliberately: the desktop fullscreen embed viewer (50 to 60, which DOM order was already producing), the billing sticky card and the preview chrome (both 50 to 20, page-level chrome that had picked the site-chrome number), and the tooltip arrow (50 to 10, local ordering inside the wrapper Radix portals).
- **The nav and the overlay layer tie at 50 on purpose** and the comment says so: Radix portals its overlays to the end of `<body>`, so the tie resolves in their favor. Reordering the ladder is a separate concern and is not in this diff.
- **Two classes deleted as no-ops.** `scene-embed-info-popover` duplicated the `z-[100]` that `@vctrl/viewer` already sets on the same element; `preset-button-group` put a z-index on a static block child, where it never applied.
- **`packages/viewer` and `packages/embed` are untouched.** They ship standalone and must not depend on app tokens.

**ESLint rejects a z-index outside the scale.** 50 is where the nav and Radix's portal layer already sit in the root stacking context, so a number at or above it is competing with them; below 50 stays free for component-local ordering. All three of Tailwind v4's escape hatches are covered: the bracket, the `z-(--custom-property)` shorthand, and a leading `!`. Negatives and concatenated values are deliberately not matched, and a test pins both so they stay decisions rather than surprises.

**`cn()` taught the tier names.** tailwind-merge validates the z-index group as `z-<number>`, so a tier is invisible to it: `cn('z-overlay', 'z-above-nav')` kept both classes and left the winner to stylesheet order, which is alphabetical, so a caller passing `z-above-nav` to a component defaulting to `z-overlay` was silently overridden by the default. That is the exact failure `cn()` exists to prevent, on the one scale where losing is invisible until something paints in the wrong layer. `extendTailwindMerge` registers the tiers, and `z-index-tiers.spec.ts` pins the list against the stylesheet in both directions, since the names living in two files is the obvious way for this to rot.

**Three file kinds excluded from Tailwind's scan.** `globals.css` scans the repo root, and the scanner cannot tell a fixture or a documented example from markup. A spec that asserts the house rules reject `z-50` was compiling `z-50` into the bundle; the `ds-*` rule's own ESLint message was compiling to a valid `hover:` color-mix rule for a variant nothing in the app uses; a `cn()` example in `shared/utils/README.md` was shipping a bare `ring-2`. Specs, config files and markdown never render, so they are excluded. `.mdx` still is, because docs pages do render. This removed 15 dead rules, four of which predate this branch.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser

`eslint-house-rules.spec.ts` gains a `z-index must come from the named scale` block: nine cases, both directions, alongside where the repo's other house rules are already proven. Mutation-gated: neutering the rule reddens every reject-case, and each alternation was removed individually to confirm the count drops for the right reason.

Verified in the running app: all seven tiers resolve as both custom properties and utilities; the real loading bar was caught mid-navigation at 60 against the nav's 50; and two probes carrying the real classes, appended in the DOM order that previously made the bar lose, now stack by tier instead. Built CSS checked after every step rather than trusting the class names to have been replaced.

Gates: `typecheck` and `lint` green across all eight projects; 869 tests pass in the platform suite, 1007 across the workspace.

## Filed rather than fixed

- `vectreal-iterative-delivery` and `vectreal-extension-architecture` still say their claims block is executed by `agent-skill-claims.spec.ts`, which #740 renamed to `documented-claims.spec.ts`. Corrected in the one skill this PR already rewrites, and pinned there by an `exists` claim so it cannot rot again; the other two belong to #740's concern in files this PR does not touch.
- `publisher-editor-scene.tsx` passes `zIndexRange={[100, 0]}` to drei's `<Html>`. That is a WebGL depth-sorting range rather than a CSS layer, and no class-string rule can see it.
- Comments inside `.ts` and `.tsx` still feed the bundle and cannot be excluded, since those files also hold the real markup. About fifteen rules come from JSDoc examples, commented-out JSX, and one sentence containing the word "ordinal". The skill now says so; fixing the fifteen is its own sweep.
- `packages/viewer/src/styles.css` is a second Tailwind entry with no exclusions of its own, and `packages/**` is outside the ESLint block's globs, so `info-popover.tsx` keeps a hardcoded `z-[100]` that renders inside the app.

## Residual risk

The two `z-page-chrome` moves (50 to 20) are the only changes that lower an element's layer. Both were checked against everything sharing their stacking context and nothing sits between 20 and 50 on those routes, but they are the sites to look at first if something turns up underneath a panel.

The mock-shop section this diff also touches is currently unreachable: its only call site in `home-page.tsx` is commented out.
