### PR TITLE
feat(viewer): render scene hotspots

### DIFF
--- a/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveHotspotInteraction } from './hotspot-interaction'
+
+const linked = { linkedCameraId: 'camera-1' }
+const unlinked = { linkedCameraId: null }
+
+describe('resolveHotspotInteraction', () => {
+	it('is a button only when there is a camera to reach and somewhere to send it', () => {
+		expect(
+			resolveHotspotInteraction(linked, { occluded: false, canActivate: true })
+				.role
+		).toBe('button')
+		expect(
+			resolveHotspotInteraction(linked, { occluded: false, canActivate: false })
+				.role
+		).toBe('image')
+		expect(
+			resolveHotspotInteraction(unlinked, {
+				occluded: false,
+				canActivate: true
+			}).role
+		).toBe('image')
+	})
+
+	it('keeps the same role while occluded', () => {
+		// The rule this pins: changing the element type mid-orbit unmounts the
+		// focused button and drops the user's place in the tab order.
+		expect(
+			resolveHotspotInteraction(linked, { occluded: true, canActivate: true })
+				.role
+		).toBe('button')
+	})
+
+	it('takes the pointer away from every occluded marker, linked or not', () => {
+		for (const marker of [linked, unlinked]) {
+			expect(
+				resolveHotspotInteraction(marker, { occluded: true, canActivate: true })
+					.pointerEvents
+			).toBe('none')
+		}
+	})
+
+	it('leaves the pointer on a marker in plain view', () => {
+		for (const marker of [linked, unlinked]) {
+			expect(
+				resolveHotspotInteraction(marker, {
+					occluded: false,
+					canActivate: true
+				}).pointerEvents
+			).toBe('auto')
+		}
+	})
+
+	it('refuses to activate an occluded marker', () => {
+		expect(
+			resolveHotspotInteraction(linked, { occluded: true, canActivate: true })
+				.activatable
+		).toBe(false)
+		expect(
+			resolveHotspotInteraction(linked, { occluded: false, canActivate: true })
+				.activatable
+		).toBe(true)
+	})
+
+	it('drops an occluded marker out of the tab order', () => {
+		expect(
+			resolveHotspotInteraction(linked, { occluded: true, canActivate: true })
+				.focusable
+		).toBe(false)
+		expect(
+			resolveHotspotInteraction(linked, { occluded: false, canActivate: true })
+				.focusable
+		).toBe(true)
+	})
+})

--- a/packages/viewer/src/components/scene/hotspot-interaction.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.ts
@@ -1,0 +1,48 @@
+import type { HotspotMarker } from './resolve-hotspot-markers'
+
+/** How a marker behaves once the depth test has had its say. */
+export interface HotspotInteraction {
+	/**
+	 * `button` for a hotspot that can move the camera, `image` for one that only
+	 * labels a point.
+	 *
+	 * Deliberately independent of occlusion. Swapping the element type mid-orbit
+	 * unmounts the focused button, which drops keyboard focus to the document
+	 * body and restarts the tab order.
+	 */
+	role: 'button' | 'image'
+	/** False while occluded: see `pointerEvents`. */
+	activatable: boolean
+	/**
+	 * False while occluded, so an invisible marker is not a tab stop. Focus that
+	 * is already on it survives, which `disabled` would not allow.
+	 */
+	focusable: boolean
+	/**
+	 * `none` while occluded. A marker faded almost out of sight must not still
+	 * swallow a click: it would fly the camera somewhere from a target the
+	 * visitor cannot see, and it would pop a label for a marker behind the model.
+	 */
+	pointerEvents: 'auto' | 'none'
+}
+
+export function resolveHotspotInteraction(
+	marker: Pick<HotspotMarker, 'linkedCameraId'>,
+	{
+		occluded,
+		canActivate
+	}: {
+		occluded: boolean
+		/** Whether the viewer was given somewhere to send an activation. */
+		canActivate: boolean
+	}
+): HotspotInteraction {
+	const isButton = marker.linkedCameraId !== null && canActivate
+
+	return {
+		role: isButton ? 'button' : 'image',
+		activatable: isButton && !occluded,
+		focusable: isButton && !occluded,
+		pointerEvents: occluded ? 'none' : 'auto'
+	}
+}

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -71,21 +71,10 @@ const markerClasses = {
 	dot: `flex shrink-0 items-center justify-center rounded-full bg-[var(--vctrl-hotspot-fill)] font-[600] text-[var(--vctrl-hotspot-ink)] ${RING_SHADOW}`,
 	dotPlain: 'h-3 w-3',
 	dotStep: 'h-5 w-5 text-[10px]',
-	/*
-	  Optical centring for the numeral, and the reason it is not simply
-	  `items-center`.
-
-	  Flex centres the text's box, not its ink. DM Sans reports ascent 10 and
-	  descent 3, and a digit has no ink below the baseline, so the drawn glyph
-	  ends up half its descent above the middle of the disc - measured at 0.50px
-	  on the 20px step disc and 0.50px on the 16px badge, which is visible on a
-	  shape that small.
-
-	  In `em` rather than pixels so it holds if either size changes, and applied
-	  to a wrapper so the disc itself does not move. Font-specific by nature: it
-	  is the metric asymmetry of DM Sans, which `styles.css` sets for the viewer.
-	*/
-	numeral: 'block translate-y-[0.05em]',
+	// Centring lives in styles.css, where `text-box` can read the rendered
+	// font's own cap metric instead of a constant calibrated to a font this
+	// package names but does not ship.
+	numeral: 'vctrl-hotspot-numeral',
 	// A raster payload is someone's photograph or icon: it needs its own ground
 	// to read against arbitrary scene colour behind it. `max-w-none` because a
 	// host application's CSS reset caps images at their container width, which

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -1,0 +1,241 @@
+import { Html } from '@react-three/drei'
+import { cn } from '@shared/utils'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { resolveHotspotInteraction } from './hotspot-interaction'
+
+import type { HotspotMarker as HotspotMarkerModel } from './resolve-hotspot-markers'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+
+/**
+ * Under the viewer's own overlay chrome, which sits at 100 (the animation
+ * controls and the info popover), so a hotspot never paints over a control.
+ * drei writes a depth-derived value inside this range onto each marker every
+ * frame, which is also what decides how two overlapping markers stack.
+ */
+const HOTSPOT_Z_INDEX_RANGE = [40, 0]
+
+/**
+ * How long the name stays up after a tap.
+ *
+ * A touch produces `pointerenter` and `pointerleave` back to back, so the
+ * hover treatment alone leaves the name unreachable on a phone - and a marker
+ * without a linked camera is not focusable either, so there is no other way to
+ * read it.
+ */
+const TOUCH_LABEL_DURATION_MS = 2500
+
+/**
+ * A white inner ring and a dark outer one, on every preset.
+ *
+ * The brand accent alone does not carry a hotspot: `#fc6c18` is 2.6:1 against
+ * the viewer's light ground and 2.9:1 against white, both under the 3:1 that a
+ * non-text indicator needs, and a white-only ring disappears against exactly
+ * the pale product shots where the accent is already weakest. The pair holds on
+ * either ground, which is why it is not simply a border.
+ */
+const RING_SHADOW =
+	'shadow-[0_0_0_1.5px_rgba(255,255,255,0.9),0_0_0_2.5px_rgba(0,0,0,0.4),0_1px_4px_rgba(0,0,0,0.35)]'
+
+/**
+ * A white ring inside a dark halo, for the same reason, and independent of the
+ * accent so the focused marker is distinguishable from the marker itself.
+ */
+const FOCUS_RING =
+	'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white focus-visible:shadow-[0_0_0_5px_rgba(0,0,0,0.55)]'
+
+const markerClasses = {
+	root: 'vctrl-viewer-hotspot pointer-events-none relative flex items-center justify-center opacity-100 transition-opacity duration-300 ease-out',
+	// Focus overrides the fade: a keyboard user who reaches an occluded marker
+	// has to be able to see which one they are on.
+	occluded: 'opacity-15 focus-within:opacity-100',
+	// Sits outside the artwork's own ring rather than flush with the box, so the
+	// resting ring is still visible when the animation is switched off.
+	pulse:
+		'vctrl-hotspot-pulse pointer-events-none absolute -inset-1 rounded-full',
+	// A 24px floor on the box that takes the pointer, which then grows to fit
+	// whatever is inside it. The plain dot is 14px: under the minimum target
+	// size, and missed by a thumb on a touch screen.
+	body: 'relative m-0 flex min-h-6 min-w-6 appearance-none items-center justify-center rounded-full border-0 bg-transparent p-0 leading-none',
+	live: 'pointer-events-auto',
+	inert: 'pointer-events-none',
+	interactive: 'cursor-pointer',
+	// `font-[600]` and `leading-[1.4]` rather than the named scale: a named value
+	// registers its theme variable in the published stylesheet's `:root, :host`
+	// block, which lands in a host application after hydration. See styles.css.
+	dot: `flex shrink-0 items-center justify-center rounded-full bg-[var(--vctrl-hotspot-accent)] font-[600] text-[var(--vctrl-hotspot-on-accent)] ${RING_SHADOW}`,
+	dotPlain: 'h-3.5 w-3.5',
+	dotStep: 'h-5 w-5 text-[10px]',
+	// A raster payload is someone's photograph or icon: it needs its own ground
+	// to read against arbitrary scene colour behind it. `max-w-none` because a
+	// host application's CSS reset caps images at their container width, which
+	// would squeeze the artwork back down to the 24px target floor.
+	image: `h-8 w-8 max-w-none shrink-0 rounded-full bg-white object-cover ${RING_SHADOW}`,
+	// A vector payload is drawn to sit on the scene directly. A frame would fight
+	// the artwork, so it gets a drop shadow for separation instead.
+	svg: 'h-7 w-7 max-w-none shrink-0 object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.45)]',
+	// Offset clear of the artwork rather than overlapping its corner.
+	badge: `absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--vctrl-hotspot-accent)] text-[10px] font-[600] text-[var(--vctrl-hotspot-on-accent)] ${RING_SHADOW}`,
+	// `rounded-full`, never `rounded`: this package clears Tailwind's radius
+	// namespace (see styles.css), so every named radius but `full` compiles to
+	// nothing once the package is consumed from npm.
+	label:
+		'pointer-events-none absolute bottom-[calc(100%+8px)] left-1/2 max-w-[180px] -translate-x-1/2 truncate rounded-full bg-[var(--vctrl-bg)] px-2 py-0.5 text-[11px] leading-[1.4] text-[var(--vctrl-text)] shadow-[0_1px_6px_rgba(0,0,0,0.3)] select-none'
+} as const
+
+export interface HotspotMarkerProps {
+	marker: HotspotMarkerModel
+	/** Computed by `SceneHotspots`, which owns the depth test for every marker. */
+	occluded: boolean
+	/** Runs when a hotspot carrying a `linkedCameraId` is activated. */
+	onActivate?: (cameraId: string) => void
+}
+
+/**
+ * A single hotspot, drawn as DOM over the canvas.
+ *
+ * DOM rather than in-scene geometry because a marker has to stay the same size
+ * at any distance, take a real focus ring, and carry text a screen reader can
+ * read. drei's `Html` handles the projection, and hides the marker on its own
+ * once it passes behind the camera.
+ */
+const HotspotMarker = ({
+	marker,
+	occluded,
+	onActivate
+}: HotspotMarkerProps) => {
+	const [labelVisible, setLabelVisible] = useState(false)
+	const touchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+	const interaction = resolveHotspotInteraction(marker, {
+		occluded,
+		canActivate: !!onActivate
+	})
+
+	const clearTouchTimeout = () => {
+		if (touchTimeout.current !== null) {
+			clearTimeout(touchTimeout.current)
+			touchTimeout.current = null
+		}
+	}
+
+	useEffect(() => clearTouchTimeout, [])
+
+	const showLabel = useCallback(() => {
+		clearTouchTimeout()
+		setLabelVisible(true)
+	}, [])
+
+	const hideLabel = useCallback(() => {
+		clearTouchTimeout()
+		setLabelVisible(false)
+	}, [])
+
+	const handlePointerEnter = useCallback(
+		(event: ReactPointerEvent<HTMLDivElement>) => {
+			clearTouchTimeout()
+			setLabelVisible(true)
+			// A touch fires enter and leave in the same gesture, so hold the name up
+			// for long enough to read instead of letting leave take it straight back.
+			if (event.pointerType !== 'mouse') {
+				touchTimeout.current = setTimeout(
+					() => setLabelVisible(false),
+					TOUCH_LABEL_DURATION_MS
+				)
+			}
+		},
+		[]
+	)
+
+	const handlePointerLeave = useCallback(
+		(event: ReactPointerEvent<HTMLDivElement>) => {
+			if (event.pointerType !== 'mouse') return
+			clearTouchTimeout()
+			setLabelVisible(false)
+		},
+		[]
+	)
+
+	const handleClick = useCallback(() => {
+		if (interaction.activatable && marker.linkedCameraId) {
+			onActivate?.(marker.linkedCameraId)
+		}
+	}, [interaction.activatable, marker.linkedCameraId, onActivate])
+
+	const bodyClasses = cn(
+		markerClasses.body,
+		interaction.pointerEvents === 'auto'
+			? markerClasses.live
+			: markerClasses.inert
+	)
+
+	const body =
+		marker.preset === 'dot' ? (
+			<span
+				className={cn(
+					markerClasses.dot,
+					marker.step === null ? markerClasses.dotPlain : markerClasses.dotStep
+				)}
+			>
+				{marker.step}
+			</span>
+		) : (
+			<>
+				<img
+					src={marker.payloadUrl ?? undefined}
+					alt=""
+					className={
+						marker.preset === 'image' ? markerClasses.image : markerClasses.svg
+					}
+				/>
+				{marker.step !== null && (
+					<span className={markerClasses.badge}>{marker.step}</span>
+				)}
+			</>
+		)
+
+	return (
+		<Html center position={marker.position} zIndexRange={HOTSPOT_Z_INDEX_RANGE}>
+			<div
+				className={cn(markerClasses.root, occluded && markerClasses.occluded)}
+				onPointerEnter={handlePointerEnter}
+				onPointerLeave={handlePointerLeave}
+			>
+				<span aria-hidden="true" className={markerClasses.pulse} />
+
+				{interaction.role === 'button' ? (
+					<button
+						type="button"
+						className={cn(
+							bodyClasses,
+							FOCUS_RING,
+							interaction.activatable && markerClasses.interactive
+						)}
+						aria-label={marker.accessibleName}
+						aria-disabled={interaction.activatable ? undefined : true}
+						tabIndex={interaction.focusable ? undefined : -1}
+						onClick={handleClick}
+						onFocus={showLabel}
+						onBlur={hideLabel}
+					>
+						{body}
+					</button>
+				) : (
+					<div
+						className={bodyClasses}
+						role="img"
+						aria-label={marker.accessibleName}
+					>
+						{body}
+					</div>
+				)}
+
+				{labelVisible && (
+					<span className={markerClasses.label}>{marker.name}</span>
+				)}
+			</div>
+		</Html>
+	)
+}
+
+export default HotspotMarker

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { resolveHotspotInteraction } from './hotspot-interaction'
 
 import type { HotspotMarker as HotspotMarkerModel } from './resolve-hotspot-markers'
-import type { PointerEvent as ReactPointerEvent } from 'react'
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react'
 
 /**
  * Under the viewer's own overlay chrome, which sits at 100 (the animation
@@ -26,23 +26,28 @@ const HOTSPOT_Z_INDEX_RANGE = [40, 0]
 const TOUCH_LABEL_DURATION_MS = 2500
 
 /**
- * A white inner ring and a dark outer one, on every preset.
+ * A hairline edge and a soft shadow, on every preset.
  *
- * The brand accent alone does not carry a hotspot: `#fc6c18` is 2.6:1 against
- * the viewer's light ground and 2.9:1 against white, both under the 3:1 that a
- * non-text indicator needs, and a white-only ring disappears against exactly
- * the pale product shots where the accent is already weakest. The pair holds on
- * either ground, which is why it is not simply a border.
+ * One pixel of dark edge is all a white disc needs to separate from a pale
+ * product, and it is the whole reason the fill can be neutral. A heavier ring
+ * turns the marker into a badge stuck onto the render; this reads as part of
+ * the viewer. The shadow does the lifting on dark scenes, where the edge itself
+ * disappears and the fill carries.
+ *
+ * The edge carries the marker alone on a white product, where a white fill has
+ * no contrast of its own, so its alpha is the one number here that is a
+ * legibility floor rather than a taste call - measured at 1.6:1 over white at
+ * 0.18, which was too weak to see.
  */
 const RING_SHADOW =
-	'shadow-[0_0_0_1.5px_rgba(255,255,255,0.9),0_0_0_2.5px_rgba(0,0,0,0.4),0_1px_4px_rgba(0,0,0,0.35)]'
+	'shadow-[0_0_0_1px_rgba(0,0,0,0.3),0_1px_3px_rgba(0,0,0,0.3)]'
 
 /**
- * A white ring inside a dark halo, for the same reason, and independent of the
- * accent so the focused marker is distinguishable from the marker itself.
+ * A white ring inside a dark halo, and independent of the fill so a focused
+ * marker is distinguishable from the marker itself whatever colour it is.
  */
 const FOCUS_RING =
-	'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white focus-visible:shadow-[0_0_0_5px_rgba(0,0,0,0.55)]'
+	'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white focus-visible:shadow-[0_0_0_4px_rgba(0,0,0,0.5)]'
 
 const markerClasses = {
 	root: 'vctrl-viewer-hotspot pointer-events-none relative flex items-center justify-center opacity-100 transition-opacity duration-300 ease-out',
@@ -54,7 +59,7 @@ const markerClasses = {
 	pulse:
 		'vctrl-hotspot-pulse pointer-events-none absolute -inset-1 rounded-full',
 	// A 24px floor on the box that takes the pointer, which then grows to fit
-	// whatever is inside it. The plain dot is 14px: under the minimum target
+	// whatever is inside it. The plain dot is 12px: well under the minimum target
 	// size, and missed by a thumb on a touch screen.
 	body: 'relative m-0 flex min-h-6 min-w-6 appearance-none items-center justify-center rounded-full border-0 bg-transparent p-0 leading-none',
 	live: 'pointer-events-auto',
@@ -63,19 +68,34 @@ const markerClasses = {
 	// `font-[600]` and `leading-[1.4]` rather than the named scale: a named value
 	// registers its theme variable in the published stylesheet's `:root, :host`
 	// block, which lands in a host application after hydration. See styles.css.
-	dot: `flex shrink-0 items-center justify-center rounded-full bg-[var(--vctrl-hotspot-accent)] font-[600] text-[var(--vctrl-hotspot-on-accent)] ${RING_SHADOW}`,
-	dotPlain: 'h-3.5 w-3.5',
+	dot: `flex shrink-0 items-center justify-center rounded-full bg-[var(--vctrl-hotspot-fill)] font-[600] text-[var(--vctrl-hotspot-ink)] ${RING_SHADOW}`,
+	dotPlain: 'h-3 w-3',
 	dotStep: 'h-5 w-5 text-[10px]',
+	/*
+	  Optical centring for the numeral, and the reason it is not simply
+	  `items-center`.
+
+	  Flex centres the text's box, not its ink. DM Sans reports ascent 10 and
+	  descent 3, and a digit has no ink below the baseline, so the drawn glyph
+	  ends up half its descent above the middle of the disc - measured at 0.50px
+	  on the 20px step disc and 0.50px on the 16px badge, which is visible on a
+	  shape that small.
+
+	  In `em` rather than pixels so it holds if either size changes, and applied
+	  to a wrapper so the disc itself does not move. Font-specific by nature: it
+	  is the metric asymmetry of DM Sans, which `styles.css` sets for the viewer.
+	*/
+	numeral: 'block translate-y-[0.05em]',
 	// A raster payload is someone's photograph or icon: it needs its own ground
 	// to read against arbitrary scene colour behind it. `max-w-none` because a
 	// host application's CSS reset caps images at their container width, which
 	// would squeeze the artwork back down to the 24px target floor.
-	image: `h-8 w-8 max-w-none shrink-0 rounded-full bg-white object-cover ${RING_SHADOW}`,
+	image: `h-7 w-7 max-w-none shrink-0 rounded-full bg-white object-cover ${RING_SHADOW}`,
 	// A vector payload is drawn to sit on the scene directly. A frame would fight
 	// the artwork, so it gets a drop shadow for separation instead.
 	svg: 'h-7 w-7 max-w-none shrink-0 object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.45)]',
 	// Offset clear of the artwork rather than overlapping its corner.
-	badge: `absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--vctrl-hotspot-accent)] text-[10px] font-[600] text-[var(--vctrl-hotspot-on-accent)] ${RING_SHADOW}`,
+	badge: `absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--vctrl-hotspot-fill)] text-[10px] font-[600] text-[var(--vctrl-hotspot-ink)] ${RING_SHADOW}`,
 	// `rounded-full`, never `rounded`: this package clears Tailwind's radius
 	// namespace (see styles.css), so every named radius but `full` compiles to
 	// nothing once the package is consumed from npm.
@@ -87,6 +107,8 @@ export interface HotspotMarkerProps {
 	marker: HotspotMarkerModel
 	/** Computed by `SceneHotspots`, which owns the depth test for every marker. */
 	occluded: boolean
+	/** Overrides the marker fill. Any CSS colour; undefined keeps the default. */
+	color?: string
 	/** Runs when a hotspot carrying a `linkedCameraId` is activated. */
 	onActivate?: (cameraId: string) => void
 }
@@ -102,6 +124,7 @@ export interface HotspotMarkerProps {
 const HotspotMarker = ({
 	marker,
 	occluded,
+	color,
 	onActivate
 }: HotspotMarkerProps) => {
 	const [labelVisible, setLabelVisible] = useState(false)
@@ -162,6 +185,14 @@ const HotspotMarker = ({
 		}
 	}, [interaction.activatable, marker.linkedCameraId, onActivate])
 
+	// Set on the marker root rather than the viewer container: drei portals every
+	// Html separately, so there is no shared ancestor inside the marker layer.
+	// Omitted entirely when no colour was passed, so the default path emits no
+	// inline style at all.
+	const colorStyle = color
+		? ({ '--vctrl-hotspot-fill': color } as CSSProperties)
+		: undefined
+
 	const bodyClasses = cn(
 		markerClasses.body,
 		interaction.pointerEvents === 'auto'
@@ -177,7 +208,7 @@ const HotspotMarker = ({
 					marker.step === null ? markerClasses.dotPlain : markerClasses.dotStep
 				)}
 			>
-				{marker.step}
+				<span className={markerClasses.numeral}>{marker.step}</span>
 			</span>
 		) : (
 			<>
@@ -189,7 +220,9 @@ const HotspotMarker = ({
 					}
 				/>
 				{marker.step !== null && (
-					<span className={markerClasses.badge}>{marker.step}</span>
+					<span className={markerClasses.badge}>
+						<span className={markerClasses.numeral}>{marker.step}</span>
+					</span>
 				)}
 			</>
 		)
@@ -198,6 +231,7 @@ const HotspotMarker = ({
 		<Html center position={marker.position} zIndexRange={HOTSPOT_Z_INDEX_RANGE}>
 			<div
 				className={cn(markerClasses.root, occluded && markerClasses.occluded)}
+				style={colorStyle}
 				onPointerEnter={handlePointerEnter}
 				onPointerLeave={handlePointerLeave}
 			>

--- a/packages/viewer/src/components/scene/hotspot-occlusion.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-occlusion.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { occlusionRayFar } from './hotspot-occlusion'
+
+describe('occlusionRayFar', () => {
+	it('stops the ray short of the hotspot itself', () => {
+		// The whole reason this function exists: a hotspot is authored by
+		// raycasting the model and storing the hit verbatim, so it sits exactly on
+		// a triangle. A ray cast the full distance hits that triangle and reports
+		// the hotspot as occluded by the surface it is pinned to.
+		expect(occlusionRayFar(4)).toBeLessThan(4)
+	})
+
+	it('scales the gap with distance so it holds at any model size', () => {
+		const near = 4 - occlusionRayFar(4)
+		const far = 40 - occlusionRayFar(40)
+
+		// Proportional, not merely larger: a flat epsilon also grows by a float
+		// ulp here, so `far > near` would pass without the gap scaling at all.
+		expect(far).toBeGreaterThan(near * 5)
+	})
+
+	it('keeps the gap small enough to still detect a real occluder', () => {
+		// A wall 2% of the way in front of the hotspot must still register.
+		expect(occlusionRayFar(4)).toBeGreaterThan(4 * 0.98)
+	})
+
+	it('keeps a gap even as the distance approaches zero', () => {
+		expect(occlusionRayFar(1e-6)).toBe(0)
+		expect(occlusionRayFar(1e-3)).toBeLessThan(1e-3)
+	})
+
+	it.each([
+		['zero', 0],
+		['a negative distance', -1],
+		['NaN', Number.NaN],
+		['Infinity', Number.POSITIVE_INFINITY]
+	])('reports nothing to cast against for %s', (_label, distance) => {
+		expect(occlusionRayFar(distance)).toBe(0)
+	})
+})

--- a/packages/viewer/src/components/scene/hotspot-occlusion.ts
+++ b/packages/viewer/src/components/scene/hotspot-occlusion.ts
@@ -1,0 +1,50 @@
+/**
+ * How often the occlusion pass runs, in seconds.
+ *
+ * Not every frame. Each test is a recursive raycast over the whole model, and
+ * there is no BVH in this stack, so per-frame testing multiplies a full triangle
+ * traversal by the number of hotspots for the entire duration of any orbit. At
+ * 15Hz the marker's own 300ms opacity transition still covers the step, and the
+ * pass keeps running while the camera is still, which a camera-motion trigger
+ * does not: an animated model can swing in front of a hotspot with nobody
+ * touching the controls.
+ */
+export const OCCLUSION_INTERVAL_SECONDS = 1 / 15
+
+/**
+ * Fraction of the camera-to-hotspot distance ignored at the far end of the ray.
+ */
+const OCCLUSION_TOLERANCE_RATIO = 0.005
+
+/** Floor for the tolerance, for a hotspot almost touching the camera. */
+const MIN_OCCLUSION_TOLERANCE = 1e-4
+
+/**
+ * How far along the camera-to-hotspot ray a hit still counts as occluding.
+ *
+ * The tolerance is the whole point. A hotspot is authored by raycasting the
+ * model and storing the intersection verbatim, so it lies *exactly* on a
+ * triangle. Testing the full distance means the nearest hit is that same
+ * triangle at the same distance, and the comparison then turns on float noise:
+ * a marker sitting in plain view flickers between drawn and faded, and while it
+ * reads as faded its linked camera cannot be reached at all.
+ *
+ * Relative rather than absolute so it holds across model scales. The viewer
+ * normalizes a model's diagonal into [0.5, 5], and a fixed epsilon that suits
+ * the top of that range swallows thin geometry at the bottom of it.
+ *
+ * Returns 0 when nothing can occlude - the hotspot is at or inside the
+ * tolerance - which callers read as "do not bother casting". The final clamp is
+ * what produces that for a zero or negative distance, so there is no separate
+ * guard for it.
+ */
+export function occlusionRayFar(distance: number): number {
+	if (!Number.isFinite(distance)) return 0
+
+	const tolerance = Math.max(
+		distance * OCCLUSION_TOLERANCE_RATIO,
+		MIN_OCCLUSION_TOLERANCE
+	)
+
+	return Math.max(distance - tolerance, 0)
+}

--- a/packages/viewer/src/components/scene/index.ts
+++ b/packages/viewer/src/components/scene/index.ts
@@ -13,6 +13,11 @@ export {
 	default as SceneEnvironment,
 	defaultEnvOptions
 } from './scene-environment'
+export { default as SceneHotspots } from './scene-hotspots'
+export {
+	resolveHotspotMarkers,
+	type HotspotMarker
+} from './resolve-hotspot-markers'
 export { default as SceneModel } from './scene-model'
 export { default as ScenePostProcessing } from './scene-postprocessing'
 export { default as SceneShadows, defaultShadowsOptions } from './scene-shadows'

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveHotspotMarkers } from './resolve-hotspot-markers'
+
+import type { HotspotDefinition } from '@vctrl/core'
+
+const hotspot = (
+	overrides: Partial<HotspotDefinition> & Pick<HotspotDefinition, 'id'>
+): HotspotDefinition => ({
+	name: overrides.id,
+	worldPosition: [0, 0, 0],
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot',
+	...overrides
+})
+
+/** Persisted JSON the type system says cannot exist, which it can. */
+const malformed = (value: unknown) => value as HotspotDefinition
+
+const ids = (markers: { id: string }[]) => markers.map((marker) => marker.id)
+
+describe('resolveHotspotMarkers', () => {
+	describe('what gets drawn', () => {
+		it('returns nothing for absent or non-array settings', () => {
+			expect(resolveHotspotMarkers(undefined)).toEqual([])
+			expect(
+				resolveHotspotMarkers(
+					malformed({ length: 1 }) as unknown as HotspotDefinition[]
+				)
+			).toEqual([])
+		})
+
+		it('drops a hotspot the author hid', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'shown' }),
+				hotspot({ id: 'hidden', visible: false })
+			])
+
+			expect(ids(markers)).toEqual(['shown'])
+		})
+
+		it('draws a hotspot whose visible flag is missing', () => {
+			const legacy = {
+				...hotspot({ id: 'legacy' })
+			} as Partial<HotspotDefinition>
+			delete legacy.visible
+
+			expect(ids(resolveHotspotMarkers([legacy as HotspotDefinition]))).toEqual(
+				['legacy']
+			)
+		})
+
+		it('hides internalOnly hotspots from a public surface', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'public' }),
+				hotspot({ id: 'internal', internalOnly: true })
+			])
+
+			expect(ids(markers)).toEqual(['public'])
+		})
+
+		it('draws internalOnly hotspots on an editing surface', () => {
+			const markers = resolveHotspotMarkers(
+				[
+					hotspot({ id: 'public' }),
+					hotspot({ id: 'internal', internalOnly: true })
+				],
+				{ includeInternal: true }
+			)
+
+			expect(ids(markers)).toEqual(['public', 'internal'])
+		})
+
+		it('still hides a hidden internalOnly hotspot on an editing surface', () => {
+			const markers = resolveHotspotMarkers(
+				[hotspot({ id: 'internal', internalOnly: true, visible: false })],
+				{ includeInternal: true }
+			)
+
+			expect(markers).toEqual([])
+		})
+
+		it('keeps only the first hotspot claiming an id', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'same', name: 'first' }),
+				hotspot({ id: 'same', name: 'second' })
+			])
+
+			expect(markers.map((marker) => marker.name)).toEqual(['first'])
+		})
+	})
+
+	describe('what reaches the renderer', () => {
+		it('carries the stored position through, axis for axis', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'a', worldPosition: [1, 2, 3] }),
+				hotspot({ id: 'b', worldPosition: [-0.5, 0, 4.25] })
+			])
+
+			expect(markers.map((marker) => marker.position)).toEqual([
+				[1, 2, 3],
+				[-0.5, 0, 4.25]
+			])
+		})
+
+		it('carries the linked camera through', () => {
+			// Without it every marker degrades to a non-focusable label and
+			// click-to-fly-camera is dead everywhere.
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'a', linkedCameraId: 'camera-7' })
+			])
+
+			expect(markers[0].linkedCameraId).toBe('camera-7')
+		})
+
+		it('tells every marker how many steps the sequence has', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'a', sequenceIndex: 0 }),
+				hotspot({ id: 'b', sequenceIndex: 1 }),
+				hotspot({ id: 'loose' })
+			])
+
+			expect(markers.map((marker) => marker.stepCount)).toEqual([2, 2, 2])
+		})
+	})
+
+	describe('malformed persisted data', () => {
+		it.each([
+			['a null entry', null],
+			['a string entry', 'hotspot'],
+			['a missing id', { ...hotspot({ id: 'x' }), id: undefined }],
+			['a non-string id', { ...hotspot({ id: 'x' }), id: 7 }],
+			['a blank id', { ...hotspot({ id: 'x' }), id: '   ' }],
+			[
+				'a missing position',
+				{ ...hotspot({ id: 'x' }), worldPosition: undefined }
+			],
+			[
+				'a two-axis position',
+				{ ...hotspot({ id: 'x' }), worldPosition: [1, 2] }
+			],
+			[
+				'a non-numeric axis',
+				{ ...hotspot({ id: 'x' }), worldPosition: [1, '2', 3] }
+			],
+			[
+				'a NaN axis',
+				{ ...hotspot({ id: 'x' }), worldPosition: [1, Number.NaN, 3] }
+			],
+			[
+				'an infinite axis',
+				{
+					...hotspot({ id: 'x' }),
+					worldPosition: [1, Number.POSITIVE_INFINITY, 3]
+				}
+			],
+			[
+				'an array-like position',
+				{
+					...hotspot({ id: 'x' }),
+					worldPosition: { 0: 1, 1: 2, 2: 3, length: 3 }
+				}
+			]
+		])('drops an entry with %s', (_label, entry) => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'ok' }),
+				malformed(entry)
+			])
+
+			expect(ids(markers)).toEqual(['ok'])
+		})
+
+		it('falls back to a default name when the stored one is unusable', () => {
+			const markers = resolveHotspotMarkers([
+				malformed({ ...hotspot({ id: 'blank' }), name: '   ' }),
+				malformed({ ...hotspot({ id: 'wrong-type' }), name: 42 })
+			])
+
+			expect(markers.map((marker) => marker.name)).toEqual([
+				'Hotspot',
+				'Hotspot'
+			])
+		})
+
+		it('ignores a sequence index that is not a finite number', () => {
+			const markers = resolveHotspotMarkers([
+				malformed({ ...hotspot({ id: 'nan' }), sequenceIndex: Number.NaN }),
+				hotspot({ id: 'real', sequenceIndex: 3 })
+			])
+
+			expect(markers.map((marker) => [marker.id, marker.step])).toEqual([
+				['real', 1],
+				['nan', null]
+			])
+		})
+
+		it('ignores a linked camera id that is not a usable string', () => {
+			const markers = resolveHotspotMarkers([
+				malformed({ ...hotspot({ id: 'a' }), linkedCameraId: 5 }),
+				malformed({ ...hotspot({ id: 'b' }), linkedCameraId: '  ' })
+			])
+
+			expect(markers.map((marker) => marker.linkedCameraId)).toEqual([
+				null,
+				null
+			])
+		})
+	})
+
+	describe('sequence', () => {
+		it('orders sequenced hotspots by sequence, then the rest as stored', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'loose-a' }),
+				hotspot({ id: 'second', sequenceIndex: 1 }),
+				hotspot({ id: 'loose-b' }),
+				hotspot({ id: 'first', sequenceIndex: 0 })
+			])
+
+			expect(ids(markers)).toEqual(['first', 'second', 'loose-a', 'loose-b'])
+		})
+
+		it('numbers steps by rank so gaps in sequenceIndex do not show', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'a', sequenceIndex: 0 }),
+				hotspot({ id: 'b', sequenceIndex: 4 }),
+				hotspot({ id: 'c' })
+			])
+
+			expect(markers.map((marker) => marker.step)).toEqual([1, 2, null])
+		})
+
+		it('numbers the steps a visitor can actually reach, not the ones stored', () => {
+			// The first stored step is hidden, so the one after it is what a visitor
+			// meets first and has to be labelled step 1.
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'hidden', sequenceIndex: 0, visible: false }),
+				hotspot({ id: 'internal', sequenceIndex: 1, internalOnly: true }),
+				hotspot({ id: 'shown', sequenceIndex: 2 })
+			])
+
+			expect(markers.map((marker) => [marker.id, marker.step])).toEqual([
+				['shown', 1]
+			])
+		})
+
+		it('announces the step and how many there are', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'a', name: 'Handle', sequenceIndex: 0 }),
+				hotspot({ id: 'b', name: 'Hinge', sequenceIndex: 1 }),
+				hotspot({ id: 'c', name: 'Spout' })
+			])
+
+			expect(markers.map((marker) => marker.accessibleName)).toEqual([
+				'Handle, step 1 of 2',
+				'Hinge, step 2 of 2',
+				'Spout'
+			])
+		})
+	})
+
+	describe('style presets', () => {
+		it('keeps a payload preset that has artwork', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'i', stylePreset: 'image', payloadUrl: 'a.png' }),
+				hotspot({ id: 's', stylePreset: 'svg', payloadUrl: 'b.svg' })
+			])
+
+			expect(
+				markers.map((marker) => [marker.preset, marker.payloadUrl])
+			).toEqual([
+				['image', 'a.png'],
+				['svg', 'b.svg']
+			])
+		})
+
+		it.each([
+			['no payloadUrl at all', undefined],
+			['a blank payloadUrl', '   '],
+			['a payloadUrl that is not a string', 12]
+		])('falls back to the dot preset with %s', (_label, payloadUrl) => {
+			const markers = resolveHotspotMarkers([
+				malformed({ ...hotspot({ id: 'x' }), stylePreset: 'image', payloadUrl })
+			])
+
+			expect(markers[0].preset).toBe('dot')
+			expect(markers[0].payloadUrl).toBeNull()
+		})
+	})
+
+	describe('occlusion', () => {
+		it('defaults occlusion on, and honours an explicit false', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'default' }),
+				hotspot({ id: 'on', occlusionEnabled: true }),
+				hotspot({ id: 'off', occlusionEnabled: false })
+			])
+
+			expect(markers.map((marker) => marker.occlusionEnabled)).toEqual([
+				true,
+				true,
+				false
+			])
+		})
+	})
+
+	it('does not mutate the settings it was given', () => {
+		const stored = [
+			hotspot({ id: 'b', sequenceIndex: 1 }),
+			hotspot({ id: 'a', sequenceIndex: 0 })
+		]
+
+		resolveHotspotMarkers(stored)
+
+		expect(stored.map((entry) => entry.id)).toEqual(['b', 'a'])
+	})
+})

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
@@ -1,0 +1,180 @@
+import type { HotspotDefinition, HotspotStylePreset } from '@vctrl/core'
+
+/**
+ * One hotspot, reduced to exactly what the renderer draws.
+ *
+ * Every decision that can be made without a camera is made here rather than in
+ * the component: this package's test runner only loads `.ts`, deliberately, so
+ * anything left inside the `.tsx` marker cannot be covered at all.
+ */
+export interface HotspotMarker {
+	id: string
+	/** Trimmed, and never empty. */
+	name: string
+	/** What a screen reader announces, including the step and how many there are. */
+	accessibleName: string
+	position: [number, number, number]
+	/**
+	 * 1-based place in the navigation sequence, or null when this hotspot is not
+	 * part of one.
+	 *
+	 * Deliberately not `sequenceIndex + 1`. The stored index only has to be a
+	 * unique non-negative integer, and the authoring swap leaves gaps whenever a
+	 * hotspot drops out of the sequence, so a scene can legitimately hold
+	 * indices 0, 1 and 4. Printing those would tell a visitor there are steps
+	 * they cannot find. The rank among the hotspots a visitor can actually reach
+	 * is what "step 2 of 3" means to whoever is looking at it.
+	 */
+	step: number | null
+	/** How many steps the sequence has, for the same reason. */
+	stepCount: number
+	/** Never `image` or `svg` without a `payloadUrl` to go with it. */
+	preset: HotspotStylePreset
+	payloadUrl: string | null
+	linkedCameraId: string | null
+	occlusionEnabled: boolean
+}
+
+export interface ResolveHotspotMarkersOptions {
+	/**
+	 * Editing surfaces pass true to draw hotspots the author marked
+	 * `internalOnly`. Public and embedded viewers never do - see below.
+	 */
+	includeInternal?: boolean
+}
+
+/** A trimmed string, or null for anything that is not a usable string. */
+function text(value: unknown): string | null {
+	if (typeof value !== 'string') return null
+	const trimmed = value.trim()
+	return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * A hotspot the runtime can place. `worldPosition` reaches the viewer straight
+ * from persisted JSON, and a malformed one would throw inside the R3F tree
+ * rather than degrade, taking the whole scene down with it.
+ */
+function drawablePosition(position: unknown): [number, number, number] | null {
+	if (!Array.isArray(position) || position.length !== 3) return null
+	// `Number.isFinite` does not coerce, so it rejects every non-number on its
+	// own; a `typeof` clause beside it would be a branch no input can reach.
+	if (!position.every((axis) => Number.isFinite(axis))) return null
+	return [position[0], position[1], position[2]]
+}
+
+/**
+ * Turns a scene's stored hotspots into the list the viewer draws, in order.
+ *
+ * Three rules, all of them the author's:
+ *
+ * - `visible: false` is never drawn. Only an explicit false hides: the field is
+ *   required by the type, so an absent one is malformed data, and dropping a
+ *   hotspot someone placed is the worse failure of the two.
+ * - `internalOnly` is only drawn on an editing surface. The published payload is
+ *   already stripped of these server-side (`redactSettingsForEmbed`), so this is
+ *   the second of two independent gates rather than the only one: the viewer is
+ *   a public npm package and a consumer can hand it any settings object at all,
+ *   including one that never passed through that redaction.
+ * - Sequenced hotspots come first, in sequence order, then the rest in the order
+ *   the author stored them. Order is what `sequenceIndex` means.
+ *
+ * Everything else here is hardening. The platform's own parser validates most of
+ * these fields on save, but it never sees `payloadUrl`, and a direct consumer of
+ * `@vctrl/viewer` goes through no parser at all: a non-string `name` would throw
+ * on `.trim()` mid-render, and a `NaN` sequence index would make the comparator
+ * return `NaN` and leave the order to the sort implementation.
+ */
+export function resolveHotspotMarkers(
+	hotspots: readonly HotspotDefinition[] | undefined,
+	{ includeInternal = false }: ResolveHotspotMarkersOptions = {}
+): HotspotMarker[] {
+	if (!Array.isArray(hotspots)) return []
+
+	const seen = new Set<string>()
+	const drawable: {
+		hotspot: HotspotDefinition
+		id: string
+		position: [number, number, number]
+	}[] = []
+
+	for (const hotspot of hotspots) {
+		if (!hotspot) continue
+
+		const id = text(hotspot.id)
+		// Two markers sharing an id would collide on React's key and one of them
+		// would inherit the other's occlusion state.
+		if (!id || seen.has(id)) continue
+
+		const position = drawablePosition(hotspot.worldPosition)
+		if (!position) continue
+
+		if (hotspot.visible === false) continue
+		if (!includeInternal && hotspot.internalOnly === true) continue
+
+		seen.add(id)
+		drawable.push({ hotspot, id, position })
+	}
+
+	const sequenced = drawable
+		.flatMap((entry) =>
+			Number.isFinite(entry.hotspot.sequenceIndex)
+				? [{ entry, order: entry.hotspot.sequenceIndex as number }]
+				: []
+		)
+		.sort((a, b) => a.order - b.order)
+
+	const unsequenced = drawable.filter(
+		({ hotspot }) => !Number.isFinite(hotspot.sequenceIndex)
+	)
+
+	const stepCount = sequenced.length
+
+	return [
+		...sequenced.map(({ entry }, index) =>
+			toMarker(entry, index + 1, stepCount)
+		),
+		...unsequenced.map((entry) => toMarker(entry, null, stepCount))
+	]
+}
+
+function toMarker(
+	{
+		hotspot,
+		id,
+		position
+	}: {
+		hotspot: HotspotDefinition
+		id: string
+		position: [number, number, number]
+	},
+	step: number | null,
+	stepCount: number
+): HotspotMarker {
+	const name = text(hotspot.name) ?? 'Hotspot'
+	const payloadUrl = text(hotspot.payloadUrl)
+
+	return {
+		id,
+		name,
+		accessibleName:
+			step === null ? name : `${name}, step ${step} of ${stepCount}`,
+		position,
+		step,
+		stepCount,
+		// Both payload presets fall back to the dot rather than rendering a broken
+		// image: `payloadUrl` is optional on the type, so an author can pick a
+		// preset and save before choosing the artwork.
+		preset:
+			(hotspot.stylePreset === 'image' || hotspot.stylePreset === 'svg') &&
+			payloadUrl
+				? hotspot.stylePreset
+				: 'dot',
+		payloadUrl,
+		linkedCameraId: text(hotspot.linkedCameraId),
+		// Occlusion defaults on: a marker floating in front of the geometry it is
+		// pinned behind reads as a bug, and a scene saved before the field existed
+		// carries no value at all.
+		occlusionEnabled: hotspot.occlusionEnabled !== false
+	}
+}

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -1,0 +1,156 @@
+import { useFrame, useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Raycaster, Vector3 } from 'three'
+
+import HotspotMarker from './hotspot-marker'
+import {
+	OCCLUSION_INTERVAL_SECONDS,
+	occlusionRayFar
+} from './hotspot-occlusion'
+import { resolveHotspotMarkers } from './resolve-hotspot-markers'
+
+import type { HotspotDefinition } from '@vctrl/core'
+import type { Object3D } from 'three'
+
+const NO_OCCLUSIONS: ReadonlySet<string> = new Set()
+
+export interface SceneHotspotsProps {
+	hotspots?: HotspotDefinition[]
+	/**
+	 * The loaded model, and the only thing allowed to occlude a hotspot. Never
+	 * the whole scene: it also holds the shadow catcher plane, which spans the
+	 * model and sits between the camera and every hotspot below the horizon.
+	 */
+	model?: Object3D
+	/** Draws `internalOnly` hotspots. Editing surfaces only. */
+	includeInternal?: boolean
+	onActivateCamera?: (cameraId: string) => void
+}
+
+/**
+ * Draws a scene's hotspots over the model.
+ *
+ * Mounted at the scene root rather than inside `Center`, because a hotspot's
+ * `worldPosition` is captured in world space by the authoring surface, after
+ * both the centering offset and the normalization scale have been applied.
+ * Nesting it under either transform would apply them a second time and every
+ * marker would drift off the geometry it was placed on.
+ *
+ * Occlusion is computed here, once for every marker, rather than through drei's
+ * `Html occlude` prop. drei tests the full camera-to-marker distance with no
+ * tolerance, which a surface-mounted hotspot fails against its own triangle,
+ * and it only re-tests when the camera moves, which strands a marker at its last
+ * value when the author toggles the setting or the model animates underneath it.
+ */
+const SceneHotspots = ({
+	hotspots,
+	model,
+	includeInternal,
+	onActivateCamera
+}: SceneHotspotsProps) => {
+	const camera = useThree((state) => state.camera)
+	const [occludedIds, setOccludedIds] =
+		useState<ReadonlySet<string>>(NO_OCCLUSIONS)
+
+	const markers = useMemo(
+		() => resolveHotspotMarkers(hotspots, { includeInternal }),
+		[hotspots, includeInternal]
+	)
+
+	const raycaster = useMemo(() => {
+		const instance = new Raycaster()
+		// Both default to a 1-unit radius, in world space, and both are radii
+		// around the ray rather than hits on it. The viewer normalizes a model's
+		// diagonal into [0.5, 5], so on a glTF carrying point-cloud or line
+		// primitives every vertex in the scene would land inside that radius and
+		// every hotspot would report itself permanently occluded.
+		instance.params.Points.threshold = 0
+		instance.params.Line.threshold = 0
+		return instance
+	}, [])
+	const target = useRef(new Vector3())
+	const direction = useRef(new Vector3())
+	const elapsed = useRef(0)
+	// Forces the next frame to re-test instead of waiting out the interval, so a
+	// changed hotspot list or a swapped model never renders against stale state.
+	const stale = useRef(true)
+
+	// Keyed on what the pass actually reads, not on array identity: a caller that
+	// rebuilds its hotspot array each render - which is the normal shape for
+	// state-derived settings - would otherwise mark every render stale and
+	// collapse the interval back to a full raycast per marker per frame.
+	const inputs = markers
+		.map(
+			(marker) =>
+				`${marker.id}:${marker.position.join()}:${marker.occlusionEnabled}`
+		)
+		.join('|')
+
+	useEffect(() => {
+		stale.current = true
+	}, [inputs, model])
+
+	useFrame((_state, delta) => {
+		elapsed.current += delta
+		if (!stale.current && elapsed.current < OCCLUSION_INTERVAL_SECONDS) return
+		const forced = stale.current
+		elapsed.current = 0
+		stale.current = false
+
+		const next = new Set<string>()
+
+		if (model) {
+			// r3f updates world matrices after every useFrame subscriber has run, and
+			// `Center` writes its offset in a layout effect, so the pass forced by a
+			// model swap would otherwise test against the previous placement.
+			if (forced) model.updateWorldMatrix(true, true)
+
+			for (const marker of markers) {
+				if (!marker.occlusionEnabled) continue
+
+				target.current.set(...marker.position)
+				direction.current.subVectors(target.current, camera.position)
+				const far = occlusionRayFar(direction.current.length())
+				if (far === 0) continue
+
+				raycaster.set(camera.position, direction.current.normalize())
+				raycaster.near = 0
+				raycaster.far = far
+				// `set` leaves this null, unlike `setFromCamera`. `Sprite.raycast`
+				// dereferences it, so a model containing one would throw here every
+				// tick and take the render call for that frame with it.
+				raycaster.camera = camera
+
+				if (raycaster.intersectObject(model, true).length > 0) {
+					next.add(marker.id)
+				}
+			}
+		}
+
+		// One state write for the whole set, and only when it actually changed:
+		// this runs inside the frame loop, where a write per marker per tick would
+		// re-render each marker's own portal root.
+		setOccludedIds((previous) =>
+			previous.size === next.size && [...next].every((id) => previous.has(id))
+				? previous
+				: next
+		)
+	})
+
+	if (markers.length === 0) return null
+
+	return (
+		<>
+			{markers.map((marker) => (
+				<HotspotMarker
+					key={marker.id}
+					marker={marker}
+					occluded={occludedIds.has(marker.id)}
+					onActivate={onActivateCamera}
+				/>
+			))}
+		</>
+	)
+}
+
+export default SceneHotspots

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -24,6 +24,8 @@ export interface SceneHotspotsProps {
 	model?: Object3D
 	/** Draws `internalOnly` hotspots. Editing surfaces only. */
 	includeInternal?: boolean
+	/** Overrides the marker fill for every hotspot in this viewer. */
+	color?: string
 	onActivateCamera?: (cameraId: string) => void
 }
 
@@ -46,6 +48,7 @@ const SceneHotspots = ({
 	hotspots,
 	model,
 	includeInternal,
+	color,
 	onActivateCamera
 }: SceneHotspotsProps) => {
 	const camera = useThree((state) => state.camera)
@@ -146,6 +149,7 @@ const SceneHotspots = ({
 					key={marker.id}
 					marker={marker}
 					occluded={occludedIds.has(marker.id)}
+					color={color}
 					onActivate={onActivateCamera}
 				/>
 			))}

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -25,6 +25,36 @@
 	--vctrl-active-bg: #d1d5db;
 	--vctrl-text: #1f2937;
 	--vctrl-border: #181818;
+
+	/*
+	  One hotspot accent for every scene, not a per-scene setting. Vectreal
+	  orange, because a hotspot is the one piece of Vectreal a visitor touches
+	  inside someone else's page, and one recognizable colour is worth more there
+	  than per-scene freedom.
+
+	  The accent alone does not carry the marker: #fc6c18 is 2.6:1 against the
+	  light viewer ground and 2.9:1 against white, so every preset also draws the
+	  white-inner/dark-outer ring in `hotspot-marker.tsx`, and the step number
+	  uses dark ink (6.6:1) rather than white (2.9:1).
+
+	  Declared on `.viewer` rather than `:root`: this stylesheet is loaded by a
+	  dynamic import into a host application, and a `:root` token would be a
+	  viewer package writing into that application's theme (the radius block
+	  above records the afternoon that cost). A host that needs a different accent
+	  overrides all three of these on the viewer container - the `-rgb` mirror
+	  included, or the pulse ring keeps the old colour. That container is the seam
+	  the host-side presentation config will use.
+
+	  `--vctrl-hotspot-accent-rgb` mirrors the hex because a hex has no valid
+	  inline alpha form; the pulse below needs one and would otherwise silently
+	  render nothing. The value is the platform's `--orange` / `--orange-rgb` from
+	  `shared/components/src/styles/globals.css`, copied because a viewer package
+	  must not read the host's tokens - keep the two in step by hand.
+	*/
+	--vctrl-hotspot-accent: #fc6c18;
+	--vctrl-hotspot-accent-rgb: 252 108 24;
+	--vctrl-hotspot-on-accent: #131313;
+
 	font-family: 'DM Sans Variable', sans-serif;
 }
 
@@ -50,6 +80,47 @@
 	--vctrl-active-bg: #d1d5db;
 	--vctrl-text: #1f2937;
 	--vctrl-border: #181818;
+}
+
+/*
+  A slow expanding ring around the marker.
+
+  Animated with `transform` and `opacity` on a dedicated element, never with
+  `box-shadow` spread: shadow spread is not compositor-accelerated, so every
+  marker would force a paint on every frame of an infinite loop, on top of a
+  canvas that already renders continuously.
+
+  The ring is drawn by the element's own border and starts outside the marker's
+  own white/dark ring, so switching the animation off leaves it visible at rest
+  rather than hiding it under the artwork. That matters: the ring is what marks a
+  dot over a 3D scene as something to touch, and a visitor who asked for reduced
+  motion still needs to be told.
+*/
+@keyframes vctrl-hotspot-pulse {
+	0% {
+		transform: scale(1);
+		opacity: 0.6;
+	}
+	70% {
+		transform: scale(2);
+		opacity: 0;
+	}
+	100% {
+		transform: scale(2);
+		opacity: 0;
+	}
+}
+
+.vctrl-hotspot-pulse {
+	border: 2px solid rgb(var(--vctrl-hotspot-accent-rgb) / 0.55);
+	border-radius: 9999px;
+	animation: vctrl-hotspot-pulse 2.4s ease-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.vctrl-hotspot-pulse {
+		animation: none;
+	}
 }
 
 @media (prefers-color-scheme: dark) {

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -27,33 +27,32 @@
 	--vctrl-border: #181818;
 
 	/*
-	  One hotspot accent for every scene, not a per-scene setting. Vectreal
-	  orange, because a hotspot is the one piece of Vectreal a visitor touches
-	  inside someone else's page, and one recognizable colour is worth more there
-	  than per-scene freedom.
+	  The hotspot marker's own colours, and deliberately not the brand accent.
 
-	  The accent alone does not carry the marker: #fc6c18 is 2.6:1 against the
-	  light viewer ground and 2.9:1 against white, so every preset also draws the
-	  white-inner/dark-outer ring in `hotspot-marker.tsx`, and the step number
-	  uses dark ink (6.6:1) rather than white (2.9:1).
+	  A hotspot sits on top of somebody's product. Vectreal orange there competes
+	  with the thing the scene exists to show, and on photographic content it
+	  reads as a sticker rather than as part of the viewer. The default is a
+	  neutral white disc with dark ink: it belongs to no palette, so it never
+	  clashes with the product, and it leaves the only strong colour on screen to
+	  the model itself.
+
+	  It also holds on both grounds without the accent's contrast problem. White
+	  carries a dark scene on its own; on a light or white product the hairline
+	  dark ring in `hotspot-marker.tsx` is what separates it. Dark ink on white is
+	  17:1, so the step numeral is legible at 10px with no special pleading.
+
+	  Colour is opt-in: `hotspotColor` on `VectrealViewer` replaces the fill per
+	  viewer, and both tokens can be overridden on the container directly. The ink
+	  does not follow the fill, so a dark or saturated one needs the ink token
+	  lightened alongside it.
 
 	  Declared on `.viewer` rather than `:root`: this stylesheet is loaded by a
 	  dynamic import into a host application, and a `:root` token would be a
-	  viewer package writing into that application's theme (the radius block
-	  above records the afternoon that cost). A host that needs a different accent
-	  overrides all three of these on the viewer container - the `-rgb` mirror
-	  included, or the pulse ring keeps the old colour. That container is the seam
-	  the host-side presentation config will use.
-
-	  `--vctrl-hotspot-accent-rgb` mirrors the hex because a hex has no valid
-	  inline alpha form; the pulse below needs one and would otherwise silently
-	  render nothing. The value is the platform's `--orange` / `--orange-rgb` from
-	  `shared/components/src/styles/globals.css`, copied because a viewer package
-	  must not read the host's tokens - keep the two in step by hand.
+	  viewer package writing into that application's theme (the radius block above
+	  records the afternoon that cost).
 	*/
-	--vctrl-hotspot-accent: #fc6c18;
-	--vctrl-hotspot-accent-rgb: 252 108 24;
-	--vctrl-hotspot-on-accent: #131313;
+	--vctrl-hotspot-fill: #ffffff;
+	--vctrl-hotspot-ink: #18181b;
 
 	font-family: 'DM Sans Variable', sans-serif;
 }
@@ -95,26 +94,34 @@
   rather than hiding it under the artwork. That matters: the ring is what marks a
   dot over a 3D scene as something to touch, and a visitor who asked for reduced
   motion still needs to be told.
+
+  `currentColor` plus a base `opacity`, never an alpha channel baked into the
+  border colour: that is what lets the fill be any CSS colour, including one a
+  caller passes at runtime that this stylesheet cannot decompose.
+
+  `color` is bound here rather than by a utility class on the element. The ring
+  is a sibling of the marker body, so it inherits nothing from it, and left to
+  plain `currentColor` it would pick up whatever colour the *host page* happens
+  to cascade into drei's portal - a ring that changes with the embedding site.
 */
 @keyframes vctrl-hotspot-pulse {
 	0% {
 		transform: scale(1);
-		opacity: 0.6;
+		opacity: 0.4;
 	}
-	70% {
-		transform: scale(2);
-		opacity: 0;
-	}
+	70%,
 	100% {
-		transform: scale(2);
+		transform: scale(1.75);
 		opacity: 0;
 	}
 }
 
 .vctrl-hotspot-pulse {
-	border: 2px solid rgb(var(--vctrl-hotspot-accent-rgb) / 0.55);
+	color: var(--vctrl-hotspot-fill);
+	border: 1px solid currentColor;
 	border-radius: 9999px;
-	animation: vctrl-hotspot-pulse 2.4s ease-out infinite;
+	opacity: 0.4;
+	animation: vctrl-hotspot-pulse 3s ease-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -82,6 +82,38 @@
 }
 
 /*
+  Optical centring for the step numeral.
+
+  Flex centres the text's *box*, and that box runs from the font's ascender to
+  its descender while a digit's ink runs from the cap height to the baseline.
+  The two are not concentric, so a numeral centred by flex alone sits high -
+  measured at 0.50px on the 20px step disc, which is visible on a shape that
+  small.
+
+  `text-box` trims the box to the cap/baseline edges, so what flex centres is
+  the ink. The browser reads the metric out of whatever font actually rendered,
+  which is the whole point: this package names DM Sans but does not ship it, so
+  a consumer's fallback font decides those metrics, and any constant written
+  here would be calibrated to a font that may never load.
+
+  The fallback is a fixed nudge for engines without `text-box` (Firefox as of
+  this writing). It is DM Sans's asymmetry specifically, and it is deliberately
+  a last resort rather than the primary mechanism: a sub-pixel transform is also
+  at the mercy of the renderer's hinting, so the same 0.05em lands differently
+  on a hinted Linux rasterizer than on macOS.
+*/
+.vctrl-hotspot-numeral {
+	display: block;
+	text-box: trim-both cap alphabetic;
+}
+
+@supports not (text-box: trim-both cap alphabetic) {
+	.vctrl-hotspot-numeral {
+		transform: translateY(0.05em);
+	}
+}
+
+/*
   A slow expanding ring around the marker.
 
   Animated with `transform` and `opacity` on a dedicated element, never with

--- a/packages/viewer/src/vectreal-viewer.stories.tsx
+++ b/packages/viewer/src/vectreal-viewer.stories.tsx
@@ -267,6 +267,15 @@ export const HotspotStyles: Story = {
 	render: hotspotRender
 }
 
+/**
+ * Colour is opt-in. The default marker is neutral so it does not compete with
+ * the product; a caller that wants the hotspots to carry a brand passes one.
+ */
+export const HotspotColor: Story = {
+	args: { hotspots: styleHotspots, hotspotColor: '#fc6c18' },
+	render: hotspotRender
+}
+
 /** The publisher's view of the same scene: the internal-only hotspot appears. */
 export const HotspotsOnAnEditingSurface: Story = {
 	args: { hotspots: styleHotspots, showInternalHotspots: true },

--- a/packages/viewer/src/vectreal-viewer.stories.tsx
+++ b/packages/viewer/src/vectreal-viewer.stories.tsx
@@ -20,6 +20,7 @@ import {
 import { defaultControlsOptions, defaultEnvOptions } from './components/scene'
 import VectrealViewer from './vectreal-viewer'
 
+import type { VectrealViewerProps } from './vectreal-viewer'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 const meta = {
 	title: 'Viewer/Vectreal Viewer',
@@ -126,6 +127,175 @@ export const Animated: Story = {
 			loopSequence: false,
 			showControls: true,
 			clips: animatedClipConfigs
+		}
+	},
+	render: (args) => (
+		<VectrealViewer {...args}>
+			<ambientLight intensity={0.8} />
+			<directionalLight position={[3, 4, 2]} intensity={1.4} />
+		</VectrealViewer>
+	)
+}
+
+/**
+ * A cube gives occlusion something to hide behind: markers on the far face sit
+ * behind a full model depth from the opening view, so the fade is visible
+ * without touching the controls.
+ */
+const createHotspotModel = (name: string) => {
+	const mesh = new Mesh(
+		new BoxGeometry(1.2, 1.2, 1.2),
+		new MeshStandardMaterial({
+			color: '#60a5fa',
+			metalness: 0.3,
+			roughness: 0.4
+		})
+	)
+	mesh.name = name
+	return mesh
+}
+
+const hotspotModel = createHotspotModel('HotspotCube')
+
+/**
+ * A data URI keeps the story self-contained: the `image` and `svg` presets take
+ * a `payloadUrl`, and a story that reached for a hosted file would render an
+ * empty frame the day that file moved.
+ */
+const markSvg = `data:image/svg+xml;utf8,${encodeURIComponent(
+	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fc6c18"><path d="M12 2 15 9l7 .6-5.3 4.6L18.3 21 12 17.3 5.7 21l1.6-6.8L2 9.6 9 9z"/></svg>'
+)}`
+
+type StoryHotspot = NonNullable<VectrealViewerProps['hotspots']>[number]
+
+const base = (
+	id: string,
+	name: string,
+	worldPosition: [number, number, number]
+): StoryHotspot => ({
+	id,
+	name,
+	worldPosition,
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot'
+})
+
+/**
+ * Every preset and every filter rule, laid out in one row in front of the
+ * geometry. Nine stored, seven drawn: the hidden one and the internal-only one
+ * never reach a public viewer.
+ */
+const styleHotspots: StoryHotspot[] = [
+	{ ...base('step-1', 'First stop', [-0.75, 0.15, 0.7]), sequenceIndex: 0 },
+	{
+		// A deliberate gap: stored indices only have to be unique, so this marker
+		// still has to read "step 2".
+		...base('step-2', 'Second stop', [-0.4, 0.15, 0.7]),
+		sequenceIndex: 4
+	},
+	base('plain', 'No sequence', [-0.05, 0.15, 0.7]),
+	{
+		...base('image-preset', 'Image preset', [0.3, 0.15, 0.7]),
+		stylePreset: 'image',
+		payloadUrl: markSvg
+	},
+	{
+		...base('svg-preset', 'SVG preset', [0.65, 0.15, 0.7]),
+		stylePreset: 'svg',
+		payloadUrl: markSvg
+	},
+	{
+		...base('badged', 'Sequenced artwork', [1.0, 0.15, 0.7]),
+		stylePreset: 'svg',
+		payloadUrl: markSvg,
+		sequenceIndex: 7
+	},
+	{
+		...base('no-payload', 'Image preset, no artwork yet', [-1.1, 0.15, 0.7]),
+		stylePreset: 'image'
+	},
+	{ ...base('hidden', 'Hidden by the author', [0, 0.6, 0.7]), visible: false },
+	{ ...base('internal', 'Internal only', [0, -0.35, 0.7]), internalOnly: true }
+]
+
+/**
+ * Occlusion only. Positions hug the cube faces, which `Center top` lifts to span
+ * y 0 to 1.2 with its faces at z ±0.6.
+ */
+const occlusionHotspots: StoryHotspot[] = [
+	{
+		...base('front-1', 'Front panel', [-0.35, 0.95, 0.62]),
+		sequenceIndex: 0,
+		// The only hotspot in these stories with somewhere to go, so the button
+		// branch - focus ring, tab stop, aria-disabled while occluded - is the one
+		// actually rendered rather than the label-only fallback.
+		linkedCameraId: 'opening'
+	},
+	{ ...base('front-2', 'Lower edge', [0.35, 0.35, 0.62]), sequenceIndex: 1 },
+	base('rear', 'Rear panel', [0, 0.85, -0.62]),
+	// Exactly on the front face, not floating in front of it. This is what the
+	// authoring surface actually stores - it raycasts the model and keeps the
+	// intersection - and a depth test without a tolerance reports it as occluded
+	// by the very triangle it sits on.
+	base('on-surface', 'Placed on the surface', [-0.2, 0.6, 0.6]),
+	{
+		...base('rear-always', 'Rear panel, always shown', [0, 0.35, -0.62]),
+		occlusionEnabled: false
+	}
+]
+
+const hotspotRender: Story['render'] = (args) => (
+	<VectrealViewer {...args}>
+		<ambientLight intensity={0.8} />
+		<directionalLight position={[3, 4, 2]} intensity={1.4} />
+		<mesh rotation={[0.2, 0.4, 0]}>
+			<boxGeometry args={[1.2, 1.2, 1.2]} />
+			<meshStandardMaterial color="#60a5fa" metalness={0.3} roughness={0.4} />
+		</mesh>
+	</VectrealViewer>
+)
+
+/**
+ * The cube is a child rather than the `model` prop, which leaves the viewer with
+ * no occlusion target at all. That is the point: without it the markers would
+ * fade on whichever frame the bounds pass happened to settle, and a snapshot of
+ * marker chrome is worth more than one of the fade.
+ */
+export const HotspotStyles: Story = {
+	args: { hotspots: styleHotspots },
+	render: hotspotRender
+}
+
+/** The publisher's view of the same scene: the internal-only hotspot appears. */
+export const HotspotsOnAnEditingSurface: Story = {
+	args: { hotspots: styleHotspots, showInternalHotspots: true },
+	render: hotspotRender
+}
+
+/**
+ * Markers on the far side of the model fade; the one with `occlusionEnabled:
+ * false` does not. Orbit to watch it reverse.
+ */
+export const HotspotOcclusion: Story = {
+	args: {
+		model: hotspotModel,
+		hotspots: occlusionHotspots,
+		// An explicit camera rather than the bounds framing pass. Occlusion is a
+		// function of where the camera is, so a story that let the framing settle
+		// on its own would snapshot whichever frame the capture happened to catch.
+		// A stored position also switches bounds framing off (see `boundsEnabled`),
+		// which is what makes the opening view repeatable.
+		cameraOptions: {
+			activeCameraId: 'opening',
+			cameras: [
+				{
+					cameraId: 'opening',
+					name: 'Opening view',
+					position: [0.9, 1.5, 3.2],
+					target: [0, 0.6, 0]
+				}
+			]
 		}
 	},
 	render: (args) => (

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -23,6 +23,7 @@ import {
 	CameraProps,
 	ControlsProps,
 	EnvironmentProps,
+	HotspotDefinition,
 	NormalizationOptions,
 	ShadowsProps
 } from '@vctrl/core'
@@ -45,6 +46,7 @@ import {
 	SceneCamera,
 	SceneControls,
 	SceneEnvironment,
+	SceneHotspots,
 	SceneModel,
 	ScenePostProcessing,
 	SceneShadows
@@ -162,6 +164,18 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 */
 	normalizationOptions?: NormalizationOptions
 
+	/**
+	 * Point-of-interest hotspots to draw over the model, straight from
+	 * `SceneSettings.hotspots`.
+	 *
+	 * Drawn in navigation-sequence order, and a sequenced hotspot carries its
+	 * step number. A hotspot the author hid (`visible: false`) is never drawn,
+	 * and neither is one marked `internalOnly` unless `showInternalHotspots`
+	 * says this is an editing surface. Clicking a hotspot that names a
+	 * `linkedCameraId` activates that camera.
+	 */
+	hotspots?: HotspotDefinition[]
+
 	// --- Editor affordances ---
 	// Editing-surface features (e.g. the publisher). Public/embedded viewers omit
 	// these. See the package README for the slim-embed surface.
@@ -171,6 +185,19 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 * Intended for editing surfaces (e.g. the publisher), not public viewers.
 	 */
 	shadowLightEditable?: boolean
+
+	/**
+	 * When true, hotspots marked `internalOnly` are drawn as well. Intended for
+	 * the publisher, where those hotspots are authored.
+	 *
+	 * Public and embedded surfaces leave this off. `internalOnly` is a
+	 * visibility contract, and the published payload is already stripped of
+	 * these server-side; this is the viewer's own half of it, which matters
+	 * because a consumer of this package can hand it any settings object,
+	 * including one that never passed through that redaction.
+	 * Default: false.
+	 */
+	showInternalHotspots?: boolean
 
 	/**
 	 * When true, the accumulative shadow bakes in a single pass on mount instead of
@@ -292,8 +319,10 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		envOptions,
 		shadowsOptions,
 		normalizationOptions,
+		hotspots,
 		// Editor affordances
 		shadowLightEditable,
+		showInternalHotspots = false,
 		staticShadowBake = false,
 		bakedShadow,
 		onShadowBakeReady,
@@ -389,6 +418,16 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 				break
 		}
 	}, [forwardAnimationCommand])
+
+	// A hotspot's linked camera goes through the same command path an external
+	// `activate_camera` takes, so a hotspot click and a host calling the embed
+	// API land on one implementation of "fly to this viewpoint".
+	const handleActivateHotspotCamera = useCallback(
+		(cameraId: string) => {
+			executeViewerCommand({ type: 'activate_camera', cameraId })
+		},
+		[executeViewerCommand]
+	)
 
 	const handleSceneCameraExecutorReady = useCallback(
 		(executor: null | ViewerCommandExecutor) => {
@@ -527,6 +566,12 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									staticBake={staticShadowBake}
 									bakedShadow={bakedShadow}
 									onShadowBakeReady={onShadowBakeReady}
+								/>
+								<SceneHotspots
+									hotspots={hotspots}
+									model={model}
+									includeInternal={showInternalHotspots}
+									onActivateCamera={handleActivateHotspotCamera}
 								/>
 								{children}
 							</SceneBounds>

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -176,6 +176,22 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 */
 	hotspots?: HotspotDefinition[]
 
+	/**
+	 * Overrides the hotspot marker fill. Any CSS colour.
+	 *
+	 * The default is a neutral white disc with dark ink, deliberately not the
+	 * Vectreal accent: a marker sits on top of somebody's product, and a
+	 * saturated one competes with the thing the scene exists to show. Pass a
+	 * colour where the hotspots are meant to carry a brand rather than get out
+	 * of the way.
+	 *
+	 * The ink stays dark whatever you pass, so a dark or saturated fill needs
+	 * `--vctrl-hotspot-ink` overridden on the viewer container to keep the step
+	 * numeral readable: white on `#18181b` navy is 1.8:1, against 18:1 for the
+	 * default pale fill.
+	 */
+	hotspotColor?: string
+
 	// --- Editor affordances ---
 	// Editing-surface features (e.g. the publisher). Public/embedded viewers omit
 	// these. See the package README for the slim-embed surface.
@@ -320,6 +336,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		shadowsOptions,
 		normalizationOptions,
 		hotspots,
+		hotspotColor,
 		// Editor affordances
 		shadowLightEditable,
 		showInternalHotspots = false,
@@ -571,6 +588,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									hotspots={hotspots}
 									model={model}
 									includeInternal={showInternalHotspots}
+									color={hotspotColor}
 									onActivateCamera={handleActivateHotspotCamera}
 								/>
 								{children}


### PR DESCRIPTION
# feat(viewer): render scene hotspots

## Root cause

`SceneSettings.hotspots` is the only settings sub-object `@vctrl/viewer` never
accepted as a prop, so the authoring pipeline persists hotspots that no runtime
surface reads — the gap belongs in the viewer, which owns every other
settings-to-render mapping, not in the publisher that writes them.

## What this does

`VectrealViewer` takes `hotspots?: HotspotDefinition[]` and draws them over the
model. Every field on the type is honoured:

| Field | Behaviour |
| --- | --- |
| `visible` | An explicit `false` is never drawn. An absent value is malformed data, and dropping a hotspot someone placed is the worse failure, so only `false` hides. |
| `internalOnly` | Drawn only when the surface opts in with `showInternalHotspots`, which defaults off. |
| `stylePreset` | `dot` is a brand-accent disc; `image` is framed artwork on its own white ground; `svg` is unframed artwork with a drop shadow. |
| `payloadUrl` | Source for the two artwork presets. Absent, blank or non-string falls back to the dot rather than rendering a broken image — the field is optional, so an author can pick a preset before choosing the artwork. |
| `occlusionEnabled` | Defaults on. An occluded marker fades to 15%, stops taking pointer events, leaves the tab order and refuses activation. |
| `sequenceIndex` | Sets draw order and the step number on the marker. |
| `linkedCameraId` | Clicking flies to that camera, through the same `activate_camera` path an external `@vctrl/embed` call takes. |
| `name` | The accessible name, and a label on hover, focus or tap. |

Step numbers are the **rank** among reachable hotspots, not `sequenceIndex + 1`.
Stored indices only have to be unique, and the authoring swap leaves gaps, so a
scene can legitimately hold 0, 1 and 4 — printing those would tell a visitor
there are steps they cannot find. Hidden and internal-only hotspots are removed
before ranking, so a public visitor is told "step 1 of 2" for what they can
actually reach.

## Rank 11: the hotspot accent is a single default, not per-scene

**Recommendation implemented: one brand accent for every scene**, as a
viewer-local `--vctrl-hotspot-accent` on the `.viewer` container.

1. **Per-scene needs a persisted field that does not exist.** It would mean a new
   column, a parser rule, a comparison rule, a publisher control and a migration
   — a schema commitment made before one customer has seen a hotspot render.
   This PR was explicitly not allowed to invent fields on `HotspotDefinition`,
   and on the merits it should not: the cheap direction is default now, field
   later, where the default becomes the fallback. The reverse — withdrawing a
   field authors have already set — is not cheap.
2. **The variable that actually matters is the host page, not the scene.** One
   scene is embedded on many sites. Rank 13 (host-side presentation config)
   already owns that axis, and it is the right one: a value per embed, not per
   scene. Overriding the three `--vctrl-hotspot-*` tokens on the viewer container
   is the seam it will use — no new API needed.
3. **A hotspot is the one piece of Vectreal a visitor touches inside someone
   else's page.** One recognisable colour is worth more there than per-scene
   freedom, and a per-scene picker is a way for a customer to choose something
   invisible against their own product.

The accent alone does not carry the marker: `#fc6c18` is 2.6:1 against the light
viewer ground and 2.9:1 against white, both under the 3:1 a non-text indicator
needs. Every preset therefore draws a white inner / dark outer ring, and the step
number uses dark ink (6.5:1) rather than white (2.9:1).

The token is declared on `.viewer`, never `:root` — this stylesheet is loaded by
a dynamic import into a host application, and the radius block above it records
what a `:root` write already cost once.

## Occlusion is the viewer's own pass, not drei's

drei's `Html occlude` was the obvious choice and is wrong here on two counts,
both confirmed in a browser:

- **No tolerance.** A hotspot is authored by raycasting the model and storing the
  intersection verbatim, so it lies *exactly* on a triangle. Testing the full
  camera-to-marker distance makes the nearest hit that same triangle, and the
  comparison turns on float noise. The `Placed on the surface` marker in the new
  occlusion story is that case: with the tolerance removed it reports occluded,
  with it it renders. `occlusionRayFar` stops the ray 0.5% short — relative, not
  absolute, because the viewer normalises model diagonals into [0.5, 5].
- **Only re-tests when the camera moves.** An author toggling the setting, or a
  model animating underneath a still camera, left markers stranded at their last
  value.

The replacement is one pass in `SceneHotspots`, throttled to 15Hz, one shared
raycaster, one state write for all markers. `Points`/`Line` raycast thresholds
are zeroed (they default to a 1-unit *world-space* radius, which on a normalised
model would report every hotspot occluded forever on any glTF carrying point or
line primitives), and `raycaster.camera` is assigned because `set()` leaves it
null and `Sprite.raycast` dereferences it.

## Verification

Storybook, in a real browser with a real WebGL context (Playwright + SwiftShader),
across the three new stories:

- 9 stored hotspots, 7 drawn publicly, 8 with `showInternalHotspots` — the hidden
  one never appears either way.
- Occlusion flips both ways across an orbit; `occlusionEnabled: false` never
  fades; the surface-mounted marker does not occlude itself.
- Hit targets measured at 24 / 28 / 32px. Focus ring white-on-dark-halo, and the
  linked marker keeps its `<button>` across an orbit while gaining
  `tabIndex=-1`, `aria-disabled` and `pointer-events: none` once occluded.
- Reduced motion leaves a static ring outside the artwork rather than nothing.
- Tap on a phone viewport shows the name and clears it after 2.5s.
- `theme="dark"` verified restored after this PR briefly deleted the
  `.viewer[data-theme]` blocks — the stylesheet diff is now purely additive.

Gates: `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform`
green, 8 tasks. `pnpm nx run-many --target=test` green.

Three review rounds; every guard mutation-tested, including in the browser for
the occlusion tolerance.

## Filed rather than fixed

Scope was `packages/viewer/src` and `packages/core/src/types` (no change was
needed to the latter — `HotspotDefinition` already carried every field). Sibling
sessions hold the publisher and embed surfaces. New rows in **Vectreal Work
Items**:

- **Pass `SceneSettings.hotspots` into the viewer from the platform's scene
  surfaces** (rank 10.1) — the one-line wiring in `scene-embed-viewer.tsx` that
  makes this reach customers.
- **Nothing bounds how many hotspots a scene can carry** — parser plus plan limit.
- **`payloadUrl` is the one hotspot field the save parser never validates** — not
  exploitable through `<img src>`, but it is also a third-party request from
  every embed visitor.
- **The hotspot hover label is clipped at the top edge of the viewer** — rank 14
  will own marker-attached UI and needs a positioning strategy anyway.
- **The brand orange is duplicated into `@vctrl/viewer`** — add the two lines to
  `documented-claims.spec.ts`.
- **The documented `npx vitest run --root .` gate does not work** — no root
  config, so it ignores every project config; 492 of 875 files fail on clean
  `main`. The real gate is the nx target.

## Residual risk

`hotspot-marker.tsx` and `scene-hotspots.tsx` have no unit coverage: this package
runs `.ts` specs only, by design, because its components need a WebGL context.
Every decision that could be pulled out of them was — filtering, ordering, step
ranking, preset fallback, name defaulting, the interaction rule and the depth
tolerance are all pure modules with mutation-gated specs. What is left uncovered
is the drei projection and the DOM itself, which the two Chromatic-snapshotted
stories now watch.
