### PR TITLE
feat(api-keys): let a key be rotated in place

### DIFF
--- a/apps/vectreal-platform/app/components/api-keys/one-time-key-dialog.tsx
+++ b/apps/vectreal-platform/app/components/api-keys/one-time-key-dialog.tsx
@@ -1,0 +1,190 @@
+import { Alert, AlertDescription } from '@shared/components/ui/alert'
+import { Button } from '@shared/components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@shared/components/ui/dialog'
+import { AlertCircle, CheckCircle2, Copy } from 'lucide-react'
+import { useEffect, useId, useState } from 'react'
+import { toast } from 'sonner'
+
+/**
+ * The one moment a key's plaintext exists outside the database.
+ *
+ * Keys are stored hashed, so this dialog is the only place the full value is
+ * ever shown. It is shared by creation and rotation rather than duplicated,
+ * because the two differ only in what the user has to do next - and after a
+ * rotation that difference is the whole point: every embed still carrying the
+ * previous secret is broken until it is updated.
+ */
+
+export type OneTimeKeyReason = 'created' | 'rotated'
+
+export interface OneTimeKeyValue {
+	plaintext: string
+	preview: string
+	name: string
+}
+
+const REASON_COPY: Record<
+	OneTimeKeyReason,
+	{ title: string; description: string; nextSteps: string[] }
+> = {
+	created: {
+		title: 'API key created',
+		description: 'Save this key now. It will not be shown again.',
+		nextSteps: [
+			'Copy the key above to a secure location',
+			'Paste it into the Embed panel of a scene, or into your own request headers',
+			'Add the site that will host the embed to the allowed domains for this project'
+		]
+	},
+	rotated: {
+		title: 'API key rotated',
+		description:
+			'The previous key stopped working the moment this one was issued.',
+		nextSteps: [
+			'Copy the key above to a secure location',
+			'Replace the old key everywhere it is already deployed - every embed still carrying it is refused right now',
+			'The Last Used column stays empty until something authenticates with the new key, which is how you confirm the update landed'
+		]
+	}
+}
+
+export function OneTimeKeyDialog({
+	open,
+	onClose,
+	apiKey,
+	reason
+}: {
+	open: boolean
+	onClose: () => void
+	apiKey: OneTimeKeyValue | null
+	reason: OneTimeKeyReason
+}) {
+	const [copied, setCopied] = useState(false)
+	const labelId = useId()
+	const copy = REASON_COPY[reason]
+
+	/*
+	  `copied` is per-key, and this component is never remounted between keys:
+	  the parent renders it continuously and only swaps `apiKey`, so state
+	  survives every open and close.
+
+	  Left alone, the copy button's 2-second "copied" window carries into the
+	  next key. That key's dialog then opens already showing a checkmark, and
+	  `handleClose` skips the "have you copied it?" confirmation because `copied`
+	  is true - dismissing a plaintext that was never copied and cannot be shown
+	  again. Rotating twice in quick succession is two clicks and a round trip.
+	*/
+	useEffect(() => {
+		setCopied(false)
+	}, [apiKey?.plaintext])
+
+	const handleCopy = async () => {
+		if (!apiKey) return
+
+		try {
+			await navigator.clipboard.writeText(apiKey.plaintext)
+			setCopied(true)
+			toast.success('API key copied to clipboard')
+			setTimeout(() => setCopied(false), 2000)
+		} catch (_error) {
+			toast.error('Failed to copy to clipboard')
+		}
+	}
+
+	const handleClose = () => {
+		if (!copied) {
+			const confirmed = window.confirm(
+				'Have you copied your API key? This is the only time it will be displayed.'
+			)
+			if (!confirmed) return
+		}
+		onClose()
+	}
+
+	if (!apiKey) return null
+
+	return (
+		<Dialog open={open} onOpenChange={(next) => !next && handleClose()}>
+			<DialogContent
+				className="max-w-2xl"
+				onEscapeKeyDown={(event) => event.preventDefault()}
+			>
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<CheckCircle2 className="text-success size-5" />
+						{copy.title}
+					</DialogTitle>
+					<DialogDescription>{copy.description}</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					<Alert
+						variant="default"
+						className="border-warning-border bg-warning-bg"
+					>
+						<AlertCircle className="text-warning size-4" />
+						<AlertDescription className="text-warning-muted-foreground">
+							<strong>Important:</strong> Copy this key now. Once you close this
+							dialog the full key is no longer accessible, and only the preview
+							(...{apiKey.preview}) remains.
+						</AlertDescription>
+					</Alert>
+
+					<div className="space-y-2">
+						<p className="text-h4" id={labelId}>
+							{apiKey.name}
+						</p>
+						<div className="flex gap-2">
+							<div
+								aria-labelledby={labelId}
+								className="text-muted-foreground bg-muted flex-1 rounded-md border p-3 font-mono text-sm break-all"
+							>
+								{apiKey.plaintext}
+							</div>
+							<Button
+								type="button"
+								variant={copied ? 'default' : 'outline'}
+								size="icon"
+								aria-label="Copy API key"
+								className="shrink-0"
+								onClick={handleCopy}
+							>
+								{copied ? (
+									<CheckCircle2 className="size-4" />
+								) : (
+									<Copy className="size-4" />
+								)}
+							</Button>
+						</div>
+						<p className="text-muted-foreground text-xs">
+							Key preview:{' '}
+							<code className="font-mono">...{apiKey.preview}</code>
+						</p>
+					</div>
+
+					<div className="bg-muted space-y-2 rounded-md p-4">
+						<h4 className="text-h4">Next steps</h4>
+						<ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
+							{copy.nextSteps.map((step) => (
+								<li key={step}>{step}</li>
+							))}
+						</ul>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button onClick={handleClose} className="w-full">
+						I have saved my key
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
@@ -27,6 +27,7 @@ import {
 	FolderOpen,
 	KeyRound,
 	Pencil,
+	RefreshCw,
 	Trash2,
 	XCircle,
 	Eye,
@@ -558,12 +559,14 @@ interface ApiKeyActionsCellProps {
 	row: ApiKeyRow
 	onEdit: (keyId: string) => void
 	onRevoke: (keyId: string) => void
+	onRotate: (keyId: string) => void
 }
 
 const ApiKeyActionsCell = memo(function ApiKeyActionsCell({
 	row,
 	onEdit,
-	onRevoke
+	onRevoke,
+	onRotate
 }: ApiKeyActionsCellProps) {
 	const isClientMounted = useIsClientMounted()
 	const trigger = (
@@ -587,6 +590,20 @@ const ApiKeyActionsCell = memo(function ApiKeyActionsCell({
 							Edit
 						</DropdownMenuItem>
 						{/*
+						  Rotate is offered only on a live key. `rotateApiKey` refuses any
+						  other state anyway, so enabling it here would just surface a
+						  server error where a disabled item explains itself.
+						*/}
+						<DropdownMenuItem
+							disabled={
+								resolveApiKeyState(toLifecycleRow(row), new Date()) !== 'active'
+							}
+							onClick={() => onRotate(row.id)}
+						>
+							<RefreshCw className="mr-2 h-4 w-4" />
+							Rotate
+						</DropdownMenuItem>
+						{/*
 						  Only an already-revoked key hides the action. An expired key
 						  keeps it on purpose: revoking one is how an owner records that
 						  it is dead deliberately rather than by lapsing, and it is the
@@ -594,7 +611,8 @@ const ApiKeyActionsCell = memo(function ApiKeyActionsCell({
 						*/}
 						<DropdownMenuItem
 							disabled={
-								resolveApiKeyState(toLifecycleRow(row), new Date()) === 'revoked'
+								resolveApiKeyState(toLifecycleRow(row), new Date()) ===
+								'revoked'
 							}
 							onClick={() => onRevoke(row.id)}
 							className={DESTRUCTIVE_MENU_ITEM}
@@ -726,11 +744,27 @@ export interface ApiKeyRow {
 	active: boolean | null
 	expiresAt: Date | null
 	revokedAt: Date | null
+	rotatedAt: Date | null
 }
 
 interface ApiKeyColumnsOptions {
 	onEdit: (keyId: string) => void
 	onRevoke: (keyId: string) => void
+	onRotate: (keyId: string) => void
+}
+
+/**
+ * Whether a rotated key has authenticated anything since it was rotated.
+ *
+ * This is the question that follows every rotation, and the answer is the only
+ * way to tell from the dashboard that an embed somewhere is still carrying the
+ * old key and being refused right now.
+ */
+function isUnusedSinceRotation(row: ApiKeyRow): boolean {
+	if (!row.rotatedAt) return false
+	if (!row.lastUsedAt) return true
+
+	return new Date(row.lastUsedAt) <= new Date(row.rotatedAt)
 }
 
 /**
@@ -877,9 +911,16 @@ export function createApiKeyColumns(
 			),
 			accessorFn: (row) => row.lastUsedAt ?? new Date(0),
 			cell: ({ row }) => (
-				<span className="text-muted-foreground text-sm">
-					{formatRelativeTime(row.original.lastUsedAt)}
-				</span>
+				<div className="flex flex-col">
+					<span className="text-muted-foreground text-sm">
+						{formatRelativeTime(row.original.lastUsedAt)}
+					</span>
+					{isUnusedSinceRotation(row.original) && (
+						<span className="text-warning text-xs">
+							Unused since rotating {formatRelativeTime(row.original.rotatedAt)}
+						</span>
+					)}
+				</div>
 			)
 		},
 		{
@@ -906,6 +947,7 @@ export function createApiKeyColumns(
 					row={row.original}
 					onEdit={options.onEdit}
 					onRevoke={options.onRevoke}
+					onRotate={options.onRotate}
 				/>
 			)
 		}

--- a/apps/vectreal-platform/app/db/schema/auth/api-keys.ts
+++ b/apps/vectreal-platform/app/db/schema/auth/api-keys.ts
@@ -31,6 +31,15 @@ export const apiKeys = pgTable(
 		lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
 		expiresAt: timestamp('expires_at', { withTimezone: true }),
 		revokedAt: timestamp('revoked_at', { withTimezone: true }),
+		/*
+		  When the secret behind this row last changed. Null means never rotated.
+
+		  Read next to `lastUsedAt`, it answers the question that follows every
+		  rotation: rotated three days ago but last used five days ago means the
+		  embed still carrying the old key was never updated, and that storefront
+		  is broken right now.
+		*/
+		rotatedAt: timestamp('rotated_at', { withTimezone: true }),
 		createdAt: timestamp('created_at', { withTimezone: true })
 			.defaultNow()
 			.notNull()

--- a/apps/vectreal-platform/app/hooks/use-once-per-fetcher-response.ts
+++ b/apps/vectreal-platform/app/hooks/use-once-per-fetcher-response.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Runs `handle` exactly once for each response a fetcher settles with.
+ *
+ * A settled fetcher's `data` outlives the render that produced it, and an effect
+ * watching it re-runs whenever anything else in its dependency list changes -
+ * `useRevalidator()`'s return value cycles identity on every revalidation, which
+ * is enough on its own. So something has to distinguish "this response again"
+ * from "a new response".
+ *
+ * It has to be identity, not content. Keying on `JSON.stringify(data)` reads as
+ * equivalent and is not: it silently drops any response whose body repeats. On
+ * the API keys route that swallowed a second revoke (same success payload), a
+ * second failure on a different key (`revokeApiKey` and `rotateApiKey` throw
+ * byte-identical "not found" messages), and every CSRF failure after the first
+ * (a fixed body carrying nothing that varies) - each one leaving the user with
+ * no toast and no sign the action had failed. Two of those were patched by
+ * making the payloads differ before the mechanism itself was recognized as the
+ * cause.
+ *
+ * A fresh response is always a fresh object and a re-render never is, so
+ * comparing the reference asks the question that was actually being asked.
+ */
+export function useOncePerFetcherResponse<TData>(
+	fetcher: { state: string; data: TData | undefined },
+	handle: (data: TData) => void
+): void {
+	const lastHandled = useRef<TData | undefined>(undefined)
+
+	/*
+	  The handler is held in a ref so callers can pass an inline closure without
+	  it re-triggering the effect. Only the response identity may do that.
+	*/
+	const handleRef = useRef(handle)
+	handleRef.current = handle
+
+	useEffect(() => {
+		if (fetcher.state !== 'idle' || fetcher.data === undefined) {
+			return
+		}
+
+		if (lastHandled.current === fetcher.data) {
+			return
+		}
+
+		lastHandled.current = fetcher.data
+		handleRef.current(fetcher.data)
+	}, [fetcher.state, fetcher.data])
+}

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
@@ -1,6 +1,7 @@
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 
 import { generateApiKey } from './api-key-generator.server'
+import { resolveApiKeyState } from './api-key-lifecycle'
 import { getDbClient } from '../../../db/client'
 import { apiKeyProjects } from '../../../db/schema/auth/api-key-projects'
 import { apiKeys } from '../../../db/schema/auth/api-keys'
@@ -416,6 +417,99 @@ export async function updateApiKey(
 	}
 
 	return updatedKey
+}
+
+/**
+ * Replace the secret behind an existing key, keeping the row.
+ *
+ * This is the only way to fix a key that has leaked without breaking every
+ * embed at once: the id, name, description, project links and expiry all
+ * survive, so the owner updates one snippet rather than re-minting and
+ * re-scoping a key everywhere it was pasted. Before this existed the only
+ * remedy was revoke-and-recreate, which is why a token published in the
+ * marketing bundle sat unrotated.
+ *
+ * Refused on any key that is not live. A revoked key must stay dead, and a
+ * rotated-but-expired key would hand back a fresh secret that still cannot
+ * authorize anything.
+ */
+export async function rotateApiKey(params: {
+	apiKeyId: string
+	userId: string
+}): Promise<ApiKeyWithDetails & { plaintext: string }> {
+	const { apiKeyId, userId } = params
+
+	const existingKey = await getApiKeyById(apiKeyId, userId)
+	if (!existingKey) {
+		throw new Error('API key not found or access denied')
+	}
+
+	await verifyOrganizationAdminAccess(
+		db,
+		existingKey.organization.id,
+		userId,
+		'api-key:rotate'
+	)
+
+	const state = resolveApiKeyState(existingKey.apiKey, new Date())
+	if (state !== 'active') {
+		throw new Error(
+			`This API key is ${state} and cannot be rotated. Create a new key instead.`
+		)
+	}
+
+	const { plaintext, hashed, preview } = generateApiKey()
+
+	/*
+	  A compare-and-swap on the secret that was read, not a blind write by id.
+
+	  Two things can land between the read above and this write, and both would
+	  otherwise be reported to the caller as a successful rotation:
+
+	    - a revoke, leaving a fresh secret on a row its owner just killed;
+	    - another rotation, after which only the last writer's plaintext is live
+	      while every earlier caller has already been handed one that authorizes
+	      nothing. Two admins reacting to the same leaked key, or one
+	      double-submitted form, is enough.
+
+	  Matching on the old `hashedKey` makes the loser update zero rows, so it
+	  raises instead of returning a dead secret.
+	*/
+	const rotated = await db
+		.update(apiKeys)
+		.set({
+			hashedKey: hashed,
+			keyPreview: preview,
+			rotatedAt: new Date(),
+			/*
+			  The old secret's usage history does not describe the new one. Left
+			  alone it would read as "already in use" the moment the key is minted,
+			  and that field is exactly what an owner checks to confirm the
+			  storefront picked the new key up.
+			*/
+			lastUsedAt: null
+		})
+		.where(
+			and(
+				eq(apiKeys.id, apiKeyId),
+				eq(apiKeys.hashedKey, existingKey.apiKey.hashedKey),
+				isNull(apiKeys.revokedAt)
+			)
+		)
+		.returning({ id: apiKeys.id })
+
+	if (rotated.length === 0) {
+		throw new Error(
+			'This API key changed while it was being rotated - it was revoked, or rotated somewhere else. Reload and check its state before trying again.'
+		)
+	}
+
+	const updatedKey = await getApiKeyById(apiKeyId, userId)
+	if (!updatedKey) {
+		throw new Error('Failed to retrieve rotated API key')
+	}
+
+	return { ...updatedKey, plaintext }
 }
 
 /**

--- a/apps/vectreal-platform/app/lib/domain/auth/preview-api-key-auth.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/preview-api-key-auth.server.ts
@@ -132,11 +132,12 @@ export async function validatePreviewApiKeyForProject(params: {
 
 	const token = getPreviewTokenFromRequest(request)
 	const now = new Date()
+	const hashedToken = token ? hashApiToken(token) : null
 
 	// No token means no lookup: an absent token can match no key, and querying
 	// for one would let an unauthenticated caller drive database load.
-	const match = token
-		? await findLiveKeyForProject(hashApiToken(token), projectId, now)
+	const match = hashedToken
+		? await findLiveKeyForProject(hashedToken, projectId, now)
 		: null
 
 	const decision = decideEmbedAccess({ request, token, match })
@@ -146,10 +147,32 @@ export async function validatePreviewApiKeyForProject(params: {
 		return decision
 	}
 
-	await db
-		.update(apiKeys)
-		.set({ lastUsedAt: now })
-		.where(eq(apiKeys.id, decision.apiKeyId))
+	/*
+	  Written only while the secret this request authenticated with is still the
+	  one on the row.
+
+	  `now` is captured before the lookup, so a slow request can reach this write
+	  long after a rotation has cleared `lastUsedAt` and a newer request has set
+	  it. Keyed on the id alone, that stale write lands and drags the column back
+	  behind `rotatedAt`, which is exactly the comparison the dashboard uses to
+	  say "Unused since rotating". The indicator would then report a key nobody
+	  had updated as one nobody had updated - by accident, for a key that was
+	  fine.
+	*/
+	// A decision can only be `ok` when a row matched, which can only happen when
+	// a token was present and hashed. The guard is here to say that in types
+	// rather than to handle a reachable case.
+	if (hashedToken) {
+		await db
+			.update(apiKeys)
+			.set({ lastUsedAt: now })
+			.where(
+				and(
+					eq(apiKeys.id, decision.apiKeyId),
+					eq(apiKeys.hashedKey, hashedToken)
+				)
+			)
+	}
 
 	return decision
 }

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-operations.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-operations.spec.ts
@@ -35,7 +35,8 @@ const EXPECTED: Record<DashboardOperation, MembershipRole[]> = {
 	'api-key:create': ['owner', 'admin'],
 	'api-key:read': ['owner', 'admin'],
 	'api-key:update': ['owner', 'admin'],
-	'api-key:revoke': ['owner', 'admin']
+	'api-key:revoke': ['owner', 'admin'],
+	'api-key:rotate': ['owner', 'admin']
 }
 
 describe('dashboard operation permissions', () => {

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-operations.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-operations.ts
@@ -40,6 +40,7 @@ export type DashboardOperation =
 	| 'api-key:read'
 	| 'api-key:update'
 	| 'api-key:revoke'
+	| 'api-key:rotate'
 
 /**
  * Operations a folder's creator may perform on it regardless of their role.
@@ -99,7 +100,13 @@ export const DASHBOARD_OPERATION_ROLES: Record<
 	'api-key:create': ['owner', 'admin'],
 	'api-key:read': ['owner', 'admin'],
 	'api-key:update': ['owner', 'admin'],
-	'api-key:revoke': ['owner', 'admin']
+	'api-key:revoke': ['owner', 'admin'],
+	/**
+	 * Same roles as revoke, and for the same reason: rotating replaces the
+	 * secret, so every embed still carrying the old one stops working. It is
+	 * revoke plus a replacement, not a lesser action.
+	 */
+	'api-key:rotate': ['owner', 'admin']
 }
 
 export interface DashboardActorContext {
@@ -156,7 +163,8 @@ const OPERATION_SUBJECTS: Record<DashboardOperation, string> = {
 	'api-key:create': 'create API keys',
 	'api-key:read': 'view API keys',
 	'api-key:update': 'edit API keys',
-	'api-key:revoke': 'revoke API keys'
+	'api-key:revoke': 'revoke API keys',
+	'api-key:rotate': 'rotate API keys'
 }
 
 /**

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys-new.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys-new.tsx
@@ -2,14 +2,6 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Alert, AlertDescription } from '@shared/components/ui/alert'
 import { Button } from '@shared/components/ui/button'
 import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle
-} from '@shared/components/ui/dialog'
-import {
 	Drawer,
 	DrawerClose,
 	DrawerContent,
@@ -37,7 +29,7 @@ import {
 } from '@shared/components/ui/select'
 import { Textarea } from '@shared/components/ui/textarea'
 import { useSetAtom } from 'jotai/react'
-import { AlertCircle, CheckCircle2, Copy, KeyRound } from 'lucide-react'
+import { AlertCircle, KeyRound } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import {
@@ -51,6 +43,7 @@ import { toast } from 'sonner'
 import { z, ZodError } from 'zod'
 
 import { Route } from './+types/api-keys-new'
+import { OneTimeKeyDialog } from '../../components/api-keys/one-time-key-dialog'
 import {
 	ProjectMultiSelect,
 	type ProjectOption
@@ -273,121 +266,6 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export { DashboardErrorBoundary as ErrorBoundary } from '../../components/errors'
-
-function OneTimeKeyDialog({
-	open,
-	onClose,
-	apiKey
-}: {
-	open: boolean
-	onClose: () => void
-	apiKey: { plaintext: string; preview: string; name: string } | null
-}) {
-	const [copied, setCopied] = useState(false)
-
-	const handleCopy = async () => {
-		if (!apiKey) return
-
-		try {
-			await navigator.clipboard.writeText(apiKey.plaintext)
-			setCopied(true)
-			toast.success('API key copied to clipboard')
-			setTimeout(() => setCopied(false), 2000)
-		} catch (_error) {
-			toast.error('Failed to copy to clipboard')
-		}
-	}
-
-	const handleClose = () => {
-		if (!copied) {
-			// Warn user if they haven't copied yet
-			const confirmed = window.confirm(
-				'Have you copied your API key? This is the only time it will be displayed.'
-			)
-			if (!confirmed) return
-		}
-		onClose()
-	}
-
-	if (!apiKey) return null
-
-	return (
-		<Dialog open={open} onOpenChange={(open) => !open && handleClose()}>
-			<DialogContent
-				className="max-w-2xl"
-				onEscapeKeyDown={(e) => e.preventDefault()}
-			>
-				<DialogHeader>
-					<DialogTitle className="flex items-center gap-2">
-						<CheckCircle2 className="text-success size-5" />
-						API Key Created Successfully
-					</DialogTitle>
-					<DialogDescription>
-						Save this key now. For security reasons, it won't be shown again.
-					</DialogDescription>
-				</DialogHeader>
-
-				<div className="space-y-4">
-					<Alert
-						variant="default"
-						className="border-warning-border bg-warning-bg"
-					>
-						<AlertCircle className="text-warning size-4" />
-						<AlertDescription className="text-warning-muted-foreground">
-							<strong>Important:</strong> Copy this key now. Once you close this
-							dialog, the full key will no longer be accessible. You'll only see
-							the preview (...{apiKey.preview}).
-						</AlertDescription>
-					</Alert>
-
-					<div className="space-y-2">
-						<label className="text-h4">API Key</label>
-						<div className="flex gap-2">
-							<div className="text-muted-foreground bg-muted flex-1 rounded-md border p-3 font-mono text-sm break-all">
-								{apiKey.plaintext}
-							</div>
-							<Button
-								type="button"
-								variant={copied ? 'default' : 'outline'}
-								size="icon"
-								className="shrink-0"
-								onClick={handleCopy}
-							>
-								{copied ? (
-									<CheckCircle2 className="size-4" />
-								) : (
-									<Copy className="size-4" />
-								)}
-							</Button>
-						</div>
-						<p className="text-muted-foreground text-xs">
-							Key preview:{' '}
-							<code className="font-mono">...{apiKey.preview}</code>
-						</p>
-					</div>
-
-					<div className="bg-muted space-y-2 rounded-md p-4">
-						<h4 className="text-h4">Next Steps</h4>
-						<ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
-							<li>Copy the API key above to a secure location</li>
-							<li>Use it in your application's authorization header</li>
-							<li>
-								Format:{' '}
-								<code className="text-xs">Authorization: Bearer vctrl_...</code>
-							</li>
-						</ul>
-					</div>
-				</div>
-
-				<DialogFooter>
-					<Button onClick={handleClose} className="w-full">
-						I've Saved My Key
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
-	)
-}
 
 export default function ApiKeysNewPage({
 	actionData,
@@ -731,6 +609,7 @@ export default function ApiKeysNewPage({
 				open={showKeyDialog}
 				onClose={handleKeyDialogClose}
 				apiKey={createdKey}
+				reason="created"
 			/>
 		</>
 	)

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys.tsx
@@ -13,7 +13,7 @@ import {
 	TabsTrigger
 } from '@shared/components/ui/tabs'
 import { KeyRound } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
 	data,
 	Outlet,
@@ -26,6 +26,10 @@ import { toast } from 'sonner'
 
 import { Route } from './+types/api-keys'
 import {
+	OneTimeKeyDialog,
+	type OneTimeKeyValue
+} from '../../components/api-keys/one-time-key-dialog'
+import {
 	DataTable,
 	createApiKeyColumns,
 	type ApiKeyRow
@@ -33,9 +37,11 @@ import {
 import { ConfirmDestructiveDialog } from '../../components/shared/confirm-destructive-dialog'
 import { FeatureUnavailablePanel } from '../../components/upgrade/feature-unavailable-panel'
 import { useDashboardTableState } from '../../hooks/use-dashboard-table-state'
+import { useOncePerFetcherResponse } from '../../hooks/use-once-per-fetcher-response'
 import {
 	getAllUserApiKeys,
 	revokeApiKey,
+	rotateApiKey,
 	type ApiKeyWithDetails
 } from '../../lib/domain/auth/api-key-repository.server'
 import { loadAuthenticatedUser } from '../../lib/domain/auth/auth-loader.server'
@@ -102,6 +108,22 @@ export async function loader({ request }: Route.LoaderArgs) {
 	)
 }
 
+/**
+ * One shape for every outcome of this action.
+ *
+ * Returning a different object per branch left the client narrowing a union
+ * with `in`, which resolved `rotatedKey` to `{}` and lost the one value that
+ * cannot be fetched again. A single optional-field contract is also what the
+ * component already assumes when it probes with `'success' in fetcher.data`.
+ */
+interface ApiKeysActionResult {
+	success?: true
+	message?: string
+	error?: string
+	/** Present only after a rotation, and only in that one response. */
+	rotatedKey?: OneTimeKeyValue
+}
+
 export async function action({ request }: Route.ActionArgs) {
 	const { user, headers } = await loadAuthenticatedUser(request)
 	const formData = await request.formData()
@@ -113,23 +135,55 @@ export async function action({ request }: Route.ActionArgs) {
 	const intent = formData.get('intent') as string
 
 	try {
-		if (intent === 'revoke') {
-			const apiKeyId = formData.get('apiKeyId') as string
+		const apiKeyId = formData.get('apiKeyId') as string
 
+		if (intent === 'revoke') {
 			if (!apiKeyId) {
-				return data({ error: 'API key ID is required' }, { headers })
+				return data<ApiKeysActionResult>(
+					{ error: 'API key ID is required' },
+					{ headers }
+				)
 			}
 
 			await revokeApiKey(apiKeyId, user.id)
-			return data(
+			return data<ApiKeysActionResult>(
 				{ success: true, message: 'API key revoked successfully' },
 				{ headers }
 			)
 		}
 
-		return data({ error: 'Invalid intent' }, { headers })
+		if (intent === 'rotate') {
+			if (!apiKeyId) {
+				return data<ApiKeysActionResult>(
+					{ error: 'API key ID is required' },
+					{ headers }
+				)
+			}
+
+			const rotated = await rotateApiKey({ apiKeyId, userId: user.id })
+
+			/*
+			  The plaintext leaves the server exactly here and is never persisted in
+			  the clear, so the client has one chance to show it. It is deliberately
+			  not put in the flash message: toasts disappear on a timer.
+			*/
+			return data<ApiKeysActionResult>(
+				{
+					success: true,
+					message: 'API key rotated.',
+					rotatedKey: {
+						plaintext: rotated.plaintext,
+						preview: rotated.apiKey.keyPreview,
+						name: rotated.apiKey.name
+					}
+				},
+				{ headers }
+			)
+		}
+
+		return data<ApiKeysActionResult>({ error: 'Invalid intent' }, { headers })
 	} catch (error) {
-		return data(
+		return data<ApiKeysActionResult>(
 			{ error: error instanceof Error ? error.message : 'An error occurred' },
 			{ headers }
 		)
@@ -166,7 +220,8 @@ function buildApiKeyRows(keys: ApiKeyWithDetails[]): ApiKeyRow[] {
 		lastUsedAt: key.apiKey.lastUsedAt,
 		active: key.apiKey.active,
 		expiresAt: key.apiKey.expiresAt,
-		revokedAt: key.apiKey.revokedAt
+		revokedAt: key.apiKey.revokedAt,
+		rotatedAt: key.apiKey.rotatedAt
 	}))
 }
 
@@ -174,12 +229,14 @@ function OrgApiKeysTable({
 	namespace,
 	rows,
 	onEdit,
-	onRevoke
+	onRevoke,
+	onRotate
 }: {
 	namespace: string
 	rows: ApiKeyRow[]
 	onEdit: (keyId: string) => void
 	onRevoke: (keyId: string) => void
+	onRotate: (keyId: string) => void
 }) {
 	const tableState = useDashboardTableState({ namespace })
 
@@ -187,9 +244,10 @@ function OrgApiKeysTable({
 		() =>
 			createApiKeyColumns({
 				onEdit,
-				onRevoke
+				onRevoke,
+				onRotate
 			}),
-		[onEdit, onRevoke]
+		[onEdit, onRevoke, onRotate]
 	)
 
 	if (rows.length === 0) {
@@ -232,10 +290,24 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 	const navigate = useNavigate()
 	const fetcher = useFetcher<typeof action>()
 	const revalidator = useRevalidator()
-	const lastHandledResponseRef = useRef<string | null>(null)
 	const [revokeDialogOpen, setRevokeDialogOpen] = useState(false)
 	const [keyToRevokeId, setKeyToRevokeId] = useState<string | null>(null)
-	const isRevoking = fetcher.state !== 'idle'
+	const [rotateDialogOpen, setRotateDialogOpen] = useState(false)
+	const [keyToRotateId, setKeyToRotateId] = useState<string | null>(null)
+	const [rotatedKey, setRotatedKey] = useState<OneTimeKeyValue | null>(null)
+	const isMutating = fetcher.state !== 'idle'
+
+	/**
+	 * Whether the in-flight request is the one this dialog would confirm.
+	 *
+	 * Both dialogs share one fetcher, so a plain `fetcher.state !== 'idle'`
+	 * marks a dialog the user just opened for a different key as already
+	 * submitting - rendering its confirm button as "Working..." and disabling
+	 * Cancel, so it cannot even be dismissed until an unrelated request
+	 * finishes.
+	 */
+	const isSubmittingFor = (keyId: string | null) =>
+		isMutating && keyId !== null && fetcher.formData?.get('apiKeyId') === keyId
 
 	const allKeys = useMemo(
 		() => Object.values(keysByOrg).flatMap((items) => items),
@@ -247,27 +319,26 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 		[allKeys]
 	)
 
-	useEffect(() => {
-		if (fetcher.state !== 'idle' || !fetcher.data) {
-			return
-		}
+	useOncePerFetcherResponse(fetcher, (result) => {
+		if ('success' in result && result.success) {
+			/*
+			  A rotation's plaintext exists only in this response. Capture it into
+			  state before the toast, because revalidating replaces `fetcher.data`
+			  and the value is unrecoverable once it is gone.
+			*/
+			if ('rotatedKey' in result && result.rotatedKey) {
+				setRotatedKey(result.rotatedKey)
+			}
 
-		const signature = JSON.stringify(fetcher.data)
-		if (lastHandledResponseRef.current === signature) {
-			return
-		}
-		lastHandledResponseRef.current = signature
-
-		if ('success' in fetcher.data && fetcher.data.success) {
-			toast.success(fetcher.data.message || 'API key revoked successfully')
+			toast.success(result.message || 'API key revoked successfully')
 			revalidator.revalidate()
 			return
 		}
 
-		if ('error' in fetcher.data && fetcher.data.error) {
-			toast.error(fetcher.data.error)
+		if ('error' in result && result.error) {
+			toast.error(result.error)
 		}
-	}, [fetcher.state, fetcher.data, revalidator])
+	})
 
 	const handleEdit = (keyId: string) => {
 		navigate(`/dashboard/api-keys/${keyId}/edit`)
@@ -279,7 +350,7 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 	}
 
 	const confirmRevoke = () => {
-		if (!keyToRevokeId || isRevoking) return
+		if (!keyToRevokeId || isMutating) return
 
 		fetcher.submit(
 			{
@@ -292,6 +363,27 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 
 		setRevokeDialogOpen(false)
 		setKeyToRevokeId(null)
+	}
+
+	const handleRotate = (keyId: string) => {
+		setKeyToRotateId(keyId)
+		setRotateDialogOpen(true)
+	}
+
+	const confirmRotate = () => {
+		if (!keyToRotateId || isMutating) return
+
+		fetcher.submit(
+			{
+				intent: 'rotate',
+				apiKeyId: keyToRotateId,
+				csrf: csrfToken
+			},
+			{ method: 'post' }
+		)
+
+		setRotateDialogOpen(false)
+		setKeyToRotateId(null)
 	}
 
 	if (organizations.length === 0) {
@@ -313,6 +405,30 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 
 	const defaultOrgId = organizations[0]?.organization.id
 	const keyToRevoke = keyToRevokeId ? keysById.get(keyToRevokeId) : null
+	const keyToRotate = keyToRotateId ? keysById.get(keyToRotateId) : null
+
+	/*
+	  Acknowledge rather than typed, matching revoke: rotating is recoverable by
+	  rotating again, and the irreversible part is not the key, it is the minutes
+	  the embed is broken until the snippet is updated. That is what the
+	  consequences below have to say out loud.
+	*/
+	const rotatePlan: DashboardConfirmationPlan = {
+		tier: 'acknowledge',
+		title: keyToRotate
+			? `Rotate "${keyToRotate.apiKey.name}"?`
+			: 'Rotate API key?',
+		description: keyToRotate
+			? `Key ending ${keyToRotate.apiKey.keyPreview} is replaced by a new one immediately.`
+			: 'The current key is replaced by a new one immediately.',
+		consequences: [
+			'Every embed still carrying the current key is refused until you paste in the new one',
+			'The new key is shown once, right after rotating, and cannot be recovered later',
+			'The name, projects and expiry stay as they are'
+		],
+		confirmLabel: 'Rotate key',
+		token: null
+	}
 
 	/*
 	  Revoking is destructive but recoverable by issuing a new key, so it sits at
@@ -365,6 +481,7 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 								)}
 								onEdit={handleEdit}
 								onRevoke={handleRevoke}
+								onRotate={handleRotate}
 							/>
 						) : (
 							<FeatureUnavailablePanel
@@ -414,6 +531,7 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 											)}
 											onEdit={handleEdit}
 											onRevoke={handleRevoke}
+											onRotate={handleRotate}
 										/>
 									) : (
 										<FeatureUnavailablePanel
@@ -437,8 +555,23 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 					open={revokeDialogOpen}
 					onOpenChange={setRevokeDialogOpen}
 					plan={revokePlan}
-					isPending={isRevoking}
+					isPending={isSubmittingFor(keyToRevokeId)}
 					onConfirm={confirmRevoke}
+				/>
+
+				<ConfirmDestructiveDialog
+					open={rotateDialogOpen}
+					onOpenChange={setRotateDialogOpen}
+					plan={rotatePlan}
+					isPending={isSubmittingFor(keyToRotateId)}
+					onConfirm={confirmRotate}
+				/>
+
+				<OneTimeKeyDialog
+					open={rotatedKey !== null}
+					onClose={() => setRotatedKey(null)}
+					apiKey={rotatedKey}
+					reason="rotated"
 				/>
 			</div>
 

--- a/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
@@ -35,6 +35,28 @@ To create a key with your own name, description or expiry instead:
 
 > A key is stored hashed, so it cannot be read back later. The **Embed** panel's key picker shows each key's name and last four characters, which is enough to tell which of your saved keys a project expects, but not enough to recover one you did not save.
 
+### Replacing a key that leaked
+
+If a key ends up somewhere it should not be, **rotate** it rather than revoking it. Rotating issues a new secret for the same key, keeping its name, description, projects and expiry, so only the snippet has to change:
+
+1. Go to [Dashboard → API Keys](/dashboard/api-keys).
+2. Open the row menu on the key and choose **Rotate**.
+3. Copy the new key - like creation, it is shown only once.
+4. Paste it into every embed that carried the old one.
+
+The old secret stops working the instant the new one is issued, so **every embed still carrying it is refused until you update it**. Plan the rotation for when you can update the embedding pages, not before.
+
+The **Last Used** column is how you confirm the update landed: it is cleared by the rotation and stays empty until something authenticates with the new key. A key showing _Unused since rotating_ has an embed somewhere that is still sending the old value and being refused.
+
+Rotation is offered only on an active key. A revoked key stays revoked, and an expired one cannot be brought back this way - create a new key instead.
+
+{/* claims
+present apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts rotatedAt: new Date()
+present apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts lastUsedAt: null
+present apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts state !== 'active'
+present apps/vectreal-platform/app/components/dashboard/table-columns.tsx Unused since rotating
+*/}
+
 ### Using the key
 
 Pass the key as the `token` query parameter in the embed URL:
@@ -62,17 +84,17 @@ Every external embed is checked against the owning project's allowed domain list
 
 Supported domain patterns:
 
-| Pattern | Matches |
-|---|---|
-| `example.com` | Exact host only |
+| Pattern         | Matches                         |
+| --------------- | ------------------------------- |
+| `example.com`   | Exact host only                 |
 | `*.example.com` | All subdomains of `example.com` |
 
 Requests from unlisted domains receive a `403 Forbidden` response.
 
 {/* claims
-present  apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.ts   trimmed.slice(2)
-present  apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.ts   patterns.length === 0
-present  apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.ts   isLocalhostLike(applicationHost)
+present apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.ts trimmed.slice(2)
+present apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.ts patterns.length === 0
+present apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.ts isLocalhostLike(applicationHost)
 */}
 
 > **Local development** - there is no blanket localhost exemption. The automatic fallback only applies when the request carries no `Referer` and no `Origin` **and** the Vectreal instance being embedded is itself running on a localhost-like host. To embed `https://vectreal.com` from a local dev server, add `localhost` or `127.0.0.1` to the allowed domains.
@@ -89,12 +111,12 @@ The hosted preview iframe can also be controlled from the parent page over `post
 
 ```html
 <div style="width: 100%; max-width: 100%; height: 400px;">
-  <iframe
-    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
-    style="width: 100%; height: 100%; border: 0;"
-    allow="autoplay; xr-spatial-tracking"
-    allowfullscreen
-  ></iframe>
+	<iframe
+		src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
+		style="width: 100%; height: 100%; border: 0;"
+		allow="autoplay; xr-spatial-tracking"
+		allowfullscreen
+	></iframe>
 </div>
 ```
 
@@ -102,12 +124,12 @@ The hosted preview iframe can also be controlled from the parent page over `post
 
 ```html
 <div style="position:relative;padding-top:56.25%;width:100%">
-  <iframe
-    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
-    style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
-    allow="autoplay; xr-spatial-tracking"
-    allowfullscreen
-  ></iframe>
+	<iframe
+		src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
+		style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
+		allow="autoplay; xr-spatial-tracking"
+		allowfullscreen
+	></iframe>
 </div>
 ```
 
@@ -119,23 +141,23 @@ Hosted preview iframes support a small `postMessage` protocol layered on top of 
 
 ### Message sources
 
-| Source | Direction | Meaning |
-|---|---|---|
-| `vectreal-host` | Parent page → iframe | A trusted host page command or trigger update |
+| Source             | Direction            | Meaning                                               |
+| ------------------ | -------------------- | ----------------------------------------------------- |
+| `vectreal-host`    | Parent page → iframe | A trusted host page command or trigger update         |
 | `vectreal-preview` | Iframe → parent page | A viewer lifecycle event or emitted interaction event |
 
 ### Host to preview messages
 
-| Type | Payload | Effect |
-|---|---|---|
-| `ping` | none | Announces the host origin so the iframe can start delivering messages, and asks for a `pong` |
-| `viewer_command` | `command: { type: 'activate_camera', cameraId: string }` | Activates one persisted scene camera |
-| `viewer_command` | `command: { type: 'set_controls_enabled', enabled: boolean }` | Temporarily enables or disables viewer orbit interaction |
-| `viewer_command` | `command: { type: 'set_transition', transitionType: 'none' \| 'linear' \| 'object_avoidance', duration?: number, easing?: string }` | Overrides the transition used by subsequent camera switches |
-| `viewer_command` | `command: { type: 'set_auto_rotate', enabled: boolean, speed?: number }` | Toggles and configures auto-rotation |
-| `viewer_command` | `command: { type: 'set_controls_options', zoom?: boolean, pan?: boolean }` | Enables or disables zoom and pan at runtime |
-| `host_scroll_progress` | `progress: number` | Reports normalized host scroll progress used by persisted `host_scroll_progress` interactions |
-| `host_message` | `message: string` | Triggers persisted `host_message` interactions by message name |
+| Type                   | Payload                                                                                                                             | Effect                                                                                        |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `ping`                 | none                                                                                                                                | Announces the host origin so the iframe can start delivering messages, and asks for a `pong`  |
+| `viewer_command`       | `command: { type: 'activate_camera', cameraId: string }`                                                                            | Activates one persisted scene camera                                                          |
+| `viewer_command`       | `command: { type: 'set_controls_enabled', enabled: boolean }`                                                                       | Temporarily enables or disables viewer orbit interaction                                      |
+| `viewer_command`       | `command: { type: 'set_transition', transitionType: 'none' \| 'linear' \| 'object_avoidance', duration?: number, easing?: string }` | Overrides the transition used by subsequent camera switches                                   |
+| `viewer_command`       | `command: { type: 'set_auto_rotate', enabled: boolean, speed?: number }`                                                            | Toggles and configures auto-rotation                                                          |
+| `viewer_command`       | `command: { type: 'set_controls_options', zoom?: boolean, pan?: boolean }`                                                          | Enables or disables zoom and pan at runtime                                                   |
+| `host_scroll_progress` | `progress: number`                                                                                                                  | Reports normalized host scroll progress used by persisted `host_scroll_progress` interactions |
+| `host_message`         | `message: string`                                                                                                                   | Triggers persisted `host_message` interactions by message name                                |
 
 Two field names differ between the SDK and the wire. `setTransition({ type })` sends
 `transitionType`, because `type` is already taken by the command envelope.
@@ -144,87 +166,87 @@ each carrying only its own field (`zoom` or `pan`), so a partial payload is norm
 
 ### Preview to host messages
 
-| Type | Payload | Meaning |
-|---|---|---|
-| `pong` | `sceneId`, `cameras` | Reply to `ping`; carries the scene's camera descriptors |
-| `viewer_event` | `event: { type: 'viewer_ready' }` | The hosted preview is ready to receive viewer commands |
-| `viewer_event` | `event: { type: 'initial_framing_completed', cameraId: string \| null }` | Initial framing and stabilization has completed |
-| `viewer_event` | `event: { type: 'camera_changed', cameraId: string }` | The active scene camera changed |
-| `interaction_event` | `eventName`, optional `payload`, optional `interactionId` | A persisted `emit_custom_event` interaction fired |
+| Type                | Payload                                                                  | Meaning                                                 |
+| ------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------- |
+| `pong`              | `sceneId`, `cameras`                                                     | Reply to `ping`; carries the scene's camera descriptors |
+| `viewer_event`      | `event: { type: 'viewer_ready' }`                                        | The hosted preview is ready to receive viewer commands  |
+| `viewer_event`      | `event: { type: 'initial_framing_completed', cameraId: string \| null }` | Initial framing and stabilization has completed         |
+| `viewer_event`      | `event: { type: 'camera_changed', cameraId: string }`                    | The active scene camera changed                         |
+| `interaction_event` | `eventName`, optional `payload`, optional `interactionId`                | A persisted `emit_custom_event` interaction fired       |
 
 ### Plain HTML example
 
 ```html
 <div style="position:relative;padding-top:56.25%;width:100%">
-  <iframe
-    id="vectreal-preview"
-    src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
-    style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
-    allow="autoplay; xr-spatial-tracking"
-    loading="lazy"
-  ></iframe>
+	<iframe
+		id="vectreal-preview"
+		src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
+		style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"
+		allow="autoplay; xr-spatial-tracking"
+		loading="lazy"
+	></iframe>
 </div>
 
 <script>
-  const iframe = document.getElementById('vectreal-preview')
-  const targetOrigin = 'https://vectreal.com'
+	const iframe = document.getElementById('vectreal-preview')
+	const targetOrigin = 'https://vectreal.com'
 
-  // The iframe cannot address the parent until the parent speaks first, so it
-  // queues every outbound event (including `viewer_ready`) until then. Ping it
-  // until `pong` arrives, otherwise a listen-only page receives nothing.
-  let handshake
-  const ping = () =>
-    iframe.contentWindow?.postMessage(
-      { source: 'vectreal-host', type: 'ping' },
-      targetOrigin
-    )
+	// The iframe cannot address the parent until the parent speaks first, so it
+	// queues every outbound event (including `viewer_ready`) until then. Ping it
+	// until `pong` arrives, otherwise a listen-only page receives nothing.
+	let handshake
+	const ping = () =>
+		iframe.contentWindow?.postMessage(
+			{ source: 'vectreal-host', type: 'ping' },
+			targetOrigin
+		)
 
-  iframe.addEventListener('load', () => {
-    ping()
-    handshake = setInterval(ping, 250)
-  })
+	iframe.addEventListener('load', () => {
+		ping()
+		handshake = setInterval(ping, 250)
+	})
 
-  window.addEventListener('message', (event) => {
-    if (event.origin !== targetOrigin) return
-    if (event.data?.source !== 'vectreal-preview') return
+	window.addEventListener('message', (event) => {
+		if (event.origin !== targetOrigin) return
+		if (event.data?.source !== 'vectreal-preview') return
 
-    if (event.data.type === 'pong') clearInterval(handshake)
+		if (event.data.type === 'pong') clearInterval(handshake)
 
-    console.log('Vectreal preview event', event.data)
-  })
+		console.log('Vectreal preview event', event.data)
+	})
 
-  function activateCamera(cameraId) {
-    iframe.contentWindow?.postMessage(
-      {
-        source: 'vectreal-host',
-        type: 'viewer_command',
-        command: { type: 'activate_camera', cameraId }
-      },
-      targetOrigin
-    )
-  }
+	function activateCamera(cameraId) {
+		iframe.contentWindow?.postMessage(
+			{
+				source: 'vectreal-host',
+				type: 'viewer_command',
+				command: { type: 'activate_camera', cameraId }
+			},
+			targetOrigin
+		)
+	}
 
-  function setControlsEnabled(enabled) {
-    iframe.contentWindow?.postMessage(
-      {
-        source: 'vectreal-host',
-        type: 'viewer_command',
-        command: { type: 'set_controls_enabled', enabled }
-      },
-      targetOrigin
-    )
-  }
+	function setControlsEnabled(enabled) {
+		iframe.contentWindow?.postMessage(
+			{
+				source: 'vectreal-host',
+				type: 'viewer_command',
+				command: { type: 'set_controls_enabled', enabled }
+			},
+			targetOrigin
+		)
+	}
 
-  function reportScrollProgress(progress) {
-    iframe.contentWindow?.postMessage(
-      {
-        source: 'vectreal-host',
-        type: 'host_scroll_progress',
-        progress
-      },
-      targetOrigin
-    )
-  }
+	function reportScrollProgress(progress) {
+		iframe.contentWindow?.postMessage(
+			{
+				source: 'vectreal-host',
+				type: 'host_scroll_progress',
+				progress
+			},
+			targetOrigin
+		)
+	}
 </script>
 ```
 
@@ -240,8 +262,8 @@ each carrying only its own field (`zoom` or `pan`), so a partial payload is norm
 
 ## Embed route
 
-| Route | URL | Description |
-|---|---|---|
+| Route     | URL                          | Description                         |
+| --------- | ---------------------------- | ----------------------------------- |
 | **Embed** | `/embed/:projectId/:sceneId` | Full viewport, immersive experience |
 
 Supports the `token` query param and `Authorization: Bearer` authentication. A
@@ -256,15 +278,15 @@ existing embeds keep their token and camera parameters.
 
 ## Status code reference
 
-| Scenario | Status |
-|---|---|
-| Missing `projectId` or `sceneId` | `400 Bad Request` |
-| No `token` or `Authorization` header | `404 Not Found` |
-| Legacy `/preview/fullscreen/...` URL | `301 Moved Permanently` |
-| Rate limited token validation | `429 Too Many Requests` |
-| Disallowed embed domain | `403 Forbidden` |
-| Draft or non-existent scene (external access) | `404 Not Found` |
-| Invalid, revoked, expired, or cross-project API key | `404 Not Found` |
+| Scenario                                            | Status                  |
+| --------------------------------------------------- | ----------------------- |
+| Missing `projectId` or `sceneId`                    | `400 Bad Request`       |
+| No `token` or `Authorization` header                | `404 Not Found`         |
+| Legacy `/preview/fullscreen/...` URL                | `301 Moved Permanently` |
+| Rate limited token validation                       | `429 Too Many Requests` |
+| Disallowed embed domain                             | `403 Forbidden`         |
+| Draft or non-existent scene (external access)       | `404 Not Found`         |
+| Invalid, revoked, expired, or cross-project API key | `404 Not Found`         |
 
 ---
 

--- a/apps/vectreal-platform/supabase/migrations/0018_abnormal_magus.sql
+++ b/apps/vectreal-platform/supabase/migrations/0018_abnormal_magus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "api_keys" ADD COLUMN "rotated_at" timestamp with time zone;

--- a/apps/vectreal-platform/supabase/migrations/meta/0018_snapshot.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/0018_snapshot.json
@@ -1,0 +1,4368 @@
+{
+  "id": "1fb6eb95-8af9-4aaf-bf16-b3ee49c520a1",
+  "prevId": "f4727c36-2f4e-44a1-9ec7-c26740101eb2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "users_select_self": {
+          "name": "users_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_insert_self": {
+          "name": "users_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_update_self": {
+          "name": "users_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())",
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference_code": {
+          "name": "reference_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "is_authenticated": {
+          "name": "is_authenticated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inquiry_type": {
+          "name": "inquiry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "failure_stage": {
+          "name": "failure_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "internal_message_id": {
+          "name": "internal_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_message_id": {
+          "name": "confirmation_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_users_id_fk": {
+          "name": "contact_submissions_user_id_users_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_submissions_reference_code_unique": {
+          "name": "contact_submissions_reference_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_owner_id_idx": {
+          "name": "organizations_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_id_users_id_fk": {
+          "name": "organizations_owner_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "organizations_select_member": {
+          "name": "organizations_select_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_insert_owner": {
+          "name": "organizations_insert_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"organizations\".\"owner_id\" = (select auth.uid())"
+        },
+        "organizations_update_owner": {
+          "name": "organizations_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_delete_owner": {
+          "name": "organizations_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_memberships_user_id_idx": {
+          "name": "organization_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_organization_id_idx": {
+          "name": "organization_memberships_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_invited_by_idx": {
+          "name": "organization_memberships_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_memberships_select_org_member": {
+          "name": "org_memberships_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_insert_org_admin": {
+          "name": "org_memberships_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_update_org_admin": {
+          "name": "org_memberships_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_delete_org_admin_or_self": {
+          "name": "org_memberships_delete_org_admin_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\n\t\t\t\t\texists (\n\t\t\t\t\t\tselect 1\n\t\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t\t)\n\t\t\t\t\tor \"organization_memberships\".\"user_id\" = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_embed_domains": {
+          "name": "allowed_embed_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "projects_select_org_member": {
+          "name": "projects_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "projects_insert_org_admin": {
+          "name": "projects_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"projects\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_update_org_admin": {
+          "name": "projects_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_delete_org_admin": {
+          "name": "projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_folders": {
+      "name": "scene_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_folders_project_id_idx": {
+          "name": "scene_folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_owner_id_idx": {
+          "name": "scene_folders_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_parent_folder_id_idx": {
+          "name": "scene_folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_folders_project_id_projects_id_fk": {
+          "name": "scene_folders_project_id_projects_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_owner_id_users_id_fk": {
+          "name": "scene_folders_owner_id_users_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_parent_folder_id_scene_folders_id_fk": {
+          "name": "scene_folders_parent_folder_id_scene_folders_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_folders_select_project_member": {
+          "name": "scene_folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_folders_insert_project_member_self_owner": {
+          "name": "scene_folders_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scene_folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_update_owner_or_admin": {
+          "name": "scene_folders_update_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_delete_owner_or_admin": {
+          "name": "scene_folders_delete_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {
+        "scene_folders_parent_not_self": {
+          "name": "scene_folders_parent_not_self",
+          "value": "\"scene_folders\".\"parent_folder_id\" is null or \"scene_folders\".\"parent_folder_id\" <> \"scene_folders\".\"id\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "folders_project_id_idx": {
+          "name": "folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "folders_parent_folder_id_idx": {
+          "name": "folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_project_id_projects_id_fk": {
+          "name": "folders_project_id_projects_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folders_parent_folder_id_folders_id_fk": {
+          "name": "folders_parent_folder_id_folders_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "folders_select_project_member": {
+          "name": "folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "folders_insert_project_admin": {
+          "name": "folders_insert_project_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_update_project_admin": {
+          "name": "folders_update_project_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_delete_project_admin": {
+          "name": "folders_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_folder_id_idx": {
+          "name": "assets_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_owner_id_idx": {
+          "name": "assets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_folder_id_folders_id_fk": {
+          "name": "assets_folder_id_folders_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_owner_id_users_id_fk": {
+          "name": "assets_owner_id_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "assets_select_project_member": {
+          "name": "assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "assets_insert_project_member_self_owner": {
+          "name": "assets_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"assets\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_update_project_member_owner": {
+          "name": "assets_update_project_member_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_delete_project_admin": {
+          "name": "assets_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scenes": {
+      "name": "scenes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scenes_project_id_idx": {
+          "name": "scenes_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_folder_id_idx": {
+          "name": "scenes_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scenes_project_id_projects_id_fk": {
+          "name": "scenes_project_id_projects_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scenes_folder_id_scene_folders_id_fk": {
+          "name": "scenes_folder_id_scene_folders_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scenes_select_project_member": {
+          "name": "scenes_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scenes_insert_project_member": {
+          "name": "scenes_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scenes\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_update_project_member": {
+          "name": "scenes_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_delete_project_admin": {
+          "name": "scenes_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_settings": {
+      "name": "scene_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera": {
+          "name": "camera",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controls": {
+          "name": "controls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactions": {
+          "name": "interactions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shadows": {
+          "name": "shadows",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalization": {
+          "name": "normalization",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_settings_created_by_idx": {
+          "name": "scene_settings_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_settings_scene_id_scenes_id_fk": {
+          "name": "scene_settings_scene_id_scenes_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_settings_created_by_users_id_fk": {
+          "name": "scene_settings_created_by_users_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_settings_scene_id_unique": {
+          "name": "scene_settings_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_settings_select_project_member": {
+          "name": "scene_settings_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_insert_project_member_self_creator": {
+          "name": "scene_settings_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_settings\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_settings_update_project_member": {
+          "name": "scene_settings_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_delete_project_admin": {
+          "name": "scene_settings_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_hotspots": {
+      "name": "scene_hotspots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "world_position_x": {
+          "name": "world_position_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_y": {
+          "name": "world_position_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_z": {
+          "name": "world_position_z",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_camera_id": {
+          "name": "linked_camera_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "internal_only": {
+          "name": "internal_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occlusion_enabled": {
+          "name": "occlusion_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_preset": {
+          "name": "style_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dot'"
+        },
+        "payload_url": {
+          "name": "payload_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_hotspots_scene_settings_id_idx": {
+          "name": "scene_hotspots_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_hotspots_sequence_index_idx": {
+          "name": "scene_hotspots_sequence_index_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_hotspots_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_hotspots_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_hotspots",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_hotspots_select_project_member": {
+          "name": "scene_hotspots_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_insert_project_member": {
+          "name": "scene_hotspots_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_update_project_member": {
+          "name": "scene_hotspots_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_delete_project_admin": {
+          "name": "scene_hotspots_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_stats": {
+      "name": "scene_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized": {
+          "name": "optimized",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_scene_bytes": {
+          "name": "initial_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_scene_bytes": {
+          "name": "current_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_optimizations": {
+          "name": "applied_optimizations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimization_settings": {
+          "name": "optimization_settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_metrics": {
+          "name": "additional_metrics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_stats_created_by_idx": {
+          "name": "scene_stats_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_stats_scene_id_scenes_id_fk": {
+          "name": "scene_stats_scene_id_scenes_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_stats_created_by_users_id_fk": {
+          "name": "scene_stats_created_by_users_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_stats_scene_id_unique": {
+          "name": "scene_stats_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_stats_select_project_member": {
+          "name": "scene_stats_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_insert_project_member_self_creator": {
+          "name": "scene_stats_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_stats\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_stats_update_project_member": {
+          "name": "scene_stats_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_delete_project_admin": {
+          "name": "scene_stats_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_assets": {
+      "name": "scene_assets",
+      "schema": "",
+      "columns": {
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_assets_scene_settings_id_idx": {
+          "name": "scene_assets_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_assets_asset_id_idx": {
+          "name": "scene_assets_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_assets_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_assets_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_assets_asset_id_assets_id_fk": {
+          "name": "scene_assets_asset_id_assets_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scene_assets_scene_settings_id_asset_id_pk": {
+          "name": "scene_assets_scene_settings_id_asset_id_pk",
+          "columns": [
+            "scene_settings_id",
+            "asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_assets_select_project_member": {
+          "name": "scene_assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_insert_project_member": {
+          "name": "scene_assets_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"scene_assets\".\"asset_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_delete_project_member": {
+          "name": "scene_assets_delete_project_member",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_published": {
+      "name": "scene_published",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_published_asset_id_idx": {
+          "name": "scene_published_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_scene_settings_id_idx": {
+          "name": "scene_published_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_published_by_idx": {
+          "name": "scene_published_published_by_idx",
+          "columns": [
+            {
+              "expression": "published_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_published_scene_id_scenes_id_fk": {
+          "name": "scene_published_scene_id_scenes_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_asset_id_assets_id_fk": {
+          "name": "scene_published_asset_id_assets_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_published_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scene_published_published_by_users_id_fk": {
+          "name": "scene_published_published_by_users_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_published_select_project_member": {
+          "name": "scene_published_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_insert_project_member_self_publisher": {
+          "name": "scene_published_insert_project_member_self_publisher",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand \"scene_published\".\"published_by\" = (select auth.uid())\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom assets a\n\t\t\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\t\t\tjoin projects p on p.id = f.project_id\n\t\t\t\t\tjoin scenes s on s.project_id = p.id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\t\t\tand a.id = \"scene_published\".\"asset_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_published_update_project_member": {
+          "name": "scene_published_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_delete_project_admin": {
+          "name": "scene_published_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_requests": {
+      "name": "scene_action_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_action_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_requests_status_idx": {
+          "name": "scene_action_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_scene_id_idx": {
+          "name": "scene_action_requests_scene_id_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_expires_at_idx": {
+          "name": "scene_action_requests_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_action_requests_request_key_unique": {
+          "name": "scene_action_requests_request_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_locks": {
+      "name": "scene_action_locks",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_key": {
+          "name": "holder_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_locks_expires_at_idx": {
+          "name": "scene_action_locks_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_runtime_limits": {
+      "name": "scene_runtime_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "in_flight": {
+          "name": "in_flight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "permission_entity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "permission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permissions_granted_by_idx": {
+          "name": "permissions_granted_by_idx",
+          "columns": [
+            {
+              "expression": "granted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_granted_by_users_id_fk": {
+          "name": "permissions_granted_by_users_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "permissions_select_recipient_or_granter": {
+          "name": "permissions_select_recipient_or_granter",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t\"permissions\".\"granted_by\" = (select auth.uid())\n\t\t\t\tor (\"permissions\".\"entity_type\" = 'user' and \"permissions\".\"entity_id\" = (select auth.uid()))\n\t\t\t\tor (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"permissions\".\"entity_id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "permissions_insert_self_or_group_owner": {
+          "name": "permissions_insert_self_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\"permissions\".\"granted_by\" = (select auth.uid())\n\t\t\t\tand (\n\t\t\t\t\t(\"permissions\".\"entity_type\" = 'user' and \"permissions\".\"entity_id\" = (select auth.uid()))\n\t\t\t\t\tor (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t)\n\t\t\t"
+        },
+        "permissions_update_granter_or_group_owner": {
+          "name": "permissions_update_granter_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)",
+          "withCheck": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)"
+        },
+        "permissions_delete_granter_or_group_owner": {
+          "name": "permissions_delete_granter_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_id_idx": {
+          "name": "group_memberships_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "group_memberships_select_owner_or_member": {
+          "name": "group_memberships_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"group_memberships\".\"group_id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_insert_owner_or_self_join": {
+          "name": "group_memberships_insert_owner_or_self_join",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        },
+        "group_memberships_update_owner": {
+          "name": "group_memberships_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_delete_owner_or_self": {
+          "name": "group_memberships_delete_owner_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_id_idx": {
+          "name": "groups_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "groups_select_owner_or_member": {
+          "name": "groups_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid()) or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"groups\".\"id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "groups_insert_self_owner": {
+          "name": "groups_insert_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_update_owner": {
+          "name": "groups_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_delete_owner": {
+          "name": "groups_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {
+        "tags_select_authenticated": {
+          "name": "tags_select_authenticated",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null"
+        },
+        "tags_insert_authenticated": {
+          "name": "tags_insert_authenticated",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(select (select auth.uid())) is not null"
+        },
+        "tags_update_authenticated": {
+          "name": "tags_update_authenticated",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null",
+          "withCheck": "(select (select auth.uid())) is not null"
+        },
+        "tags_delete_authenticated": {
+          "name": "tags_delete_authenticated",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tag_assignments": {
+      "name": "tag_assignments",
+      "schema": "",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tag_assignments_tag_id_idx": {
+          "name": "tag_assignments_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_assignments_tag_id_tags_id_fk": {
+          "name": "tag_assignments_tag_id_tags_id_fk",
+          "tableFrom": "tag_assignments",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tag_assignments_tag_id_target_type_target_id_pk": {
+          "name": "tag_assignments_tag_id_target_type_target_id_pk",
+          "columns": [
+            "tag_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "tag_assignments_select_target_member": {
+          "name": "tag_assignments_select_target_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "tag_assignments_insert_target_member": {
+          "name": "tag_assignments_insert_target_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t(select (select auth.uid())) is not null\n\t\t\t\tand (\n\t\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t)\n\t\t\t"
+        },
+        "tag_assignments_delete_target_member": {
+          "name": "tag_assignments_delete_target_member",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_preview": {
+          "name": "key_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_organization_id_idx": {
+          "name": "api_keys_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_organization_id_organizations_id_fk": {
+          "name": "api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "api_keys_select_org_admin": {
+          "name": "api_keys_select_org_admin",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_insert_org_admin": {
+          "name": "api_keys_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_update_org_admin": {
+          "name": "api_keys_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_delete_org_admin": {
+          "name": "api_keys_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_key_projects": {
+      "name": "api_key_projects",
+      "schema": "",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_projects_api_key_id_idx": {
+          "name": "api_key_projects_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_projects_project_id_idx": {
+          "name": "api_key_projects_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_projects_api_key_id_api_keys_id_fk": {
+          "name": "api_key_projects_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_projects_project_id_projects_id_fk": {
+          "name": "api_key_projects_project_id_projects_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_key_projects_api_key_id_project_id_pk": {
+          "name": "api_key_projects_api_key_id_project_id_pk",
+          "columns": [
+            "api_key_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "api_key_projects_select_org_admin_and_project_member": {
+          "name": "api_key_projects_select_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_insert_org_admin_and_project_member": {
+          "name": "api_key_projects_insert_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_delete_org_admin": {
+          "name": "api_key_projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "billing_state": {
+          "name": "billing_state",
+          "type": "billing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_stripe_subscription_id_idx": {
+          "name": "org_subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_customer_id_idx": {
+          "name": "org_subscriptions_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_billing_state_idx": {
+          "name": "org_subscriptions_billing_state_idx",
+          "columns": [
+            {
+              "expression": "billing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_subscriptions_organization_id_unique": {
+          "name": "org_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {
+        "org_subscriptions_select_org_member": {
+          "name": "org_subscriptions_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_subscriptions_insert_org_admin": {
+          "name": "org_subscriptions_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_update_org_admin": {
+          "name": "org_subscriptions_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_delete_org_admin": {
+          "name": "org_subscriptions_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_limit_overrides": {
+      "name": "org_limit_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_key": {
+          "name": "limit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_limit_overrides_org_key_uidx": {
+          "name": "org_limit_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "limit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_limit_overrides_organization_id_organizations_id_fk": {
+          "name": "org_limit_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_limit_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_limit_overrides_select_org_member": {
+          "name": "org_limit_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_limit_overrides_insert_org_admin": {
+          "name": "org_limit_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_update_org_admin": {
+          "name": "org_limit_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_delete_org_admin": {
+          "name": "org_limit_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_entitlement_overrides": {
+      "name": "org_entitlement_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_key": {
+          "name": "entitlement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_entitlement_overrides_org_key_uidx": {
+          "name": "org_entitlement_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_entitlement_overrides_organization_id_organizations_id_fk": {
+          "name": "org_entitlement_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_entitlement_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_entitlement_overrides_select_org_member": {
+          "name": "org_entitlement_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_insert_org_admin": {
+          "name": "org_entitlement_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_update_org_admin": {
+          "name": "org_entitlement_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_delete_org_admin": {
+          "name": "org_entitlement_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_usage_counters": {
+      "name": "org_usage_counters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter_key": {
+          "name": "counter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_usage_counters_org_key_window_uidx": {
+          "name": "org_usage_counters_org_key_window_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_usage_counters_window_end_idx": {
+          "name": "org_usage_counters_window_end_idx",
+          "columns": [
+            {
+              "expression": "window_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_usage_counters_organization_id_organizations_id_fk": {
+          "name": "org_usage_counters_organization_id_organizations_id_fk",
+          "tableFrom": "org_usage_counters",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_usage_counters_select_org_member": {
+          "name": "org_usage_counters_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_usage_counters_insert_org_admin": {
+          "name": "org_usage_counters_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_update_org_admin": {
+          "name": "org_usage_counters_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_delete_org_admin": {
+          "name": "org_usage_counters_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.billing_webhook_events": {
+      "name": "billing_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_webhook_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_webhook_events_provider_event_id_uidx": {
+          "name": "billing_webhook_events_provider_event_id_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_status_idx": {
+          "name": "billing_webhook_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_created_at_idx": {
+          "name": "billing_webhook_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.consent_records": {
+      "name": "consent_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "necessary": {
+          "name": "necessary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "functional": {
+          "name": "functional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_country": {
+          "name": "ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "consent_records_user_id_users_id_fk": {
+          "name": "consent_records_user_id_users_id_fk",
+          "tableFrom": "consent_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_records_user_id_unique": {
+          "name": "consent_records_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "consent_records_anonymous_id_unique": {
+          "name": "consent_records_anonymous_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anonymous_id"
+          ]
+        }
+      },
+      "policies": {
+        "consent_records_select_self": {
+          "name": "consent_records_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_insert_self": {
+          "name": "consent_records_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_update_self": {
+          "name": "consent_records_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())",
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.contact_submission_status": {
+      "name": "contact_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.membership_role": {
+      "name": "membership_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "texture",
+        "material",
+        "model",
+        "environment",
+        "other"
+      ]
+    },
+    "public.scene_status": {
+      "name": "scene_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.scene_action_request_status": {
+      "name": "scene_action_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.permission_entity": {
+      "name": "permission_entity",
+      "schema": "public",
+      "values": [
+        "user",
+        "group"
+      ]
+    },
+    "public.permission_type": {
+      "name": "permission_type",
+      "schema": "public",
+      "values": [
+        "read",
+        "write",
+        "admin",
+        "delete"
+      ]
+    },
+    "public.billing_state": {
+      "name": "billing_state",
+      "schema": "public",
+      "values": [
+        "none",
+        "trialing",
+        "active",
+        "past_due",
+        "unpaid",
+        "canceled",
+        "paused",
+        "incomplete",
+        "incomplete_expired"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "business",
+        "enterprise"
+      ]
+    },
+    "public.billing_webhook_event_status": {
+      "name": "billing_webhook_event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/vectreal-platform/supabase/migrations/meta/_journal.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1787169099333,
       "tag": "0017_shallow_kat_farrell",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1787406189506,
+      "tag": "0018_abnormal_magus",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/vectreal-platform/tests/api-key-lifecycle.spec.ts
+++ b/apps/vectreal-platform/tests/api-key-lifecycle.spec.ts
@@ -145,6 +145,32 @@ describe('api key lifecycle', () => {
 		})
 	})
 
+	/*
+	  A static pin, not a behavioural test, and deliberately labelled as one.
+
+	  `validatePreviewApiKeyForProject` records `lastUsedAt` with a timestamp
+	  captured before its lookup. Keyed on the row id alone, a slow request that
+	  authenticated with a since-rotated secret can land that stale timestamp
+	  after a rotation cleared the column and a newer request refilled it -
+	  dragging `lastUsedAt` back behind `rotatedAt` and making the dashboard
+	  report a healthy key as "Unused since rotating".
+
+	  Reproducing that needs three requests interleaved around a rotation in a
+	  specific order, which nothing here can arrange deterministically. So this
+	  asserts the guard is still in the predicate, which at least fails when
+	  someone simplifies it away. It does not prove the runtime behaviour.
+	*/
+	it('still guards the lastUsedAt write on the secret that authenticated', () => {
+		const normalized = authSource.replace(/\s+/g, '')
+
+		expect(
+			normalized.includes(
+				'.set({lastUsedAt:now}).where(and(eq(apiKeys.id,decision.apiKeyId),eq(apiKeys.hashedKey,hashedToken)))'
+			),
+			'The lastUsedAt write is no longer predicated on the hash that authenticated the request. A stale write from a superseded key can now overwrite a newer one, which is what "Unused since rotating" reads.'
+		).toBe(true)
+	})
+
 	describe('isApiKeyLive agrees with the query on every row shape', () => {
 		it.each(ALL_ROWS.map((row) => [describeRow(row), row] as const))(
 			'%s',

--- a/apps/vectreal-platform/tests/critical-path.spec.ts
+++ b/apps/vectreal-platform/tests/critical-path.spec.ts
@@ -72,15 +72,23 @@ const FUNNEL: FunnelStep[] = [
 /*
   Steps with no test that imports them, each for the same structural reason:
   the decision is entangled with the database lookup inside a `.server.ts`, so
-  nothing can import it without Postgres. The fix is the one `embed-asset-policy`
-  already demonstrates - lift the decision into a pure module and leave the
-  lookup behind - not a mock.
+  nothing can import it without Postgres. There are two ways out, and both have
+  now been used: lift the decision into a pure module and leave the lookup
+  behind, as `embed-asset-policy` did, or exercise the lookup for real from
+  `tests/integration`, as `api-key-lifecycle.integration.spec.ts` did for key
+  minting and rotation. A mock is neither.
+
+  One caveat on the integration route out, because this file otherwise reads as
+  a stronger guarantee than it is: `ci-quality.yaml` runs `lint,typecheck,test,
+  build-ci` and never `test-integration`, and the unit config excludes
+  `tests/integration/**`. So a module can leave this set on the strength of a
+  spec no pull request actually executes. The spec is real and does exercise the
+  module - it just has to be run deliberately, with a local database.
 
   Removing an entry is the only way this list is allowed to change.
 */
 const KNOWN_UNGUARDED = new Set([
-	'app/lib/domain/scene/server/scene-settings.operations.server.ts',
-	'app/lib/domain/auth/api-key-repository.server.ts'
+	'app/lib/domain/scene/server/scene-settings.operations.server.ts'
 ])
 
 function collectSpecFiles(dir: string): string[] {

--- a/apps/vectreal-platform/tests/integration/api-key-lifecycle.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/api-key-lifecycle.integration.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Rotation, checked against the authorization path it exists to fix.
+ *
+ * Asserting that `hashedKey` changed would only prove the repository agrees
+ * with itself. What matters is the thing a customer experiences: after a
+ * rotation the old snippet stops working and the new one starts, with the same
+ * key row, name and project scope. So every assertion here goes through
+ * `validatePreviewApiKeyForProject` - the same function `/embed` calls.
+ *
+ * Opt-in, because it writes to whatever `DATABASE_URL` points at:
+ *
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ *
+ * Every row it creates is namespaced by a fresh uuid and dropped in `afterAll`.
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+type Schema = typeof import('../../app/db/schema')
+type Repository =
+	typeof import('../../app/lib/domain/auth/api-key-repository.server')
+type PreviewAuth =
+	typeof import('../../app/lib/domain/auth/preview-api-key-auth.server')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+
+/**
+ * A request shaped like a real embed load.
+ *
+ * The referer host matches the application host, which
+ * `isEmbedRequestHostAllowed` allows outright, so these assertions turn on the
+ * key and never on the project's domain list.
+ */
+function embedRequest(projectId: string, sceneId: string, token: string) {
+	return new Request(
+		`https://embed.test/embed/${projectId}/${sceneId}?token=${encodeURIComponent(token)}`,
+		{ headers: { referer: 'https://embed.test/product/widget' } }
+	)
+}
+
+describe('api key rotation', () => {
+	// Loaded in `beforeAll` rather than at module scope: these modules call
+	// `getDbClient()` on import, which throws without a `DATABASE_URL`.
+	let schema: Schema
+	let createApiKey: Repository['createApiKey']
+	let rotateApiKey: Repository['rotateApiKey']
+	let revokeApiKey: Repository['revokeApiKey']
+	let validatePreviewApiKeyForProject: PreviewAuth['validatePreviewApiKeyForProject']
+	let db: Db
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+	const sceneId = randomUUID()
+
+	let apiKeyId: string
+	let originalPlaintext: string
+	let rotatedPlaintext: string
+
+	beforeAll(async () => {
+		schema = await import('../../app/db/schema')
+		;({ createApiKey, rotateApiKey, revokeApiKey } =
+			await import('../../app/lib/domain/auth/api-key-repository.server'))
+		;({ validatePreviewApiKeyForProject } =
+			await import('../../app/lib/domain/auth/preview-api-key-auth.server'))
+		db = (await import('../../app/db/client')).getDbClient()
+
+		await db.insert(schema.users).values({
+			id: ownerId,
+			email: `owner-${ownerId}@rotate.test`,
+			name: 'Owner'
+		})
+		await db
+			.insert(schema.organizations)
+			.values({ id: organizationId, name: `rotate-${organizationId}`, ownerId })
+		await db.insert(schema.organizationMemberships).values({
+			userId: ownerId,
+			organizationId,
+			role: 'owner'
+		})
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Rotate project',
+			slug: `rotate-${projectId}`
+		})
+
+		const created = await createApiKey({
+			userId: ownerId,
+			organizationId,
+			name: 'Storefront key',
+			description: 'Pasted into a product page',
+			projectIds: [projectId]
+		})
+
+		apiKeyId = created.apiKey.id
+		originalPlaintext = created.plaintext
+	})
+
+	afterAll(async () => {
+		if (!db) return
+		await db.delete(schema.apiKeys).where(eq(schema.apiKeys.id, apiKeyId))
+		await db.delete(schema.projects).where(eq(schema.projects.id, projectId))
+		await db
+			.delete(schema.organizationMemberships)
+			.where(eq(schema.organizationMemberships.userId, ownerId))
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, organizationId))
+		await db.delete(schema.users).where(eq(schema.users.id, ownerId))
+	})
+
+	it('authorizes an embed with the key it just minted', async () => {
+		const decision = await validatePreviewApiKeyForProject({
+			request: embedRequest(projectId, sceneId, originalPlaintext),
+			projectId
+		})
+
+		expect(decision.ok).toBe(true)
+	})
+
+	it('hands back a new secret and keeps everything else', async () => {
+		const rotated = await rotateApiKey({ apiKeyId, userId: ownerId })
+		rotatedPlaintext = rotated.plaintext
+
+		expect(rotatedPlaintext).not.toBe(originalPlaintext)
+		expect(rotated.apiKey.id).toBe(apiKeyId)
+		expect(rotated.apiKey.name).toBe('Storefront key')
+		expect(rotated.apiKey.description).toBe('Pasted into a product page')
+		expect(rotated.projects.map((project) => project.id)).toEqual([projectId])
+		expect(rotated.apiKey.keyPreview).toBe(rotatedPlaintext.slice(-4))
+		expect(rotated.apiKey.rotatedAt).not.toBeNull()
+
+		/*
+		  Cleared on purpose. Carried over, it would read as "the new key is
+		  already in use" from the moment it was minted, and that field is exactly
+		  what an owner checks to confirm the storefront picked the new key up.
+		*/
+		expect(rotated.apiKey.lastUsedAt).toBeNull()
+	})
+
+	it('refuses the key that was in the old snippet', async () => {
+		const decision = await validatePreviewApiKeyForProject({
+			request: embedRequest(projectId, sceneId, originalPlaintext),
+			projectId
+		})
+
+		expect(decision).toEqual({ ok: false, error: 'invalid_token' })
+	})
+
+	it('authorizes the key from the new snippet', async () => {
+		const decision = await validatePreviewApiKeyForProject({
+			request: embedRequest(projectId, sceneId, rotatedPlaintext),
+			projectId
+		})
+
+		expect(decision.ok).toBe(true)
+	})
+
+	it('records the use, so the dashboard can tell the key was picked up', async () => {
+		/*
+		  Every other assertion here stops at `decision.ok`, which leaves the
+		  `lastUsedAt` write itself untested - and that column is the whole basis
+		  of the "Unused since rotating" warning. Without this, deleting the write
+		  would keep the suite green while the dashboard silently reported every
+		  rotated key as never adopted.
+		*/
+		const [row] = await db
+			.select({ lastUsedAt: schema.apiKeys.lastUsedAt })
+			.from(schema.apiKeys)
+			.where(eq(schema.apiKeys.id, apiKeyId))
+
+		expect(row.lastUsedAt).not.toBeNull()
+	})
+
+	it('never reports success for a rotation that lost a race', async () => {
+		/*
+		  Both callers read the row before either writes, so both hold the same
+		  starting secret. Without the compare-and-swap on `hashedKey` both
+		  updates match and both return success, leaving one admin holding a
+		  plaintext that authorizes nothing - presented as the new live key.
+		*/
+		const results = await Promise.allSettled([
+			rotateApiKey({ apiKeyId, userId: ownerId }),
+			rotateApiKey({ apiKeyId, userId: ownerId })
+		])
+
+		const winners = results.filter(
+			(result): result is PromiseFulfilledResult<
+				Awaited<ReturnType<typeof rotateApiKey>>
+			> => result.status === 'fulfilled'
+		)
+
+		expect(winners).toHaveLength(1)
+
+		rotatedPlaintext = winners[0].value.plaintext
+		const decision = await validatePreviewApiKeyForProject({
+			request: embedRequest(projectId, sceneId, rotatedPlaintext),
+			projectId
+		})
+		expect(decision.ok).toBe(true)
+	})
+
+	it('refuses to rotate an expired key', async () => {
+		await db
+			.update(schema.apiKeys)
+			.set({ expiresAt: new Date(Date.now() - 60_000) })
+			.where(eq(schema.apiKeys.id, apiKeyId))
+
+		await expect(rotateApiKey({ apiKeyId, userId: ownerId })).rejects.toThrow(
+			/expired/
+		)
+
+		await db
+			.update(schema.apiKeys)
+			.set({ expiresAt: null })
+			.where(eq(schema.apiKeys.id, apiKeyId))
+	})
+
+	it('refuses to rotate a revoked key, so revoking stays final', async () => {
+		await revokeApiKey(apiKeyId, ownerId)
+
+		await expect(rotateApiKey({ apiKeyId, userId: ownerId })).rejects.toThrow(
+			/revoked/
+		)
+
+		const decision = await validatePreviewApiKeyForProject({
+			request: embedRequest(projectId, sceneId, rotatedPlaintext),
+			projectId
+		})
+
+		expect(decision).toEqual({ ok: false, error: 'invalid_token' })
+	})
+})

--- a/apps/vectreal-platform/tests/one-time-key-dialog.spec.tsx
+++ b/apps/vectreal-platform/tests/one-time-key-dialog.spec.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+/**
+ * The guard on an unrecoverable value, for the dashboard's copy of this dialog.
+ *
+ * `tests/embed-created-key-dialog.spec.tsx` already asserts the same rules for
+ * the embed panel's dialog. That the two exist at all is the duplication this
+ * work is about; until they are merged, both need the guard, because the bug
+ * they prevent - dismissing a plaintext that was never copied, which cannot be
+ * shown again - was fixed in one of them and not the other.
+ *
+ * Rotation is what made it reachable: repeating it is two clicks and a round
+ * trip, well inside the two-second window the copy button stays lit.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	OneTimeKeyDialog,
+	type OneTimeKeyValue
+} from '../app/components/api-keys/one-time-key-dialog'
+
+const FIRST: OneTimeKeyValue = {
+	plaintext: 'vctrl_firstsecretab3x',
+	preview: 'ab3x',
+	name: 'Storefront key'
+}
+
+const SECOND: OneTimeKeyValue = {
+	plaintext: 'vctrl_secondsecret9zQ1',
+	preview: '9zQ1',
+	name: 'Storefront key'
+}
+
+const writeText = vi.fn(async () => undefined)
+
+beforeEach(() => {
+	vi.stubGlobal('navigator', { clipboard: { writeText } })
+	writeText.mockClear()
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.restoreAllMocks()
+})
+
+const confirmWith = (answer: boolean) =>
+	vi.spyOn(window, 'confirm').mockReturnValue(answer)
+
+const dismiss = () =>
+	fireEvent.click(screen.getByRole('button', { name: /saved my key/i }))
+
+describe('OneTimeKeyDialog', () => {
+	it('shows nothing until a key exists', () => {
+		render(
+			<OneTimeKeyDialog
+				open
+				apiKey={null}
+				reason="created"
+				onClose={vi.fn()}
+			/>
+		)
+
+		expect(screen.queryByText(FIRST.plaintext)).toBeNull()
+	})
+
+	it('asks before dismissing a key that was never copied', () => {
+		const confirm = confirmWith(false)
+		const onClose = vi.fn()
+
+		render(
+			<OneTimeKeyDialog open apiKey={FIRST} reason="created" onClose={onClose} />
+		)
+		dismiss()
+
+		expect(confirm).toHaveBeenCalledOnce()
+		expect(onClose).not.toHaveBeenCalled()
+	})
+
+	it('does not ask once the key has been copied', async () => {
+		const confirm = confirmWith(true)
+		const onClose = vi.fn()
+
+		render(
+			<OneTimeKeyDialog open apiKey={FIRST} reason="created" onClose={onClose} />
+		)
+		fireEvent.click(screen.getByRole('button', { name: /copy api key/i }))
+		await waitFor(() => expect(writeText).toHaveBeenCalledWith(FIRST.plaintext))
+
+		dismiss()
+
+		expect(confirm).not.toHaveBeenCalled()
+		expect(onClose).toHaveBeenCalledOnce()
+	})
+
+	/*
+	  The regression this file exists for. The parent renders this component
+	  continuously and only swaps `apiKey`, so nothing remounts it between keys
+	  and `copied` survives - along with the 2s window in which the button still
+	  reads as copied.
+	*/
+	it('does not let a second key inherit the first key’s copied state', async () => {
+		const onClose = vi.fn()
+		const { rerender } = render(
+			<OneTimeKeyDialog open apiKey={FIRST} reason="rotated" onClose={onClose} />
+		)
+
+		fireEvent.click(screen.getByRole('button', { name: /copy api key/i }))
+		await waitFor(() => expect(writeText).toHaveBeenCalledWith(FIRST.plaintext))
+
+		// A second rotation, well within the copied-state timeout.
+		rerender(
+			<OneTimeKeyDialog
+				open
+				apiKey={SECOND}
+				reason="rotated"
+				onClose={onClose}
+			/>
+		)
+		await screen.findByText(SECOND.plaintext)
+
+		const confirm = confirmWith(false)
+		dismiss()
+
+		expect(
+			confirm,
+			'the second key was never copied, so dismissing it must ask first'
+		).toHaveBeenCalledOnce()
+		expect(onClose).not.toHaveBeenCalled()
+	})
+
+	it('tells a rotating user that the old key is already dead', () => {
+		render(
+			<OneTimeKeyDialog open apiKey={FIRST} reason="rotated" onClose={vi.fn()} />
+		)
+
+		expect(screen.getByText(/previous key stopped working/i)).not.toBeNull()
+		expect(screen.getByText(/every embed still carrying it/i)).not.toBeNull()
+	})
+
+	it('does not tell a creating user anything about a previous key', () => {
+		render(
+			<OneTimeKeyDialog open apiKey={FIRST} reason="created" onClose={vi.fn()} />
+		)
+
+		expect(screen.queryByText(/previous key stopped working/i)).toBeNull()
+	})
+})

--- a/apps/vectreal-platform/tests/use-once-per-fetcher-response.spec.tsx
+++ b/apps/vectreal-platform/tests/use-once-per-fetcher-response.spec.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * The rule that broke three times.
+ *
+ * Every case below is a real defect this hook's predecessor shipped, found in
+ * three separate review rounds while adding key rotation. They are written as
+ * distinct tests rather than one because each was patched separately before the
+ * mechanism itself was recognized as the cause.
+ */
+
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useOncePerFetcherResponse } from '../app/hooks/use-once-per-fetcher-response'
+
+type Fetcher<T> = { state: string; data: T | undefined }
+
+function renderWith<T>(fetcher: Fetcher<T>, handle: (data: T) => void) {
+	function Probe({ value }: { value: Fetcher<T> }) {
+		useOncePerFetcherResponse(value, handle)
+		return null
+	}
+
+	const view = render(<Probe value={fetcher} />)
+	return {
+		settle: (next: Fetcher<T>) => view.rerender(<Probe value={next} />)
+	}
+}
+
+const idle = <T,>(data: T): Fetcher<T> => ({ state: 'idle', data })
+
+describe('useOncePerFetcherResponse', () => {
+	it('ignores a fetcher that has not been used', () => {
+		const handle = vi.fn()
+		renderWith({ state: 'idle', data: undefined }, handle)
+
+		expect(handle).not.toHaveBeenCalled()
+	})
+
+	it('ignores a response that is still in flight', () => {
+		const handle = vi.fn()
+		renderWith({ state: 'submitting', data: { ok: true } }, handle)
+
+		expect(handle).not.toHaveBeenCalled()
+	})
+
+	it('handles a settled response once', () => {
+		const handle = vi.fn()
+		renderWith(idle({ ok: true }), handle)
+
+		expect(handle).toHaveBeenCalledOnce()
+	})
+
+	it('does not re-handle the same response when the component re-renders', () => {
+		const handle = vi.fn()
+		const response = { ok: true }
+		const { settle } = renderWith(idle(response), handle)
+
+		// The same object, as a revalidation cycle would deliver it.
+		settle({ state: 'idle', data: response })
+		settle({ state: 'idle', data: response })
+
+		expect(handle).toHaveBeenCalledOnce()
+	})
+
+	/*
+	  Defect 1: two revokes returned `{ success: true, message: 'API key revoked
+	  successfully' }`, so the second was swallowed - no toast, no revalidation.
+	*/
+	it('handles a second response whose body repeats the first', () => {
+		const handle = vi.fn()
+		const { settle } = renderWith(
+			idle({ success: true, message: 'API key revoked successfully' }),
+			handle
+		)
+
+		settle(idle({ success: true, message: 'API key revoked successfully' }))
+
+		expect(handle).toHaveBeenCalledTimes(2)
+	})
+
+	/*
+	  Defect 2: `revokeApiKey` and `rotateApiKey` throw byte-identical messages
+	  for a key that cannot be found, so a second failure looked like the first.
+	*/
+	it('handles a second failure carrying the same message', () => {
+		const handle = vi.fn()
+		const { settle } = renderWith(
+			idle({ error: 'API key not found or access denied' }),
+			handle
+		)
+
+		settle(idle({ error: 'API key not found or access denied' }))
+
+		expect(handle).toHaveBeenCalledTimes(2)
+	})
+
+	/*
+	  Defect 3: a CSRF rejection body carries nothing that varies, so after the
+	  first one the page went silently unresponsive to every further attempt.
+	*/
+	it('handles every repeat of a fixed rejection body', () => {
+		const handle = vi.fn()
+		const csrf = () => idle({ success: false, error: 'Invalid CSRF token' })
+		const { settle } = renderWith(csrf(), handle)
+
+		settle(csrf())
+		settle(csrf())
+
+		expect(handle).toHaveBeenCalledTimes(3)
+	})
+
+	it('does not re-run when only the handler identity changes', () => {
+		const first = vi.fn()
+		const response = { ok: true }
+
+		function Probe({ handle }: { handle: (data: unknown) => void }) {
+			useOncePerFetcherResponse({ state: 'idle', data: response }, handle)
+			return null
+		}
+
+		const view = render(<Probe handle={first} />)
+		const second = vi.fn()
+		view.rerender(<Probe handle={second} />)
+
+		expect(first).toHaveBeenCalledOnce()
+		expect(second).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
## Summary

Replacing a compromised API key meant revoke-and-recreate, which breaks every
embed at once and then needs each one re-scoped and re-pasted by hand. That is
why the token published in the marketing bundle has sat unrotated: there was no
move that did not take the storefront down with it.

Rotation issues a new secret for the same key row. Only the snippet changes.

**Stacked on #744** (`refactor/api-key-lifecycle-owner`), which this needs for a
trustworthy answer to "is this key live". Review that one first; merge it, and
this retargets to `main`.

Second of four PRs in the API key security chain. The plan had rotate and delete
as one PR; its own sentence gave it away ("rotated in place **or** deleted
outright"), so delete is split out and follows.

## Root cause

There is no rotate path, so the only way to replace a leaked key is
revoke-and-recreate, which breaks every live embed simultaneously. The fix
belongs in the repository beside `revokeApiKey`, not in a workaround that
re-mints and re-scopes a second key.

## Changes

- `rotateApiKey` - new secret, same row. Keeps id, name, description, project
  links, expiry and `createdAt`. Refused on any key that is not live: a revoked
  key must stay dead, and a rotated-but-expired key would hand back a secret
  that still cannot authorize anything.
- `api-key:rotate` added to `DashboardOperation` and both total `Record`s, so a
  missing rule is a compile error. Owner and admin, matching revoke - rotating
  is revoke plus a replacement, not a lesser action.
- One new nullable column, `rotated_at`, generated by `drizzle-generate`.
  Additive, no backfill, safe on a live table.
- Rotate in the row menu, offered only on a live key, behind an acknowledge-tier
  confirmation that says the embed breaks until the snippet is updated.
- The show-once dialog moves out of `api-keys-new.tsx`, where it was local, into
  `components/api-keys/` so creation and rotation share one.
- **Last Used** gains "Unused since rotating". Rotation clears `last_used_at`,
  so that pair is the only way to tell from the dashboard that an embed
  somewhere is still sending the old key and being refused.
- `publish-embed.mdx` documents rotation, with four executable claims anchored to
  implementation lines.

`app/lib/domain/auth/api-key-repository.server.ts` leaves `KNOWN_UNGUARDED` in
`critical-path.spec.ts`. The new integration spec exercises minting, rotation,
revocation and a rotation race against a real Postgres, asserting through
`validatePreviewApiKeyForProject` - the same function `/embed` calls, so the
assertions are about what a customer experiences rather than about a stored hash.

## What the review loop found

Four rounds. Rounds 1-3 each found something real; round 4 came back clean.
Every finding was verified against the code before being fixed - three of the
reviewers had no shell and were reading statically.

| Round | Finding | Consequence |
| --- | --- | --- |
| 1 | Two concurrent rotations both reported success | The loser is handed a plaintext that authorizes nothing, presented as the new live key |
| 1 | Stale `last_used_at` write from a slow request | "Unused since rotating" reports a key that *was* picked up |
| 1 | `copied` state carried between keys | The confirm guard is skipped and an unrecoverable plaintext is dismissed |
| 1 | `isMutating` shared by both dialogs | A dialog you just opened shows "Working..." and cannot be cancelled |
| 1 | Revoke responses byte-identical | Second revoke of a session swallowed - no toast, no revalidation |
| 2 | Error responses collide the same way | Same bug, other half |
| 2 | Nothing asserted `last_used_at` is written | The column the new indicator reads had no behavioural test |
| 3 | CSRF rejections collide too | After the first, the page goes silently unresponsive |

The third finding is the one that mattered most - it loses a key permanently.
A spec for the *embed* panel's dialog already covered that exact bug, so the fix
existed in one of the two show-once dialogs and not the other.

### The response de-duplication was a missing root cause, not three bugs

Rounds 1, 2 and 3 found the same symptom in three places. Two were patched by
making payloads differ before the mechanism was recognised as the cause: keying
on `JSON.stringify(fetcher.data)` assumes response *content* is unique, and it
is not. The third collision - a CSRF body that carries nothing varying - could
not be fixed that way at all.

Those patches are reverted. `useOncePerFetcherResponse` keys on the response
object's identity, which is the question that was actually being asked: a fresh
response is always a fresh object, a re-render never is. It lives in a hook
rather than inline because this rule has now broken three times and
`api-keys.tsx` has no spec of its own.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [x] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

`typecheck,lint` over `vctrl/core`, `vctrl/hooks`, `vctrl/viewer`,
`vectreal-platform` (8 tasks, matching 4 projects x 2 targets). 898 unit tests
across 82 files. 53 integration tests against local Supabase.

> **The integration tests do not run in CI, here or anywhere.** `ci-quality.yaml`
> runs `lint,typecheck,test,build-ci` and never `test-integration`, and the unit
> config excludes `tests/integration/**`. So the rotation race, the `lastUsedAt`
> assertion and the revoke-then-rotate refusal were all verified locally and no
> pull request re-runs them. This is not new to this PR - it is true of all five
> integration spec files - but it qualifies the evidence above, and it qualifies
> the ratchet change below. Filed as `Now`.
>
> The consequence for `critical-path.spec.ts`: `api-key-repository.server.ts`
> leaves `KNOWN_UNGUARDED` on the strength of a spec CI never executes. The spec
> is real and does exercise the module; it just has to be run deliberately. A
> caveat now says so in that file rather than letting the ratchet read as a
> stronger guarantee than it is.

**Mutation gate.** Each mutation was applied to the production line and a
specific assertion confirmed red, then restored:

| Mutation | Result |
| --- | --- |
| drop the compare-and-swap on `hashedKey` | race test red - both rotations fulfil |
| write back the old hash | old key still authorizes, new one refused |
| drop the not-live guard | revoked/expired rotation tests red |
| delete the `lastUsedAt` write | red |
| drop the dialog's copied-state reset | red |
| revert the hook to content-based dedup | all three defect tests red |
| break a doc claim anchor | red |

**One gap, stated rather than papered over.** The `lastUsedAt` *hash guard*
cannot be mutation-gated here: reproducing it needs three requests interleaved
around a rotation in a fixed order, which I cannot arrange deterministically.
The predicate is pinned statically instead, and the test says in its own comment
that it does not prove the runtime behaviour.

The rotation-race test *is* real. Both calls reach their first `await` in the
same synchronous turn, so both reads necessarily see the pre-rotation hash; I
ran it five times before trusting it.

Not verified in a browser yet - the dev port was occupied. The rotate flow's
riskiest behaviour is covered by `tests/one-time-key-dialog.spec.tsx` instead.

## Filed rather than fixed

- **Dashboard mutations carry the same de-duplication bug** and it is worse
  there: a swallowed response also skips `setPendingIds(new Set())`, so a row
  stays visibly stuck pending. `use-dashboard-mutations.ts` owns create, rename,
  move and delete for projects, folders and scenes. Filed as `Now`; the fix is
  to point it at the new hook.
- Prettier destroys `{/* claims */}` blocks in MDX - nothing configures the
  `mdx` parser, so it normalises the emphasis characters. It mangled the
  pre-existing wildcard-domain claims block too.
- The two show-once dialogs should become one; that needs the embed dialog's
  copy moved out of `EMBED_COPY` first.

