### PR TITLE
fix(embed): keep tokenized embed URLs out of search indexes

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -124,6 +124,13 @@ VITE_PUBLIC_POSTHOG_UI_HOST=https://eu.posthog.com
 # VITE_PUBLIC_VECTREAL_API_KEY_PROD:
 #   API token used in newsroom article iframes and the landing page demo fallback.
 #   Generate or copy from your Vectreal dashboard → API Keys.
+#
+#   Public by construction. VITE_PUBLIC_* is inlined at build time, so this ships
+#   in the client bundle to every visitor - and an embed authenticates by a token
+#   in its URL anyway, since an iframe cannot set request headers. Moving it
+#   server-side would not hide it. The control that matters is the owning
+#   project's allowed-domain list, so scope this key to a project that allows
+#   only vectreal.com, and rotate it from the dashboard rather than revoking it.
 VITE_PUBLIC_VECTREAL_API_KEY_PROD=your-vectreal-api-key
 #
 # VITE_PUBLIC_DEMO_SCENE_URL:

--- a/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-chapters.ts
+++ b/apps/vectreal-platform/app/components/home/scroll-interaction-section/mock-shop-chapters.ts
@@ -1,6 +1,19 @@
 // Scene chapters for the home-page mock-shop scrollytell section, plus the pure
 // helpers that map scroll progress onto chapters and the filmstrip transform.
 
+/*
+  The token below is public, by construction rather than by accident.
+
+  `VITE_PUBLIC_*` is inlined at build time, so this value ships in the client
+  bundle to every visitor. That is not a mistake to be corrected by moving it
+  server-side: an embed authenticates by a token in its URL, because an iframe
+  cannot set request headers, so the value lands in the page source either way.
+  Every customer's embed carries theirs the same way.
+
+  What keeps it from being a free pass is the owning project's allowed-domain
+  list, checked on every embed request. Treat that list as the control, and keep
+  this key scoped to a project that allows only vectreal.com.
+*/
 export const DEMO_SCENE_URL =
 	typeof import.meta !== 'undefined' &&
 	(import.meta.env.VITE_PUBLIC_DEMO_SCENE_URL as string | undefined)

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-response-headers.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-response-headers.ts
@@ -1,0 +1,61 @@
+/**
+ * The headers every `/embed` response carries, whatever its status.
+ *
+ * An embed URL carries its API key in the query string, because an iframe
+ * cannot set request headers. That is not a leak in itself - the same token is
+ * in the `src` of every customer's embed, visible to anyone who views source -
+ * but it does mean the URL must not be retained anywhere that outlives the
+ * request, and a search index is exactly that.
+ *
+ * Pure, and separate from the route, because `embed-layout.tsx` reaches
+ * `getDbClient()` on import and throws without `DATABASE_URL`, so no spec can
+ * import it. This is the `scene-route-params.ts` pattern.
+ */
+
+export const EMBED_RESPONSE_HEADERS: Readonly<Record<string, string>> = {
+	/**
+	 * Never cached: the response depends on a token, a referer and the scene's
+	 * publication state, none of which are in the cache key.
+	 */
+	'Cache-Control': 'no-store',
+
+	/**
+	 * The control that actually keeps tokenized URLs out of search results.
+	 *
+	 * `/embed` already renders `<meta name="robots" content="noindex, nofollow">`
+	 * through `buildMeta(..., { private: true })`, but a meta tag only works if
+	 * the crawler renders the page. The header does not depend on that, and it
+	 * applies to the error responses too, which render no document at all.
+	 */
+	'X-Robots-Tag': 'noindex, nofollow',
+
+	/**
+	 * Defense in depth, matching what browsers already default to.
+	 *
+	 * Nothing in the app sets a referrer policy, so the current default already
+	 * sends only the origin cross-origin and the token never rides along. Stating
+	 * it means a laxer policy introduced later cannot silently start leaking a
+	 * tokenized URL to every third-party host an embed happens to touch.
+	 */
+	'Referrer-Policy': 'strict-origin-when-cross-origin'
+}
+
+/**
+ * Re-issues `response` carrying the headers above.
+ *
+ * Applied to every return from the embed loader, not only the successful one.
+ * A 404 for an unpublished scene and a 403 for a disallowed domain are just as
+ * indexable as a 200, and they are the ones a crawler is most likely to reach.
+ */
+export function withEmbedResponseHeaders(response: Response): Response {
+	const headers = new Headers(response.headers)
+
+	for (const [name, value] of Object.entries(EMBED_RESPONSE_HEADERS)) {
+		headers.set(name, value)
+	}
+
+	return new Response(response.body, {
+		status: response.status,
+		headers
+	})
+}

--- a/apps/vectreal-platform/app/routes/layouts/embed-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/embed-layout.tsx
@@ -4,6 +4,10 @@ import { data, Outlet, type MetaFunction } from 'react-router'
 import { Route } from './+types/embed-layout'
 import { validatePreviewApiKeyForProject } from '../../lib/domain/auth/preview-api-key-auth.server'
 import {
+	EMBED_RESPONSE_HEADERS,
+	withEmbedResponseHeaders
+} from '../../lib/domain/embed/embed-response-headers'
+import {
 	parseSceneRouteParams,
 	SCENE_ROUTE_PARAM_ERRORS
 } from '../../lib/domain/scene/scene-route-params'
@@ -20,15 +24,6 @@ export const meta: MetaFunction = () =>
 		{ private: true }
 	)
 
-function withNoStoreHeaders(response: Response): Response {
-	const headers = new Headers(response.headers)
-	headers.set('Cache-Control', 'no-store')
-	return new Response(response.body, {
-		status: response.status,
-		headers
-	})
-}
-
 /**
  * External embeds authenticate by preview API key and nothing else.
  *
@@ -39,7 +34,7 @@ function withNoStoreHeaders(response: Response): Response {
 export async function loader({ request, params }: Route.LoaderArgs) {
 	const parsedParams = parseSceneRouteParams(params)
 	if (!parsedParams.ok) {
-		return withNoStoreHeaders(
+		return withEmbedResponseHeaders(
 			ApiResponse.badRequest(SCENE_ROUTE_PARAM_ERRORS[parsedParams.reason])
 		)
 	}
@@ -51,7 +46,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		Boolean(tokenFromQuery) || Boolean(request.headers.get('authorization')?.trim())
 
 	if (!hasTokenCredential) {
-		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
+		return withEmbedResponseHeaders(ApiResponse.notFound('Scene not found'))
 	}
 
 	const authResult = await validatePreviewApiKeyForProject({
@@ -61,26 +56,53 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 	if (!authResult.ok) {
 		if (authResult.error === 'rate_limited') {
-			return withNoStoreHeaders(ApiResponse.error('Too many requests', 429))
+			return withEmbedResponseHeaders(ApiResponse.error('Too many requests', 429))
 		}
 		if (authResult.error === 'domain_not_allowed') {
-			return withNoStoreHeaders(ApiResponse.forbidden('Forbidden'))
+			return withEmbedResponseHeaders(ApiResponse.forbidden('Forbidden'))
 		}
 
-		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
+		return withEmbedResponseHeaders(ApiResponse.notFound('Scene not found'))
 	}
 
 	const previewScene = await getPublishedScenePreview(projectId, sceneId)
 	if (!previewScene) {
-		return withNoStoreHeaders(ApiResponse.notFound('Scene not found'))
+		return withEmbedResponseHeaders(ApiResponse.notFound('Scene not found'))
 	}
 
-	return data({
-		projectId,
-		sceneId,
-		tokenFromQuery,
-		authenticatedByApiKeyId: authResult.apiKeyId
-	})
+	/*
+	  The success path carried no headers at all until now, so it was the one
+	  response a crawler could actually reach and index, and the only one not
+	  marked `no-store` - while being the only one whose body embeds the token
+	  and the id of the key that authorized it.
+	*/
+	return data(
+		{
+			projectId,
+			sceneId,
+			tokenFromQuery,
+			authenticatedByApiKeyId: authResult.apiKeyId
+		},
+		{ headers: EMBED_RESPONSE_HEADERS }
+	)
+}
+
+/**
+ * Without this the headers above never reach the browser.
+ *
+ * `/embed/:projectId/:sceneId` renders a document, so React Router builds the
+ * HTTP response through `getDocumentHeaders`. For any route module with no
+ * `headers` export it takes `new Headers(parentHeaders)` and then merges only
+ * `Set-Cookie` from the loader - every other header the loader set is dropped
+ * on the floor. `Cache-Control`, `X-Robots-Tag` and `Referrer-Policy` all
+ * qualify, so the loader would have been setting them into nothing.
+ *
+ * No other route in this app exports `headers`, which is why it looks
+ * unnecessary and is not. The child route has no loader of its own, so it falls
+ * through to `new Headers(parentHeaders)` and passes these along unchanged.
+ */
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+	return loaderHeaders
 }
 
 const EmbedLayout = () => {

--- a/apps/vectreal-platform/app/routes/robots[.]txt.ts
+++ b/apps/vectreal-platform/app/routes/robots[.]txt.ts
@@ -26,6 +26,19 @@ export async function loader() {
 		'Disallow: /dashboard',
 		'Disallow: /onboarding',
 		'Disallow: /preview',
+		/*
+		  `/embed` is deliberately absent, and adding it would make things worse.
+
+		  Those URLs carry an API key in the query string, so keeping them out of
+		  search results matters. Disallowing a path stops the crawl, not the
+		  indexing: a URL discovered elsewhere can still be listed, with no
+		  snippet, and Google cannot see the `noindex` it was told to obey because
+		  it is no longer allowed to fetch the page and read it.
+
+		  `/embed` answers every request with `X-Robots-Tag: noindex, nofollow`
+		  (`embed-response-headers.ts`) and renders the matching meta tag. Both
+		  require the crawler to be allowed in.
+		*/
 		'',
 		'# API and auth endpoints',
 		'Disallow: /api/',

--- a/apps/vectreal-platform/tests/embed-response-headers.spec.ts
+++ b/apps/vectreal-platform/tests/embed-response-headers.spec.ts
@@ -1,0 +1,160 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { ApiResponse } from '@shared/utils'
+import { describe, expect, it } from 'vitest'
+
+import {
+	EMBED_RESPONSE_HEADERS,
+	withEmbedResponseHeaders
+} from '../app/lib/domain/embed/embed-response-headers'
+
+/**
+ * An embed URL carries its API key in the query string, so the response must
+ * not end up anywhere that outlives the request. The failure paths matter more
+ * than the success one here: a crawler that finds an embed URL without a token
+ * gets the 404, and that is the response most likely to be indexed.
+ */
+
+const ORIGINAL = Object.entries(EMBED_RESPONSE_HEADERS)
+
+describe('embed response headers', () => {
+	it('tells crawlers not to index, whatever the status', () => {
+		const responses = [
+			ApiResponse.notFound('Scene not found'),
+			ApiResponse.forbidden('Forbidden'),
+			ApiResponse.error('Too many requests', 429),
+			ApiResponse.badRequest('Bad request'),
+			new Response('ok', { status: 200 })
+		]
+
+		for (const response of responses) {
+			const wrapped = withEmbedResponseHeaders(response)
+
+			expect(
+				wrapped.headers.get('X-Robots-Tag'),
+				`status ${wrapped.status} is indexable`
+			).toBe('noindex, nofollow')
+		}
+	})
+
+	it('keeps every declared header on every status', () => {
+		for (const [name, value] of ORIGINAL) {
+			const wrapped = withEmbedResponseHeaders(
+				ApiResponse.notFound('Scene not found')
+			)
+
+			expect(wrapped.headers.get(name), `${name} is missing`).toBe(value)
+		}
+	})
+
+	it('never lets an embed response be stored', () => {
+		const wrapped = withEmbedResponseHeaders(new Response('ok'))
+
+		expect(wrapped.headers.get('Cache-Control')).toBe('no-store')
+	})
+
+	it('does not send a full tokenized URL to another origin', () => {
+		const wrapped = withEmbedResponseHeaders(new Response('ok'))
+
+		/*
+		  Matching the browser default rather than tightening past it. The point
+		  is that a laxer policy introduced later cannot silently start attaching
+		  a tokenized URL to requests leaving the page.
+		*/
+		expect(wrapped.headers.get('Referrer-Policy')).toBe(
+			'strict-origin-when-cross-origin'
+		)
+	})
+
+	it('preserves the status and body it was handed', async () => {
+		const wrapped = withEmbedResponseHeaders(
+			new Response('scene payload', { status: 418 })
+		)
+
+		expect(wrapped.status).toBe(418)
+		expect(await wrapped.text()).toBe('scene payload')
+	})
+
+	it('keeps headers the response already carried', () => {
+		const response = new Response('ok', {
+			headers: { 'Set-Cookie': 'session=abc' }
+		})
+
+		expect(withEmbedResponseHeaders(response).headers.get('Set-Cookie')).toBe(
+			'session=abc'
+		)
+	})
+
+	/*
+	  The half the rest of this file cannot see.
+
+	  Everything above proves the helper returns the right `Response`. None of it
+	  proves the browser receives one: for a document route, React Router builds
+	  the HTTP response with `getDocumentHeaders`, which for a module without a
+	  `headers` export keeps only `Set-Cookie` from the loader and discards the
+	  rest. This PR's first draft did exactly that - a correct helper, wired into
+	  a route that threw its output away, with all seven assertions above passing.
+
+	  So the invariant is between the two halves: anything that builds these
+	  headers in a loader has to export `headers` as well, or it is setting them
+	  into nothing.
+	*/
+	describe('the routes that use them actually propagate them', () => {
+		const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+		function collectRouteFiles(dir: string): string[] {
+			return readdirSync(dir).flatMap((entry) => {
+				const full = join(dir, entry)
+				if (statSync(full).isDirectory()) return collectRouteFiles(full)
+				return /\.tsx?$/.test(entry) ? [full] : []
+			})
+		}
+
+		const usingRoutes = collectRouteFiles(join(APP_ROOT, 'app/routes'))
+			.map((file) => ({ file, source: readFileSync(file, 'utf8') }))
+			.filter(
+				({ source }) =>
+					source.includes('withEmbedResponseHeaders') ||
+					source.includes('EMBED_RESPONSE_HEADERS')
+			)
+
+		it('finds at least one route using them', () => {
+			// Without this the filter could silently match nothing and the check
+			// below would pass by asserting over an empty list.
+			expect(usingRoutes.length).toBeGreaterThan(0)
+		})
+
+		it.each(usingRoutes.map(({ file }) => file.replace(APP_ROOT, '')))(
+			'%s exports headers, so the loader values survive',
+			(relative) => {
+				const { source } = usingRoutes.find(({ file }) =>
+					file.endsWith(relative)
+				)!
+
+				expect(
+					/export function headers\b|export const headers\b/.test(source),
+					`${relative} builds embed response headers in its loader but does not export "headers". React Router keeps only Set-Cookie from a loader on a document route, so X-Robots-Tag, Referrer-Policy and Cache-Control are discarded before the response is sent.`
+				).toBe(true)
+
+				expect(
+					source.includes('loaderHeaders'),
+					`${relative} exports "headers" but does not forward loaderHeaders, so the values the loader set are still dropped.`
+				).toBe(true)
+			}
+		)
+	})
+
+	it('overrides a weaker value rather than appending to it', () => {
+		// `set`, not `append`. Two Cache-Control values would let the permissive
+		// one win depending on who parses it.
+		const response = new Response('ok', {
+			headers: { 'Cache-Control': 'public, max-age=86400' }
+		})
+
+		expect(
+			withEmbedResponseHeaders(response).headers.get('Cache-Control')
+		).toBe('no-store')
+	})
+})


### PR DESCRIPTION
## Summary

An embed URL carries its API key in the query string, because an iframe cannot
set request headers. Nothing stopped a crawler retaining one: no route in this
repo sets `X-Robots-Tag`, and the `noindex` meta tag `/embed` already renders
only helps for a crawler that renders the page.

Independent of #744 and #746 - no file overlap, branches off `main`, lands in
any order.

## Root cause

`/embed` responses carry no directive telling a crawler not to retain them, and
the meta tag that exists only applies to a rendered document. The fix belongs on
the response headers, where it covers the failure paths too, not on robots.txt.

## Changes

- Every `/embed` response carries `X-Robots-Tag: noindex, nofollow`,
  `Referrer-Policy: strict-origin-when-cross-origin` and `Cache-Control:
  no-store`, from one shared set.
- **The success path carried no headers at all.** It was the only response with
  a document to render, the only one not marked `no-store`, and the only one
  whose body embeds both the token and the id of the key that authorized it.
- The header set lives in a pure module, because the route reaches
  `getDbClient()` on import and no spec can load it.
- Comments at both sites recording why the marketing token is public by
  construction, so the next reader does not "fix" it by moving it server-side
  and believe the exposure is gone.

### Deliberately no `Disallow: /embed`

This contradicts the catalogue row that asked for it, and the reasoning is
recorded in `robots[.]txt.ts` rather than only here.

Disallowing a path stops the crawl, not the indexing. A URL discovered elsewhere
can still be listed, without a snippet, and Google is then no longer permitted
to fetch the page and read the `noindex` it was told to obey. Both controls that
actually work - the header and the meta tag - require the crawler to be let in.

## What the review loop found

**Round 1 found that this PR was a no-op**, which is the only reason it is worth
reading the diff twice.

`embed-layout.tsx` set the headers on its loader responses but exported no
`headers` function. For a document route, React Router's `getDocumentHeaders`
takes `new Headers(parentHeaders)` for any module without that export and merges
back only `Set-Cookie` - every other header the loader set is discarded before
the response is sent (`react-router/dist/.../server-runtime/headers.js`, the
`headersFn == null` branch). No route in this app exports `headers`, which is
exactly why nothing looked missing.

All seven assertions passed the entire time, because they proved the helper
returned a correct `Response` and never that a browser received one. That is the
same failure the delivery skill calls the tautological assertion: one half of a
contract, tested against itself, in a change whose whole point was the other
half.

So the spec now pins the invariant *between* the halves. It scans `app/routes/**`
for anything referencing the embed header set and fails unless that route also
exports `headers` and forwards `loaderHeaders`. Round 2 came back clean.

Confirmed by source trace rather than assumed: the loader **returns** non-2xx
`Response` objects instead of throwing, so they are tagged as data rather than
errors and `loaderHeaders[id]` is populated. The headers therefore reach the
browser on 404, 403 and 429 - the paths a crawler is most likely to hit.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

`typecheck,lint` over the four projects (8 tasks). 856 unit tests across 80
files.

Mutation gate: removing the `headers` export - the exact round-1 bug - turns the
propagation test red with a message explaining why. Removing `X-Robots-Tag` from
the set turns the coverage test red.

**Not verified against a running server.** The propagation claim rests on a read
of the installed React Router source plus the static pin, not on a live
`curl -I`. The dev port was occupied by another process. Worth one `curl -I` on
staging against both a 200 and a no-token 404 before this is trusted in
production.

`no-store` on the success path is new behaviour but not a caching regression:
`cdn-cache-policy.server.ts:30` already lists `/embed` as never-cache-at-edge,
and the Cloudflare ruleset fail-closes anything outside its allowlist.

## Filed rather than fixed

**The embed API key is sent to PostHog on every consented embed view.**
`root.tsx:127` captures `$current_url: window.location.href`, and PostHog JS
attaches `$current_url` to every event automatically - so `preview_viewed`
carries it too, as would any event added later. On vectreal.com's own pages the
newsroom embeds and the home mock shop are same-origin iframes where the consent
cookie is readable, so every analytics-consenting visitor ships
`VITE_PUBLIC_VECTREAL_API_KEY_PROD` to a third party.

Headers do not help with this and patching the one call site would not either;
it belongs in `sanitize_properties` on `posthog.init`, which runs for every
event. Filed as `Now` and kept separate because it is a different mechanism.
