### PR TITLE
ci: run the quality gate on agent-instruction changes

### DIFF
--- a/.github/workflows/ci-quality.yaml
+++ b/.github/workflows/ci-quality.yaml
@@ -20,6 +20,13 @@ on:
       - 'eslint.config.mts'
       - 'vitest.shared.mts'
       - 'tsconfig.base.json'
+      # Agent instructions carry claims about this code that
+      # documented-claims.spec.ts executes. Without these the spec never runs
+      # on the PRs most likely to invalidate it.
+      - '.agents/**'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - '.github/pull_request_template.md'
       - '.github/workflows/ci-quality.yaml'
       - '.github/workflows/cd-platform-staging.yaml'
       - '.github/workflows/cd-platform-production.yaml'

--- a/apps/vectreal-platform/project.json
+++ b/apps/vectreal-platform/project.json
@@ -275,6 +275,9 @@
 				"cwd": "apps/vectreal-platform",
 				"command": "pnpm dlx react-email dev --dir app/lib/email/templates --port 3000"
 			}
+		},
+		"test": {
+			"inputs": ["default", "^production", "agentInstructions"]
 		}
 	}
 }

--- a/nx.json
+++ b/nx.json
@@ -12,6 +12,11 @@
 			"!{projectRoot}/vitest.config.ts",
 			"!{projectRoot}/vitest.integration.config.ts",
 			"!{projectRoot}/tests/**"
+		],
+		"agentInstructions": [
+			"{workspaceRoot}/.agents/skills/**/*",
+			"{workspaceRoot}/CLAUDE.md",
+			"{workspaceRoot}/AGENTS.md"
 		]
 	},
 	"targetDefaults": {


### PR DESCRIPTION
## Summary

Makes the quality gate run when agent instructions change, so the `claims` blocks
in the skills are actually verified against the code they describe.

## Root cause

`documented-claims.spec.ts` executes the skills' factual claims about this
repository, but it never ran on the PRs most likely to invalidate them:
`ci-quality.yaml`'s `paths:` filter omitted `.agents/**`, `CLAUDE.md` and
`AGENTS.md`, and those files belong to no project's Nx inputs, so the fix belongs
in the path filter plus a named input rather than in the job's run condition.

Both halves were needed. Adding the paths alone would have triggered a workflow
that scheduled nothing:

```
$ npx nx show projects --affected --files=.agents/skills/vectreal-brand-ux-design/SKILL.md
["@vctrl/root"]
```

`@vctrl/root` has no `lint`, `test` or `build` target, so the run would have
reported success while executing zero tasks — worse than not running, because it
looks like coverage.

## Changes

- `.github/workflows/ci-quality.yaml`: add `.agents/**`, `CLAUDE.md`, `AGENTS.md`
  and `.github/pull_request_template.md` to the `pull_request` paths.
- `nx.json`: add an `agentInstructions` named input covering those globs.
- `apps/vectreal-platform/project.json`: reference it from the `test` target,
  which is where `documented-claims.spec.ts` lives.

Scoped deliberately. Putting the globs in `sharedGlobals` also works and is one
line shorter, but marks **all eleven** projects affected, rebuilding the whole
monorepo for a typo in a skill:

| | affected by a `SKILL.md` edit |
| --- | --- |
| before | `@vctrl/root` (zero tasks) |
| via `sharedGlobals` | all 11 projects |
| **this PR** | `@vctrl/root`, `vectreal-platform` |

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] No product code changed.

Verified:

- `nx show projects --affected` now returns `vectreal-platform` for a `SKILL.md`
  edit and for a `CLAUDE.md` edit; a route edit is unchanged.
- `nx affected -t test --files=.agents/skills/.../SKILL.md` schedules
  `vectreal-platform:test`, so the claims spec actually runs.
- The `test` target is plugin-inferred, so adding an explicit entry risked
  clobbering it. Confirmed the merge preserves the executor and command
  (`nx:run-commands` / `vitest`) and that `nx test vectreal-platform` still runs.
- `nx run-many -t typecheck,test -p vectreal-platform` passes.
- Workflow YAML parses; `merge_group` trigger is present and unfiltered.
- `nx.json` and `project.json` re-formatted with the repo's Prettier config, so
  the diff is 15 added lines and no reflow churn.

## A local-only failure worth knowing about

While verifying this I hit `vectreal-platform:lint` failing on a clean tree with:

```
apps/vectreal-platform/package.json
  54:3  error  The "express" package is not used by "vectreal-platform" project  @nx/dependency-checks
```

**It is not a repo defect.** `express` is declared and genuinely imported by
`apps/vectreal-platform/server.mjs`, but it was not present in the shared
`node_modules` this worktree symlinks to, so the rule could not resolve it and
reported the misleading "not used". CI installs fresh (`+ express 5.2.1` in the
log) and `nx run vectreal-platform:lint` passes there, which this PR's own
Quality Gate run confirms.

Recorded because the message points at the wrong thing: reinstall before trusting
a dependency-shaped lint failure in a worktree.

## Follow-up this unblocks

`main`'s ruleset has no `required_status_checks`, so lint, typecheck, test and
`build-ci` can all be red and a PR still merges. This PR is a prerequisite for
turning that on, not a substitute for it.

Order matters. GitHub documents that a workflow skipped by a paths filter reports
nothing and leaves a required check pending forever, so requiring the
paths-filtered `pull_request` trigger without this change would make skill-only
PRs permanently unmergeable. `ci-quality.yaml` already carries an unfiltered
`merge_group:` trigger, so a merge queue is the cleaner route than an always-run
gate job. Note also that protected-branch rules do not apply to admins unless
explicitly configured to.
