### PR TITLE
fix(analytics): stop sending the embed API key to PostHog

### DIFF
--- a/apps/vectreal-platform/app/entry.client.tsx
+++ b/apps/vectreal-platform/app/entry.client.tsx
@@ -11,6 +11,7 @@ import { hydrateRoot } from 'react-dom/client'
 import { HydratedRouter } from 'react-router/dom'
 
 import { readConsentCookie } from './lib/consent/consent-cookie'
+import { redactEmbedTokenFromProperties } from './lib/posthog/redact-embed-token'
 
 if (
 	!import.meta.env.DEV ||
@@ -34,7 +35,33 @@ if (
 		// ConsentProvider switches persistence to 'localStorage+cookie' and calls
 		// opt_in_capturing() once the user accepts analytics.
 		persistence: 'memory',
-		capture_pageview: false
+		capture_pageview: false,
+		/*
+		  An embed authenticates by a `token` query parameter, so on `/embed` the
+		  page URL contains a live API key - and PostHog attaches `$current_url`
+		  to every event, not just `$pageview`. Without this, each captured event
+		  from an embed carried the key out to a third party.
+
+		  Here rather than at a capture site: this runs for every event, including
+		  the properties PostHog adds itself, so there is no list of call sites to
+		  keep in step and no way for a new event to miss it.
+		*/
+		before_send: (event) => {
+			if (!event) return event
+
+			/*
+			  Session replay is excluded, and not because it is safe. A `$snapshot`
+			  carries a whole rrweb payload, and walking one on every snapshot
+			  would cost far more than the rest of this does on a normal event.
+			  Redacting inside a replay is a different problem with a different
+			  tool - PostHog's own masking - so it is filed rather than half-done
+			  here. Replay is remote-config controlled and not enabled in this
+			  file, so whether it is on at all has to be checked in the project.
+			*/
+			if (event.event === '$snapshot') return event
+
+			return redactEmbedTokenFromProperties(event)
+		}
 	})
 	posthog.register({ client_type: 'web' })
 

--- a/apps/vectreal-platform/app/lib/posthog/redact-embed-token.ts
+++ b/apps/vectreal-platform/app/lib/posthog/redact-embed-token.ts
@@ -1,0 +1,109 @@
+/**
+ * Strips embed API keys out of anything on its way to PostHog.
+ *
+ * An embed authenticates by a `token` query parameter, because an iframe cannot
+ * set request headers. That makes the token part of `window.location.href` on
+ * every `/embed` page - and PostHog attaches `$current_url` to every event it
+ * sends, not only to `$pageview`. So the key was leaving the browser on each
+ * captured event from an embed, and would have done so for any event added
+ * later.
+ *
+ * Applied through `before_send` at init rather than at a capture site, for that
+ * reason: there is no list of call sites to keep in step, and a property that
+ * PostHog adds itself is covered too.
+ *
+ * Pure and free of any PostHog import, so the rules below are testable directly.
+ */
+
+const REDACTED = 'redacted'
+
+/**
+ * A `token` query parameter and its value, wherever it appears.
+ *
+ * `[?&]` anchors it to a real parameter position, so `mytoken=` and prose like
+ * "failed: token=missing" are left alone. The value runs to the next `&`, `#`
+ * or whitespace. Case-insensitive deliberately: over-redacting an analytics
+ * property costs nothing, missing one costs a live credential.
+ */
+const TOKEN_PARAM = /([?&]token=)[^&#\s]*/gi
+
+/**
+ * The cheap reject, run before the rewrite on every string of every event.
+ *
+ * Deliberately **not** global. `TOKEN_PARAM` carries `/g` because it rewrites
+ * every occurrence, and `String.replace` resets `lastIndex` for it. `.test()`
+ * does not: a global regex used here would advance `lastIndex` on a match and
+ * return false on the next call, so alternate values would sail through
+ * unredacted.
+ *
+ * Case-insensitive, matching the regex it guards. A case-sensitive
+ * `includes('token=')` here made the `i` flag below pointless - `?Token=` never
+ * reached the rewrite at all.
+ */
+const HAS_TOKEN_PARAM = /token=/i
+
+/**
+ * The same value with any embed token in it replaced.
+ *
+ * Rewrites the parameter in place rather than parsing and re-serializing a URL,
+ * for two reasons found in review:
+ *
+ *   - PostHog's autocapture records `$elements[].attr__href` from the raw
+ *     `getAttribute('href')`, which can be relative. A parse-based version
+ *     skipped anything `new URL()` could not take on its own, so a relative
+ *     href carrying a token would have gone out intact the day someone put a
+ *     link in the embed chrome.
+ *   - `searchParams.set()` re-serializes the whole query with form-encoding
+ *     rules, turning spaces into `+` and escaping characters the URL grammar
+ *     leaves alone. Harmless, but it means reporting a URL the visitor never
+ *     had.
+ *
+ * Matching is on the value, never on the property name. PostHog puts its own
+ * project key in `properties.token` for ingestion, and stripping that by name
+ * is a documented way to break every event with a 401.
+ */
+export function redactEmbedToken(value: string): string {
+	// Cheap reject first: this runs on every string property of every event.
+	if (!HAS_TOKEN_PARAM.test(value)) {
+		return value
+	}
+
+	return value.replace(TOKEN_PARAM, `$1${REDACTED}`)
+}
+
+/**
+ * The same properties, with any embed token in them replaced.
+ *
+ * Walks nested objects and arrays because PostHog nests some of what it sends -
+ * `$set`, `$set_once`, and whatever a caller passes - and a token one level down
+ * leaves the browser exactly as readily as one at the top.
+ */
+export function redactEmbedTokenFromProperties<T>(properties: T): T {
+	if (typeof properties === 'string') {
+		return redactEmbedToken(properties) as T
+	}
+
+	if (Array.isArray(properties)) {
+		return properties.map((entry) => redactEmbedTokenFromProperties(entry)) as T
+	}
+
+	/*
+	  Plain objects only. A Date, a RegExp or a class instance is returned as it
+	  is rather than rebuilt as a bare object, which would silently change what
+	  the caller passed.
+	*/
+	if (
+		properties !== null &&
+		typeof properties === 'object' &&
+		Object.getPrototypeOf(properties) === Object.prototype
+	) {
+		return Object.fromEntries(
+			Object.entries(properties).map(([key, value]) => [
+				key,
+				redactEmbedTokenFromProperties(value)
+			])
+		) as T
+	}
+
+	return properties
+}

--- a/apps/vectreal-platform/tests/redact-embed-token.spec.ts
+++ b/apps/vectreal-platform/tests/redact-embed-token.spec.ts
@@ -1,0 +1,218 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	redactEmbedTokenFromProperties,
+	redactEmbedToken
+} from '../app/lib/posthog/redact-embed-token'
+
+/**
+ * A live API key must not leave the browser inside an analytics event.
+ *
+ * The leak this prevents was not at a capture site. PostHog attaches
+ * `$current_url` to every event it sends, and on `/embed` that URL carries the
+ * token, so the key rode out on every captured event - including ones nobody
+ * wrote, and any added later.
+ */
+
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+const EMBED_URL =
+	'https://vectreal.com/embed/395a09f0-9340/488bd4a1-46d3?token=vctrl_liveSecretab3x'
+
+describe('redactEmbedToken', () => {
+	it('replaces the token in an embed URL', () => {
+		const redacted = redactEmbedToken(EMBED_URL)
+
+		expect(redacted).not.toContain('vctrl_liveSecretab3x')
+		expect(new URL(redacted).searchParams.get('token')).toBe('redacted')
+	})
+
+	it('keeps every other part of the URL intact', () => {
+		const redacted = new URL(
+			redactEmbedToken(`${EMBED_URL}&transition=linear&autoRotate=0`)
+		)
+
+		expect(redacted.origin).toBe('https://vectreal.com')
+		expect(redacted.pathname).toBe('/embed/395a09f0-9340/488bd4a1-46d3')
+		expect(redacted.searchParams.get('transition')).toBe('linear')
+		expect(redacted.searchParams.get('autoRotate')).toBe('0')
+	})
+
+	/*
+	  PostHog's autocapture records `$elements[].attr__href` from the raw
+	  `getAttribute('href')`, which is whatever the markup said - often relative.
+	  A parse-based redaction skipped those entirely.
+	*/
+	it('redacts a relative URL, which autocapture can produce', () => {
+		expect(redactEmbedToken('/embed/a/b?token=vctrl_liveSecretab3x')).toBe(
+			'/embed/a/b?token=redacted'
+		)
+		expect(redactEmbedToken('?token=vctrl_liveSecretab3x')).toBe(
+			'?token=redacted'
+		)
+	})
+
+	it('stops at a fragment rather than eating it', () => {
+		expect(redactEmbedToken('/e?token=vctrl_secret#camera-2')).toBe(
+			'/e?token=redacted#camera-2'
+		)
+	})
+
+	it('leaves the rest of the query byte-for-byte alone', () => {
+		// A parse-and-reserialize version turned spaces into `+` and escaped
+		// characters the URL grammar leaves literal, reporting a URL the visitor
+		// never had.
+		const url = `${EMBED_URL}&label=a%20b&note=it's~(fine)`
+
+		expect(redactEmbedToken(url)).toBe(
+			url.replace('vctrl_liveSecretab3x', 'redacted')
+		)
+	})
+
+	it('redacts a capitalised parameter name', () => {
+		// The regex was case-insensitive while the cheap-reject guard in front of
+		// it was not, so this returned unredacted before reaching the rewrite.
+		expect(redactEmbedToken('https://vectreal.com/e?Token=vctrl_secret')).toBe(
+			'https://vectreal.com/e?Token=redacted'
+		)
+		expect(redactEmbedToken('https://vectreal.com/e?TOKEN=vctrl_secret')).toBe(
+			'https://vectreal.com/e?TOKEN=redacted'
+		)
+	})
+
+	it('redacts consistently across repeated calls', () => {
+		/*
+		  A global regex in the guard would advance `lastIndex` on a match and
+		  report false on the next call, letting every other value through.
+		*/
+		const url = 'https://vectreal.com/e?token=vctrl_secret'
+
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			expect(redactEmbedToken(url), `call ${attempt}`).toBe(
+				'https://vectreal.com/e?token=redacted'
+			)
+		}
+	})
+
+	it('does not match a parameter that merely ends in token', () => {
+		const url = 'https://vectreal.com/x?mytoken=vctrl_liveSecretab3x'
+
+		expect(redactEmbedToken(url)).toBe(url)
+	})
+
+	it('leaves a URL without a token alone', () => {
+		const url = 'https://vectreal.com/pricing?utm_source=x'
+
+		expect(redactEmbedToken(url)).toBe(url)
+	})
+
+	it('leaves prose that merely mentions a token alone', () => {
+		// The cheap `includes` pre-check matches this. The `[?&]` anchor is what
+		// stops it being rewritten: there is no parameter position here.
+		const message = 'Request failed: token=missing'
+
+		expect(redactEmbedToken(message)).toBe(message)
+	})
+
+	it('does not throw on a value that is not a URL', () => {
+		expect(() => redactEmbedToken('token=')).not.toThrow()
+	})
+})
+
+describe('redactEmbedTokenFromProperties', () => {
+	it('redacts the property PostHog adds to every event', () => {
+		const event = redactEmbedTokenFromProperties({
+			event: 'preview_viewed',
+			properties: { $current_url: EMBED_URL, scene_id: 'abc' }
+		})
+
+		expect(JSON.stringify(event)).not.toContain('vctrl_liveSecretab3x')
+		expect(event.properties.scene_id).toBe('abc')
+	})
+
+	it('redacts a token nested below the top level', () => {
+		const event = redactEmbedTokenFromProperties({
+			properties: {
+				$set: { last_seen_on: EMBED_URL },
+				breadcrumbs: [{ url: EMBED_URL }]
+			}
+		})
+
+		expect(JSON.stringify(event)).not.toContain('vctrl_liveSecretab3x')
+	})
+
+	it('redacts every URL-valued property, not a named list of them', () => {
+		/*
+		  The point of walking the object rather than picking known keys: PostHog
+		  adds `$initial_current_url`, `$referrer` and others without this code
+		  knowing their names, and invents more between versions.
+		*/
+		const event = redactEmbedTokenFromProperties({
+			properties: {
+				$current_url: EMBED_URL,
+				$initial_current_url: EMBED_URL,
+				$referrer: EMBED_URL,
+				some_future_property: EMBED_URL
+			}
+		})
+
+		for (const value of Object.values(event.properties)) {
+			expect(value).not.toContain('vctrl_liveSecretab3x')
+		}
+	})
+
+	it('leaves values it does not understand as they are', () => {
+		const date = new Date('2026-08-22T12:00:00.000Z')
+		const event = redactEmbedTokenFromProperties({
+			properties: { when: date, count: 3, ok: true, missing: null }
+		})
+
+		expect(event.properties.when).toBe(date)
+		expect(event.properties.count).toBe(3)
+		expect(event.properties.ok).toBe(true)
+		expect(event.properties.missing).toBeNull()
+	})
+})
+
+/*
+  The other half of the contract. The redaction is correct and useless unless
+  PostHog is actually told to run it, and nothing else in the suite can see that
+  - `entry.client.tsx` calls `posthog.init` at module scope against a real
+  browser global, so importing it here is not an option.
+*/
+describe('posthog is wired to use it', () => {
+	const entryClient = readFileSync(
+		join(APP_ROOT, 'app/entry.client.tsx'),
+		'utf8'
+	)
+
+	/*
+	  Asserted by ordering rather than by proximity. The first version allowed
+	  120 characters between the two and broke the moment a comment was added
+	  between them, which is a test that fails for a reason unrelated to the
+	  behaviour it guards.
+	*/
+	it('registers the redaction with before_send', () => {
+		const hook = entryClient.indexOf('before_send')
+		const call = entryClient.indexOf('redactEmbedTokenFromProperties(')
+
+		expect(
+			hook,
+			'posthog.init no longer configures before_send, so nothing filters events.'
+		).toBeGreaterThan(-1)
+
+		expect(
+			call,
+			'redactEmbedTokenFromProperties is never called, so the embed token is captured verbatim.'
+		).toBeGreaterThan(-1)
+
+		expect(
+			call,
+			'redactEmbedTokenFromProperties is called outside before_send, so it does not run for every event.'
+		).toBeGreaterThan(hook)
+	})
+})


### PR DESCRIPTION
## Summary

An embed authenticates by a `token` query parameter, because an iframe cannot
set request headers. So on `/embed` the page URL contains a live API key - and
PostHog attaches `$current_url` to **every** event it sends, not only
`$pageview`. Every captured event from an embed carried the key out to a third
party, and any event added later would have too.

Independent of #744, #746 and #748 - branches off `main`, no file overlap.

## Root cause

The token is in the URL, and PostHog copies the URL into every event. The fix
belongs where events are configured, not at a capture site: patching
`root.tsx`'s `$pageview` would have left `preview_viewed` and everything future
still leaking.

## How reachable this is

Gated on analytics consent, so it never fired for a visitor who declined.

It fired on vectreal.com's own pages. The newsroom article embeds and the home
mock shop are **same-origin** iframes, so the consent cookie is readable there,
and those embeds carry `VITE_PUBLIC_VECTREAL_API_KEY_PROD`. Every
analytics-consenting visitor to those pages sent that key to PostHog.

A third-party storefront was usually spared only because a consent cookie tends
to be unreadable in a cross-site iframe. That is an accident of browser policy,
not a control anyone chose.

## Changes

- `redact-embed-token.ts` - pure, no PostHog import. Rewrites a `token`
  parameter in place wherever it appears, and walks nested objects and arrays
  because PostHog nests `$set`, `$set_once` and whatever a caller passes.
- Wired through `before_send` at init, so it runs for every event including the
  properties PostHog adds itself.
- `$snapshot` is skipped **deliberately**, and this is the honest limit of the
  PR: a session replay carries a whole rrweb payload, walking one per snapshot
  would cost more than this does on every normal event, and redacting inside a
  replay is a different problem with a different tool. Replay is remote-config
  controlled and not configured in this repo, so whether it is even on has to be
  checked in the project. Filed, with the two specific checks.

### Matching is on the value, never the property name

`calculateEventProperties()` sets `properties.token` to PostHog's own **project**
key, which ingestion requires. Stripping that by key name is a documented way to
break every event with a 401 (PostHog/posthog-js#3438). This never inspects key
names - only string values containing `token=`, which a `phc_...` project key
does not. Worth knowing before anyone "simplifies" it.

## What the review loop found

Three rounds. Each fix made the code smaller, and each round's finding was
narrower than the last.

| Round | Finding |
| --- | --- |
| 1 | `new URL(value)` skipped **relative** URLs, and autocapture records `$elements[].attr__href` from the raw `getAttribute('href')`, which can be relative |
| 1 | `searchParams.set()` re-serialized the whole query, turning spaces into `+` and escaping characters the URL grammar leaves alone |
| 2 | The rewrite regex was case-insensitive but the cheap-reject guard in front of it was not, so `?Token=` bypassed redaction entirely |
| 3 | Clean |

Rounds 1 and 2 together replaced URL parsing with an in-place rewrite, which
covers relative URLs, preserves the rest of the query byte for byte, and is less
code than it replaced.

The round-2 fix had its own trap, caught while writing it rather than after: the
guard must be a **non-global** regex. `String.replace` resets `lastIndex` for a
global one, but `.test()` does not - a global guard would match, advance, and
then return false on the next call, letting every other value through. Making
the guard global fails five tests.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

`typecheck,lint` over the four projects (8 tasks). 872 unit tests across 81
files.

Mutation gate, every guard: dropping the `[?&]` anchor, letting the value run
past a fragment, restoring the absolute-URL-only restriction, reverting the
guard to a case-sensitive `includes`, making the guard global, and unwiring
`before_send` each turn specific tests red.

**Not verified against a live PostHog project.** The claim that `before_send`
runs for every capture path rests on a trace of the installed `posthog-js@1.414.0`
source, not on watching events arrive. Worth confirming on staging with one
embed pageview before trusting it in production.

The wiring test asserts `redactEmbedTokenFromProperties` appears after
`before_send` in the source, not that it is syntactically inside the callback.
Its comment says so. A stronger version would need to parse the file, which was
not worth it for a one-line config, but it is a weaker guard than it looks.
