### PR TITLE
ci: run the integration tests on pull requests

### DIFF
--- a/.github/workflows/ci-quality.yaml
+++ b/.github/workflows/ci-quality.yaml
@@ -124,3 +124,76 @@ jobs:
           path: coverage/
           retention-days: 7
           if-no-files-found: ignore
+
+  # The integration suite exists because the unit tests could not have caught the
+  # two defects that reached production: the embed manifest and the asset gate
+  # disagreed about which assets an embed may fetch, and `*.myshopify.com` could
+  # not be saved at all. Both live in the seam between a decision and the rows it
+  # reads, which only a real database exercises.
+  #
+  # Until now nothing ran it. `vitest.config.ts` excludes `tests/integration/**`
+  # and the quality gate runs `lint,typecheck,test,build-ci`, so the suite was
+  # opt-in on a developer's machine and `critical-path.spec.ts` was letting
+  # modules leave KNOWN_UNGUARDED on the strength of specs no pull request
+  # executed.
+  #
+  # Separate job because a service container is job-scoped, and unconditional for
+  # the same reason ci-quality has no paths filter: a skipped job reports nothing,
+  # so a required check would wait on it forever.
+  integration:
+    name: Integration Tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    env:
+      NX_DAEMON: 'false'
+    services:
+      # Supabase's own image, not stock postgres. The migrations create policies
+      # `TO authenticated` over `auth.uid()`, and Postgres resolves both at
+      # CREATE POLICY time, so a stock image needs a hand-written bootstrap of
+      # roles and an auth schema - a second description of the database that can
+      # drift from the one `supabase start` gives developers. This image already
+      # carries them. The tag tracks `[db] major_version` in supabase/config.toml.
+      postgres:
+        image: supabase/postgres:17.4.1.075
+        env:
+          POSTGRES_PASSWORD: postgres
+        # 54322 is the port `supabase start` publishes and the port the
+        # test-integration target already points DATABASE_URL at.
+        ports:
+          - 54322:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Apply migrations
+        shell: bash
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+          cd apps/vectreal-platform/supabase/migrations
+          for migration in $(ls -1 *.sql | sort); do
+            echo "→ $migration"
+            psql -v ON_ERROR_STOP=1 -h 127.0.0.1 -p 54322 -U postgres -d postgres \
+              -q -f "$migration"
+          done
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run integration tests
+        run: pnpm nx run vectreal-platform:test-integration

--- a/apps/vectreal-platform/tests/critical-path.spec.ts
+++ b/apps/vectreal-platform/tests/critical-path.spec.ts
@@ -78,12 +78,20 @@ const FUNNEL: FunnelStep[] = [
   `tests/integration`, as `api-key-lifecycle.integration.spec.ts` did for key
   minting and rotation. A mock is neither.
 
-  One caveat on the integration route out, because this file otherwise reads as
-  a stronger guarantee than it is: `ci-quality.yaml` runs `lint,typecheck,test,
-  build-ci` and never `test-integration`, and the unit config excludes
-  `tests/integration/**`. So a module can leave this set on the strength of a
-  spec no pull request actually executes. The spec is real and does exercise the
-  module - it just has to be run deliberately, with a local database.
+  That second route out used to be worth less than it looked. `ci-quality.yaml`
+  ran `lint,typecheck,test,build-ci` and never `test-integration`, and the unit
+  config excludes `tests/integration/**`, so a module could leave this set on
+  the strength of a spec no pull request executed. It now has an Integration
+  Tests job that runs the suite against a supabase/postgres service on every
+  pull request, so those specs are a gate rather than a note.
+
+  That does not move `scene-settings.operations.server.ts`, and running the
+  suite in CI was never going to: no spec imports it at all. It is 669 lines
+  orchestrating quota checks, entitlements, asset upload and four tables, and
+  `uploadSceneAssets` puts Supabase Storage on the path beside Postgres, which
+  is why it did not fall out of the same work that closed
+  `api-key-repository.server`. Closing it needs a spec that drives
+  `saveSceneSettings` end to end, and storage in the job to run it against.
 
   Removing an entry is the only way this list is allowed to change.
 */


### PR DESCRIPTION
## Summary

Adds an `Integration Tests` job to `ci-quality.yaml` that runs `vectreal-platform:test-integration` against a `supabase/postgres` service container, so the five integration specs are executed by pull requests instead of only by whoever remembers to start a local stack.

## Root cause

The integration suite was written but never wired to a runner: `ci-quality.yaml` names `lint,typecheck,test,build-ci` and the unit config excludes `tests/integration/**`, so nothing in CI could reach those specs — the gate that was meant to execute them simply did not name them, which is where the fix belongs.

#747 and #749 changed *when* the quality gate runs. Neither changed *what* it runs.

This is not only missing coverage. `critical-path.spec.ts` lets a module leave `KNOWN_UNGUARDED` once a spec imports it, and #746 removed `api-key-repository.server.ts` on the strength of `api-key-lifecycle.integration.spec.ts`. That spec is real and does exercise the module, but no pull request ran it, so the ratchet had turned on a promise nothing kept. It is kept now.

## Changes

- New `integration` job: `supabase/postgres:17.4.1.075` service on 54322, the repository's 19 migrations applied with `psql` in filename order, then `pnpm nx run vectreal-platform:test-integration`.
- `critical-path.spec.ts`: the comment claiming CI never runs `test-integration` was true when written and is not now. Replaced, along with a straight answer on the remaining entry.

### Why supabase/postgres and not stock postgres

The migrations create policies `TO authenticated` over `auth.uid()`, and Postgres resolves both the role and the function at `CREATE POLICY` time. A stock image needs a hand-written bootstrap of roles and an `auth` schema — a second description of the database, free to drift from the one `supabase start` gives developers. Supabase's image already carries the roles, the `auth` schema and `auth.uid()`, so the repository's own migrations stay the only schema definition in play. All 19 apply to it unmodified.

### Two deliberate consequences

- The job is unconditional. A service container is job-scoped, and a skipped job reports nothing at all, so making this a required check later needs it to always report — the same reasoning as #749.
- `cd-platform-production.yaml` calls this workflow, so a production deploy now clears the integration suite as well.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

Ran the CI recipe locally: a fresh `supabase/postgres:17.4.1.075` container, the 19 migrations applied with `psql -v ON_ERROR_STOP=1` in filename order (all clean), then the suite.

```
✓ tests/integration/asset-reference-counting.integration.spec.ts   (6 tests)
✓ tests/integration/scene-hotspots.integration.spec.ts            (10 tests)
✓ tests/integration/api-key-lifecycle.integration.spec.ts          (8 tests)
✓ tests/integration/embed-asset-authorization.integration.spec.ts  (6 tests)
✓ tests/integration/dashboard-folder-sql.integration.spec.ts      (23 tests)
Test Files 5 passed | Tests 53 passed   1.2s
```

Mutation, because a job that runs a green suite proves nothing on its own: changed `rotateApiKey` to keep the stored `hashedKey` and `keyPreview` instead of replacing them — the exact regression #746's ratchet notch exists to catch. Four tests fail, including *refuses the key that was in the old snippet* and *authorizes the key from the new snippet*. Restored, green again.

Repository gates:

- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — 8 tasks, green
- `pnpm nx run-many -t test` — 5 projects, green

- [x] Unit / integration tests added or updated
- [ ] No tests required

## Is `scene-settings.operations.server.ts` closeable now?

No, and running the suite in CI was never going to close it. **No spec imports it at all** — the modules the integration specs reach are `scene-settings-repository.server` and `scene-settings-service.server`, which are different modules. Its only importers are `scene/server/index.ts` and `routes/api/scenes.$sceneId.ts`.

It is 669 lines orchestrating quota checks, entitlements, asset upload and four tables, and `uploadSceneAssets` puts Supabase Storage on the path beside Postgres. That is why it did not fall out of the same work that closed `api-key-repository.server`: closing it needs a spec driving `saveSceneSettings` end to end, and storage in this job to run it against. The entry stays, and the comment above it now says this instead of describing a caveat that no longer exists.

## Follow-up for a maintainer

`Integration Tests` is a new check context and is **not** yet in the `Main protection` ruleset's required checks. It cannot be added before this merges — a required context that does not exist on `main` leaves every pull request waiting forever. Worth adding straight after.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes