### PR TITLE
ci: run the quality gate on every pull request

### DIFF
--- a/.github/workflows/ci-quality.yaml
+++ b/.github/workflows/ci-quality.yaml
@@ -4,32 +4,12 @@ on:
   workflow_call:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
-    paths:
-      - 'apps/vectreal-platform/**'
-      - 'packages/core/**'
-      - 'packages/embed/**'
-      - 'packages/hooks/**'
-      - 'packages/viewer/**'
-      - 'packages/viewer-e2e/**'
-      - 'shared/**'
-      - 'storybook/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'nx.json'
-      - 'eslint.config.mts'
-      - 'vitest.shared.mts'
-      - 'tsconfig.base.json'
-      # Agent instructions carry claims about this code that
-      # documented-claims.spec.ts executes. Without these the spec never runs
-      # on the PRs most likely to invalidate it.
-      - '.agents/**'
-      - 'CLAUDE.md'
-      - 'AGENTS.md'
-      - '.github/pull_request_template.md'
-      - '.github/workflows/ci-quality.yaml'
-      - '.github/workflows/cd-platform-staging.yaml'
-      - '.github/workflows/cd-platform-production.yaml'
+    # No paths filter. A workflow skipped by one reports nothing at all, so a
+    # required check would sit at "Expected - Waiting for status" forever and the
+    # PR could never merge. 62 tracked files, including all of terraform/ and
+    # most of .github/, were outside the old filter. `nx affected` already does
+    # the real filtering: a README-only change resolves to @vctrl/root, which has
+    # no targets, so the run is an install and nothing else.
   merge_group:
     branches:
       - 'main'


### PR DESCRIPTION
## Summary

Removes the `paths:` filter from the `pull_request` trigger so the Quality Gate
runs on every PR. This is the prerequisite for making it a **required status
check**; it is deliberately a separate, revertible change from flipping the
ruleset.

## Root cause

The quality gate cannot be required while a paths filter can skip it, because
GitHub reports *nothing* for a workflow that was never triggered rather than a
pass, so the fix belongs in the trigger rather than in the ruleset.

GitHub's own guidance:

> If a workflow is skipped due to path filtering [...] checks associated with
> that workflow will remain in a "Pending" state. A pull request that requires
> those checks to be successful will be blocked from merging.
> **You should not use path or branch filtering to skip workflow runs if the
> workflow is required.**

Note this is not the same as a *job* skipped by an `if:` conditional, which
reports Success. A workflow never triggered reports nothing at all.

**62 of 1108 tracked files were outside the filter.** Requiring the check without
this change would have made any PR touching only those permanently unmergeable:

| Area | Files outside the old filter |
| --- | --- |
| `.github/` | 28 |
| `terraform/` | 10 |
| `.claude/`, `.vscode/`, `assets/` | 10 |
| `README.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, dotfiles | 14 |

## Changes

- `.github/workflows/ci-quality.yaml`: drop `paths:` from the `pull_request`
  trigger. `types:` is unchanged, and the `push:` trigger keeps its own filter,
  which does not affect required checks on PRs.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] No product code changed.

The cost of always running it is close to zero, because `nx affected` already
does the real filtering. Verified for each previously-uncovered area:

| Changed file | `nx show projects --affected` | Tasks the gate would run |
| --- | --- | --- |
| `README.md` | `@vctrl/root` | none |
| `CHANGELOG.md` | `@vctrl/root` | none |
| `.github/workflows/cd-chromatic.yaml` | `@vctrl/root` | none |
| `terraform/cloudflare.tf` | `terraform` | none |

`@vctrl/root` has no targets at all. The `terraform` project's targets are
`plan-infrastructure`, `apply-infrastructure`, `setup-fly-secrets-*` and
`verify-fly-secrets` — none of the four the gate runs. Confirmed end to end:

```
$ npx nx affected -t lint,typecheck,test,build-ci --files=terraform/cloudflare.tf
NX   No tasks were run
```

So a docs- or infra-only PR pays for a checkout and an install, and nothing else.

- Workflow YAML parses; `paths` is gone from `pull_request`, `types` preserved,
  `merge_group` still present, job name still `Quality Gate`.

## Follow-up: the ruleset change this unblocks

Once this merges, `main`'s ruleset (`1512968`) needs a `required_status_checks`
rule for the check named **`Quality Gate`**. Today its rules are `deletion`,
`non_fast_forward`, `pull_request`, `code_scanning` and `code_quality` — nothing
requires CI, so lint, typecheck, test and `build-ci` can all be red and the PR
still merges.

Two things to decide when enabling it:

- **Admins bypass protected-branch rules by default.** If the rule is meant to
  bind everyone, the ruleset's bypass actors need to be empty.
- `ci-quality.yaml` also carries an unfiltered `merge_group:` trigger, so a merge
  queue remains available later if the team wants one; it is not needed for this.
