### PR TITLE
ci: keep one change from reaching main twice

### DIFF
--- a/.github/workflows/ci-quality.yaml
+++ b/.github/workflows/ci-quality.yaml
@@ -61,6 +61,64 @@ jobs:
         with:
           fetch-depth: 0
 
+      # A branch cut from another pull request keeps that pull request's commits.
+      # Once the parent squash-merges, its work sits on main under a new sha, so
+      # this branch's merge base is behind it and GitHub re-renders the parent's
+      # files as this branch's work. Squashing then copies the parent's commit
+      # message into this commit's body and release-please records the one change
+      # twice. #750 was cut from #748 and displayed all six of #748's files after
+      # #748 merged.
+      #
+      # The tell is exact: the three-dot diff GitHub renders names files that
+      # merging would not change, because they already carry that content on the
+      # base branch. Rebasing removes both symptoms because it removes the cause.
+      - name: Check the diff is this branch's own work
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Explicit refspec: on a pull request, actions/checkout configures
+          # `remote.origin.fetch` for the merge ref, so `git fetch origin main`
+          # would leave `origin/main` stale or absent.
+          git fetch --no-tags --quiet origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          base="origin/$BASE_REF"
+
+          # merge-tree answers "those two conflict" and "I cannot read one of those"
+          # with the same exit code, so the head has to be known good before its
+          # failure can be read as a conflict. Without this, a head the checkout
+          # does not have would take the skip below and report success.
+          git rev-parse --verify --quiet "$HEAD_SHA^{commit}" > /dev/null || {
+            echo "Head commit $HEAD_SHA is not in this checkout, so nothing was compared."
+            exit 1
+          }
+
+          # A conflicting branch cannot merge at all, so its diff says nothing here.
+          if ! tree=$(git merge-tree --write-tree "$base" "$HEAD_SHA"); then
+            echo "Branch conflicts with $base, so its merge result is undefined. Skipping."
+            exit 0
+          fi
+
+          comm -23 \
+            <(git diff --name-only "$base...$HEAD_SHA" | sort) \
+            <(git diff --name-only "$base" "$tree" | sort) > "$RUNNER_TEMP/displayed-but-unchanged.txt"
+
+          if [[ -s "$RUNNER_TEMP/displayed-but-unchanged.txt" ]]; then
+            echo "This pull request displays files it does not change:"
+            sed 's/^/  /' "$RUNNER_TEMP/displayed-but-unchanged.txt"
+            echo
+            echo "Each already carries this content on $base, so the branch is stacked"
+            echo "on work that has since merged. Rebase onto $base: the diff above is"
+            echo "what reviewers are being shown, and squashing would record those"
+            echo "commits in the changelog a second time."
+            exit 1
+          fi
+
+          echo "Every file in the diff is this branch's own work."
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
 


### PR DESCRIPTION
## Summary

Makes a pull request's work reach `main` exactly once, so release-please cannot record the same change twice. Fixes the mechanism behind the duplicated v1.0.0 changelog entries and behind #750 re-displaying all six of #748's files.

## Root cause

`main` did not have one commit per pull request: `allow_merge_commit` was true with `merge_commit_message: PR_TITLE`, so a merge-commit merge landed the branch's own conventional commits *and* a merge commit whose body was the pull request title, and release-please parsed both — the rule belongs in the repository's merge settings, not in a per-PR workaround.

A correction to the premise this was filed under: the duplicates are not squash artifacts. Every duplicated pair in the pending v1.0.0 notes is (merge commit, branch commit), and every squash-merged pull request appears exactly once.

```
035b217  Merge pull request #722   feat(viewer): play glTF animation clips
11ff088                            feat(viewer): play glTF animation clips
0653914  Merge pull request #707   feat(newsroom): morph the featured card into the article hero
7202075                            feat(newsroom): morph the featured card into the article hero
ad67c71  Merge pull request #716   feat(newsroom): add article for previewing scenes without the Publisher
7b6ba8d                            feat(newsroom): add article for previewing scenes without the Publisher
d1f7cf0  Merge pull request #702   fix(newsroom): make the author card reachable on touch and link to LinkedIn
15e3b11                            fix(newsroom): make the author card reachable on touch and link to LinkedIn
9e58c82  Merge pull request #710   fix(nav): pick the navbar with CSS and unify it across the publisher
52368ac                            fix(nav): pick the navbar with CSS and keep one instance across the publisher
```

The squash half is real but separate, and it is what the CI step here addresses: a branch cut from another pull request keeps the parent's commits, so once the parent squash-merges under a new sha this branch's merge base sits behind it, GitHub re-renders the parent's files as this branch's work, and squashing copies the parent's commit message into this commit's body.

## Changes

- Repository settings, changed out of band because they cannot live in a file: `allow_merge_commit` is now `false`, the "Main protection" ruleset allows `squash` alone (it allowed `merge` and `squash`), and `required_linear_history` is on so a merge commit cannot reach `main` even through a bypassing actor.
- `ci-quality.yaml` gains one step, before `pnpm install`, that fails a pull request whose displayed diff is not its own work. It compares the three-dot diff GitHub renders against what `git merge-tree` says merging would actually change and names every file in the first but not the second.

The check lives inside the existing `Quality Gate` job on purpose: that job is already the required status check, so the guard is enforced without adding a second context to the ruleset.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

Behavior fixture rebuilding #748/#750 — a two-commit parent squashed onto `main` under a new sha, the child still carrying the originals, and `origin/main` deleted to match what a runner's narrow refspec leaves behind:

```
ok    exit 1  child stacked on a squash-merged parent   (names all six parent files)
ok    exit 0  the same child, rebased onto main
ok    exit 0  fresh branch off main
ok    exit 0  branch behind main, no overlap
ok    exit 0  branch conflicting with main              (skips, does not fail)
ok    exit 1  head commit absent from the checkout      (fails loudly, does not skip)
```

Both load-bearing lines were mutated and the fixture went red for each: three-dot swapped for two-dot, and the head verification removed. The second mutation is how the silent-pass bug was found in the first place — `git merge-tree` exits 1 both for a genuine conflict and for a revision it cannot read, so the skip meant for conflicting branches also swallowed a missing head and reported success.

Repository gates:

- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — 8 tasks, green
- `pnpm nx run-many -t test` — 5 projects, 974 platform tests, green

- [ ] Unit / integration tests added or updated
- [x] No tests required (explain why)

The fixture is not committed. It is a shell harness that has to re-extract the `run:` block out of the workflow YAML, and that extraction would be the fragile half of the test. Naming it here rather than folding an unowned new file into this diff; worth landing separately as a proper spec so the check cannot rot.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes