### PR TITLE
fix(publisher): anchor a hotspot to the model under the pointer

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
@@ -1,11 +1,26 @@
 import { Html, TransformControls } from '@react-three/drei'
 import { useFrame, useThree } from '@react-three/fiber'
+import { useModelContext } from '@vctrl/hooks/use-load-model'
 import { useAtom, useAtomValue } from 'jotai/react'
-import { memo, useCallback, useEffect, useRef, useState, type FC } from 'react'
+import {
+	memo,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type FC
+} from 'react'
 import * as THREE from 'three'
 
 import { PublisherViewCube } from './publisher-view-cube'
 import { usePublisherViewerCapture } from './publisher-viewer-capture-context'
+import {
+	isHotspotOccluded,
+	isHotspotPlacementGesture,
+	prepareHotspotRaycaster,
+	resolveHotspotAnchor
+} from '../../lib/domain/scene/scene-hotspot-placement'
 import {
 	isClickToPlaceActiveAtom,
 	processAtom
@@ -17,6 +32,7 @@ import {
 } from '../../lib/stores/scene-settings-store'
 
 import type { HotspotDefinition } from '@vctrl/core'
+import type { Object3D } from 'three'
 
 // ---------------------------------------------------------------------------
 // Inject CSS keyframes for the pulsing dot animation (once per document)
@@ -50,6 +66,7 @@ interface HotspotDotProps {
 	isSelected: boolean
 	isHotspotToolActive: boolean
 	activeCameraId?: string
+	modelRoot: Object3D | null
 	onSelect: (id: string) => void
 	onActivateCamera: (cameraId: string) => void
 }
@@ -60,13 +77,21 @@ const HotspotDot: FC<HotspotDotProps> = memo(
 		isSelected,
 		isHotspotToolActive,
 		activeCameraId,
+		modelRoot,
 		onSelect,
 		onActivateCamera
 	}) => {
 		const [hovered, setHovered] = useState(false)
 		const wrapperRef = useRef<HTMLDivElement>(null)
 		const posVec = useRef(new THREE.Vector3(...hotspot.worldPosition))
-		const { camera, raycaster, scene } = useThree()
+		const { camera } = useThree()
+		// Private, so the per-frame occlusion test cannot leave R3F's own pointer
+		// raycaster aimed at a hotspot.
+		const occlusionRay = useMemo(
+			() => prepareHotspotRaycaster(new THREE.Raycaster()),
+			[]
+		)
+		const occlusionDir = useRef(new THREE.Vector3())
 
 		// Keep position in sync with atom changes (e.g. after gizmo drag or click-to-place)
 		useEffect(() => {
@@ -84,18 +109,14 @@ const HotspotDot: FC<HotspotDotProps> = memo(
 
 			const origin = camera.position
 			const target = posVec.current
-			const dist = origin.distanceTo(target)
-			const dir = new THREE.Vector3().subVectors(target, origin).normalize()
+			const distance = origin.distanceTo(target)
 
-			raycaster.set(origin, dir)
+			occlusionRay.set(
+				origin,
+				occlusionDir.current.subVectors(target, origin).normalize()
+			)
 
-			const meshes: THREE.Mesh[] = []
-			scene.traverse((o) => {
-				if (o instanceof THREE.Mesh && !o.userData.editorOverlay) meshes.push(o)
-			})
-
-			const hits = raycaster.intersectObjects(meshes, true)
-			const occluded = hits.length > 0 && hits[0].distance < dist - 0.05
+			const occluded = isHotspotOccluded(occlusionRay, modelRoot, distance)
 			wrapperRef.current.style.opacity = occluded ? '0.18' : '1'
 		})
 
@@ -195,77 +216,87 @@ HotspotDot.displayName = 'HotspotDot'
 
 interface HotspotGizmoProps {
 	hotspot: HotspotDefinition
+	/**
+	 * Set when a press lands on a translate handle, so `ClickToPlace` can tell a
+	 * gizmo nudge from a click on the model. three-stdlib stops neither the event
+	 * nor its propagation, and a nudge shorter than the drag tolerance otherwise
+	 * reads as a placement aimed at whatever the arrow tip covers.
+	 */
+	grabbedRef: React.MutableRefObject<boolean>
 	onMove: (id: string, position: [number, number, number]) => void
 }
 
-const HotspotGizmo = memo(({ hotspot, onMove }: HotspotGizmoProps) => {
-	const meshRef = useRef<THREE.Mesh>(null)
-	const isDraggingRef = useRef(false)
-	const { commandExecutor } = usePublisherViewerCapture()
-	// TransformControls `object` prop requires the mesh to already be in the scene
-	const [meshMounted, setMeshMounted] = useState(false)
+const HotspotGizmo = memo(
+	({ hotspot, grabbedRef, onMove }: HotspotGizmoProps) => {
+		const meshRef = useRef<THREE.Mesh>(null)
+		const isDraggingRef = useRef(false)
+		const { commandExecutor } = usePublisherViewerCapture()
+		// TransformControls `object` prop requires the mesh to already be in the scene
+		const [meshMounted, setMeshMounted] = useState(false)
 
-	// Imperatively sync position when the atom changes (e.g. after click-to-place).
-	// Guarded so we don't fight TransformControls while the user is dragging.
-	useEffect(() => {
-		if (meshRef.current && !isDraggingRef.current) {
-			const [x, y, z] = hotspot.worldPosition
-			meshRef.current.position.set(x, y, z)
-		}
-	}, [hotspot.worldPosition])
+		// Imperatively sync position when the atom changes (e.g. after click-to-place).
+		// Guarded so we don't fight TransformControls while the user is dragging.
+		useEffect(() => {
+			if (meshRef.current && !isDraggingRef.current) {
+				const [x, y, z] = hotspot.worldPosition
+				meshRef.current.position.set(x, y, z)
+			}
+		}, [hotspot.worldPosition])
 
-	const handleDragStart = useCallback(() => {
-		isDraggingRef.current = true
-		commandExecutor.current?.execute({
-			type: 'set_controls_enabled',
-			enabled: false
-		})
-	}, [commandExecutor])
+		const handleDragStart = useCallback(() => {
+			isDraggingRef.current = true
+			grabbedRef.current = true
+			commandExecutor.current?.execute({
+				type: 'set_controls_enabled',
+				enabled: false
+			})
+		}, [commandExecutor, grabbedRef])
 
-	const handleDragEnd = useCallback(() => {
-		isDraggingRef.current = false
-		commandExecutor.current?.execute({
-			type: 'set_controls_enabled',
-			enabled: true
-		})
-		if (meshRef.current) {
+		const handleDragEnd = useCallback(() => {
+			isDraggingRef.current = false
+			commandExecutor.current?.execute({
+				type: 'set_controls_enabled',
+				enabled: true
+			})
+			if (meshRef.current) {
+				const p = meshRef.current.position
+				onMove(hotspot.id, [p.x, p.y, p.z])
+			}
+		}, [commandExecutor, hotspot.id, onMove])
+
+		const handleObjectChange = useCallback(() => {
+			if (!meshRef.current || !isDraggingRef.current) return
 			const p = meshRef.current.position
 			onMove(hotspot.id, [p.x, p.y, p.z])
-		}
-	}, [commandExecutor, hotspot.id, onMove])
+		}, [hotspot.id, onMove])
 
-	const handleObjectChange = useCallback(() => {
-		if (!meshRef.current || !isDraggingRef.current) return
-		const p = meshRef.current.position
-		onMove(hotspot.id, [p.x, p.y, p.z])
-	}, [hotspot.id, onMove])
+		return (
+			<>
+				<mesh
+					ref={(node) => {
+						;(meshRef as React.MutableRefObject<THREE.Mesh | null>).current =
+							node
+						if (node && !meshMounted) setMeshMounted(true)
+					}}
+					position={hotspot.worldPosition as [number, number, number]}
+				>
+					<sphereGeometry args={[0.001, 1, 1]} />
+					<meshBasicMaterial visible={false} />
+				</mesh>
 
-	return (
-		<>
-			<mesh
-				ref={(node) => {
-					;(meshRef as React.MutableRefObject<THREE.Mesh | null>).current = node
-					if (node && !meshMounted) setMeshMounted(true)
-				}}
-				position={hotspot.worldPosition as [number, number, number]}
-				userData={{ editorOverlay: true }}
-			>
-				<sphereGeometry args={[0.001, 1, 1]} />
-				<meshBasicMaterial visible={false} />
-			</mesh>
-
-			{meshMounted && meshRef.current && (
-				<TransformControls
-					object={meshRef.current}
-					mode="translate"
-					onMouseDown={handleDragStart}
-					onMouseUp={handleDragEnd}
-					onObjectChange={handleObjectChange}
-				/>
-			)}
-		</>
-	)
-})
+				{meshMounted && meshRef.current && (
+					<TransformControls
+						object={meshRef.current}
+						mode="translate"
+						onMouseDown={handleDragStart}
+						onMouseUp={handleDragEnd}
+						onObjectChange={handleObjectChange}
+					/>
+				)}
+			</>
+		)
+	}
+)
 HotspotGizmo.displayName = 'HotspotGizmo'
 
 // ---------------------------------------------------------------------------
@@ -275,45 +306,106 @@ HotspotGizmo.displayName = 'HotspotGizmo'
 interface ClickToPlaceProps {
 	isActive: boolean
 	activeHotspotId: string | null
+	modelRoot: Object3D | null
+	gizmoGrabbedRef: React.MutableRefObject<boolean>
 	onPlace: (id: string, position: [number, number, number]) => void
 }
 
+/**
+ * Places the armed hotspot where a click lands on the model.
+ *
+ * The gesture is resolved on pointerup rather than pointerdown because
+ * OrbitControls shares this canvas: a press is only a placement once it has
+ * ended without having turned into an orbit.
+ *
+ * The release is read off the window rather than the canvas: a drag that ends
+ * outside it still reports, and correctly fails the distance test rather than
+ * leaving the press half-open. Nothing here captures the pointer, so nothing
+ * can be released out from under a co-tenant mid-drag.
+ */
 function ClickToPlace({
 	isActive,
 	activeHotspotId,
+	modelRoot,
+	gizmoGrabbedRef,
 	onPlace
 }: ClickToPlaceProps) {
-	const { raycaster, camera, scene, gl } = useThree()
+	const { camera, gl } = useThree()
+	const placementRay = useMemo(
+		() => prepareHotspotRaycaster(new THREE.Raycaster()),
+		[]
+	)
 
 	useEffect(() => {
 		if (!isActive || !activeHotspotId) return
 
-		const handlePointerDown = (e: PointerEvent) => {
-			const canvas = gl.domElement
-			const rect = canvas.getBoundingClientRect()
-			const x = ((e.clientX - rect.left) / rect.width) * 2 - 1
-			const y = -((e.clientY - rect.top) / rect.height) * 2 + 1
+		const canvas = gl.domElement
+		let pressed: { button: number; x: number; y: number } | null = null
+		// The gizmo outlives this effect: it stays mounted while the tool is
+		// disarmed, which is exactly where auto-disarm leaves the author after every
+		// placement. A grab recorded back then would be consumed by the first click
+		// of the next armed session, silently swallowing it.
+		gizmoGrabbedRef.current = false
 
-			raycaster.setFromCamera(new THREE.Vector2(x, y), camera)
-
-			const meshes: THREE.Object3D[] = []
-			scene.traverse((obj) => {
-				if (obj instanceof THREE.Mesh && !obj.userData.editorOverlay) {
-					meshes.push(obj)
-				}
-			})
-
-			const hits = raycaster.intersectObjects(meshes, false)
-			if (hits.length > 0) {
-				const p = hits[0].point
-				onPlace(activeHotspotId, [p.x, p.y, p.z])
-			}
+		const handlePointerDown = (event: PointerEvent) => {
+			pressed = { button: event.button, x: event.clientX, y: event.clientY }
 		}
 
-		gl.domElement.addEventListener('pointerdown', handlePointerDown)
-		return () =>
-			gl.domElement.removeEventListener('pointerdown', handlePointerDown)
-	}, [isActive, activeHotspotId, camera, scene, raycaster, gl, onPlace])
+		const handlePointerUp = (event: PointerEvent) => {
+			const down = pressed
+			pressed = null
+			// Consumed here rather than cleared on the next press: the gizmo and this
+			// handler both listen on the canvas, and their registration order is not
+			// ours to decide.
+			const grabbedGizmo = gizmoGrabbedRef.current
+			gizmoGrabbedRef.current = false
+			if (!down) return
+
+			const isPlacement = isHotspotPlacementGesture({
+				button: down.button,
+				downX: down.x,
+				downY: down.y,
+				upX: event.clientX,
+				upY: event.clientY,
+				grabbedGizmo
+			})
+			if (!isPlacement) return
+
+			const rect = canvas.getBoundingClientRect()
+			placementRay.setFromCamera(
+				new THREE.Vector2(
+					((event.clientX - rect.left) / rect.width) * 2 - 1,
+					-((event.clientY - rect.top) / rect.height) * 2 + 1
+				),
+				camera
+			)
+
+			const anchor = resolveHotspotAnchor(placementRay, modelRoot)
+			if (anchor) onPlace(activeHotspotId, anchor)
+		}
+
+		const handlePointerCancel = () => {
+			pressed = null
+			gizmoGrabbedRef.current = false
+		}
+
+		canvas.addEventListener('pointerdown', handlePointerDown)
+		window.addEventListener('pointerup', handlePointerUp)
+		window.addEventListener('pointercancel', handlePointerCancel)
+		return () => {
+			canvas.removeEventListener('pointerdown', handlePointerDown)
+			window.removeEventListener('pointerup', handlePointerUp)
+			window.removeEventListener('pointercancel', handlePointerCancel)
+		}
+	}, [
+		isActive,
+		activeHotspotId,
+		camera,
+		gizmoGrabbedRef,
+		gl,
+		modelRoot,
+		onPlace
+	])
 
 	return null
 }
@@ -327,10 +419,17 @@ export const PublisherEditorScene = memo(() => {
 
 	const [hotspots, setHotspots] = useAtom(hotspotsAtom)
 	const [activeHotspotId, setActiveHotspotId] = useAtom(activeHotspotIdAtom)
-	const isClickToPlaceActive = useAtomValue(isClickToPlaceActiveAtom)
+	const [isClickToPlaceActive, setIsClickToPlaceActive] = useAtom(
+		isClickToPlaceActiveAtom
+	)
 	const process = useAtomValue(processAtom)
 	const [selectedCameraId, setSelectedCameraId] = useAtom(selectedCameraIdAtom)
 	const isHotspotToolActive = process.activeComposeTool === 'hotspots'
+	const isPlacementArmed = isClickToPlaceActive && isHotspotToolActive
+	// The object the viewer renders, and the only thing a hotspot anchors to.
+	const { file } = useModelContext()
+	const modelRoot = file?.model ?? null
+	const gizmoGrabbedRef = useRef(false)
 
 	const handleSelectHotspot = useCallback(
 		(id: string) => {
@@ -355,13 +454,19 @@ export const PublisherEditorScene = memo(() => {
 		[setHotspots]
 	)
 
+	/**
+	 * Disarms on success. Placing is one deliberate act, and leaving the tool
+	 * armed meant every later click on the canvas moved the hotspot again -
+	 * including clicks the author made to orbit or to pick a different one.
+	 */
 	const handlePlaceHotspot = useCallback(
 		(id: string, position: [number, number, number]) => {
 			setHotspots((prev) =>
 				prev.map((h) => (h.id === id ? { ...h, worldPosition: position } : h))
 			)
+			setIsClickToPlaceActive(false)
 		},
-		[setHotspots]
+		[setHotspots, setIsClickToPlaceActive]
 	)
 
 	const activeHotspot = hotspots.find((h) => h.id === activeHotspotId) ?? null
@@ -375,6 +480,7 @@ export const PublisherEditorScene = memo(() => {
 					isSelected={hotspot.id === activeHotspotId}
 					isHotspotToolActive={isHotspotToolActive}
 					activeCameraId={selectedCameraId ?? undefined}
+					modelRoot={modelRoot}
 					onSelect={handleSelectHotspot}
 					onActivateCamera={handleActivateHotspotCamera}
 				/>
@@ -384,17 +490,29 @@ export const PublisherEditorScene = memo(() => {
 				<HotspotGizmo
 					key={activeHotspot.id}
 					hotspot={activeHotspot}
+					grabbedRef={gizmoGrabbedRef}
 					onMove={handleMoveHotspot}
 				/>
 			)}
 
 			<ClickToPlace
-				isActive={isClickToPlaceActive && isHotspotToolActive}
+				isActive={isPlacementArmed}
 				activeHotspotId={activeHotspotId}
+				modelRoot={modelRoot}
+				gizmoGrabbedRef={gizmoGrabbedRef}
 				onPlace={handlePlaceHotspot}
 			/>
 
-			<PublisherViewCube />
+			{/*
+			 * Withdrawn while a placement is armed. drei's GizmoViewcube guards its
+			 * faces with R3F's `stopPropagation`, which halts R3F's own traversal
+			 * and never touches the native event, so the cube cannot stop the
+			 * native listener above from reading a click on it as a placement -
+			 * relocating the hotspot to whatever geometry sits behind that corner
+			 * and disarming, so the affordance vanishes in the same moment. Taking
+			 * the cube off screen removes the overlap rather than guarding it.
+			 */}
+			{!isPlacementArmed && <PublisherViewCube />}
 		</>
 	)
 })

--- a/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
@@ -19,7 +19,8 @@ import {
 	isHotspotOccluded,
 	isHotspotPlacementGesture,
 	prepareHotspotRaycaster,
-	resolveHotspotAnchor
+	resolveHotspotAnchor,
+	resolveHotspotOcclusionTolerance
 } from '../../lib/domain/scene/scene-hotspot-placement'
 import {
 	isClickToPlaceActiveAtom,
@@ -28,6 +29,7 @@ import {
 import {
 	activeHotspotIdAtom,
 	hotspotsAtom,
+	normalizationAtom,
 	selectedCameraIdAtom
 } from '../../lib/stores/scene-settings-store'
 
@@ -57,6 +59,18 @@ function useHotspotStyles() {
 	}, [])
 }
 
+/**
+ * The gizmo's live position during a drag, shared with the marker that follows
+ * it.
+ *
+ * Refs rather than state on purpose: a drag emits a position every frame, and
+ * routing that through React is what this exists to stop.
+ */
+interface HotspotDragState {
+	hotspotId: React.MutableRefObject<null | string>
+	position: React.MutableRefObject<THREE.Vector3>
+}
+
 // ---------------------------------------------------------------------------
 // 2-D hotspot dot rendered via drei Html (no 3-D geometry)
 // ---------------------------------------------------------------------------
@@ -67,6 +81,18 @@ interface HotspotDotProps {
 	isHotspotToolActive: boolean
 	activeCameraId?: string
 	modelRoot: Object3D | null
+	/**
+	 * World-unit occlusion slack for this model, held by the owner and refreshed
+	 * when the model or its transform changes.
+	 */
+	occlusionTolerance: React.MutableRefObject<number>
+	/**
+	 * Where the gizmo is while a drag is in flight, and whose drag it is. The
+	 * dragged marker reads this instead of its stored position, so the drag can
+	 * keep the marker glued to the gizmo without writing the scene settings on
+	 * every frame.
+	 */
+	drag: HotspotDragState
 	onSelect: (id: string) => void
 	onActivateCamera: (cameraId: string) => void
 }
@@ -78,11 +104,14 @@ const HotspotDot: FC<HotspotDotProps> = memo(
 		isHotspotToolActive,
 		activeCameraId,
 		modelRoot,
+		occlusionTolerance,
+		drag,
 		onSelect,
 		onActivateCamera
 	}) => {
 		const [hovered, setHovered] = useState(false)
 		const wrapperRef = useRef<HTMLDivElement>(null)
+		const anchorRef = useRef<THREE.Group>(null)
 		const posVec = useRef(new THREE.Vector3(...hotspot.worldPosition))
 		const { camera } = useThree()
 		// Private, so the per-frame occlusion test cannot leave R3F's own pointer
@@ -96,10 +125,23 @@ const HotspotDot: FC<HotspotDotProps> = memo(
 		// Keep position in sync with atom changes (e.g. after gizmo drag or click-to-place)
 		useEffect(() => {
 			posVec.current.set(...hotspot.worldPosition)
+			anchorRef.current?.position.copy(posVec.current)
 		}, [hotspot.worldPosition])
 
-		// Occlusion: raycast from camera toward hotspot every frame, mutate opacity directly
+		// Occlusion: raycast from camera toward hotspot every frame, mutate opacity
+		// directly. Priority -1 so this writes the group's position before drei's
+		// `Html` projects from it: at equal priority `Html` subscribes first, being
+		// a child, and the marker would trail the gizmo by a frame. Negative
+		// priorities sort early without taking rendering over, which only `> 0` does.
 		useFrame(() => {
+			// A drag moves the gizmo directly and commits once, on release, so the
+			// dragged marker tracks the gizmo from here rather than from a stored
+			// position that is deliberately not being rewritten yet.
+			if (drag.hotspotId.current === hotspot.id) {
+				posVec.current.copy(drag.position.current)
+				anchorRef.current?.position.copy(posVec.current)
+			}
+
 			if (!wrapperRef.current) return
 
 			if (hotspot.occlusionEnabled === false) {
@@ -116,9 +158,14 @@ const HotspotDot: FC<HotspotDotProps> = memo(
 				occlusionDir.current.subVectors(target, origin).normalize()
 			)
 
-			const occluded = isHotspotOccluded(occlusionRay, modelRoot, distance)
+			const occluded = isHotspotOccluded(
+				occlusionRay,
+				modelRoot,
+				distance,
+				occlusionTolerance.current
+			)
 			wrapperRef.current.style.opacity = occluded ? '0.18' : '1'
-		})
+		}, -1)
 
 		const isLinkedCameraActive =
 			!isHotspotToolActive &&
@@ -136,75 +183,75 @@ const HotspotDot: FC<HotspotDotProps> = memo(
 		const showLabel = isSelected || hovered
 
 		return (
-			<Html
-				center
+			<group
+				ref={anchorRef}
 				position={hotspot.worldPosition as [number, number, number]}
-				zIndexRange={[100, 0]}
-				style={{ pointerEvents: 'none' }}
 			>
-				<div
-					ref={wrapperRef}
-					style={{
-						pointerEvents: 'auto',
-						transition: 'opacity 0.35s ease',
-						position: 'relative',
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'center'
-					}}
-					onClick={(e) => {
-						e.stopPropagation()
-						if (isHotspotToolActive) {
-							onSelect(hotspot.id)
-						} else if (hotspot.linkedCameraId) {
-							onActivateCamera(hotspot.linkedCameraId)
-						}
-					}}
-					onMouseEnter={() => setHovered(true)}
-					onMouseLeave={() => setHovered(false)}
-				>
-					{/* Pulsing circle */}
+				<Html center zIndexRange={[100, 0]} style={{ pointerEvents: 'none' }}>
 					<div
-						className={isSelected ? 'vctrl-hp-selected' : 'vctrl-hp'}
+						ref={wrapperRef}
 						style={{
-							width: 13,
-							height: 13,
-							borderRadius: '50%',
-							background: accentColor,
-							color: accentColor,
-							border: '2px solid rgba(255,255,255,0.55)',
-							boxSizing: 'border-box',
-							cursor: 'pointer',
-							flexShrink: 0
+							pointerEvents: 'auto',
+							transition: 'opacity 0.35s ease',
+							position: 'relative',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center'
 						}}
-					/>
-
-					{/* Floating label above the dot */}
-					{showLabel && (
+						onClick={(e) => {
+							e.stopPropagation()
+							if (isHotspotToolActive) {
+								onSelect(hotspot.id)
+							} else if (hotspot.linkedCameraId) {
+								onActivateCamera(hotspot.linkedCameraId)
+							}
+						}}
+						onMouseEnter={() => setHovered(true)}
+						onMouseLeave={() => setHovered(false)}
+					>
+						{/* Pulsing circle */}
 						<div
+							className={isSelected ? 'vctrl-hp-selected' : 'vctrl-hp'}
 							style={{
-								position: 'absolute',
-								bottom: 'calc(100% + 7px)',
-								left: '50%',
-								transform: 'translateX(-50%)',
-								fontSize: 11,
-								lineHeight: 1.4,
-								padding: '2px 8px',
-								whiteSpace: 'nowrap',
-								borderRadius: 4,
-								background: 'rgba(0,0,0,0.82)',
-								color: '#fff',
-								backdropFilter: 'blur(6px)',
-								border: '1px solid rgba(255,255,255,0.13)',
-								pointerEvents: 'none',
-								userSelect: 'none'
+								width: 13,
+								height: 13,
+								borderRadius: '50%',
+								background: accentColor,
+								color: accentColor,
+								border: '2px solid rgba(255,255,255,0.55)',
+								boxSizing: 'border-box',
+								cursor: 'pointer',
+								flexShrink: 0
 							}}
-						>
-							{hotspot.name || 'Hotspot'}
-						</div>
-					)}
-				</div>
-			</Html>
+						/>
+
+						{/* Floating label above the dot */}
+						{showLabel && (
+							<div
+								style={{
+									position: 'absolute',
+									bottom: 'calc(100% + 7px)',
+									left: '50%',
+									transform: 'translateX(-50%)',
+									fontSize: 11,
+									lineHeight: 1.4,
+									padding: '2px 8px',
+									whiteSpace: 'nowrap',
+									borderRadius: 4,
+									background: 'rgba(0,0,0,0.82)',
+									color: '#fff',
+									backdropFilter: 'blur(6px)',
+									border: '1px solid rgba(255,255,255,0.13)',
+									pointerEvents: 'none',
+									userSelect: 'none'
+								}}
+							>
+								{hotspot.name || 'Hotspot'}
+							</div>
+						)}
+					</div>
+				</Html>
+			</group>
 		)
 	}
 )
@@ -223,11 +270,12 @@ interface HotspotGizmoProps {
 	 * reads as a placement aimed at whatever the arrow tip covers.
 	 */
 	grabbedRef: React.MutableRefObject<boolean>
+	drag: HotspotDragState
 	onMove: (id: string, position: [number, number, number]) => void
 }
 
 const HotspotGizmo = memo(
-	({ hotspot, grabbedRef, onMove }: HotspotGizmoProps) => {
+	({ hotspot, grabbedRef, drag, onMove }: HotspotGizmoProps) => {
 		const meshRef = useRef<THREE.Mesh>(null)
 		const isDraggingRef = useRef(false)
 		const { commandExecutor } = usePublisherViewerCapture()
@@ -246,14 +294,21 @@ const HotspotGizmo = memo(
 		const handleDragStart = useCallback(() => {
 			isDraggingRef.current = true
 			grabbedRef.current = true
+			// Seeded before the id is published. three-stdlib dispatches `mouseDown`
+			// with no `objectChange` - the first of those comes from a pointermove,
+			// many frames later - so a marker that began following an unseeded
+			// vector would sit at the world origin until the pointer moved.
+			if (meshRef.current) drag.position.current.copy(meshRef.current.position)
+			drag.hotspotId.current = hotspot.id
 			commandExecutor.current?.execute({
 				type: 'set_controls_enabled',
 				enabled: false
 			})
-		}, [commandExecutor, grabbedRef])
+		}, [commandExecutor, drag, grabbedRef, hotspot.id])
 
 		const handleDragEnd = useCallback(() => {
 			isDraggingRef.current = false
+			drag.hotspotId.current = null
 			commandExecutor.current?.execute({
 				type: 'set_controls_enabled',
 				enabled: true
@@ -262,13 +317,79 @@ const HotspotGizmo = memo(
 				const p = meshRef.current.position
 				onMove(hotspot.id, [p.x, p.y, p.z])
 			}
-		}, [commandExecutor, hotspot.id, onMove])
+		}, [commandExecutor, drag, hotspot.id, onMove])
 
+		/**
+		 * Publishes the drag rather than committing it.
+		 *
+		 * Committing here wrote `hotspotsAtom` on every frame, and the settings
+		 * object rebuilt from that atom is the memo key for the unsaved-changes
+		 * check - two full canonical serializations of every scene setting, twice
+		 * per frame at 60fps, while every marker and the sidebar re-rendered. The
+		 * position reaches the marker through a ref instead, and the atom is
+		 * written once, on release.
+		 */
 		const handleObjectChange = useCallback(() => {
 			if (!meshRef.current || !isDraggingRef.current) return
-			const p = meshRef.current.position
-			onMove(hotspot.id, [p.x, p.y, p.z])
-		}, [hotspot.id, onMove])
+			drag.position.current.copy(meshRef.current.position)
+		}, [drag])
+
+		/**
+		 * Finishes a drag the gizmo is about to be torn away from.
+		 *
+		 * Switching compose tools unmounts the gizmo mid-drag, and only
+		 * `handleDragEnd` commits the edit and turns orbiting back on. Without this
+		 * the position lives in a mesh about to be discarded and the camera stays
+		 * locked. While the drag committed on every frame neither mattered.
+		 */
+		const finishInterruptedDrag = useCallback(() => {
+			if (!isDraggingRef.current) return
+			isDraggingRef.current = false
+			drag.hotspotId.current = null
+			commandExecutor.current?.execute({
+				type: 'set_controls_enabled',
+				enabled: true
+			})
+			// Read the mesh, as `handleDragEnd` does: the published vector is a frame
+			// old at best and never written at worst.
+			const p = meshRef.current?.position
+			if (p) onMove(hotspot.id, [p.x, p.y, p.z])
+		}, [commandExecutor, drag, hotspot.id, onMove])
+
+		/**
+		 * Hands the gizmo the release it is waiting for when a gesture is cancelled.
+		 *
+		 * three-stdlib's `TransformControls` listens for `pointerup` on the document
+		 * and does not listen for `pointercancel` at all, so a cancelled touch or
+		 * pen gesture leaves it dragging: it clears that flag only inside its own
+		 * `pointerUp`, and its document-level `pointermove` admits a buttonless
+		 * move, so the mesh keeps translating under the bare cursor and the next
+		 * click commits somewhere the author never dragged to.
+		 *
+		 * Replaying the release rather than writing its state directly, because its
+		 * `pointerUp` is what drops the axis and fires `mouseUp` - and `mouseUp` is
+		 * `handleDragEnd`, which already commits and re-enables orbiting. It takes
+		 * no pointer capture, so nothing is left holding the pointer either.
+		 */
+		const handlePointerCancel = useCallback((event: PointerEvent) => {
+			if (!isDraggingRef.current) return
+			document.dispatchEvent(
+				new PointerEvent('pointerup', {
+					bubbles: true,
+					button: 0,
+					pointerId: event.pointerId,
+					pointerType: event.pointerType
+				})
+			)
+		}, [])
+
+		useEffect(() => {
+			window.addEventListener('pointercancel', handlePointerCancel)
+			return () => {
+				window.removeEventListener('pointercancel', handlePointerCancel)
+				finishInterruptedDrag()
+			}
+		}, [finishInterruptedDrag, handlePointerCancel])
 
 		return (
 			<>
@@ -430,6 +551,45 @@ export const PublisherEditorScene = memo(() => {
 	const { file } = useModelContext()
 	const modelRoot = file?.model ?? null
 	const gizmoGrabbedRef = useRef(false)
+	const dragHotspotIdRef = useRef<null | string>(null)
+	const dragPositionRef = useRef(new THREE.Vector3())
+	const drag = useMemo<HotspotDragState>(
+		() => ({ hotspotId: dragHotspotIdRef, position: dragPositionRef }),
+		[]
+	)
+	/**
+	 * Walks the whole model, so it is resolved once here rather than per marker
+	 * per frame - and in a frame rather than in a memo.
+	 *
+	 * Normalization rescales an ancestor group without touching the model, so the
+	 * size this measures changes without `modelRoot` doing so. A render-phase
+	 * `useMemo` keyed on the normalization settings looks like it covers that and
+	 * does not: R3F applies the new scale in the commit phase, after every
+	 * render-phase memo in the same update, so the memo measures the previous
+	 * scale and nothing recomputes it afterwards. On a large model clamped to a
+	 * small one that leaves a slack wider than the whole model, and occlusion
+	 * stops firing entirely. `SceneModel` solves its clipping sphere the same way,
+	 * one file over.
+	 *
+	 * Priority -2 so the refresh lands before the markers read it at -1.
+	 */
+	const normalization = useAtomValue(normalizationAtom)
+	const occlusionTolerance = useRef(0)
+	const occlusionToleranceStale = useRef(true)
+
+	useEffect(() => {
+		occlusionToleranceStale.current = true
+	}, [modelRoot, normalization])
+
+	useFrame(() => {
+		if (!occlusionToleranceStale.current) return
+		const tolerance = resolveHotspotOcclusionTolerance(modelRoot)
+		// Zero means the model has no geometry in the graph yet. Leave the slack as
+		// it was and try again next frame rather than latching onto nothing.
+		if (tolerance <= 0) return
+		occlusionTolerance.current = tolerance
+		occlusionToleranceStale.current = false
+	}, -2)
 
 	const handleSelectHotspot = useCallback(
 		(id: string) => {
@@ -481,6 +641,8 @@ export const PublisherEditorScene = memo(() => {
 					isHotspotToolActive={isHotspotToolActive}
 					activeCameraId={selectedCameraId ?? undefined}
 					modelRoot={modelRoot}
+					occlusionTolerance={occlusionTolerance}
+					drag={drag}
 					onSelect={handleSelectHotspot}
 					onActivateCamera={handleActivateHotspotCamera}
 				/>
@@ -491,6 +653,7 @@ export const PublisherEditorScene = memo(() => {
 					key={activeHotspot.id}
 					hotspot={activeHotspot}
 					grabbedRef={gizmoGrabbedRef}
+					drag={drag}
 					onMove={handleMoveHotspot}
 				/>
 			)}

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+/**
+ * When the panel gives up the click-to-place arming it took.
+ *
+ * The arming lives in an atom, which outlives the panel that set it. Switching
+ * compose tools unmounts the panel without deselecting anything, so the canvas
+ * stayed armed under a tool that shows no placement affordance at all - and the
+ * next click anywhere on the model moved a hotspot the author was no longer
+ * editing.
+ */
+
+import { act, render } from '@testing-library/react'
+import { getDefaultStore } from 'jotai'
+import { describe, expect, it, beforeEach } from 'vitest'
+
+import HotspotsSettingsPanel from './hotspots-settings-panel'
+import { isClickToPlaceActiveAtom } from '../../../../lib/stores/publisher-config-store'
+import {
+	activeHotspotIdAtom,
+	cameraAtom,
+	hotspotsAtom
+} from '../../../../lib/stores/scene-settings-store'
+
+import type { HotspotDefinition } from '@vctrl/core'
+
+const store = getDefaultStore()
+
+const hotspot: HotspotDefinition = {
+	id: '00000000-0000-4000-8000-000000000001',
+	name: 'Nose cone',
+	worldPosition: [1, 2, 3],
+	visible: true,
+	internalOnly: false,
+	occlusionEnabled: true,
+	stylePreset: 'dot',
+	linkedCameraId: 'hotspot-camera-1'
+}
+
+const arrange = () => {
+	store.set(hotspotsAtom, [hotspot])
+	store.set(activeHotspotIdAtom, hotspot.id)
+	store.set(cameraAtom, {
+		cameras: [
+			{
+				cameraId: 'hotspot-camera-1',
+				kind: 'hotspot',
+				name: 'Nose cone Camera'
+			}
+		]
+	})
+	store.set(isClickToPlaceActiveAtom, true)
+}
+
+describe('HotspotsSettingsPanel arming', () => {
+	beforeEach(() => {
+		store.set(hotspotsAtom, [])
+		store.set(activeHotspotIdAtom, null)
+		store.set(isClickToPlaceActiveAtom, false)
+	})
+
+	it('disarms click-to-place when the panel unmounts', () => {
+		arrange()
+		const { unmount } = render(<HotspotsSettingsPanel />)
+
+		expect(store.get(isClickToPlaceActiveAtom)).toBe(true)
+
+		unmount()
+
+		expect(store.get(isClickToPlaceActiveAtom)).toBe(false)
+	})
+
+	/**
+	 * The `act` is load-bearing, not ceremony. Setting the atom from outside it
+	 * leaves the re-render deferred, and the assertion then passes only because
+	 * some later call happens to flush it - which is what an incidental
+	 * `rerender()` was doing here before.
+	 */
+	it('disarms click-to-place when the hotspot is deselected', () => {
+		arrange()
+		render(<HotspotsSettingsPanel />)
+
+		expect(store.get(isClickToPlaceActiveAtom)).toBe(true)
+
+		act(() => {
+			store.set(activeHotspotIdAtom, null)
+		})
+
+		expect(store.get(isClickToPlaceActiveAtom)).toBe(false)
+	})
+
+	it('leaves the arming alone while a hotspot stays selected', () => {
+		arrange()
+		render(<HotspotsSettingsPanel />)
+
+		// Settle every effect the mount queued: the deselect branch runs on mount
+		// too, and would disarm here if it read the selection wrongly.
+		act(() => {})
+
+		expect(store.get(isClickToPlaceActiveAtom)).toBe(true)
+	})
+})

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -95,12 +95,26 @@ const HotspotsSettingsPanel = memo(() => {
 
 	const allCameras = camera.cameras ?? []
 
-	// Auto-disable click-to-place when deselecting a hotspot
+	/**
+	 * Click-to-place is armed from this panel, so it is disarmed here too: when
+	 * the hotspot it was aimed at is deselected, and when the panel goes away.
+	 *
+	 * The cleanup is the load-bearing half. Switching compose tools unmounts the
+	 * panel without deselecting anything, and the atom outlives it, so the
+	 * canvas stayed armed under a tool that shows no placement affordance at all.
+	 */
 	useEffect(() => {
 		if (!selectedId) {
 			setIsClickToPlaceActive(false)
 		}
 	}, [selectedId, setIsClickToPlaceActive])
+
+	useEffect(
+		() => () => {
+			setIsClickToPlaceActive(false)
+		},
+		[setIsClickToPlaceActive]
+	)
 
 	const selectedHotspot = useMemo(
 		() => hotspots.find((h) => h.id === selectedId) ?? null,

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.spec.ts
@@ -1,4 +1,5 @@
 import {
+	BoxGeometry,
 	BufferGeometry,
 	DoubleSide,
 	Float32BufferAttribute,
@@ -18,12 +19,12 @@ import {
 import { describe, expect, it } from 'vitest'
 
 import {
-	HOTSPOT_OCCLUSION_TOLERANCE,
 	HOTSPOT_PLACEMENT_DRAG_TOLERANCE_PX,
 	isHotspotOccluded,
 	isHotspotPlacementGesture,
 	prepareHotspotRaycaster,
-	resolveHotspotAnchor
+	resolveHotspotAnchor,
+	resolveHotspotOcclusionTolerance
 } from './scene-hotspot-placement'
 
 const WIDTH = 800
@@ -67,6 +68,8 @@ function editorScene() {
 	// three-stdlib's TransformControlsPlane, which drei mounts with the gizmo:
 	// PlaneGeometry(1e5, 1e5), material invisible, parked on the gizmo and kept
 	// facing the camera while translating.
+	// `DoubleSide` is copied from the real object rather than exercised: every ray
+	// here meets the plane's front face.
 	const gizmoPlane = new Mesh(
 		new PlaneGeometry(1e5, 1e5, 2, 2),
 		new MeshBasicMaterial({ visible: false, side: DoubleSide })
@@ -255,35 +258,57 @@ describe('isHotspotOccluded', () => {
 		// dimmed no matter where the gizmo sat.
 		parkGizmoAt(new Vector3(3, 1, 2))
 		const distance = 4
+		const tolerance = resolveHotspotOcclusionTolerance(model)
 
-		expect(isHotspotOccluded(rayTowards(marker), scene, distance)).toBe(true)
-		expect(isHotspotOccluded(rayTowards(marker), model, distance)).toBe(false)
+		expect(
+			isHotspotOccluded(rayTowards(marker), scene, distance, tolerance)
+		).toBe(true)
+		expect(
+			isHotspotOccluded(rayTowards(marker), model, distance, tolerance)
+		).toBe(false)
 	})
 
 	/**
-	 * Pins the tolerance's lower bound. Every anchor `resolveHotspotAnchor`
-	 * returns sits a faceting error inside the surface, so without slack a marker
-	 * is occluded by the face it was placed on.
+	 * Pins the tolerance's lower bound. Half a percent of the radius stands in for
+	 * the gizmo nudge, the largest of the three drifts the slack exists for and
+	 * the one that sets this bound - storage rounding and Draco re-quantization
+	 * are orders of magnitude smaller. Without slack the face the marker sits on
+	 * reads as covering it.
 	 */
 	it('does not dim a marker sitting just inside the face it was placed on', () => {
 		const { camera, model, rayThrough, rayTowards } = editorScene()
 
 		const placed = resolveHotspotAnchor(rayThrough(...OVER_THE_MODEL), model)!
-		// A hair further in than the anchor came back: a nudge of the gizmo, or a
-		// re-quantized mesh under an unchanged saved position, puts it here.
-		const marker = new Vector3(...placed).lerp(new Vector3(0, 1, 0), 0.01)
-
-		expect(
-			distanceFromModelSurface([marker.x, marker.y, marker.z])
-		).toBeLessThan(HOTSPOT_OCCLUSION_TOLERANCE)
+		const marker = new Vector3(...placed).lerp(new Vector3(0, 1, 0), 0.005)
 
 		expect(
 			isHotspotOccluded(
 				rayTowards(marker),
 				model,
-				camera.position.distanceTo(marker)
+				camera.position.distanceTo(marker),
+				resolveHotspotOcclusionTolerance(model)
 			)
 		).toBe(false)
+	})
+
+	/**
+	 * Pins the ceiling. A twentieth of the radius behind the near face is sunk,
+	 * not seated, and slack wide enough to forgive that would stop a marker
+	 * dimming when it is genuinely inside the model.
+	 */
+	it('dims a marker sunk a twentieth of the radius behind the near face', () => {
+		const { camera, model, rayTowards } = editorScene()
+
+		const marker = new Vector3(0, 1, 0.95)
+
+		expect(
+			isHotspotOccluded(
+				rayTowards(marker),
+				model,
+				camera.position.distanceTo(marker),
+				resolveHotspotOcclusionTolerance(model)
+			)
+		).toBe(true)
 	})
 
 	it('still reports geometry that genuinely covers the marker', () => {
@@ -296,7 +321,8 @@ describe('isHotspotOccluded', () => {
 			isHotspotOccluded(
 				rayTowards(marker),
 				model,
-				camera.position.distanceTo(marker)
+				camera.position.distanceTo(marker),
+				resolveHotspotOcclusionTolerance(model)
 			)
 		).toBe(true)
 	})
@@ -308,30 +334,89 @@ describe('isHotspotOccluded', () => {
 	it('reports nothing occluded before a model is loaded', () => {
 		const { rayTowards } = editorScene()
 
-		expect(isHotspotOccluded(rayTowards(new Vector3(0, 1, 1)), null, 4)).toBe(
-			false
-		)
+		expect(
+			isHotspotOccluded(rayTowards(new Vector3(0, 1, 1)), null, 4, 0.01)
+		).toBe(false)
+	})
+})
+
+describe('resolveHotspotOcclusionTolerance', () => {
+	it('is nothing before a model is loaded', () => {
+		expect(resolveHotspotOcclusionTolerance(null)).toBe(0)
 	})
 
 	/**
-	 * Pins the tolerance's ceiling. A tenth of a unit behind the near face is
-	 * sunk, not seated, and slack wide enough to forgive that would stop the
-	 * marker dimming when it is genuinely inside the model.
+	 * A root carrying no geometry measures as an empty box, whose min is
+	 * +Infinity and max -Infinity. Left alone that yields a negative slack, which
+	 * widens the occlusion test instead of narrowing it.
 	 */
-	it('dims a marker sunk a tenth of a unit behind the near face', () => {
-		const { camera, model, rayTowards } = editorScene()
+	it('is nothing for a root with no geometry in it', () => {
+		expect(resolveHotspotOcclusionTolerance(new Group())).toBe(0)
+	})
 
-		const marker = new Vector3(0, 1, 0.9)
+	/**
+	 * Pins the measure itself, not just how it scales. Without this the suite
+	 * cannot tell the bounding-box diagonal from twice or half of it.
+	 */
+	it('is a fixed fraction of the bounding-box diagonal', () => {
+		const cube = new Group()
+		cube.add(new Mesh(new BoxGeometry(2, 4, 4), new MeshBasicMaterial()))
 
-		expect(
-			distanceFromModelSurface([marker.x, marker.y, marker.z])
-		).toBeCloseTo(0.1, 6)
+		// 2 x 4 x 4 has a diagonal of 6, and the slack is half a percent of it.
+		// Spelled as a literal: writing the constant on both sides would pin the
+		// shape of the measure while saying nothing about its value, and the two
+		// behavioural tests either side only bracket it within a factor of ten.
+		expect(resolveHotspotOcclusionTolerance(cube)).toBeCloseTo(0.03, 10)
+	})
+
+	it('measures the model as the world sees it, through every ancestor', () => {
+		const { model, normalizationScale } = editorScene()
+
+		const unscaled = resolveHotspotOcclusionTolerance(model)
+		normalizationScale.scale.setScalar(3)
+
+		expect(resolveHotspotOcclusionTolerance(model)).toBeCloseTo(unscaled * 3, 8)
+	})
+
+	/**
+	 * The reason the slack is derived from the model rather than written in world
+	 * units. Nothing bounds the size a scene arrives at - runtime normalization is
+	 * off by default - so a constant that seats a marker on a unit model swallows
+	 * a tenth of a model a tenth that size.
+	 */
+	it('scales with the model, so a tenth-size scene judges the same', () => {
+		const small = editorScene()
+		small.normalizationScale.scale.setScalar(0.1)
+		small.camera.position.set(0, 1, 0.5)
+		small.camera.lookAt(0, 1, 0)
+
+		const tolerance = resolveHotspotOcclusionTolerance(small.model)
+		expect(tolerance).toBeCloseTo(
+			resolveHotspotOcclusionTolerance(editorScene().model) * 0.1,
+			6
+		)
+
+		const seated = new Vector3(
+			...resolveHotspotAnchor(small.rayThrough(...OVER_THE_MODEL), small.model)!
+		).lerp(new Vector3(0, 1, 0), 0.005)
+		// A twentieth of this model's radius, which is a two-hundredth of a unit.
+		const sunk = new Vector3(0, 1, 0.095)
 
 		expect(
 			isHotspotOccluded(
-				rayTowards(marker),
-				model,
-				camera.position.distanceTo(marker)
+				small.rayTowards(seated),
+				small.model,
+				small.camera.position.distanceTo(seated),
+				tolerance
+			)
+		).toBe(false)
+
+		expect(
+			isHotspotOccluded(
+				small.rayTowards(sunk),
+				small.model,
+				small.camera.position.distanceTo(sunk),
+				tolerance
 			)
 		).toBe(true)
 	})

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.spec.ts
@@ -1,0 +1,433 @@
+import {
+	BufferGeometry,
+	DoubleSide,
+	Float32BufferAttribute,
+	Group,
+	Mesh,
+	MeshBasicMaterial,
+	PerspectiveCamera,
+	PlaneGeometry,
+	Points,
+	PointsMaterial,
+	Raycaster,
+	Scene,
+	SphereGeometry,
+	Vector2,
+	Vector3
+} from 'three'
+import { describe, expect, it } from 'vitest'
+
+import {
+	HOTSPOT_OCCLUSION_TOLERANCE,
+	HOTSPOT_PLACEMENT_DRAG_TOLERANCE_PX,
+	isHotspotOccluded,
+	isHotspotPlacementGesture,
+	prepareHotspotRaycaster,
+	resolveHotspotAnchor
+} from './scene-hotspot-placement'
+
+const WIDTH = 800
+const HEIGHT = 500
+
+/**
+ * The publisher editor's scene graph, in the shape the viewer builds it.
+ *
+ * The model sits under `<Center top>` and `SceneModel`'s normalization scale
+ * group; the shadow catcher and the gizmo plane are siblings. A unit sphere is
+ * the model because a curved surface is what makes a flat plane parked on it
+ * diverge from the geometry around the point it touches.
+ *
+ * The shadow catcher and the gizmo plane are here to be *hit*. A raycast scoped
+ * to the model cannot observe either one, so the suites that care about them
+ * resolve the same ray twice - against `model` and against `scene` - and assert
+ * that the wide root reproduces the defect. Without that pairing both objects
+ * would be decoration.
+ */
+function editorScene() {
+	const scene = new Scene()
+
+	const center = new Group()
+	center.position.set(0, 1, 0)
+	const normalizationScale = new Group()
+	const model = new Group()
+	model.add(new Mesh(new SphereGeometry(1, 128, 128), new MeshBasicMaterial()))
+	normalizationScale.add(model)
+	center.add(normalizationScale)
+	scene.add(center)
+
+	// drei ContactShadows / AccumulativeShadows / the loading shadow plane: all
+	// untagged ground meshes the viewer mounts beneath the model.
+	const shadowCatcher = new Mesh(
+		new PlaneGeometry(20, 20),
+		new MeshBasicMaterial()
+	)
+	shadowCatcher.rotation.x = -Math.PI / 2
+	scene.add(shadowCatcher)
+
+	// three-stdlib's TransformControlsPlane, which drei mounts with the gizmo:
+	// PlaneGeometry(1e5, 1e5), material invisible, parked on the gizmo and kept
+	// facing the camera while translating.
+	const gizmoPlane = new Mesh(
+		new PlaneGeometry(1e5, 1e5, 2, 2),
+		new MeshBasicMaterial({ visible: false, side: DoubleSide })
+	)
+	scene.add(gizmoPlane)
+
+	const camera = new PerspectiveCamera(50, WIDTH / HEIGHT, 0.1, 1000)
+	camera.position.set(0, 1, 5)
+	camera.lookAt(0, 1, 0)
+
+	/** Parks the gizmo on a placed hotspot, as TransformControls does. */
+	const parkGizmoAt = (point: Vector3) => {
+		gizmoPlane.position.copy(point)
+		// Mirrors what TransformControls does while translating. This camera looks
+		// straight down -z, so it is close to a no-op here; it is copied so the
+		// fixture stays honest about the object it stands in for. The ray builders
+		// below flush world matrices, so nothing needs flushing here.
+		gizmoPlane.quaternion.copy(camera.quaternion)
+	}
+
+	const rayThrough = (px: number, py: number) => {
+		camera.updateMatrixWorld(true)
+		scene.updateMatrixWorld(true)
+		const raycaster = prepareHotspotRaycaster(new Raycaster())
+		raycaster.setFromCamera(
+			new Vector2((px / WIDTH) * 2 - 1, -(py / HEIGHT) * 2 + 1),
+			camera
+		)
+		return raycaster
+	}
+
+	const rayTowards = (marker: Vector3) => {
+		camera.updateMatrixWorld(true)
+		scene.updateMatrixWorld(true)
+		const raycaster = prepareHotspotRaycaster(new Raycaster())
+		raycaster.set(
+			camera.position,
+			marker.clone().sub(camera.position).normalize()
+		)
+		return raycaster
+	}
+
+	return {
+		camera,
+		model,
+		normalizationScale,
+		parkGizmoAt,
+		rayThrough,
+		rayTowards,
+		scene
+	}
+}
+
+/** Distance from a point to the surface of the unit sphere at [0, 1, 0]. */
+const distanceFromModelSurface = (anchor: [number, number, number]): number =>
+	Math.abs(new Vector3(...anchor).distanceTo(new Vector3(0, 1, 0)) - 1)
+
+/**
+ * A ray hits the sphere's triangles, not its ideal surface, so a correct anchor
+ * still sits a faceting error inside it - up to about 3.7e-4 at 128 segments,
+ * measured across the silhouette. The misplacements this suite is about are two
+ * orders of magnitude larger than this bound.
+ */
+const ON_THE_SURFACE = 2e-3
+
+/** A pixel over the front of the sphere, clear of its silhouette. */
+const OVER_THE_MODEL: [number, number] = [460, 210]
+
+describe('resolveHotspotAnchor', () => {
+	/**
+	 * The defect this module exists for, and the pairing that makes the rest of
+	 * the suite mean something.
+	 *
+	 * `scene` is what the editor used to raycast, one level above the model. The
+	 * gizmo's invisible 100,000-unit plane is nearer the camera than the surface
+	 * under the pointer, so the anchor comes back off the model - while still
+	 * projecting onto the clicked pixel, which is why it looked right until the
+	 * camera moved.
+	 */
+	it('lands off the model when the root is widened past it', () => {
+		const { model, parkGizmoAt, rayThrough, scene } = editorScene()
+
+		parkGizmoAt(new Vector3(0, 1, 1))
+		const ray = rayThrough(...OVER_THE_MODEL)
+
+		const widened = resolveHotspotAnchor(ray, scene)
+
+		expect(widened).not.toBeNull()
+		expect(distanceFromModelSurface(widened!)).toBeGreaterThan(0.1)
+		expect(resolveHotspotAnchor(ray, model)).not.toEqual(widened)
+	})
+
+	it('anchors on the model, not on the gizmo plane parked in front of it', () => {
+		const { model, parkGizmoAt, rayThrough } = editorScene()
+
+		// A hotspot already placed on the front of the sphere.
+		parkGizmoAt(new Vector3(0, 1, 1))
+
+		const anchor = resolveHotspotAnchor(rayThrough(...OVER_THE_MODEL), model)
+
+		expect(anchor).not.toBeNull()
+		expect(distanceFromModelSurface(anchor!)).toBeLessThan(ON_THE_SURFACE)
+	})
+
+	/**
+	 * The shadow catchers are the same failure with no gizmo in the scene: a
+	 * click just under the model used to snap the hotspot to y roughly 0, out on
+	 * the ground plane, where nothing is drawn.
+	 */
+	it('returns nothing below the model, where the widened root finds the shadow catcher', () => {
+		const { model, rayThrough, scene } = editorScene()
+
+		const ray = rayThrough(400, 400)
+
+		const widened = resolveHotspotAnchor(ray, scene)
+		expect(widened).not.toBeNull()
+		expect(widened![1]).toBeCloseTo(0, 6)
+
+		expect(resolveHotspotAnchor(ray, model)).toBeNull()
+	})
+
+	it('returns nothing when the pointer is off the model', () => {
+		const { model, parkGizmoAt, rayThrough } = editorScene()
+
+		parkGizmoAt(new Vector3(0, 1, 1))
+
+		expect(resolveHotspotAnchor(rayThrough(760, 60), model)).toBeNull()
+	})
+
+	it('returns nothing before a model is loaded', () => {
+		const { rayThrough } = editorScene()
+
+		expect(resolveHotspotAnchor(rayThrough(400, 250), null)).toBeNull()
+	})
+
+	it('reads through the offset and the scale between the model and the scene', () => {
+		const { model, normalizationScale, rayThrough } = editorScene()
+
+		// Normalization rescales an ancestor group rather than the glTF, so the
+		// anchor has to be read in world space or it lands at the unscaled point.
+		normalizationScale.scale.setScalar(2)
+
+		const anchor = resolveHotspotAnchor(rayThrough(400, 250), model)
+
+		expect(anchor).not.toBeNull()
+		// <Center top> holds the sphere's centre at y = 1 and the scale group grows
+		// its radius to 2, so the front face is at [0, 1, 2].
+		expect(anchor![0]).toBeCloseTo(0, 5)
+		expect(anchor![1]).toBeCloseTo(1, 5)
+		expect(anchor![2]).toBeCloseTo(2, 5)
+	})
+
+	/**
+	 * The replaced filter took `Mesh` and nothing else. Recursing the subtree
+	 * picks up point and line primitives too, and three counts those as hit from
+	 * a world unit away unless the thresholds are zeroed.
+	 */
+	it('ignores a stray point primitive floating in front of the surface', () => {
+		const { model, rayThrough } = editorScene()
+
+		const strayGeometry = new BufferGeometry()
+		// Half a unit in front of the sphere's front face, dead on the ray, so any
+		// threshold above zero claims it: three compares the radial distance with a
+		// strict `<`.
+		strayGeometry.setAttribute(
+			'position',
+			new Float32BufferAttribute([0, 1, 1.5], 3)
+		)
+		model.add(new Points(strayGeometry, new PointsMaterial()))
+
+		const anchor = resolveHotspotAnchor(rayThrough(400, 250), model)
+
+		expect(anchor).not.toBeNull()
+		expect(distanceFromModelSurface(anchor!)).toBeLessThan(ON_THE_SURFACE)
+	})
+})
+
+describe('isHotspotOccluded', () => {
+	it('reports occluded when the root is widened past the model', () => {
+		const { model, parkGizmoAt, rayTowards, scene } = editorScene()
+
+		const marker = new Vector3(0, 1, 1)
+		// The gizmo belongs to another hotspot, one the author dragged off to the
+		// side. It is three units clear of this marker and still covers it, because
+		// the plane is 100,000 units wide - which is why every marker in the scene
+		// dimmed no matter where the gizmo sat.
+		parkGizmoAt(new Vector3(3, 1, 2))
+		const distance = 4
+
+		expect(isHotspotOccluded(rayTowards(marker), scene, distance)).toBe(true)
+		expect(isHotspotOccluded(rayTowards(marker), model, distance)).toBe(false)
+	})
+
+	/**
+	 * Pins the tolerance's lower bound. Every anchor `resolveHotspotAnchor`
+	 * returns sits a faceting error inside the surface, so without slack a marker
+	 * is occluded by the face it was placed on.
+	 */
+	it('does not dim a marker sitting just inside the face it was placed on', () => {
+		const { camera, model, rayThrough, rayTowards } = editorScene()
+
+		const placed = resolveHotspotAnchor(rayThrough(...OVER_THE_MODEL), model)!
+		// A hair further in than the anchor came back: a nudge of the gizmo, or a
+		// re-quantized mesh under an unchanged saved position, puts it here.
+		const marker = new Vector3(...placed).lerp(new Vector3(0, 1, 0), 0.01)
+
+		expect(
+			distanceFromModelSurface([marker.x, marker.y, marker.z])
+		).toBeLessThan(HOTSPOT_OCCLUSION_TOLERANCE)
+
+		expect(
+			isHotspotOccluded(
+				rayTowards(marker),
+				model,
+				camera.position.distanceTo(marker)
+			)
+		).toBe(false)
+	})
+
+	it('still reports geometry that genuinely covers the marker', () => {
+		const { camera, model, rayTowards } = editorScene()
+
+		// The far side of the sphere: the near face is in the way.
+		const marker = new Vector3(0, 1, -1)
+
+		expect(
+			isHotspotOccluded(
+				rayTowards(marker),
+				model,
+				camera.position.distanceTo(marker)
+			)
+		).toBe(true)
+	})
+
+	/**
+	 * `modelRoot` is `file?.model ?? null` and is genuinely null until the model
+	 * loads. Answering `true` there would dim every marker permanently.
+	 */
+	it('reports nothing occluded before a model is loaded', () => {
+		const { rayTowards } = editorScene()
+
+		expect(isHotspotOccluded(rayTowards(new Vector3(0, 1, 1)), null, 4)).toBe(
+			false
+		)
+	})
+
+	/**
+	 * Pins the tolerance's ceiling. A tenth of a unit behind the near face is
+	 * sunk, not seated, and slack wide enough to forgive that would stop the
+	 * marker dimming when it is genuinely inside the model.
+	 */
+	it('dims a marker sunk a tenth of a unit behind the near face', () => {
+		const { camera, model, rayTowards } = editorScene()
+
+		const marker = new Vector3(0, 1, 0.9)
+
+		expect(
+			distanceFromModelSurface([marker.x, marker.y, marker.z])
+		).toBeCloseTo(0.1, 6)
+
+		expect(
+			isHotspotOccluded(
+				rayTowards(marker),
+				model,
+				camera.position.distanceTo(marker)
+			)
+		).toBe(true)
+	})
+})
+
+describe('isHotspotPlacementGesture', () => {
+	const gesture = (
+		patch: Partial<Parameters<typeof isHotspotPlacementGesture>[0]>
+	) => ({
+		button: 0,
+		// Deliberately different: with both at 100, reading `downX` where `downY`
+		// belongs is unobservable, and a coordinate in the wrong place is the bug
+		// class this whole module exists for.
+		downX: 100,
+		downY: 200,
+		upX: 100,
+		upY: 200,
+		grabbedGizmo: false,
+		...patch
+	})
+
+	it('accepts a primary-button click that did not travel', () => {
+		expect(isHotspotPlacementGesture(gesture({}))).toBe(true)
+	})
+
+	/**
+	 * Both bounds are spelled as literals rather than in terms of the constant.
+	 * Written as `100 + TOLERANCE` these were true for every value, including
+	 * zero - which rejects nearly every real click, since a click jitters.
+	 */
+	it('accepts a click that jittered by three pixels', () => {
+		expect(isHotspotPlacementGesture(gesture({ upX: 103 }))).toBe(true)
+	})
+
+	/**
+	 * Pointer coordinates are integers, so travelling exactly the tolerance is a
+	 * real, common case sitting on the boundary the constant names.
+	 */
+	it('accepts a click that travelled exactly the tolerance', () => {
+		expect(
+			isHotspotPlacementGesture(
+				gesture({ upX: 100 + HOTSPOT_PLACEMENT_DRAG_TOLERANCE_PX })
+			)
+		).toBe(true)
+	})
+
+	it('rejects a drag of five pixels', () => {
+		expect(isHotspotPlacementGesture(gesture({ upX: 105 }))).toBe(false)
+	})
+
+	/**
+	 * 3 across and 2 down is 3.6 as the crow flies but 5 by city block, so
+	 * summing the axes instead would reject a click this accepts.
+	 */
+	it('measures travel as a straight line, not per axis', () => {
+		expect(isHotspotPlacementGesture(gesture({ upX: 103, upY: 202 }))).toBe(
+			true
+		)
+	})
+
+	it('rejects a drag that travelled diagonally', () => {
+		expect(isHotspotPlacementGesture(gesture({ upX: 104, upY: 204 }))).toBe(
+			false
+		)
+	})
+
+	it('rejects the secondary button, which OrbitControls pans with', () => {
+		expect(isHotspotPlacementGesture(gesture({ button: 2 }))).toBe(false)
+	})
+
+	it('rejects the middle button', () => {
+		expect(isHotspotPlacementGesture(gesture({ button: 1 }))).toBe(false)
+	})
+
+	/**
+	 * The gizmo sits on the hotspot and the placement tool is armed at the same
+	 * time. A nudge of a translate arrow is a sub-tolerance primary click, and
+	 * the anchor under the arrow tip is nowhere near the hotspot being adjusted.
+	 */
+	it('rejects a nudge that grabbed a gizmo handle', () => {
+		expect(isHotspotPlacementGesture(gesture({ grabbedGizmo: true }))).toBe(
+			false
+		)
+	})
+})
+
+describe('prepareHotspotRaycaster', () => {
+	it('zeroes the point and line thresholds that three defaults to one', () => {
+		const raycaster = new Raycaster()
+
+		expect(raycaster.params.Points.threshold).toBe(1)
+		expect(raycaster.params.Line.threshold).toBe(1)
+
+		prepareHotspotRaycaster(raycaster)
+
+		expect(raycaster.params.Points.threshold).toBe(0)
+		expect(raycaster.params.Line.threshold).toBe(0)
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.ts
@@ -1,0 +1,147 @@
+/**
+ * What a hotspot may be anchored to, and what counts as asking to anchor it.
+ *
+ * Both rules used to live inline in the editor's pointer handler, phrased as
+ * subtraction: every `Mesh` in the scene except the one carrying
+ * `userData.editorOverlay`. Nothing but the hotspot's own anchor ever carried
+ * that tag, so the set silently grew to include drei's `TransformControls`
+ * plane - an invisible `PlaneGeometry(1e5, 1e5)` parked on the gizmo and turned
+ * to face the camera - along with every shadow catcher the viewer mounts. The
+ * nearest hit was normally one of those, and the hotspot ended up on a point
+ * that lines up with the model only from the camera it was placed from.
+ *
+ * Phrasing it as an allowlist over the rendered model is what removes the
+ * cause: nothing anyone adds to the scene later can join the set by omission.
+ *
+ * This sits in the flat `domain/scene` tier with the rest of the
+ * `scene-hotspot-*` family rather than in `client/`, even though the settings
+ * parser will never share it. `three` is imported for types only, so the module
+ * stays runtime-dependency-free and runs under the node test environment like
+ * its siblings.
+ */
+
+import type { Object3D, Raycaster } from 'three'
+
+/**
+ * How far the pointer may travel between press and release and still count as
+ * a placement rather than an orbit.
+ *
+ * OrbitControls shares the canvas, so a press that turns into a drag is a
+ * camera move; without a threshold the first frame of every orbit re-placed the
+ * armed hotspot. It has a floor as well as a ceiling: a real click jitters by a
+ * pixel or two, and at zero almost none of them would register.
+ */
+export const HOTSPOT_PLACEMENT_DRAG_TOLERANCE_PX = 4
+
+/**
+ * How far in front of a marker geometry has to be before it counts as covering
+ * it.
+ *
+ * A ray hits triangles rather than the ideal surface, so an anchor resolved by
+ * `resolveHotspotAnchor` comes back a faceting error *inside* the model. Without
+ * the slack every marker would read as occluded by the very face it was placed
+ * on.
+ */
+export const HOTSPOT_OCCLUSION_TOLERANCE = 0.05
+
+export interface HotspotPlacementGesture {
+	/** `PointerEvent.button`: 0 is the primary button. */
+	button: number
+	downX: number
+	downY: number
+	upX: number
+	upY: number
+	/**
+	 * Whether the press landed on a `TransformControls` handle.
+	 *
+	 * The gizmo and the armed placement tool are always on screen together, and
+	 * three-stdlib stops neither propagation nor the event. A nudge of an arrow
+	 * shorter than the drag tolerance therefore reads as a click, and the anchor
+	 * it resolves is under the arrow tip - tens of pixels from the hotspot the
+	 * author was adjusting.
+	 */
+	grabbedGizmo: boolean
+}
+
+/**
+ * Whether a press-and-release was a click asking to place, rather than a camera
+ * drag, a gizmo nudge, or a secondary-button gesture that happens to start over
+ * the canvas.
+ */
+export function isHotspotPlacementGesture(
+	gesture: HotspotPlacementGesture,
+	tolerancePx: number = HOTSPOT_PLACEMENT_DRAG_TOLERANCE_PX
+): boolean {
+	if (gesture.button !== 0) return false
+	if (gesture.grabbedGizmo) return false
+
+	return (
+		Math.hypot(gesture.upX - gesture.downX, gesture.upY - gesture.downY) <=
+		tolerancePx
+	)
+}
+
+/**
+ * Prepares a raycaster for hotspot work.
+ *
+ * `Raycaster` defaults `Points.threshold` and `Line.threshold` to 1, meaning a
+ * ray passing within a *world unit* of a point or line primitive counts as a
+ * hit. The filter this module replaced took `Mesh` and nothing else, so on a
+ * glTF carrying `POINTS` or `LINES` - scan and CAD exports do - recursing the
+ * model subtree would otherwise anchor hotspots to stray points floating a unit
+ * off the surface.
+ */
+export function prepareHotspotRaycaster<T extends Raycaster>(raycaster: T): T {
+	raycaster.params.Points.threshold = 0
+	raycaster.params.Line.threshold = 0
+
+	return raycaster
+}
+
+/**
+ * The world-space point a pointer lands on, or `null` when it missed the model.
+ *
+ * `modelRoot` must be the object the viewer mounts, not an ancestor of it.
+ * Widening it to the scene root puts the gizmo plane and the shadow catchers
+ * back in the set, which is the whole defect: the viewer mounts both as
+ * siblings of the model's `<Center>` wrapper, not inside it.
+ *
+ * Missing returns nothing rather than falling back to whatever else the ray
+ * crossed: a click on the background is not a placement, and answering it with
+ * a point in mid-air is how hotspots ended up floating beside the model.
+ */
+export function resolveHotspotAnchor(
+	raycaster: Raycaster,
+	modelRoot: Object3D | null
+): [number, number, number] | null {
+	if (!modelRoot) return null
+
+	const hit = raycaster.intersectObject(modelRoot, true)[0]
+	if (!hit) return null
+
+	// `point` is world space, which is what a hotspot stores. The model hangs
+	// under the viewer's <Center> offset and its normalization scale group, so
+	// reading anything local would land the marker at an unscaled, un-offset
+	// position.
+	return [hit.point.x, hit.point.y, hit.point.z]
+}
+
+/**
+ * Whether the model stands between `origin` and a marker `distance` away.
+ *
+ * Reads the same subtree as `resolveHotspotAnchor` so the two cannot disagree
+ * about what counts as geometry: while this walked the whole scene, the gizmo's
+ * 100,000-unit plane covered every marker from every angle and dimmed them all.
+ */
+export function isHotspotOccluded(
+	raycaster: Raycaster,
+	modelRoot: Object3D | null,
+	distance: number,
+	tolerance: number = HOTSPOT_OCCLUSION_TOLERANCE
+): boolean {
+	if (!modelRoot) return false
+
+	const hit = raycaster.intersectObject(modelRoot, true)[0]
+
+	return !!hit && hit.distance < distance - tolerance
+}

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.ts
@@ -15,10 +15,11 @@
  *
  * This sits in the flat `domain/scene` tier with the rest of the
  * `scene-hotspot-*` family rather than in `client/`, even though the settings
- * parser will never share it. `three` is imported for types only, so the module
- * stays runtime-dependency-free and runs under the node test environment like
- * its siblings.
+ * parser will never share it. Nothing here touches the DOM or a renderer, so it
+ * runs under the node test environment like its siblings.
  */
+
+import { Box3, Vector3 } from 'three'
 
 import type { Object3D, Raycaster } from 'three'
 
@@ -35,14 +36,61 @@ export const HOTSPOT_PLACEMENT_DRAG_TOLERANCE_PX = 4
 
 /**
  * How far in front of a marker geometry has to be before it counts as covering
- * it.
+ * it, as a fraction of the model's bounding-box diagonal.
  *
- * A ray hits triangles rather than the ideal surface, so an anchor resolved by
- * `resolveHotspotAnchor` comes back a faceting error *inside* the model. Without
- * the slack every marker would read as occluded by the very face it was placed
- * on.
+ * What it forgives is drift, not geometry: `resolveHotspotAnchor` returns an
+ * exact point on a triangle, so a clean round trip is exact. A stored position
+ * moves off the surface for three reasons, in ascending size. `scene_hotspots`
+ * holds it in `real` columns, worth about 1e-7 of the value. Draco re-quantizes
+ * vertices on the next save, worth about 1e-4 of the model. And an author can
+ * nudge a marker inward with the gizmo, which is the term that actually sets
+ * this floor - it is a screen-space gesture, so unlike the other two it does
+ * not scale with the model at all. Without the slack a marker would read as
+ * occluded by the very face it sits on.
+ *
+ * Measured against the model because nothing bounds the size a scene arrives
+ * at: runtime normalization is off by default. The literal this replaced was
+ * 0.05 world units, a tenth of a half-unit model and a ten-thousandth of a
+ * 500-unit one - the same setting meaning "forgive the surface" on one scene
+ * and "ignore the model" on another.
+ *
+ * Camera distance would be the easier reference and is the wrong one: nothing
+ * bounds the dolly, so zooming out would widen the slack until markers behind
+ * real geometry stopped dimming.
+ *
+ * The diagonal is the same measure the viewer normalizes on. It is
+ * axis-aligned, so rotating a model changes it somewhat - which is tolerable
+ * because this is a floor under a rounding error, not a threshold anything is
+ * calibrated to.
  */
-export const HOTSPOT_OCCLUSION_TOLERANCE = 0.05
+export const HOTSPOT_OCCLUSION_TOLERANCE_FRACTION = 0.005
+
+/**
+ * The slack in world units for a given model, for a caller to hold and refresh.
+ *
+ * Separate from `isHotspotOccluded` because that runs once per marker per frame
+ * and this walks the whole model. It has to be recomputed when the model
+ * changes and when anything rescales it: normalization moves an ancestor group,
+ * so the size this reads changes without the model itself doing so. Read it
+ * after the transform is live - a render-phase memo runs before React commits
+ * the new scale, and would measure the previous one.
+ */
+export function resolveHotspotOcclusionTolerance(
+	modelRoot: Object3D | null
+): number {
+	if (!modelRoot) return 0
+
+	modelRoot.updateWorldMatrix(true, false)
+
+	// Size rather than bounding sphere: `Box3.getSize` answers zero for a root
+	// with no geometry in it, where `getBoundingSphere` answers a radius of -1
+	// and would hand back negative slack, widening the occlusion test instead of
+	// narrowing it.
+	return (
+		new Box3().setFromObject(modelRoot).getSize(new Vector3()).length() *
+		HOTSPOT_OCCLUSION_TOLERANCE_FRACTION
+	)
+}
 
 export interface HotspotPlacementGesture {
 	/** `PointerEvent.button`: 0 is the primary button. */
@@ -137,7 +185,7 @@ export function isHotspotOccluded(
 	raycaster: Raycaster,
 	modelRoot: Object3D | null,
 	distance: number,
-	tolerance: number = HOTSPOT_OCCLUSION_TOLERANCE
+	tolerance: number
 ): boolean {
 	if (!modelRoot) return false
 


### PR DESCRIPTION
## Summary

Click-to-place in the publisher editor anchored hotspots to invisible editor geometry rather than to the model, so a placed hotspot sat off the surface as soon as the camera moved. This fixes the anchoring, the pointer gesture that triggers it, and the per-frame settings writes a gizmo drag produced.

## Root cause

Click-to-place and the hotspot occlusion test both built their raycast set by subtracting a `userData.editorOverlay` tag from every `Mesh` in the scene, and nothing but the hotspot's own anchor ever carried that tag, so the nearest hit was normally drei `TransformControls`' invisible `PlaneGeometry(1e5, 1e5)` — parked on the gizmo and turned to face the camera — or a shadow catcher, anchoring the hotspot to a point that lines up with the model only from the camera it was placed from.

The target set is now an allowlist over the rendered model root, so nothing added to the scene later can join it by omission. The rule lives in the domain layer beside the other `scene-hotspot-*` modules and is read by both the placement raycast and the occlusion test, so the two cannot drift apart.

## Measured before the fix

Unit sphere of radius 1 at `[0,1,0]`, 800x500 canvas, the editor's scene graph reproduced (`<Center top>` -> normalization scale group -> model; shadow catcher and gizmo plane as siblings).

| Action | Anchored to | Distance off the model surface |
| --- | --- | --- |
| 1st click, dead centre | the model | 0.000 |
| 2nd click, 60px right | gizmo plane | 0.114 |
| 3rd click, 40px up | gizmo plane | 0.175 |
| Click just past the silhouette | gizmo plane, `[1.073, 1.000, 0.000]` | in empty space, no model under the pointer |
| Click below the model, no gizmo mounted | shadow catcher, `[2.000, 0.000, -1.702]` | snapped to y approximately 0 |

Reprojecting the anchored point and the intended surface point as the camera orbits: 0 px apart at the placement camera, 10 px at 20 degrees, 19 px at 45 degrees, 20 px at 90 degrees. A reload reframes from the saved camera, which is when the discrepancy becomes visible.

The spec was written first and observed failing on each of these before any fix: 0.136 off surface, `[0, -3.2e-16, 1.43]` on the ground plane, `[2.686, 2.418, 1]` in empty space, and a false occlusion result.

## Changes

**New `app/lib/domain/scene/scene-hotspot-placement.ts`** — single owner of what a hotspot may anchor to and what counts as asking to anchor one.

- `resolveHotspotAnchor` and `isHotspotOccluded` raycast the rendered model root only.
- `isHotspotPlacementGesture` rejects non-primary buttons, drags past a four-pixel tolerance, and presses that grabbed a `TransformControls` handle.
- `prepareHotspotRaycaster` zeroes three's `Points` and `Line` thresholds, which default to a full world unit; a glTF carrying `POINTS` or `LINES` primitives would otherwise anchor to a stray primitive off the surface.
- `resolveHotspotOcclusionTolerance` derives the occlusion slack from the model's bounding-box diagonal.

**`publisher-editor-scene.tsx`**

- Both raycasts go through the module; each marker uses a private raycaster instead of mutating the shared R3F one.
- The placement gesture resolves on `pointerup`, read from `window` because OrbitControls shares the canvas, instead of on `pointerdown`.
- Click-to-place disarms after a successful placement.
- The orientation cube is not rendered while a placement is armed. drei's `GizmoViewcube` guards its faces with R3F's `stopPropagation`, which does not stop a native listener, so a click on the cube would otherwise also relocate the hotspot.
- A gizmo drag publishes its position through a ref and writes `hotspotsAtom` once, on release, instead of on every frame.
- The now-unread `userData.editorOverlay` tag is removed.

**`hotspots-settings-panel.tsx`** — the panel disarms click-to-place when it unmounts. Switching compose tools unmounts it without deselecting anything, leaving the canvas armed under a tool that shows no placement affordance.

**Specs** — 24 cases for the domain module, 3 for the panel's arming lifecycle.

## Why the gizmo drag no longer writes per frame

`handleObjectChange` wrote `hotspotsAtom` on every frame of a drag. The settings object rebuilt from that atom is the `useMemo` key for the unsaved-changes check, which runs two full canonical serializations of every scene setting — so a drag cost two serializations per frame at 60fps while every marker and the sidebar re-rendered.

The position now reaches the marker through a ref that the marker reads in its own `useFrame`, and the atom is written once in `handleDragEnd`. `handleDragStart` seeds the published position from the mesh before publishing the hotspot id, because three-stdlib dispatches `mouseDown` with no accompanying `objectChange` — the first of those comes from a pointermove many frames later, and an unseeded vector would put the marker at the world origin until then. A cleanup effect finishes a drag interrupted by unmount: it commits from the mesh and re-enables orbit controls, which `handleDragStart` disabled.

The marker's `useFrame` runs at priority `-1` so it writes the group position before drei's `Html` projects from it. At equal priority `Html` subscribes first, being a child, and the marker would trail the gizmo by one frame. Negative priorities sort early without taking over rendering, which only priorities above zero do.

Two interruptions now end a drag that `TransformControls` never finishes. On unmount, the edit is committed from the mesh and orbit controls are re-enabled, since only the drag-end path does either. On `pointercancel`, which `TransformControls` does not listen for, the release it is waiting for is dispatched to the document so its own handler drops the axis, detaches its move listener and fires the drag-end path. Without that the control stays internally dragging, and because its move handler admits a buttonless move the mesh keeps following the bare cursor until the next click commits somewhere the author never dragged to.

## Why the occlusion slack is derived from the model

The slack was `0.05` in absolute world units. What it forgives is drift, not geometry: `resolveHotspotAnchor` returns an exact point on a triangle, so a clean round trip is exact, but a stored position moves off the surface because `scene_hotspots` holds it in `real` columns, because Draco re-quantizes vertices on the next save, and because an author can nudge a marker inward. All of those scale with the model, and nothing bounds the size a scene arrives at, since runtime normalization is off by default. `0.05` world units is a tenth of a half-unit model and a ten-thousandth of a 500-unit one.

It is now half a percent of the model's bounding-box diagonal, the same measure the viewer normalizes on. The resolver walks the whole model, so the owner holds the result and the occlusion test reads it rather than recomputing per marker per frame.

The refresh happens in a frame, not in a memo. Normalization rescales an ancestor group without changing the model, so the size changes without `modelRoot` doing so — but a render-phase `useMemo` keyed on the normalization settings measures the previous scale, because R3F applies the new one in the commit phase, after every render-phase memo in the same update. Nothing recomputes afterwards, so the slack stays wrong until the next toggle; on a large model clamped to a small one it ends up wider than the whole model and occlusion stops firing. A staleness flag set in an effect and cleared inside `useFrame` avoids that, matching how `SceneModel` maintains its clipping sphere.

Camera distance was considered as the reference and rejected: nothing bounds the dolly, so zooming out would widen the slack until markers behind real geometry stopped dimming. The diagonal is axis-aligned, so rotating a model changes it somewhat, which is tolerable for a floor under a rounding error.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes) — no viewer change
- [ ] No tests required

Every guard was broken and confirmed to turn a test red: widening the raycast root back to the scene in either function, the drag tolerance one step in each direction, its signature default, `<=` to `<`, `hypot` to summed axes, both axis mixups in the gesture, dropping the button gate, dropping the gizmo-handle gate, the occlusion resolver returning a fixed `0.05`, doubling its measure, swapping the size measure for a bounding sphere, dropping the ancestor matrix flush, the tolerance fraction at four values across its range, the resolver's null-model branch, deleting the tolerance term, either raycaster threshold assignment, both null-root branches, taking the last intersection instead of the first, and dropping `recursive`. The fixture is load-bearing: shrinking the gizmo plane to 1x1, removing it or the shadow catcher, or dropping the `<Center>` offset each turns tests red.

One equivalent mutant survives — `<` to `<=` on the occlusion comparison — which requires a float64 distance exactly equal to the threshold.

Verified in the browser: orbit-length drag, right-button click, background click, stray click while disarmed, first and second placement, the panel's coordinate inputs, and the orientation cube withdrawing while armed and returning on disarm.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [ ] I updated documentation where needed — none applies; the rules are documented at their owner
- [ ] I linked the related issue above — tracked outside GitHub

## Known gaps

**The gizmo drag path has no automated or browser verification.** three-stdlib's `TransformControls` does not respond to synthetic pointer events in a headless preview — a grid sweep of press-and-drag around the gizmo produced no movement — and the repository has no R3F component-test setup, so neither the per-frame publish nor the drag commit is exercised by a test. The change is bounded by `handleDragEnd` still committing from the mesh: if the ref-following path is wrong, the marker fails to track during a drag and snaps to the correct position on release, rather than dragging breaking.

**Deferred, not addressed here.** Hotspots render as children of `SceneBounds`, outside both the `<Center top>` wrapper and the normalization scale group, so changing normalization moves the model while hotspots stay put. Fixing that means storing positions in model-local space, which changes the meaning of every persisted `worldPosition` and has to be agreed with the viewer and embed runtimes before either side moves.

**Scope.** This covers anchoring, the placement gesture, the arming lifecycle, and the per-frame settings writes. The remaining per-frame cost is one raycast per marker per frame, which is unchanged.
