### PR TITLE
feat(observability): add error tracking, and report the failures that were being swallowed

### DIFF
--- a/apps/vectreal-platform/app/components/errors/auth-error-boundary.tsx
+++ b/apps/vectreal-platform/app/components/errors/auth-error-boundary.tsx
@@ -7,8 +7,11 @@ import {
 	useRouteError
 } from 'react-router'
 
+import { useErrorReport } from '../../lib/observability/use-error-report'
+
 export function AuthErrorBoundary() {
 	const error = useRouteError()
+	useErrorReport(error)
 	const location = useLocation()
 
 	let statusCode: number | undefined

--- a/apps/vectreal-platform/app/components/errors/dashboard-error-boundary.tsx
+++ b/apps/vectreal-platform/app/components/errors/dashboard-error-boundary.tsx
@@ -2,12 +2,18 @@ import { Button } from '@shared/components/ui/button'
 import { AlertCircle, Home, RefreshCw } from 'lucide-react'
 import { isRouteErrorResponse, Link, useRouteError } from 'react-router'
 
+import { useErrorReport } from '../../lib/observability/use-error-report'
+
 /**
  * Error boundary component for dashboard routes.
  * Displays user-friendly error messages with retry/navigation options.
+ *
+ * Re-exported as `ErrorBoundary` by every dashboard route, so this one call is
+ * what makes those routes report rather than swallow.
  */
 export function DashboardErrorBoundary() {
 	const error = useRouteError()
+	useErrorReport(error)
 
 	let errorMessage = 'An unexpected error occurred'
 	let errorDetails: string | undefined

--- a/apps/vectreal-platform/app/components/errors/public-error-boundary.tsx
+++ b/apps/vectreal-platform/app/components/errors/public-error-boundary.tsx
@@ -2,8 +2,11 @@ import { Button } from '@shared/components/ui/button'
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import { isRouteErrorResponse, useRouteError } from 'react-router'
 
+import { useErrorReport } from '../../lib/observability/use-error-report'
+
 export function PublicErrorBoundary() {
 	const error = useRouteError()
+	useErrorReport(error)
 
 	let statusCode: number | undefined
 	let title = 'Something went wrong'

--- a/apps/vectreal-platform/app/entry.server.tsx
+++ b/apps/vectreal-platform/app/entry.server.tsx
@@ -15,11 +15,13 @@ import {
 	isAnonymousCacheableRequest,
 	PUBLIC_CACHE_CONTROL
 } from './lib/http/cacheable-public-paths.server'
+import { reportServerError } from './lib/observability/report-server-error.server'
 
 import type { RenderToPipeableStreamOptions } from 'react-dom/server'
 import type {
 	ActionFunctionArgs,
 	EntryContext,
+	HandleErrorFunction,
 	LoaderFunctionArgs,
 	RouterContextProvider
 } from 'react-router'
@@ -66,6 +68,21 @@ export function handleDataRequest(
 	return response
 }
 
+/**
+ * Every unhandled server-side error, in one place.
+ *
+ * React Router calls this for loader, action, resource-route and
+ * document-render failures. It does *not* call it for a thrown `Response` that
+ * carries no underlying error, so deliberate 404s and 403s never arrive here -
+ * the framework filters them before we see them.
+ *
+ * Exporting this replaces React Router's built-in handler, which logged to
+ * stdout and did nothing else. `reportServerError` keeps the log.
+ */
+export const handleError: HandleErrorFunction = (error, { request }) => {
+	reportServerError(error, { request })
+}
+
 export default function handleRequest(
 	request: Request,
 	responseStatusCode: number,
@@ -109,11 +126,14 @@ export default function handleRequest(
 				},
 				onError(error: unknown) {
 					responseStatusCode = 500
-					// Log streaming rendering errors from inside the shell.  Don't log
-					// errors encountered during initial shell rendering since they'll
-					// reject and get logged in handleDocumentRequest.
+					/*
+					  Report streaming rendering errors from inside the shell. Errors
+					  during initial shell rendering are left alone: those reject the
+					  render, and the rejection reaches `handleError` above, so
+					  reporting them here as well would double every one of them.
+					*/
 					if (shellRendered) {
-						console.error(error)
+						reportServerError(error, { request })
 					}
 				}
 			}

--- a/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
@@ -12,6 +12,7 @@ import {
 	scenePublished,
 	scenes
 } from '../../../db/schema'
+import { reportServerError } from '../../observability/report-server-error.server'
 
 import type { SceneAssetBinaryDataMap } from '../../../types/api'
 
@@ -255,7 +256,6 @@ export async function uploadSceneAssets(
 				mimeType: asset.mimeType
 			})
 		} catch (error) {
-			console.error(`Failed to upload asset ${fileName}:`, error)
 			throw new Error(
 				`Failed to upload asset ${fileName}: ${getErrorMessage(error)}`,
 				error instanceof Error ? { cause: error } : undefined
@@ -303,7 +303,6 @@ export async function downloadAsset(assetId: string): Promise<{
 			fileName: asset.name
 		}
 	} catch (error) {
-		console.error(`Failed to download asset ${assetId}:`, error)
 		throw new Error(
 			`Failed to download asset ${assetId}: ${getErrorMessage(error)}`,
 			error instanceof Error ? { cause: error } : undefined
@@ -336,10 +335,9 @@ export async function downloadAssets(
 			continue
 		}
 
-		console.error(
-			`Failed to download asset ${assetId}:`,
-			getErrorMessage(outcome.reason)
-		)
+		// Dropped from the results rather than failing the batch, so the caller
+		// gets a short list and no indication that it is short.
+		reportServerError(outcome.reason, { properties: { assetId } })
 	}
 
 	return results
@@ -444,10 +442,7 @@ export async function deleteAssets(assetIds: string[]): Promise<void> {
 
 			await db.delete(assets).where(eq(assets.id, assetId))
 		} catch (error) {
-			console.error(
-				`Failed to delete asset ${assetId}:`,
-				getErrorMessage(error)
-			)
+			reportServerError(error, { properties: { assetId } })
 		}
 	}
 }

--- a/apps/vectreal-platform/app/lib/domain/auth/auth-loader.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/auth-loader.server.ts
@@ -1,6 +1,7 @@
 import { redirect } from 'react-router'
 
 import { getAuthUser } from '../../http/auth.server'
+import { reportServerError } from '../../observability/report-server-error.server'
 import { hasSupabaseAuthCookie } from '../../sessions/supabase-auth-cookie'
 import { createSupabaseClient } from '../../supabase.server'
 import {
@@ -106,7 +107,7 @@ export async function loadAuthenticatedUser(
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
-		console.error('Failed to initialize user:', error)
+		reportServerError(error, { request })
 
 		if (message.startsWith('email_conflict:')) {
 			const { client, headers: signOutHeaders } =

--- a/apps/vectreal-platform/app/lib/domain/billing/stripe-subscription-sync.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/stripe-subscription-sync.server.ts
@@ -22,6 +22,7 @@ import Stripe from 'stripe'
 import { type BillingState, type Plan } from '../../../constants/plan-config'
 import { getDbClient } from '../../../db/client'
 import { orgSubscriptions } from '../../../db/schema/billing/subscriptions'
+import { reportServerError } from '../../observability/report-server-error.server'
 import { getStripeClient } from '../../stripe.server'
 
 // ---------------------------------------------------------------------------
@@ -267,10 +268,17 @@ export async function cancelStripeSubscriptionsForOrganization(
 			{ organizationId, stripeSubscriptionId: row.stripeSubscriptionId }
 		)
 	} catch (err) {
-		// Non-blocking: log the failure so operators can reconcile manually.
-		console.error(
-			'[billing] Failed to cancel Stripe subscription during account deletion - subscription may require manual cleanup',
-			{ organizationId, stripeSubscriptionId: row.stripeSubscriptionId, err }
-		)
+		/*
+		  Non-blocking, and it needs a human: the account is gone while the Stripe
+		  subscription keeps billing. This used to say "log the failure so
+		  operators can reconcile manually" into a stream with no alerting on it,
+		  which meant no operator was ever told.
+		*/
+		reportServerError(err, {
+			properties: {
+				organizationId,
+				stripeSubscriptionId: row.stripeSubscriptionId
+			}
+		})
 	}
 }

--- a/apps/vectreal-platform/app/lib/domain/billing/stripe-webhook-processor.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/stripe-webhook-processor.server.ts
@@ -38,6 +38,7 @@ import {
 import { getDbClient } from '../../../db/client'
 import { orgSubscriptions } from '../../../db/schema/billing/subscriptions'
 import { billingWebhookEvents } from '../../../db/schema/billing/webhook-events'
+import { reportServerError } from '../../observability/report-server-error.server'
 import {
 	getStripeClient,
 	resolveStripeWebhookSecret
@@ -211,10 +212,13 @@ async function handleCheckoutSessionCompleted(
 				{ oldSubscriptionId, newSubscriptionId: subscriptionId, organizationId }
 			)
 		} catch (err) {
-			console.error('[stripe-webhook] Failed to cancel replaced subscription', {
-				oldSubscriptionId,
-				newSubscriptionId: subscriptionId,
-				err
+			// The customer is now billed for two live subscriptions.
+			reportServerError(err, {
+				properties: {
+					oldSubscriptionId,
+					newSubscriptionId: subscriptionId,
+					organizationId
+				}
 			})
 		}
 	}

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-mutations.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-mutations.server.ts
@@ -30,6 +30,7 @@ import {
 	renameOperationFor
 } from './dashboard-operations'
 import { assertDashboardPermission } from './dashboard-permissions.server'
+import { reportServerError } from '../../observability/report-server-error.server'
 import { deleteAssets } from '../asset/asset-storage.server'
 import {
 	deleteProject,
@@ -162,7 +163,7 @@ async function runDelete(
 			// nothing. A stranded object is the cheaper outcome.
 			await deleteAssets(orphanedAssetIds)
 		} catch (error) {
-			console.error('Failed to clean up published assets after delete:', error)
+			reportServerError(error)
 		}
 	}
 

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-folder-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-folder-repository.server.ts
@@ -8,6 +8,7 @@ import { sceneFolders } from '../../../../db/schema/project/scene-folders'
 import { scenePublished } from '../../../../db/schema/project/scene-published'
 import { sceneSettings } from '../../../../db/schema/project/scene-settings'
 import { scenes } from '../../../../db/schema/project/scenes'
+import { reportServerError } from '../../../observability/report-server-error.server'
 import {
 	deleteAssets,
 	selectUnreferencedAssetIds
@@ -834,10 +835,9 @@ export async function deleteScene(
 			// reporting a completed delete as a failure.
 			await deleteAssets(orphanedAssetIds)
 		} catch (error) {
-			console.error(
-				`Failed to clean up orphaned assets for scene ${sceneId}:`,
-				error
-			)
+			// The delete is reported to the user as complete; the objects stay in
+			// storage and are billed for.
+			reportServerError(error, { properties: { sceneId } })
 		}
 	}
 

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-manifest.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-manifest.server.ts
@@ -1,6 +1,7 @@
 import { SCENE_THUMBNAIL_FILENAME } from '@vctrl/core'
 
 import { sceneSettingsService } from './scene-settings-service.server'
+import { reportServerError } from '../../../observability/report-server-error.server'
 import {
 	buildEmbedAssetRefs,
 	buildPublishedModelRef,
@@ -52,10 +53,9 @@ export async function buildSceneManifest(
 		])
 
 	if (settingsResult.status === 'rejected') {
-		console.error('Failed to load scene manifest segment:', {
-			sceneId,
-			error: settingsResult.reason
-		})
+		// The manifest is still returned, one segment short, so an embed renders
+		// something incomplete rather than failing visibly.
+		reportServerError(settingsResult.reason, { properties: { sceneId } })
 	}
 
 	const sceneMeta =

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
@@ -44,6 +44,7 @@ import {
 	SaveSceneSettingsParams,
 	UpdateSceneSettingsParams
 } from '../../../../types/api'
+import { reportServerError } from '../../../observability/report-server-error.server'
 import {
 	createSceneStatsFromReport,
 	resolveSceneByteMetricsScope,
@@ -479,10 +480,7 @@ class SceneSettingsService {
 				return row
 			})
 		} catch (error) {
-			console.error('Failed to query scene settings with assets:', {
-				sceneId,
-				error
-			})
+			reportServerError(error, { properties: { sceneId } })
 			return null
 		}
 
@@ -518,8 +516,9 @@ class SceneSettingsService {
 					}
 				}
 			} catch (error) {
-				console.error('Failed to download some assets:', error)
-				// Continue without asset data rather than failing completely
+				// Continues without asset data rather than failing completely, so
+				// the caller renders a scene that is quietly missing pieces.
+				reportServerError(error, { properties: { sceneId } })
 			}
 		}
 
@@ -559,10 +558,7 @@ class SceneSettingsService {
 				return row
 			})
 		} catch (error) {
-			console.error('Failed to query scene settings with asset refs:', {
-				sceneId,
-				error
-			})
+			reportServerError(error, { properties: { sceneId } })
 			return null
 		}
 
@@ -582,10 +578,8 @@ class SceneSettingsService {
 					new TextDecoder().decode(gltfAssetData.data)
 				) as ExtendedGLTFDocument
 			} catch (error) {
-				console.error('Failed to download glTF JSON asset:', {
-					sceneId,
-					assetId: gltfAsset.id,
-					error
+				reportServerError(error, {
+					properties: { sceneId, assetId: gltfAsset.id }
 				})
 			}
 		}
@@ -607,7 +601,7 @@ class SceneSettingsService {
 			)
 			return result?.assets ?? []
 		} catch (error) {
-			console.error('Failed to query scene asset records:', { sceneId, error })
+			reportServerError(error, { properties: { sceneId } })
 			return []
 		}
 	}

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
@@ -11,6 +11,7 @@ import { getDbClient } from '../../../../db/client'
 import { projects } from '../../../../db/schema/project/projects'
 import { scenePublished } from '../../../../db/schema/project/scene-published'
 import { scenes } from '../../../../db/schema/project/scenes'
+import { reportServerError } from '../../../observability/report-server-error.server'
 import { uploadSceneAssets } from '../../asset/asset-storage.server'
 import {
 	hasEntitlement,
@@ -449,11 +450,12 @@ export async function saveSceneSettings(
 		}
 		return ApiResponse.success(result)
 	} catch (error) {
-		console.error('Failed to save scene settings:', {
-			requestId: request.requestId,
-			userId,
-			sceneId: request.sceneId || null,
-			error
+		reportServerError(error, {
+			properties: {
+				requestId: request.requestId,
+				userId,
+				sceneId: request.sceneId || null
+			}
 		})
 		return ApiResponse.serverError(
 			error instanceof Error ? error.message : 'Failed to save scene settings'
@@ -514,7 +516,9 @@ export async function getSceneSettings(
 
 		return ApiResponse.success({ ...finalResult, meta, assetData: serialized })
 	} catch (error) {
-		console.error('Failed to get scene settings:', error)
+		reportServerError(error, {
+			properties: { sceneId: request.sceneId || null }
+		})
 		return ApiResponse.serverError(
 			error instanceof Error ? error.message : 'Failed to get scene settings'
 		)
@@ -625,7 +629,9 @@ export async function publishScene(
 
 		return ApiResponse.success({ ...result, sceneId, stats })
 	} catch (error) {
-		console.error('Failed to publish scene:', error)
+		reportServerError(error, {
+			properties: { sceneId: request.sceneId || null }
+		})
 		return ApiResponse.serverError(
 			error instanceof Error ? error.message : 'Failed to publish scene'
 		)
@@ -659,7 +665,9 @@ export async function revokeScenePublish(
 
 		return ApiResponse.success(result)
 	} catch (error) {
-		console.error('Failed to revoke scene publish state:', error)
+		reportServerError(error, {
+			properties: { sceneId: request.sceneId || null }
+		})
 		return ApiResponse.serverError(
 			error instanceof Error
 				? error.message

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
@@ -45,7 +45,7 @@ export class SceneSettingsParser {
 			const requestData = await parseActionRequest(request)
 			return this.parseSceneSettingsRequestData(requestData)
 		} catch (error) {
-			console.error('Failed to parse scene settings request:', error)
+			console.warn('Failed to parse scene settings request:', error)
 			return ApiResponse.badRequest('Invalid request format')
 		}
 	}
@@ -228,7 +228,7 @@ export class SceneSettingsParser {
 				currentSceneBytes
 			}
 		} catch (error) {
-			console.error('Failed to parse scene settings request:', error)
+			console.warn('Failed to parse scene settings request:', error)
 			return ApiResponse.badRequest('Invalid request format')
 		}
 	}
@@ -267,7 +267,7 @@ export class SceneSettingsParser {
 				try {
 					settings = JSON.parse(requestData.settings)
 				} catch (error) {
-					console.error('Failed to parse settings:', error)
+					console.warn('Failed to parse settings:', error)
 					return ApiResponse.badRequest('Invalid settings data format')
 				}
 			} else if (
@@ -284,7 +284,7 @@ export class SceneSettingsParser {
 				try {
 					settings = JSON.parse(requestData.settingsData)
 				} catch (error) {
-					console.error('Failed to parse settingsData:', error)
+					console.warn('Failed to parse settingsData:', error)
 					return ApiResponse.badRequest('Invalid settings data format')
 				}
 			} else if (
@@ -297,7 +297,7 @@ export class SceneSettingsParser {
 
 		// Validate that we have a valid settings object
 		if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
-			console.error('Invalid settings format:', settings)
+			console.warn('Invalid settings format:', settings)
 			return ApiResponse.badRequest('Settings must be a valid object')
 		}
 
@@ -656,7 +656,7 @@ export class SceneSettingsParser {
 						return ApiResponse.badRequest('Invalid gltfJson format')
 					}
 				} catch (error) {
-					console.error('Failed to parse gltfJson:', error)
+					console.warn('Failed to parse gltfJson:', error)
 					return ApiResponse.badRequest('Invalid gltfJson format')
 				}
 			}
@@ -685,7 +685,7 @@ export class SceneSettingsParser {
 			try {
 				payload = JSON.parse(payload)
 			} catch (error) {
-				console.error('Failed to parse scene meta:', error)
+				console.warn('Failed to parse scene meta:', error)
 				return ApiResponse.badRequest('Invalid scene metadata format')
 			}
 		}
@@ -727,7 +727,7 @@ export class SceneSettingsParser {
 				}
 				return parsed
 			} catch (error) {
-				console.error('Failed to parse optimizationReport:', error)
+				console.warn('Failed to parse optimizationReport:', error)
 				return ApiResponse.badRequest('Invalid optimization report format')
 			}
 		}
@@ -755,7 +755,7 @@ export class SceneSettingsParser {
 
 				return parsed as Optimizations
 			} catch (error) {
-				console.error('Failed to parse optimizationSettings:', error)
+				console.warn('Failed to parse optimizationSettings:', error)
 				return ApiResponse.badRequest('Invalid optimization settings format')
 			}
 		}

--- a/apps/vectreal-platform/app/lib/domain/user/user-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/user/user-repository.server.ts
@@ -257,12 +257,6 @@ export async function ensureUserExists(
 		const { user } = await ensureUserExistsDb(db, supabaseUser)
 		return user
 	} catch (error) {
-		console.error('Database error in ensureUserExists:', {
-			error,
-			userId: supabaseUser.id,
-			userEmail: supabaseUser.email,
-			userName: supabaseUser.user_metadata?.name
-		})
 		throw error
 	}
 }

--- a/apps/vectreal-platform/app/lib/observability/critical-flows.ts
+++ b/apps/vectreal-platform/app/lib/observability/critical-flows.ts
@@ -1,0 +1,188 @@
+/**
+ * The funnel this product exists to serve, as data.
+ *
+ * One list, two readers. `tests/critical-path.spec.ts` asserts that every
+ * step's owning module is exercised by a spec; `error-report.ts` tags a
+ * reported error with the steps whose routes it arrived on. They read the same
+ * array on purpose: the set of flows that is test-guarded and the set that is
+ * observable have to stay identical, and a second copy of the list is the one
+ * thing that guarantees they will not.
+ *
+ * Pure and free of any database or PostHog import, so both readers - and the
+ * spec that checks the patterns below - can import it directly.
+ */
+
+export type CriticalFlowRoute = {
+	/**
+	 * The route module, exactly as `app/routes.tsx` registers it.
+	 *
+	 * Carried so the spec can assert the route is still mounted. A pattern for a
+	 * route that has been renamed or unmounted matches nothing and would tag
+	 * nothing, silently, forever.
+	 */
+	file: string
+	/** Pathnames that route serves. */
+	pattern: RegExp
+}
+
+export type CriticalFlow = {
+	/**
+	 * Stable id, sent to PostHog as part of `critical_flows`.
+	 *
+	 * Renaming one renames it in every saved insight and alert, so treat these
+	 * as an external contract rather than as a label.
+	 */
+	id: string
+	/** What the user is doing. */
+	step: string
+	/** The module that owns the decision for this step, relative to the app. */
+	module: string
+	/**
+	 * The registered routes that reach that module.
+	 *
+	 * Derived from the modules' actual importers, not from what the step sounds
+	 * like it should serve. Several steps share a route because several steps
+	 * genuinely run there - `/api/scenes/:sceneId` both saves a scene and serves
+	 * the manifest - which is why attribution below returns a list.
+	 */
+	routes: CriticalFlowRoute[]
+}
+
+const API_SCENE = {
+	file: './routes/api/scenes.$sceneId.ts',
+	pattern: /^\/api\/scenes(\/[^/]+)?$/
+}
+
+const API_PROJECT_KEYS = {
+	file: './routes/api/projects.$projectId.api-keys.ts',
+	pattern: /^\/api\/projects\/[^/]+\/api-keys$/
+}
+
+export const CRITICAL_FLOWS: CriticalFlow[] = [
+	{
+		id: 'save-scene',
+		step: 'save a scene',
+		module: 'app/lib/domain/scene/server/scene-settings.operations.server.ts',
+		routes: [API_SCENE]
+	},
+	{
+		id: 'publish-scene',
+		step: 'publish it, and decide what an embed may fetch',
+		module: 'app/lib/domain/scene/embed-asset-policy.ts',
+		routes: [
+			API_SCENE,
+			{
+				file: './routes/api/scenes.$sceneId.assets.$assetId.ts',
+				pattern: /^\/api\/scenes\/[^/]+\/assets\/[^/]+$/
+			},
+			{
+				file: './routes/api/scenes.$sceneId.thumbnail.$assetId.ts',
+				pattern: /^\/api\/scenes\/[^/]+\/thumbnail\/[^/]+$/
+			}
+		]
+	},
+	{
+		id: 'mint-api-key',
+		step: 'mint an API key scoped to the project',
+		module: 'app/lib/domain/auth/api-key-repository.server.ts',
+		routes: [
+			API_PROJECT_KEYS,
+			{
+				file: './routes/dashboard-page/api-keys.tsx',
+				pattern: /^\/dashboard\/api-keys(\/.*)?$/
+			}
+		]
+	},
+	{
+		id: 'allow-domain',
+		step: 'allow the storefront domain',
+		module: 'app/lib/domain/embed/embed-domain-policy.ts',
+		routes: [
+			API_PROJECT_KEYS,
+			/*
+			  The edit drawer is mounted twice, under the project list and under the
+			  project detail page, so it answers on two unrelated paths. Both are
+			  listed because both reach the module.
+			*/
+			{
+				file: './routes/dashboard-page/projects/projects-edit.tsx',
+				pattern: /^\/dashboard\/projects\/edit\/[^/]+$/
+			},
+			{
+				file: './routes/dashboard-page/projects/projects-edit.tsx',
+				pattern: /^\/dashboard\/projects\/[^/]+\/edit$/
+			}
+		]
+	},
+	{
+		id: 'copy-snippet',
+		step: 'copy a snippet that carries the key',
+		module: 'app/lib/domain/embed/embed-snippet.ts',
+		routes: [
+			/*
+			  `/dashboard/projects/:projectId/:sceneId` and
+			  `/dashboard/projects/edit/:projectId` are the same shape, so the scene
+			  page's pattern has to exclude the drawer explicitly. Without the
+			  lookaheads an error in the edit drawer would be filed under "copy a
+			  snippet", which is worse than filing it under nothing.
+			*/
+			{
+				file: './routes/dashboard-page/projects/scene.tsx',
+				pattern: /^\/dashboard\/projects\/(?!edit\/)[^/]+\/(?!edit$)[^/]+$/
+			},
+			/*
+			  Named by the layout, not the leaf page, because the layout is what
+			  imports the module - and the layout runs for every path beneath it.
+			*/
+			{
+				file: './routes/layouts/preview-layout.tsx',
+				pattern: /^\/preview\/[^/]+\/[^/]+$/
+			},
+			{
+				file: './routes/embed-page/legacy-embed-redirect.ts',
+				pattern: /^\/preview\/fullscreen\/[^/]+\/[^/]+\/?$/
+			}
+		]
+	},
+	{
+		id: 'authorize-embed',
+		step: 'authorize the third-party request',
+		module: 'app/lib/domain/embed/embed-access-policy.ts',
+		routes: [
+			{
+				file: './routes/layouts/embed-layout.tsx',
+				pattern: /^\/embed\/[^/]+\/[^/]+$/
+			},
+			API_SCENE,
+			{
+				file: './routes/api/scenes.$sceneId.assets.$assetId.ts',
+				pattern: /^\/api\/scenes\/[^/]+\/assets\/[^/]+$/
+			}
+		]
+	},
+	{
+		id: 'serve-manifest',
+		step: 'serve the embed manifest',
+		module: 'app/lib/domain/scene/server/scene-manifest.server.ts',
+		routes: [
+			API_SCENE,
+			{
+				file: './routes/layouts/publisher-layout.tsx',
+				pattern: /^\/publisher(\/[^/]+)?$/
+			}
+		]
+	}
+]
+
+/**
+ * The ids of every critical flow served by a pathname, in funnel order.
+ *
+ * A list rather than a single id because one route serves several steps.
+ * Callers that only need "was this on the funnel at all" should read the
+ * length; the ids are for narrowing once an alert has fired.
+ */
+export function criticalFlowsForPathname(pathname: string): string[] {
+	return CRITICAL_FLOWS.filter((flow) =>
+		flow.routes.some((route) => route.pattern.test(pathname))
+	).map((flow) => flow.id)
+}

--- a/apps/vectreal-platform/app/lib/observability/error-report.ts
+++ b/apps/vectreal-platform/app/lib/observability/error-report.ts
@@ -1,0 +1,194 @@
+import { isRouteErrorResponse } from 'react-router'
+
+import { criticalFlowsForPathname } from './critical-flows'
+import {
+	redactEmbedToken,
+	redactEmbedTokenFromProperties
+} from '../posthog/redact-embed-token'
+
+/**
+ * Everything both reporting sinks agree on, with no PostHog import on either
+ * side.
+ *
+ * There are two sinks because there have to be - the browser reports through
+ * `posthog-js` and the server through `posthog-node` - but there is only one
+ * set of rules about what counts as reportable, what an error is called, and
+ * what travels with it. Those rules live here, pure, so they are testable
+ * without a PostHog client and cannot drift apart between the two sides.
+ *
+ * @see use-error-report.ts - the client sink, called by every error boundary
+ * @see report-server-error.server.ts - the server sink, called by entry.server
+ */
+
+export type ErrorSource = 'client-boundary' | 'server'
+
+export type ErrorReport = {
+	/**
+	 * The error to hand to `captureException`, already stripped of embed tokens.
+	 * Never the caller's object: see `redactError`.
+	 */
+	error: Error
+	/** Properties to send alongside it. */
+	properties: Record<string, unknown>
+}
+
+/**
+ * What a call site may attach, beyond what the error and request already say.
+ *
+ * Scalars only, and that is a guarantee rather than a style preference.
+ * `redactEmbedTokenFromProperties` walks strings, arrays and plain objects; a
+ * class instance is returned untouched, by design, so that redacting cannot
+ * silently rebuild somebody's `Date` as a bare object. An `Error` passed as a
+ * property would therefore travel to PostHog with its message and stack
+ * unredacted - and the habit this replaces was logging `{ sceneId, error }`.
+ * The type makes that a compile error instead of a leak. The error itself is
+ * the first argument.
+ */
+export type ErrorProperties = Record<
+	string,
+	string | number | boolean | null | undefined
+>
+
+export type ErrorReportContext = {
+	source: ErrorSource
+	/** Used for critical-flow attribution. Undefined where it is not knowable. */
+	pathname?: string
+	/** HTTP method, server side only. */
+	method?: string
+	/** What the call site knows and the request does not. */
+	properties?: ErrorProperties
+}
+
+/**
+ * The same error with any embed API key removed from its message and stack.
+ *
+ * An embed authenticates by a `token` query parameter, so a live credential
+ * turns up in the URL of every `/embed` request - and therefore in the message
+ * of anything that formats that URL into a failure, and in any stack frame that
+ * names it. `#750` already had to stop the client sending that key to PostHog
+ * through `$current_url`; an exception reporter that ships it in the message
+ * instead would put it straight back.
+ *
+ * `posthog-js` covers its own side through the `before_send` hook installed in
+ * `entry.client.tsx`, which walks every property of every event. `posthog-node`
+ * has no equivalent, and `captureException` serializes `message` and `stack`
+ * itself rather than reading our property bag, so the only place to intervene
+ * is the error object handed to it. Doing it here rather than in the server
+ * sink keeps both sides on one rule.
+ *
+ * A copy rather than a mutation: the caller's error is also on its way to the
+ * application's own logs and to whatever else holds a reference to it, and
+ * rewriting somebody else's exception in place is not this module's business.
+ * `name`, `message` and `stack` are what PostHog groups on, so all three are
+ * carried across - and nothing else is. Dropping `cause` and any custom fields
+ * is the point rather than an oversight: they are exactly where an unreviewed
+ * value would ride out, and the redaction rule has to be "these three, checked"
+ * rather than "everything, hopefully".
+ */
+function redactError(error: Error): Error {
+	const redacted = new Error(redactEmbedToken(error.message))
+	redacted.name = error.name
+	redacted.stack = error.stack ? redactEmbedToken(error.stack) : undefined
+	return redacted
+}
+
+/**
+ * The same value as an `Error`, whatever it started as.
+ *
+ * A thrown string, a thrown object and a rejected non-Error all reach a
+ * boundary, and `captureException` needs a name and a message to group on.
+ *
+ * `JSON.stringify` throws on a circular structure, and thrown objects are
+ * circular all the time - a DOM event, a Node error holding its socket, a
+ * component's props. An exception reporter that throws while describing an
+ * exception takes out the request it was reporting on, so the failure is
+ * absorbed rather than allowed to escape.
+ */
+function toError(value: unknown): Error {
+	if (value instanceof Error) return redactError(value)
+	if (typeof value === 'string') return new Error(redactEmbedToken(value))
+
+	let described: string
+	try {
+		described = JSON.stringify(value) ?? String(value)
+	} catch {
+		described = String(value)
+	}
+
+	return new Error(redactEmbedToken(described))
+}
+
+/**
+ * What to report for an error, or `null` if it is not a defect.
+ *
+ * The one judgement call here is the status floor. A thrown `Response` is the
+ * product working: a 404 for a scene that does not exist, a 403 for a member
+ * who may not delete, a 429 for someone hammering sign-in. Reporting those
+ * would bury the real failures under routine traffic, which is the failure mode
+ * that makes teams stop reading their exception feed. Anything at 500 or above
+ * is reported, because a deliberate 500 is still something being wrong.
+ *
+ * A route error response that wraps a real error (`error.error`, which React
+ * Router sets when a loader threw rather than returned) is reported as that
+ * inner error, so the stack survives.
+ */
+export function buildErrorReport(
+	error: unknown,
+	{ source, pathname, method, properties }: ErrorReportContext
+): ErrorReport | null {
+	let reportable: unknown = error
+	let routeStatus: number | undefined
+
+	if (isRouteErrorResponse(error)) {
+		routeStatus = error.status
+		/*
+		  Read off the shape rather than the type. React Router's
+		  `ErrorResponseImpl` carries the original error here when a loader threw
+		  rather than returned, but the exported `ErrorResponse` type does not
+		  declare the field - so this is a narrowing of what is actually there,
+		  not a cast that claims something stronger.
+		*/
+		const thrown = (error as { error?: unknown }).error
+		if (thrown instanceof Error) {
+			reportable = thrown
+		} else {
+			if (error.status < 500) return null
+			reportable = new Error(
+				`${error.status} ${error.statusText || 'Error'}`.trim()
+			)
+		}
+	}
+
+	const criticalFlows =
+		pathname === undefined ? [] : criticalFlowsForPathname(pathname)
+
+	return {
+		error: toError(reportable),
+		/*
+		  Redacted as one bag, through the same function `entry.client.tsx` hands
+		  to `before_send`, so caller properties are covered by the rule that
+		  covers everything else rather than by whatever each call site
+		  remembered.
+		*/
+		properties: redactEmbedTokenFromProperties({
+			/*
+			  Caller properties first. The computed keys below are the contract
+			  alerts filter on, so a call site must not be able to shadow one by
+			  passing `on_critical_path` of its own.
+			*/
+			...properties,
+			error_source: source,
+			/*
+			  The boolean is what an alert filters on; the ids are for narrowing
+			  once it has fired. A list property is awkward to threshold against,
+			  and "is anything on the funnel broken" is the question worth paging
+			  someone about.
+			*/
+			on_critical_path: criticalFlows.length > 0,
+			critical_flows: criticalFlows,
+			...(pathname === undefined ? {} : { pathname }),
+			...(method === undefined ? {} : { request_method: method }),
+			...(routeStatus === undefined ? {} : { route_status: routeStatus })
+		})
+	}
+}

--- a/apps/vectreal-platform/app/lib/observability/report-server-error.server.ts
+++ b/apps/vectreal-platform/app/lib/observability/report-server-error.server.ts
@@ -1,0 +1,91 @@
+import { buildErrorReport } from './error-report'
+import {
+	distinctIdFromRequest,
+	getPosthogClient
+} from '../posthog/posthog-client.server'
+
+import type { ErrorProperties } from './error-report'
+
+/**
+ * The one path by which a server-side error leaves the process.
+ *
+ * Called from `entry.server.tsx` and nowhere else, through the two hooks that
+ * between them see every unhandled error the server produces:
+ *
+ *   - `handleError`, which React Router calls for every loader, action,
+ *     resource-route and document-render failure. Exporting it *replaces* the
+ *     framework's own handler, which is why this function logs as well as
+ *     reports - dropping the log would be a regression on the one signal the
+ *     product already had.
+ *   - `onError` inside `renderToPipeableStream`, for errors thrown after the
+ *     shell has flushed. Those never reject the render promise, so
+ *     `handleError` never sees them and this is their only route out.
+ *
+ * PostHog was chosen over a dedicated vendor because it is already a
+ * dependency, already has a client and a shutdown hook in this process, already
+ * carries the session id the browser is reporting under, and needs no new data
+ * processing agreement. See the PR for the full argument.
+ *
+ * It is also called directly, from anywhere a failure is caught and turned into
+ * a response or a degraded result instead of being allowed to escape. Those
+ * never reach `handleError` - the framework only sees what is thrown past it -
+ * so before this they were visible only as a `console.error` chosen per call
+ * site. `stripe-subscription-sync.server.ts` asked an operator to reconcile a
+ * subscription by hand through one of those, into a log with no alerting on it.
+ *
+ * Sending is fire-and-forget on purpose. `captureException` queues onto the
+ * shared client's batch; nothing about serving this request waits on PostHog,
+ * and PostHog being down must not turn a 500 into a hang.
+ */
+export type ServerErrorContext = {
+	/**
+	 * The request being served, when the failure happened inside one.
+	 *
+	 * Optional because much of the code that swallows a failure is a repository
+	 * or a service with no request in scope, and an unattributed report is worth
+	 * far more than none. What is lost without it is the pathname, the method,
+	 * the reporting session and therefore the critical-flow tag - so pass it
+	 * wherever it is in scope.
+	 */
+	request?: Request
+	/** What the call site knows and the request does not. Scalars only. */
+	properties?: ErrorProperties
+}
+
+export function reportServerError(
+	error: unknown,
+	{ request, properties }: ServerErrorContext = {}
+): void {
+	/*
+	  A client that navigated away mid-response is not a defect, and its abort
+	  surfaces here as an error. React Router's own default handler skips these
+	  for the same reason; reporting them would fill the feed with the browser
+	  behaving normally.
+	*/
+	if (request?.signal.aborted) return
+
+	const report = buildErrorReport(error, {
+		source: 'server',
+		pathname: request ? new URL(request.url).pathname : undefined,
+		method: request?.method,
+		properties
+	})
+	if (!report) return
+
+	/*
+	  The one console.error the house rule allows, and the reason it can be
+	  banned everywhere else: every caller's structured context is logged here
+	  instead, so the sweep that replaced those calls did not cost Fly anything.
+
+	  Redacted rather than raw - an embed token in a stack frame is a live
+	  credential wherever it lands, and log retention is not a secret store.
+	*/
+	// eslint-disable-next-line no-console -- the single reporting sink
+	console.error(report.error, report.properties)
+
+	getPosthogClient()?.captureException(
+		report.error,
+		request ? distinctIdFromRequest(request) : undefined,
+		report.properties
+	)
+}

--- a/apps/vectreal-platform/app/lib/observability/use-error-report.ts
+++ b/apps/vectreal-platform/app/lib/observability/use-error-report.ts
@@ -1,0 +1,67 @@
+import { usePostHog } from '@posthog/react'
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router'
+
+import { buildErrorReport } from './error-report'
+
+/**
+ * The one path by which a rendered error leaves the browser.
+ *
+ * Every error boundary in the app calls this and nothing else calls
+ * `captureException`. That is the whole point of the module:
+ * `tests/error-boundary-reporting.spec.ts` enumerates the files that declare an
+ * `ErrorBoundary` and fails unless each one resolves to a component that
+ * imports this hook, so a boundary added tomorrow cannot quietly swallow what
+ * it catches. Before this existed there was exactly one `captureException` in
+ * the product, in root's `ErrorBoundary`, and React never rendered it: React
+ * Router composes the root error element as `<Layout><ErrorBoundary/></Layout>`
+ * and root's `Layout` returns its own fallback without rendering `children`
+ * whenever `useRouteError()` is set.
+ *
+ * Safe to call unconditionally with no error - boundaries are components, so
+ * the call cannot be moved inside an `if`. `undefined` reports nothing.
+ *
+ * Two things it deliberately does not do:
+ *
+ *   - It does not report during SSR. `usePostHog()` has no provider on the
+ *     server and effects do not run there; server-side errors are the server
+ *     sink's job, and it sees strictly more of them than this could.
+ *   - It does not opt anyone in. `posthog-js` is initialised opted out and
+ *     stays that way until analytics consent is granted, so a visitor who has
+ *     not accepted reports nothing from the browser. That is the consent
+ *     promise working as written, and it is the reason the server sink is not
+ *     optional.
+ */
+export function useErrorReport(error: unknown): void {
+	const posthog = usePostHog()
+	/*
+	  The router's location, not `window.location`. They agree in a browser -
+	  React Router pushes history before it renders - but only one of them is the
+	  router's own state, and reading the global made the flow attribution depend
+	  on a side effect of navigation rather than on the route that failed.
+	*/
+	const { pathname } = useLocation()
+	/*
+	  Guards the report, not the render, and has two jobs. StrictMode
+	  double-invokes mount effects, and it is commented out in `entry.client.tsx`
+	  rather than removed - so without this, turning it back on would double
+	  every exception in the feed, with the cause nowhere near the switch that
+	  caused it. And `pathname` is a dependency below, so a location change while
+	  one error is still on screen must not re-send it.
+	*/
+	const reported = useRef<unknown>(undefined)
+
+	useEffect(() => {
+		if (error === undefined || error === null) return
+		if (reported.current === error) return
+
+		const report = buildErrorReport(error, {
+			source: 'client-boundary',
+			pathname
+		})
+		if (!report) return
+
+		reported.current = error
+		posthog?.captureException(report.error, report.properties)
+	}, [error, pathname, posthog])
+}

--- a/apps/vectreal-platform/app/lib/posthog/posthog-client.server.ts
+++ b/apps/vectreal-platform/app/lib/posthog/posthog-client.server.ts
@@ -1,0 +1,57 @@
+import { PostHog } from 'posthog-node'
+
+/**
+ * The process-wide `posthog-node` client, and the only one.
+ *
+ * Extracted from `posthog-middleware.ts` when the server error sink became a
+ * second caller. Two clients would mean two batching queues, two flush
+ * intervals and two shutdown hooks over one project - and an exception captured
+ * on a client nobody shuts down is an exception that never leaves the machine.
+ *
+ * Returns `null` when PostHog is not configured, which is the normal state of a
+ * local dev environment. Every caller has to handle that, and none of them may
+ * treat it as an error: analytics being off is not a reason for a request to
+ * fail.
+ */
+
+let sharedPosthogClient: null | PostHog = null
+let shutdownHookRegistered = false
+
+export function getPosthogClient(): null | PostHog {
+	const token = process.env.VITE_PUBLIC_POSTHOG_TOKEN
+	const host = process.env.VITE_PUBLIC_POSTHOG_HOST
+
+	if (!token || !host) {
+		return null
+	}
+
+	if (!sharedPosthogClient) {
+		sharedPosthogClient = new PostHog(token, {
+			host,
+			// Batch events and flush on interval to keep requests non-blocking.
+			flushAt: 20,
+			flushInterval: 10_000
+		})
+	}
+
+	if (!shutdownHookRegistered) {
+		shutdownHookRegistered = true
+		process.once('beforeExit', () => {
+			sharedPosthogClient?.shutdown().catch(() => {})
+		})
+	}
+
+	return sharedPosthogClient
+}
+
+/**
+ * The distinct id the browser is reporting under, if it told us.
+ *
+ * `posthog-js` injects this header on same-origin requests
+ * (`__add_tracing_headers` in `entry.client.tsx`). Passing it through ties a
+ * server-side exception to the session that provoked it, which is the
+ * difference between "something 500'd" and "this is what the user was doing".
+ */
+export function distinctIdFromRequest(request: Request): string | undefined {
+	return request.headers.get('X-POSTHOG-DISTINCT-ID') ?? undefined
+}

--- a/apps/vectreal-platform/app/lib/posthog/posthog-middleware.ts
+++ b/apps/vectreal-platform/app/lib/posthog/posthog-middleware.ts
@@ -1,40 +1,11 @@
-import { PostHog } from 'posthog-node'
+import { getPosthogClient } from './posthog-client.server'
 
 import type { Route } from '../../+types/root'
+import type { PostHog } from 'posthog-node'
 import type { RouterContextProvider } from 'react-router'
 
 export interface PostHogContext extends RouterContextProvider {
 	posthog?: PostHog
-}
-
-let sharedPosthogClient: null | PostHog = null
-let shutdownHookRegistered = false
-
-function getPosthogClient(): null | PostHog {
-	const token = process.env.VITE_PUBLIC_POSTHOG_TOKEN
-	const host = process.env.VITE_PUBLIC_POSTHOG_HOST
-
-	if (!token || !host) {
-		return null
-	}
-
-	if (!sharedPosthogClient) {
-		sharedPosthogClient = new PostHog(token, {
-			host,
-			// Batch events and flush on interval to keep requests non-blocking.
-			flushAt: 20,
-			flushInterval: 10_000
-		})
-	}
-
-	if (!shutdownHookRegistered) {
-		shutdownHookRegistered = true
-		process.once('beforeExit', () => {
-			sharedPosthogClient?.shutdown().catch(() => {})
-		})
-	}
-
-	return sharedPosthogClient
 }
 
 /**

--- a/apps/vectreal-platform/app/root.tsx
+++ b/apps/vectreal-platform/app/root.tsx
@@ -28,6 +28,7 @@ import {
 } from './components/theme'
 import { shouldRenderConsentUi } from './lib/consent/consent-surfaces'
 import { isAnonymousCacheableRequest } from './lib/http/cacheable-public-paths.server'
+import { useErrorReport } from './lib/observability/use-error-report'
 import { posthogMiddleware } from './lib/posthog/posthog-middleware'
 import { buildMeta } from './lib/seo'
 import {
@@ -146,6 +147,16 @@ const CriticalStyles = () => (
 
 export function Layout({ children }: { children: ReactNode }) {
 	const error = useRouteError()
+	/*
+	  Reporting lives here, not only in `ErrorBoundary` below, because this is the
+	  branch that actually runs. React Router composes the root error element as
+	  `<Layout><ErrorBoundary/></Layout>`, and the branch below returns its own
+	  fallback without ever rendering `children` - so for a root-level error the
+	  `ErrorBoundary` element is created and then discarded, and every
+	  `captureException` written inside it was unreachable. `useErrorReport`
+	  ignores an absent error, so the normal render path is unaffected.
+	*/
+	useErrorReport(error)
 	const rootLoaderData = useLoaderData<RootLoader>()
 	// Only route-derived force-dark is known at render time; the visitor's own
 	// preference is applied before paint by ThemeScript (reads the cookie), so it
@@ -153,8 +164,6 @@ export function Layout({ children }: { children: ReactNode }) {
 	const forceDarkTheme = Boolean(rootLoaderData?.forceDarkTheme)
 
 	if (error) {
-		console.error('Error in root layout:', error)
-
 		// Extract error message safely
 		let errorMessage = 'An unexpected error occurred'
 		if (error instanceof Error) {
@@ -216,9 +225,18 @@ export function Layout({ children }: { children: ReactNode }) {
 	)
 }
 
+/**
+ * The root fallback.
+ *
+ * `Layout` above short-circuits before rendering this for any error it can see,
+ * so in practice this renders only if that changes. It reports through the same
+ * hook regardless: a boundary whose reporting depends on which of two branches
+ * ran is exactly the arrangement this change exists to remove. The two cannot
+ * both report one error, because the branch that renders this is the branch
+ * that does not render its own fallback.
+ */
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-	const posthog = usePostHog()
-	posthog?.captureException(error as Error)
+	useErrorReport(error)
 
 	let errorMessage = 'An unexpected error occurred'
 	if (error instanceof Error) {

--- a/apps/vectreal-platform/app/routes/api/auth/callback.ts
+++ b/apps/vectreal-platform/app/routes/api/auth/callback.ts
@@ -7,6 +7,7 @@ import {
 	getSafeNextPath
 } from '../../../lib/domain/auth/auth-redirect.server'
 import { initializeUserDefaults } from '../../../lib/domain/user/user-repository.server'
+import { reportServerError } from '../../../lib/observability/report-server-error.server'
 import { createSupabaseClient } from '../../../lib/supabase.server'
 
 import type { PostHogContext } from '../../../lib/posthog/posthog-middleware'
@@ -24,7 +25,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 	const { error } = await client.auth.exchangeCodeForSession(code)
 
 	if (error) {
-		console.error('[auth/callback] code exchange failed', {
+		console.warn('[auth/callback] code exchange failed', {
 			message: error.message
 		})
 		return redirect(
@@ -47,10 +48,9 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 	try {
 		userWithDefaults = await initializeUserDefaults(userData.user)
 	} catch (dbError) {
-		console.error('[auth/callback] user initialization failed', {
-			error: dbError,
-			userId: userData.user.id,
-			userEmail: userData.user.email
+		reportServerError(dbError, {
+			request,
+			properties: { userId: userData.user.id }
 		})
 
 		try {

--- a/apps/vectreal-platform/app/routes/api/auth/send-email.ts
+++ b/apps/vectreal-platform/app/routes/api/auth/send-email.ts
@@ -20,6 +20,7 @@ import { ApiResponse } from '@shared/utils'
 
 import { sendAuthEmail } from '../../../lib/email/auth-email-sender.server'
 import { verifyAuthHookRequest } from '../../../lib/email/auth-hook-verifier.server'
+import { reportServerError } from '../../../lib/observability/report-server-error.server'
 
 import type { Route } from './+types/send-email'
 
@@ -56,8 +57,7 @@ export async function action({ request }: Route.ActionArgs): Promise<Response> {
 		await sendAuthEmail(payload)
 		return ApiResponse.success({ ok: true })
 	} catch (err) {
-		const message = err instanceof Error ? err.message : 'Unknown error'
-		console.error('[auth/send-email] failed to deliver auth email', { message })
+		reportServerError(err, { request })
 		return ApiResponse.serverError('Failed to deliver auth email')
 	}
 }

--- a/apps/vectreal-platform/app/routes/api/auth/social-signin.ts
+++ b/apps/vectreal-platform/app/routes/api/auth/social-signin.ts
@@ -5,6 +5,7 @@ import { Route } from './+types/social-signin'
 import { ensureValidCsrfFormData } from '../../../lib/http/csrf.server'
 import { recordRateLimitAttempt } from '../../../lib/http/rate-limit.server'
 import { verifyTurnstileToken } from '../../../lib/http/turnstile.server'
+import { reportServerError } from '../../../lib/observability/report-server-error.server'
 import { createSupabaseClient } from '../../../lib/supabase.server'
 
 const OAUTH_PROVIDERS = new Set(['google', 'github'])
@@ -92,10 +93,7 @@ export async function action({ request }: Route.ActionArgs) {
 	})
 
 	if (error) {
-		console.error('[auth/social-signin] OAuth initialization failed', {
-			provider,
-			message: error.message
-		})
+		reportServerError(error, { request, properties: { provider } })
 		return ApiResponse.serverError(
 			'Authentication provider is temporarily unavailable'
 		)
@@ -107,11 +105,9 @@ export async function action({ request }: Route.ActionArgs) {
 		})
 	}
 
-	console.error(
-		'[auth/social-signin] OAuth initialization returned no redirect URL',
-		{
-			provider
-		}
+	reportServerError(
+		new Error('OAuth initialization returned no redirect URL'),
+		{ request, properties: { provider } }
 	)
 
 	return ApiResponse.serverError(

--- a/apps/vectreal-platform/app/routes/api/billing/reconcile.ts
+++ b/apps/vectreal-platform/app/routes/api/billing/reconcile.ts
@@ -27,6 +27,7 @@ import { ApiResponse } from '@shared/utils'
 
 import { Route } from './+types/reconcile'
 import { reconcileStripeSubscriptions } from '../../../lib/domain/billing/stripe-reconciliation.server'
+import { reportServerError } from '../../../lib/observability/report-server-error.server'
 
 // ---------------------------------------------------------------------------
 // Auth guard
@@ -117,7 +118,7 @@ export async function action({ request }: Route.ActionArgs): Promise<Response> {
 		return ApiResponse.success(report)
 	} catch (err) {
 		const message = err instanceof Error ? err.message : 'Reconciliation failed'
-		console.error('[billing/reconcile] fatal error', { message })
+		reportServerError(err, { request })
 		return ApiResponse.serverError(message)
 	}
 }

--- a/apps/vectreal-platform/app/routes/api/billing/webhook.ts
+++ b/apps/vectreal-platform/app/routes/api/billing/webhook.ts
@@ -32,6 +32,7 @@ import {
 	constructStripeEvent,
 	processStripeWebhookEvent
 } from '../../../lib/domain/billing/stripe-webhook-processor.server'
+import { reportServerError } from '../../../lib/observability/report-server-error.server'
 
 // ---------------------------------------------------------------------------
 // Action
@@ -87,10 +88,9 @@ export async function action({ request }: Route.ActionArgs): Promise<Response> {
 	} catch (err) {
 		const message =
 			err instanceof Error ? err.message : 'Internal processing error'
-		console.error('[billing/webhook] processing failed', {
-			eventId: event.id,
-			eventType: event.type,
-			message
+		reportServerError(err, {
+			request,
+			properties: { eventId: event.id, eventType: event.type }
 		})
 		// Return 500 so Stripe will retry the event
 		return ApiResponse.serverError(message)

--- a/apps/vectreal-platform/app/routes/api/consent.ts
+++ b/apps/vectreal-platform/app/routes/api/consent.ts
@@ -8,6 +8,7 @@ import {
 } from '../../lib/consent/consent-cookie'
 import { upsertConsent } from '../../lib/domain/consent/consent-repository.server'
 import { ensureSameOriginMutation } from '../../lib/http/csrf.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 import { createSupabaseClient } from '../../lib/supabase.server'
 
 function parseChoices(body: unknown): ConsentChoices | null {
@@ -82,7 +83,12 @@ export async function action({ request }: Route.ActionArgs) {
 			})
 		}
 	} catch (err) {
-		console.error('[consent] DB persist failed (non-fatal):', err)
+		/*
+		  Non-fatal for the visitor - their choice is still applied by cookie -
+		  but the row is lost, so the record of consent and the behaviour it
+		  governs have silently diverged. That is worth knowing about.
+		*/
+		reportServerError(err, { request })
 	}
 
 	return data(

--- a/apps/vectreal-platform/app/routes/api/contact/webhook.ts
+++ b/apps/vectreal-platform/app/routes/api/contact/webhook.ts
@@ -5,6 +5,7 @@ import {
 	processResendWebhookEvent,
 	verifyResendWebhook
 } from '../../../lib/domain/contact/resend-webhook-processor.server'
+import { reportServerError } from '../../../lib/observability/report-server-error.server'
 
 export async function action({ request }: Route.ActionArgs): Promise<Response> {
 	if (request.method !== 'POST') {
@@ -57,9 +58,9 @@ export async function action({ request }: Route.ActionArgs): Promise<Response> {
 	} catch (err) {
 		const message =
 			err instanceof Error ? err.message : 'Internal processing error'
-		console.error('[contact/webhook] processing failed', {
-			eventType: event.type,
-			message
+		reportServerError(err, {
+			request,
+			properties: { eventType: event.type }
 		})
 		return ApiResponse.serverError(message)
 	}

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.assets.$assetId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.assets.$assetId.ts
@@ -13,6 +13,7 @@ import { getScene } from '../../lib/domain/scene/server/scene-folder-repository.
 import { getPublishedScenePreview } from '../../lib/domain/scene/server/scene-preview-repository.server'
 import { sceneSettingsService } from '../../lib/domain/scene/server/scene-settings-service.server'
 import { getAuthUser } from '../../lib/http/auth.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 
 const db = getDbClient()
 
@@ -169,10 +170,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 			const assetData = await downloadAsset(assetId)
 			return assetResponse(assetData.data, assetData.mimeType)
 		} catch (error) {
-			console.error('Failed to stream preview scene asset', {
-				sceneId,
-				assetId,
-				error
+			reportServerError(error, {
+				request,
+				properties: { sceneId, assetId }
 			})
 			return new Response('Failed to load asset', {
 				status: 500,
@@ -214,11 +214,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		const assetData = await downloadAsset(assetId)
 		return assetResponse(assetData.data, assetData.mimeType, authHeaders)
 	} catch (error) {
-		console.error('Failed to stream scene asset', {
-			sceneId,
-			assetId,
-			userId: auth.user.id,
-			error
+		reportServerError(error, {
+			request,
+			properties: { sceneId, assetId, userId: auth.user.id }
 		})
 		return new Response('Failed to load asset', {
 			status: 500,

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.thumbnail.$assetId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.thumbnail.$assetId.ts
@@ -6,6 +6,7 @@ import { assets } from '../../db/schema'
 import { downloadAsset } from '../../lib/domain/asset/asset-storage.server'
 import { getScene } from '../../lib/domain/scene/server/scene-folder-repository.server'
 import { getAuthUser } from '../../lib/http/auth.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 
 const db = getDbClient()
 
@@ -115,11 +116,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 			})()
 		})
 	} catch (error) {
-		console.error('Failed to stream thumbnail asset', {
-			sceneId,
-			assetId,
-			userId: auth.user.id,
-			error
+		reportServerError(error, {
+			request,
+			properties: { sceneId, assetId, userId: auth.user.id }
 		})
 		return new Response('Failed to load thumbnail', { status: 500, headers })
 	}

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
@@ -36,6 +36,7 @@ import {
 	ensureValidCsrfToken
 } from '../../lib/http/csrf.server'
 import { ensurePost, parseActionRequest } from '../../lib/http/requests.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 
 import type { PublishedModelRow } from '../../lib/domain/scene/embed-asset-policy'
 import type { SceneSettingsAction } from '../../types/api'
@@ -366,10 +367,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 			return withManifestCacheHeaders(ApiResponse.success(manifest), etag)
 		} catch (error) {
-			console.error('Failed to load preview scene manifest:', {
-				sceneId,
-				projectId: previewProjectId,
-				error
+			reportServerError(error, {
+				request,
+				properties: { sceneId, projectId: previewProjectId }
 			})
 			return withNoStoreHeaders(ApiResponse.serverError('Failed to load scene'))
 		}
@@ -418,10 +418,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 			etag
 		)
 	} catch (error) {
-		console.error('Failed to load scene manifest:', {
-			sceneId,
-			userId: authResult.user.id,
-			error
+		reportServerError(error, {
+			request,
+			properties: { sceneId, userId: authResult.user.id }
 		})
 		return ApiResponse.error(
 			error instanceof Error ? error.message : 'Failed to load scene',
@@ -905,12 +904,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			)
 		}
 
-		console.error('Scene operation failed:', {
-			action,
-			requestId: requestData.requestId,
-			userId: authResult.user.id,
-			sceneId: requestData.sceneId || null,
-			error
+		reportServerError(error, {
+			request,
+			properties: {
+				action,
+				requestId: requestData.requestId,
+				userId: authResult.user.id,
+				sceneId: requestData.sceneId || null
+			}
 		})
 		return withAdditionalHeaders(
 			ApiResponse.serverError(

--- a/apps/vectreal-platform/app/routes/confirm-pending.tsx
+++ b/apps/vectreal-platform/app/routes/confirm-pending.tsx
@@ -24,6 +24,7 @@ import { AuthErrorBoundary } from '../components/errors'
 import { clearReferralAttribution } from '../lib/domain/analytics/referral-attribution'
 import { ensureValidCsrfFormData } from '../lib/http/csrf.server'
 import { recordRateLimitAttempt } from '../lib/http/rate-limit.server'
+import { reportServerError } from '../lib/observability/report-server-error.server'
 import { buildMeta } from '../lib/seo'
 import { createSupabaseClient } from '../lib/supabase.server'
 
@@ -127,9 +128,12 @@ export async function action({ request }: Route.ActionArgs) {
 	})
 
 	if (error) {
-		console.error('[auth/confirm-pending] resend failed', {
-			message: error.message
-		})
+		/*
+		  The response still says `sent: true`, because telling a visitor which
+		  addresses exist is an enumeration oracle. That makes this failure
+		  invisible from the outside as well as the inside unless it is reported.
+		*/
+		reportServerError(error, { request })
 	}
 
 	return data<ActionData>({ sent: true }, { headers })

--- a/apps/vectreal-platform/app/routes/contact-page.tsx
+++ b/apps/vectreal-platform/app/routes/contact-page.tsx
@@ -30,6 +30,7 @@ import {
 } from '../lib/domain/contact/contact-submission.server'
 import { ensureValidCsrfFormData } from '../lib/http/csrf.server'
 import { verifyTurnstileToken } from '../lib/http/turnstile.server'
+import { reportServerError } from '../lib/observability/report-server-error.server'
 import { buildPageMeta } from '../lib/seo'
 import { LEGAL_PAGE_SEO_BY_PATH } from '../lib/seo-registry'
 import { createSupabaseClient } from '../lib/supabase.server'
@@ -101,10 +102,9 @@ export async function action({ request, context }: Route.ActionArgs) {
 			source
 		})
 	} catch (error) {
-		console.error('[contact/action] failed to process contact submission', {
-			error,
-			source,
-			isAuthenticated: Boolean(user)
+		reportServerError(error, {
+			request,
+			properties: { source, isAuthenticated: Boolean(user) }
 		})
 
 		result = {

--- a/apps/vectreal-platform/app/routes/dashboard-page/billing-upgrade-success.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/billing-upgrade-success.tsx
@@ -25,6 +25,7 @@ import { orgSubscriptions } from '../../db/schema/billing/subscriptions'
 import { loadAuthenticatedUser } from '../../lib/domain/auth/auth-loader.server'
 import { syncSubscriptionFromStripe } from '../../lib/domain/billing/stripe-subscription-sync.server'
 import { getUserOrganizations } from '../../lib/domain/user/user-repository.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 import { getStripeClient } from '../../lib/stripe.server'
 
 import type { Route } from './+types/billing-upgrade-success'
@@ -163,10 +164,17 @@ async function syncCompletedCheckout(
 		try {
 			await stripe.subscriptions.cancel(oldSubscriptionId)
 		} catch (err) {
-			console.error(
-				'[billing] Failed to cancel previous subscription after switch',
-				{ oldSubscriptionId, newSubscriptionId: subscription.id, err }
-			)
+			/*
+			  The customer now holds two live Stripe subscriptions and is billed
+			  for both. No request in scope here - this runs from a helper - so
+			  the report carries the ids instead.
+			*/
+			reportServerError(err, {
+				properties: {
+					oldSubscriptionId,
+					newSubscriptionId: subscription.id
+				}
+			})
 		}
 	}
 
@@ -220,8 +228,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 	try {
 		checkoutData = await syncCompletedCheckout(sessionId, organizationId)
 	} catch (error) {
-		// Non-critical - Stripe unavailable, continue gracefully
-		console.error('[billing] Failed to sync checkout session', error)
+		// Non-critical for the page, which still renders: the subscription is
+		// reconciled by the webhook. Reported because "the webhook will fix it"
+		// is a claim nobody is checking.
+		reportServerError(error, { request })
 	}
 
 	return data(checkoutData, { headers })

--- a/apps/vectreal-platform/app/routes/dashboard-page/settings.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/settings.tsx
@@ -53,6 +53,7 @@ import {
 	updateUserProfile
 } from '../../lib/domain/user/user-repository.server'
 import { ensureValidCsrfFormData } from '../../lib/http/csrf.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 import {
 	createSupabaseAdminClient,
 	createSupabaseClient
@@ -209,13 +210,16 @@ export async function action({ request }: Route.ActionArgs) {
 			const { error: deleteAuthError } =
 				await adminClient.auth.admin.deleteUser(authenticatedUser.id)
 			if (deleteAuthError) {
-				console.error(
-					'[settings] failed to delete auth account after user data deletion',
-					{
-						userId: authenticatedUser.id,
-						error: deleteAuthError
-					}
-				)
+				/*
+				  Reported here rather than left to the throw below: that throw
+				  carries a message written for the user, so the provider's own
+				  error - the only thing that says why the delete failed - would
+				  not survive it.
+				*/
+				reportServerError(deleteAuthError, {
+					request,
+					properties: { userId: authenticatedUser.id }
+				})
 				throw new Error(
 					'Your account data was deleted, but we could not fully remove your sign-in account. Please contact support.'
 				)

--- a/apps/vectreal-platform/app/routes/pricing-page/pricing-page.tsx
+++ b/apps/vectreal-platform/app/routes/pricing-page/pricing-page.tsx
@@ -11,18 +11,24 @@ import {
 import { BasicCard, PageHero } from '../../components/layout-components'
 import { PRICING_PAGE_COPY } from '../../constants/product-copy'
 import { getCheckoutOptions } from '../../lib/domain/billing/billing-dashboard-loader.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 import { buildPageMeta } from '../../lib/seo'
 import { PUBLIC_SEO_PAGES } from '../../lib/seo-registry'
 
 import type { Route } from './+types/pricing-page'
 
-export async function loader(_: Route.LoaderArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
 	try {
 		const prices = await getCheckoutOptions()
 		return data({ prices })
 	} catch (error) {
-		// Stripe may not be configured in all environments - graceful fallback
-		console.error('Failed to load checkout options for pricing page.', error)
+		/*
+		  Degrades to a page with no prices on it. Stripe genuinely may not be
+		  configured outside production, which is why this is a fallback rather
+		  than a throw - and also why it needs reporting: in production the same
+		  branch means the pricing page is quietly selling nothing.
+		*/
+		reportServerError(error, { request })
 		return data({ prices: null })
 	}
 }

--- a/apps/vectreal-platform/app/routes/signin-page/signin-page.tsx
+++ b/apps/vectreal-platform/app/routes/signin-page/signin-page.tsx
@@ -24,6 +24,7 @@ import { Route } from './+types/signin-page'
 import { captureServerEvent } from '../../lib/domain/analytics/server-events.server'
 import { ensureValidCsrfFormData } from '../../lib/http/csrf.server'
 import { recordRateLimitAttempt } from '../../lib/http/rate-limit.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 import { buildMeta } from '../../lib/seo'
 import { createSupabaseClient } from '../../lib/supabase.server'
 
@@ -171,10 +172,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 		authData = response.data
 		authError = response.error
 	} catch (error) {
-		console.error('[auth/sign-in] unexpected sign-in error', {
-			error,
-			email: normalizedEmail
-		})
+		reportServerError(error, { request })
 		return data<SigninActionData>(
 			{
 				formError: AUTH_ERROR_MESSAGES.unknown,
@@ -212,10 +210,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 				: 'unknown'
 
 		if (!invalidCredentials && !captchaFailed) {
-			console.error('[auth/sign-in] sign-in failed', {
-				message: authError.message,
-				email: normalizedEmail
-			})
+			reportServerError(authError, { request })
 		}
 
 		return data<SigninActionData>(

--- a/apps/vectreal-platform/app/routes/signup-page/signup-page.tsx
+++ b/apps/vectreal-platform/app/routes/signup-page/signup-page.tsx
@@ -28,6 +28,7 @@ import { getReferralAttribution } from '../../lib/domain/analytics/referral-attr
 import { captureServerEvent } from '../../lib/domain/analytics/server-events.server'
 import { ensureValidCsrfFormData } from '../../lib/http/csrf.server'
 import { recordRateLimitAttempt } from '../../lib/http/rate-limit.server'
+import { reportServerError } from '../../lib/observability/report-server-error.server'
 import { buildMeta } from '../../lib/seo'
 import { createSupabaseClient } from '../../lib/supabase.server'
 
@@ -186,10 +187,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 		signupData = response.data
 		signupError = response.error
 	} catch (err) {
-		console.error('[auth/sign-up] unexpected error', {
-			err,
-			email: normalizedEmail
-		})
+		reportServerError(err, { request })
 		return data<SignupActionData>(
 			{
 				formError: 'Unable to create your account right now. Please try again.',
@@ -238,10 +236,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 			message.includes('password')
 
 		if (!isClientError) {
-			console.error('[auth/sign-up] signup failed', {
-				message: signupError.message,
-				email: normalizedEmail
-			})
+			reportServerError(signupError, { request })
 		}
 
 		return data<SignupActionData>(

--- a/apps/vectreal-platform/tests/critical-path.spec.ts
+++ b/apps/vectreal-platform/tests/critical-path.spec.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
+import { CRITICAL_FLOWS } from '../app/lib/observability/critical-flows'
+
 /**
  * The funnel this product exists to serve, and a ratchet that keeps it guarded.
  *
@@ -26,48 +28,18 @@ import { describe, expect, it } from 'vitest'
  * the set or this fails, and a new unguarded module on the funnel fails
  * immediately. The gaps stay visible and countable instead of being discovered
  * by a customer.
+ *
+ * The list itself moved to `app/lib/observability/critical-flows.ts` when error
+ * reporting started tagging exceptions with the step they happened on. It is
+ * the same array, read by both: the set of flows that is test-guarded and the
+ * set that is observable have to be one set, and two copies of a list are how
+ * they stop being.
  */
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const APP = 'apps/vectreal-platform'
 
-type FunnelStep = {
-	/** What the user is doing. */
-	step: string
-	/** The module that owns the decision for this step, relative to the app. */
-	module: string
-}
-
-const FUNNEL: FunnelStep[] = [
-	{
-		step: 'save a scene',
-		module: 'app/lib/domain/scene/server/scene-settings.operations.server.ts'
-	},
-	{
-		step: 'publish it, and decide what an embed may fetch',
-		module: 'app/lib/domain/scene/embed-asset-policy.ts'
-	},
-	{
-		step: 'mint an API key scoped to the project',
-		module: 'app/lib/domain/auth/api-key-repository.server.ts'
-	},
-	{
-		step: 'allow the storefront domain',
-		module: 'app/lib/domain/embed/embed-domain-policy.ts'
-	},
-	{
-		step: 'copy a snippet that carries the key',
-		module: 'app/lib/domain/embed/embed-snippet.ts'
-	},
-	{
-		step: 'authorize the third-party request',
-		module: 'app/lib/domain/embed/embed-access-policy.ts'
-	},
-	{
-		step: 'serve the embed manifest',
-		module: 'app/lib/domain/scene/server/scene-manifest.server.ts'
-	}
-]
+const FUNNEL = CRITICAL_FLOWS
 
 /*
   Steps with no test that imports them, each for the same structural reason:

--- a/apps/vectreal-platform/tests/error-boundary-reporting.spec.ts
+++ b/apps/vectreal-platform/tests/error-boundary-reporting.spec.ts
@@ -1,0 +1,217 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every error boundary reports what it catches, and this is what keeps it true.
+ *
+ * The failure this exists to prevent has already happened once, quietly, over
+ * many pull requests. The product had exactly one `captureException`, in root's
+ * `ErrorBoundary`. Twenty-eight route modules then declared boundaries of their
+ * own, each rendering a friendly fallback and dropping the error - and because a
+ * route boundary catches *before* the root one, every one of them made the
+ * product quieter rather than safer. More resilient-looking UI, less signal, no
+ * test that could notice.
+ *
+ * So this file enumerates the files that declare an `ErrorBoundary` and asserts
+ * each resolves to a component that goes through `useErrorReport`. Most of them
+ * declare nothing themselves - they re-export a shared boundary, sometimes
+ * through the `components/errors` barrel - so the check follows the re-export
+ * chain to the module that actually defines the component. A boundary that
+ * renders a fallback and reports nothing fails here on the commit that adds it.
+ *
+ * The ratchet has no exception list on purpose. There is no defensible reason
+ * for a boundary not to report, and an allowlist is where that reason would go.
+ */
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const APP_DIR = join(REPO_ROOT, 'apps/vectreal-platform/app')
+
+/** The single client reporting path. Import path fragment, not a file path. */
+const REPORTER = 'lib/observability/use-error-report'
+
+/**
+ * The hook has to be imported *and* called.
+ *
+ * Checking only the import is how the first draft of this file passed a
+ * mutation that deleted the call and left the import behind - which is a state
+ * lint would eventually catch as an unused binding, but the whole point of this
+ * file is not to be relying on that.
+ */
+function reportsThroughTheOnePath(source: string): boolean {
+	return source.includes(REPORTER) && /useErrorReport\s*\(/.test(source)
+}
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx']
+
+function collectSources(dir: string): string[] {
+	return readdirSync(dir).flatMap((entry) => {
+		const full = join(dir, entry)
+		if (statSync(full).isDirectory()) return collectSources(full)
+		if (/\.spec\.tsx?$/.test(entry)) return []
+		return SOURCE_EXTENSIONS.some((ext) => entry.endsWith(ext)) ? [full] : []
+	})
+}
+
+const SOURCES = collectSources(APP_DIR)
+
+const read = (file: string) => readFileSync(file, 'utf8')
+const show = (file: string) => relative(REPO_ROOT, file)
+
+/** `export function X` / `export const X`, which is where a chain terminates. */
+function declares(source: string, name: string): boolean {
+	return new RegExp(
+		`export\\s+(?:async\\s+)?function\\s+${name}\\b|export\\s+const\\s+${name}\\b`
+	).test(source)
+}
+
+type Binding = { local: string; exported: string; from?: string }
+
+/**
+ * Every `export { ... }` clause, flattened to one entry per name.
+ *
+ * Parsed as a clause and then split, rather than matched name-by-name with one
+ * regex, because the interesting forms differ only in punctuation:
+ * `export { A as ErrorBoundary } from './x'`, the same without `from`, and a
+ * multi-name clause where `ErrorBoundary` is not the first entry.
+ */
+function exportBindings(source: string): Binding[] {
+	const bindings: Binding[] = []
+	const clause = /export\s*\{([^}]*)\}\s*(?:from\s*['"]([^'"]+)['"])?/g
+	let match: null | RegExpExecArray
+
+	while ((match = clause.exec(source)) !== null) {
+		const from = match[2]
+		for (const entry of match[1].split(',')) {
+			const [local, exported] = entry.trim().split(/\s+as\s+/)
+			if (!local) continue
+			bindings.push({
+				local: local.trim(),
+				exported: (exported ?? local).trim(),
+				...(from ? { from } : {})
+			})
+		}
+	}
+
+	return bindings
+}
+
+/** Where a locally-bound name was imported from, and under what name there. */
+function importOf(
+	source: string,
+	local: string
+): { from: string; name: string } | null {
+	const clause = /import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g
+	let match: null | RegExpExecArray
+
+	while ((match = clause.exec(source)) !== null) {
+		for (const entry of match[1].split(',')) {
+			const [imported, alias] = entry.trim().split(/\s+as\s+/)
+			if (!imported) continue
+			if ((alias ?? imported).trim() === local) {
+				return { from: match[2], name: imported.trim() }
+			}
+		}
+	}
+
+	return null
+}
+
+/** A relative specifier as a file on disk, resolving barrels and extensions. */
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+	if (!specifier.startsWith('.')) return null
+	const base = resolve(dirname(fromFile), specifier)
+	const candidates = [
+		...SOURCE_EXTENSIONS.map((ext) => `${base}${ext}`),
+		...SOURCE_EXTENSIONS.map((ext) => join(base, `index${ext}`))
+	]
+	return candidates.find((candidate) => existsSync(candidate)) ?? null
+}
+
+/**
+ * The module that actually defines a name, following re-exports.
+ *
+ * `seen` is not paranoia about hand-written cycles: a barrel that re-exports a
+ * name it also imports is a normal shape, and without the guard the first one
+ * added would hang the suite rather than fail it.
+ */
+function definingModule(
+	file: string,
+	name: string,
+	seen = new Set<string>()
+): string | null {
+	const key = `${file}#${name}`
+	if (seen.has(key)) return null
+	seen.add(key)
+
+	const source = read(file)
+	if (declares(source, name)) return file
+
+	const binding = exportBindings(source).find((b) => b.exported === name)
+	if (!binding) return null
+
+	if (binding.from) {
+		const target = resolveSpecifier(file, binding.from)
+		return target ? definingModule(target, binding.local, seen) : null
+	}
+
+	const imported = importOf(source, binding.local)
+	if (!imported) return null
+	const target = resolveSpecifier(file, imported.from)
+	return target ? definingModule(target, imported.name, seen) : null
+}
+
+const BOUNDARY_FILES = SOURCES.filter((file) => {
+	const source = read(file)
+	return (
+		declares(source, 'ErrorBoundary') ||
+		exportBindings(source).some((b) => b.exported === 'ErrorBoundary')
+	)
+})
+
+describe('error boundary reporting', () => {
+	/*
+	  The anti-tautology guard. Every assertion below is `it.each` over the list
+	  collected above, so a collector that silently matched nothing - a renamed
+	  directory, a regex that stopped matching - would report a green suite with
+	  no tests in it. The number is a floor, not a count, so adding a boundary
+	  does not require editing this file.
+	*/
+	it('finds the boundaries it is supposed to be checking', () => {
+		expect(BOUNDARY_FILES.length).toBeGreaterThanOrEqual(25)
+	})
+
+	it.each(BOUNDARY_FILES.map(show))('%s resolves to a component', (file) => {
+		const resolved = definingModule(join(REPO_ROOT, file), 'ErrorBoundary')
+		expect(
+			resolved,
+			`${file} exports an ErrorBoundary whose definition could not be followed. Re-export it from a module that defines it, rather than through a form this cannot resolve.`
+		).not.toBeNull()
+	})
+
+	it.each(BOUNDARY_FILES.map(show))('%s reports what it catches', (file) => {
+		const resolved = definingModule(join(REPO_ROOT, file), 'ErrorBoundary')
+		if (!resolved) return // reported by the assertion above
+
+		expect(
+			reportsThroughTheOnePath(read(resolved)),
+			`${file} declares an ErrorBoundary, and ${show(resolved)} - the component it resolves to - does not call useErrorReport from ${REPORTER}. A boundary that renders a fallback without reporting makes the product quieter, not safer: it catches the error before the root boundary ever sees it.`
+		).toBe(true)
+	})
+
+	/*
+	  The server half of the same rule. Boundaries are a browser mechanism and
+	  cover nothing that fails before a component renders - a loader that throws,
+	  an action that rejects, an API route with no UI at all. `handleError` is the
+	  framework's one hook for those, and exporting it replaces React Router's
+	  own handler, so an entry.server that stops calling the sink does not fall
+	  back to anything.
+	*/
+	it('routes server-side errors through the same module', () => {
+		const entry = read(join(APP_DIR, 'entry.server.tsx'))
+		expect(entry).toMatch(/export const handleError/)
+		expect(entry).toContain('lib/observability/report-server-error.server')
+	})
+})

--- a/apps/vectreal-platform/tests/error-boundary-reports.spec.tsx
+++ b/apps/vectreal-platform/tests/error-boundary-reports.spec.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+/**
+ * The boundaries actually report, rendered rather than grepped.
+ *
+ * `error-boundary-reporting.spec.ts` is a ratchet over source text: it proves
+ * every boundary is wired to the one reporting path. It cannot prove that path
+ * runs, and this whole change exists because the product's only
+ * `captureException` was wired and unreachable - root's `ErrorBoundary`, which
+ * React Router composes as `<Layout><ErrorBoundary/></Layout>`, never rendered
+ * because root's `Layout` returns its own fallback without rendering
+ * `children`. A grep would have called that code covered.
+ *
+ * So these render a route that throws, through the real router, and assert an
+ * exception left through a real PostHog client interface.
+ */
+
+import { PostHogProvider } from '@posthog/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { createRoutesStub } from 'react-router'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+	AuthErrorBoundary,
+	DashboardErrorBoundary,
+	PublicErrorBoundary
+} from '../app/components/errors'
+
+import type { PostHog } from 'posthog-js'
+import type { ComponentType } from 'react'
+
+function fakePostHog() {
+	return { captureException: vi.fn() } as unknown as PostHog & {
+		captureException: ReturnType<typeof vi.fn>
+	}
+}
+
+function renderThrowing(Boundary: ComponentType, error: unknown) {
+	const posthog = fakePostHog()
+	const Stub = createRoutesStub([
+		{
+			path: '/dashboard/projects/p1/s1',
+			Component: () => {
+				throw error
+			},
+			ErrorBoundary: Boundary
+		}
+	])
+
+	render(
+		<PostHogProvider client={posthog}>
+			<Stub initialEntries={['/dashboard/projects/p1/s1']} />
+		</PostHogProvider>
+	)
+
+	return posthog
+}
+
+const BOUNDARIES: [string, ComponentType][] = [
+	['DashboardErrorBoundary', DashboardErrorBoundary],
+	['PublicErrorBoundary', PublicErrorBoundary],
+	['AuthErrorBoundary', AuthErrorBoundary]
+]
+
+describe('a rendered boundary reports', () => {
+	it.each(BOUNDARIES)('%s captures the error it catches', async (_, Boundary) => {
+		const posthog = renderThrowing(Boundary, new Error('render blew up'))
+
+		await waitFor(() => {
+			expect(posthog.captureException).toHaveBeenCalledTimes(1)
+		})
+		expect(posthog.captureException.mock.calls[0][0]).toMatchObject({
+			message: 'render blew up'
+		})
+	})
+
+	it('still renders its fallback', async () => {
+		renderThrowing(DashboardErrorBoundary, new Error('render blew up'))
+		expect(await screen.findByText('render blew up')).toBeInTheDocument()
+	})
+
+	/*
+	  The property the alert filters on, produced end to end rather than asserted
+	  against `buildErrorReport` in isolation. The route above is on the funnel,
+	  so an error there has to arrive tagged as such.
+	*/
+	it('tags an error on the critical path', async () => {
+		const posthog = renderThrowing(DashboardErrorBoundary, new Error('boom'))
+
+		await waitFor(() => expect(posthog.captureException).toHaveBeenCalled())
+		expect(posthog.captureException.mock.calls[0][1]).toMatchObject({
+			error_source: 'client-boundary',
+			on_critical_path: true,
+			critical_flows: ['copy-snippet']
+		})
+	})
+
+	/*
+	  A 404 is the product working. Reporting one would bury the real failures
+	  under routine traffic, and a boundary that renders "Page Not Found" is the
+	  most common boundary render there is.
+
+	  Thrown from a loader rather than from render, because that is the only
+	  place it can come from: a `Response` thrown during render stays a
+	  `Response`, and it is the data layer that turns one into the
+	  `ErrorResponse` the boundary branches on. The first version of this test
+	  threw from the component and proved nothing.
+	*/
+	it('does not report a deliberate 404', async () => {
+		const posthog = fakePostHog()
+		const Stub = createRoutesStub([
+			{
+				path: '/',
+				loader() {
+					throw new Response('nope', { status: 404 })
+				},
+				Component: () => null,
+				ErrorBoundary: DashboardErrorBoundary
+			}
+		])
+
+		render(
+			<PostHogProvider client={posthog}>
+				<Stub initialEntries={['/']} />
+			</PostHogProvider>
+		)
+
+		expect(await screen.findByText('Page Not Found')).toBeInTheDocument()
+		expect(posthog.captureException).not.toHaveBeenCalled()
+	})
+
+	/*
+	  One failure, one event, under StrictMode's double-invoked mount effect.
+	  The predecessor called `captureException` during render, which made every
+	  re-render another event for the same failure.
+
+	  StrictMode specifically, and not a plain `rerender`: the effect's
+	  dependencies are stable across a re-render, so React does not run it again
+	  and a re-render proves nothing. The first version of this test did exactly
+	  that, and stayed green with the guard deleted. StrictMode is the case the
+	  guard exists for - it is commented out in `entry.client.tsx` rather than
+	  removed, so re-enabling it must not double the exception feed.
+	*/
+	it('reports one event when the mount effect is invoked twice', async () => {
+		const posthog = fakePostHog()
+		const Stub = createRoutesStub([
+			{
+				path: '/',
+				Component: () => {
+					throw new Error('render blew up')
+				},
+				ErrorBoundary: DashboardErrorBoundary
+			}
+		])
+
+		render(
+			<StrictMode>
+				<PostHogProvider client={posthog}>
+					<Stub initialEntries={['/']} />
+				</PostHogProvider>
+			</StrictMode>
+		)
+
+		await waitFor(() => expect(posthog.captureException).toHaveBeenCalled())
+		expect(posthog.captureException).toHaveBeenCalledTimes(1)
+	})
+})

--- a/apps/vectreal-platform/tests/error-report.spec.ts
+++ b/apps/vectreal-platform/tests/error-report.spec.ts
@@ -1,0 +1,227 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	CRITICAL_FLOWS,
+	criticalFlowsForPathname
+} from '../app/lib/observability/critical-flows'
+import { buildErrorReport } from '../app/lib/observability/error-report'
+
+/**
+ * What the reporting rules actually do, tested without a PostHog client.
+ *
+ * Note what this file does *not* contain: any of the module paths in
+ * `CRITICAL_FLOWS`. `critical-path.spec.ts` decides whether a funnel module is
+ * covered by searching every spec's source text for an import of it, so writing
+ * one of those paths here as a string would report that module as guarded by
+ * this file. Flows are referred to by id below for that reason.
+ */
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+describe('critical flow attribution', () => {
+	it('has a unique id per step', () => {
+		const ids = CRITICAL_FLOWS.map((flow) => flow.id)
+		expect(new Set(ids).size).toBe(ids.length)
+	})
+
+	/*
+	  Every pattern is checked against the route table rather than against a
+	  reviewer's memory of it. A pattern for a route that has moved matches
+	  nothing and tags nothing, silently and forever, which is the failure mode
+	  worth a test: it looks exactly like "no errors on the critical path".
+	*/
+	it('names only routes that are still registered', () => {
+		const routeConfig = readFileSync(
+			join(REPO_ROOT, 'apps/vectreal-platform/app/routes.tsx'),
+			'utf8'
+		)
+		const missing = CRITICAL_FLOWS.flatMap((flow) =>
+			flow.routes
+				.filter((route) => !routeConfig.includes(`'${route.file}'`))
+				.map((route) => `${flow.id} -> ${route.file}`)
+		)
+		expect(missing).toEqual([])
+	})
+
+	it.each([
+		['/api/scenes/abc', ['save-scene', 'publish-scene', 'authorize-embed', 'serve-manifest']],
+		['/api/scenes/abc/assets/xyz', ['publish-scene', 'authorize-embed']],
+		['/api/scenes/abc/thumbnail/xyz', ['publish-scene']],
+		['/api/projects/p1/api-keys', ['mint-api-key', 'allow-domain']],
+		['/dashboard/api-keys/new', ['mint-api-key']],
+		['/dashboard/projects/edit/p1', ['allow-domain']],
+		['/dashboard/projects/p1/edit', ['allow-domain']],
+		['/embed/p1/s1', ['authorize-embed']],
+		['/preview/p1/s1', ['copy-snippet']],
+		['/publisher/s1', ['serve-manifest']],
+		// Off the funnel entirely. Reported, but not as a critical-path failure.
+		['/pricing', []],
+		['/dashboard/billing', []],
+		['/news-room/some-article', []]
+	])('%s belongs to %j', (pathname, expected) => {
+		expect(criticalFlowsForPathname(pathname)).toEqual(expected)
+	})
+
+	/*
+	  The scene page and the edit drawer are the same URL shape, and the drawer's
+	  route sorts first. Without the lookaheads in the scene pattern, an error in
+	  "allow the storefront domain" would be filed under "copy a snippet" - a
+	  wrong attribution, which is worse than none because it is believed.
+	*/
+	it('does not confuse the scene page with the edit drawer', () => {
+		expect(criticalFlowsForPathname('/dashboard/projects/p1/s1')).toEqual([
+			'copy-snippet'
+		])
+		expect(criticalFlowsForPathname('/dashboard/projects/edit/p1')).not.toContain(
+			'copy-snippet'
+		)
+		expect(criticalFlowsForPathname('/dashboard/projects/p1/edit')).not.toContain(
+			'copy-snippet'
+		)
+	})
+})
+
+describe('buildErrorReport', () => {
+	const server = { source: 'server' } as const
+
+	it('reports a thrown Error, tagged with its source', () => {
+		const report = buildErrorReport(new Error('boom'), server)
+		expect(report?.error.message).toBe('boom')
+		expect(report?.properties.error_source).toBe('server')
+	})
+
+	it('reports a thrown string', () => {
+		expect(buildErrorReport('boom', server)?.error.message).toBe('boom')
+	})
+
+	/*
+	  Thrown objects are circular all the time - a DOM event, a Node error
+	  holding its socket, a component's props - and `JSON.stringify` throws on
+	  one. A reporter that throws while describing an exception takes out the
+	  request it was reporting on, which is a worse outage than the error it was
+	  called for.
+	*/
+	it('survives a thrown value it cannot serialize', () => {
+		const circular: Record<string, unknown> = { kind: 'weird' }
+		circular.self = circular
+
+		expect(() => buildErrorReport(circular, server)).not.toThrow()
+		expect(buildErrorReport(circular, server)).not.toBeNull()
+	})
+
+	/*
+	  A 404 for a scene that does not exist, or a 403 for a member who may not
+	  delete, is the product working. Reporting those buries the real failures
+	  under routine traffic, which is how teams end up not reading the feed.
+	*/
+	it.each([404, 403, 429, 499])('drops a deliberate %i', (status) => {
+		expect(
+			buildErrorReport(
+				{ status, statusText: 'No', data: null, internal: false },
+				server
+			)
+		).toBeNull()
+	})
+
+	it('reports a 500 response, with its status', () => {
+		const report = buildErrorReport(
+			{ status: 500, statusText: 'Boom', data: null, internal: false },
+			server
+		)
+		expect(report?.properties.route_status).toBe(500)
+		expect(report?.error.message).toBe('500 Boom')
+	})
+
+	it('unwraps the real error a route response is carrying', () => {
+		const report = buildErrorReport(
+			{
+				status: 404,
+				statusText: 'Not Found',
+				data: null,
+				internal: false,
+				error: new Error('the loader actually threw')
+			},
+			server
+		)
+		expect(report?.error.message).toBe('the loader actually threw')
+		expect(report?.properties.route_status).toBe(404)
+	})
+
+	it('marks a funnel path as on the critical path', () => {
+		const report = buildErrorReport(new Error('boom'), {
+			source: 'server',
+			pathname: '/api/scenes/abc/assets/xyz',
+			method: 'GET'
+		})
+		expect(report?.properties.on_critical_path).toBe(true)
+		expect(report?.properties.critical_flows).toContain('authorize-embed')
+		expect(report?.properties.request_method).toBe('GET')
+	})
+
+	it('leaves a path off the funnel unmarked', () => {
+		const report = buildErrorReport(new Error('boom'), {
+			source: 'client-boundary',
+			pathname: '/pricing'
+		})
+		expect(report?.properties.on_critical_path).toBe(false)
+		expect(report?.properties.critical_flows).toEqual([])
+	})
+
+	/*
+	  An embed authenticates by a `token` query parameter, so a live API key is in
+	  the URL of every embed request - and therefore in the message of anything
+	  that formats that URL into a failure, and in any stack frame naming it.
+	  `posthog-js` strips those through `before_send`; `posthog-node` has no such
+	  hook and serializes `message` and `stack` itself, so the only place to
+	  intervene is the error handed to it. #750 already had to stop the client
+	  leaking this key. An exception reporter is not allowed to put it back.
+	*/
+	describe('embed token redaction', () => {
+		it('strips the token from the message', () => {
+			const report = buildErrorReport(
+				new Error('fetch failed: /embed/p/s?token=vk_live_secret&x=1'),
+				server
+			)
+			expect(report?.error.message).not.toContain('vk_live_secret')
+			expect(report?.error.message).toContain('token=redacted')
+			// The rest of the URL survives, or the report is useless.
+			expect(report?.error.message).toContain('/embed/p/s')
+			expect(report?.error.message).toContain('x=1')
+		})
+
+		it('strips the token from the stack', () => {
+			const error = new Error('boom')
+			error.stack = 'Error: boom\n    at /embed/p/s?token=vk_live_secret:1:1'
+			expect(buildErrorReport(error, server)?.error.stack).not.toContain(
+				'vk_live_secret'
+			)
+		})
+
+		it('strips the token from the reported pathname', () => {
+			const report = buildErrorReport(new Error('boom'), {
+				source: 'server',
+				pathname: '/embed/p/s?token=vk_live_secret'
+			})
+			expect(String(report?.properties.pathname)).not.toContain(
+				'vk_live_secret'
+			)
+		})
+
+		it('does not rewrite the caller’s error in place', () => {
+			const original = new Error('token=vk_live_secret')
+			buildErrorReport(original, server)
+			expect(original.message).toBe('token=vk_live_secret')
+		})
+
+		it('keeps name and stack, which is what PostHog groups on', () => {
+			const original = new TypeError('boom')
+			const report = buildErrorReport(original, server)
+			expect(report?.error.name).toBe('TypeError')
+			expect(report?.error.stack).toBe(original.stack)
+		})
+	})
+})

--- a/apps/vectreal-platform/tests/eslint-house-rules.spec.ts
+++ b/apps/vectreal-platform/tests/eslint-house-rules.spec.ts
@@ -1,13 +1,22 @@
 /**
- * The house rules in `eslint.config.mts`, proven to fire.
+ * The house rules in `eslint.config.mts`, proven to fire and proven to be on.
  *
  * A `no-restricted-syntax` selector is a string. Nothing type-checks it, and a
  * subtly wrong one silently matches nothing while lint stays green - which
  * looks exactly like compliance. These lint real snippets through the repo's
  * own config and assert both directions: the violation is caught, and the
  * correct form is not.
+ *
+ * That covers a rule being wrong. It does not cover a rule being *absent*,
+ * which is a separate failure with the same symptom, and the one that actually
+ * shipped: flat config replaces rule options rather than merging them, so a
+ * second block re-declaring a rule over a subset of files turns the first
+ * block's rules off for that subset. The final describe checks the resolved
+ * config for every file in scope, because everything above lints at one
+ * hardcoded path and a hardcoded path is what the regression slipped past.
  */
 
+import { globSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import { ESLint } from 'eslint'
@@ -366,39 +375,121 @@ describe('server code reports rather than logs', () => {
 
 
 /**
- * The rules reach route modules too, and adding one did not turn the others off.
+ * Every file a house rule is scoped to actually has it.
  *
- * This is a regression test for a defect in the change that added the
- * `console.error` ban. Flat config does not merge rule options: the last
- * matching block replaces them. Scoping a second `no-restricted-syntax` block
- * to `apps/vectreal-platform/app/routes/**` therefore disabled cn(), the
- * z-index scale and the inline-SVG ban for every route file, and lint stayed
- * green because the only probe path in this file was under `app/components/`.
+ * This is a regression test, and the bug it pins shipped in the change that
+ * added the `console.error` ban. Flat config does not merge rule options: when
+ * two blocks configure the same rule and both match a file, the later one
+ * *replaces* the earlier. Scoping a second `no-restricted-syntax` block to
+ * `apps/vectreal-platform/app/routes/**` therefore left route files with only
+ * that block's two selectors and silently dropped cn(), the z-index scale and
+ * the inline-SVG ban across every page and API route.
  *
- * A rule that has been switched off is indistinguishable from a codebase that
- * complies, which is why the check is per-scope rather than global.
+ * Lint stayed green, because a rule that is switched off reports nothing and so
+ * does a codebase that complies. The tests above stayed green too: they lint
+ * snippets at one hardcoded path, which proves a rule *exists* but not that it
+ * is *active* where it is scoped.
+ *
+ * So this asks ESLint to resolve the real config for every source file in scope
+ * and checks the shape of the answer, rather than guessing which scopes are
+ * worth probing. Guessing is what left the hole: the probe path was under
+ * `app/components/`, and the block that broke things did not match it.
  */
-describe('house rules apply in every scope', () => {
-	const CN_VIOLATION =
-		'export const A = ({ className }: { className?: string }) => (\n' +
-		'\t<div className={`space-y-4 ${className}`} />\n)\n'
-
-	it.each([
-		['a component', IN_SCOPE],
-		['a route module', ROUTE_MODULE]
-	])('still enforces cn() in %s', async (_, filePath) => {
-		expect(await messagesFor(CN_VIOLATION, filePath)).toHaveLength(1)
+describe('house rules survive config resolution', () => {
+	/*
+	  Resolved per file rather than sampled. 701 files take under a second,
+	  because ESLint caches resolution per directory - cheap enough that there is
+	  no reason to check a subset and hope it was representative.
+	*/
+	const SOURCES = globSync(['apps/**/*.{ts,tsx}', 'shared/**/*.{ts,tsx}'], {
+		cwd: ROOT,
+		exclude: (path) =>
+			path.includes('node_modules') ||
+			path.includes('/build/') ||
+			path.includes('/dist/')
 	})
 
-	it.each([
-		['a component', IN_SCOPE],
-		['a route module', ROUTE_MODULE]
-	])('still enforces the z-index scale in %s', async (_, filePath) => {
-		const messages = await messagesFor(
-			'export const A = () => <div className="z-[999]" />\n',
-			filePath
+	/**
+	 * The four exceptions `eslint.config.mts` declares through `ignores`, as
+	 * shapes.
+	 *
+	 * Duplicated from the config on purpose, and the duplication is what makes
+	 * the check sound: without it, a block that resolved a subset of files to
+	 * *zero* selectors would be indistinguishable from a file the config
+	 * deliberately exempts. The assertion below fails if this list goes stale in
+	 * either direction.
+	 */
+	const DECLARED_EXCEPTIONS: [string, RegExp][] = [
+		['specs assert on literal class strings', /\.spec\.tsx?$/],
+		['stories show raw values beside their tokens', /\.stories\.tsx?$/],
+		['mail clients do not resolve custom properties', /\/lib\/email\/templates\//],
+		['icons are where inline SVG is supposed to live', /\/assets\/icons\//]
+	]
+
+	let resolved: { file: string; selectors: number }[]
+
+	beforeAll(async () => {
+		resolved = []
+		for (const file of SOURCES) {
+			const config = await eslint.calculateConfigForFile(resolve(ROOT, file))
+			const rule = config.rules?.['no-restricted-syntax']
+			// [severity, ...selectors]
+			resolved.push({
+				file,
+				selectors: Array.isArray(rule) ? rule.length - 1 : 0
+			})
+		}
+	})
+
+	it('finds the files it is supposed to be checking', () => {
+		expect(SOURCES.length).toBeGreaterThan(400)
+	})
+
+	/*
+	  The assertion that would have caught the regression. A clobbered file keeps
+	  the overriding block's selectors and loses the rest, so it lands strictly
+	  between "fully exempt" and "fully covered" - a state nothing else produces.
+	*/
+	it('gives every file either the full rule set or none of it', () => {
+		const full = Math.max(...resolved.map((entry) => entry.selectors))
+		const partial = resolved.filter(
+			(entry) => entry.selectors > 0 && entry.selectors < full
 		)
 
-		expect(messages.length).toBeGreaterThanOrEqual(1)
+		expect(
+			partial.map((entry) => `${entry.file} (${entry.selectors}/${full})`),
+			'These files resolved to some house rules but not all of them, which means a config block re-declared no-restricted-syntax over a subset and replaced the rest. Flat config does not merge rule options. Add the selectors to the existing array instead of opening a new block, or use a different rule id.'
+		).toEqual([])
+	})
+
+	/*
+	  The other half. Without this, switching a subset off entirely would read as
+	  "these files are exempt" and pass the assertion above.
+	*/
+	it('exempts only what the config says it exempts', () => {
+		const unexplained = resolved
+			.filter((entry) => entry.selectors === 0)
+			.filter(({ file }) =>
+				DECLARED_EXCEPTIONS.every(([, pattern]) => !pattern.test(file))
+			)
+			.map((entry) => entry.file)
+
+		expect(
+			unexplained,
+			'These files have no house rules and are not one of the exceptions eslint.config.mts declares. Either the ignores grew and this list needs the new reason, or a config block turned the rules off by accident.'
+		).toEqual([])
+	})
+
+	/*
+	  The ratchet turns one way. An exception that no longer exempts anything is a
+	  claim about the config that has stopped being true, and leaving it here
+	  would let the list above quietly stop meaning anything.
+	*/
+	it.each(DECLARED_EXCEPTIONS)('%s: still exempts something', (_, pattern) => {
+		expect(
+			resolved.some(
+				(entry) => pattern.test(entry.file) && entry.selectors === 0
+			)
+		).toBe(true)
 	})
 })

--- a/apps/vectreal-platform/tests/eslint-house-rules.spec.ts
+++ b/apps/vectreal-platform/tests/eslint-house-rules.spec.ts
@@ -18,16 +18,31 @@ const ROOT = resolve(__dirname, '../../..')
 /** A path inside the glob the rules are scoped to (`apps/**`, `shared/**`). */
 const IN_SCOPE = resolve(ROOT, 'apps/vectreal-platform/app/components/probe.tsx')
 
+/** A server-only module, where console.error is banned outright. */
+const SERVER_MODULE = resolve(
+	ROOT,
+	'apps/vectreal-platform/app/lib/domain/probe/probe.server.ts'
+)
+
+/** A route module, where the ban applies to the loader and action only. */
+const ROUTE_MODULE = resolve(
+	ROOT,
+	'apps/vectreal-platform/app/routes/probe-page/probe.tsx'
+)
+
 let eslint: ESLint
 
 beforeAll(() => {
 	eslint = new ESLint({ cwd: ROOT })
 })
 
+/** The house rules, whichever rule id each one is implemented as. */
+const HOUSE_RULES = new Set(['no-restricted-syntax', 'no-console'])
+
 async function messagesFor(code: string, filePath = IN_SCOPE) {
 	const [result] = await eslint.lintText(code, { filePath })
 	return result.messages.filter(
-		(message) => message.ruleId === 'no-restricted-syntax'
+		(message) => message.ruleId && HOUSE_RULES.has(message.ruleId)
 	)
 }
 
@@ -234,5 +249,156 @@ describe('SVG must live in an icon component', () => {
 		)
 
 		expect(messages).toEqual([])
+	})
+})
+
+
+/**
+ * `console.error` is not a reporting strategy.
+ *
+ * Every server-side failure that gets caught and turned into a response, a
+ * fallback or an empty list is invisible to `handleError`, which only sees what
+ * is thrown past it. Thirty-odd call sites each answered that with a
+ * `console.error` into a stream with no grouping or alerting -
+ * `stripe-subscription-sync.server.ts` used one to ask an operator to reconcile
+ * a subscription still billing a deleted account.
+ *
+ * Both directions are asserted. A selector that matched nothing would leave
+ * lint green, which is indistinguishable from compliance.
+ */
+describe('server code reports rather than logs', () => {
+	it('rejects console.error in a server-only module', async () => {
+		const messages = await messagesFor(
+			'export function save() {\n' +
+				'\ttry {\n\t\treturn 1\n\t} catch (error) {\n' +
+				'\t\tconsole.error("failed", error)\n\t\treturn null\n\t}\n}\n',
+			SERVER_MODULE
+		)
+
+		expect(messages).toHaveLength(1)
+		/*
+		  `no-console` has a fixed message, so unlike the route rule below this
+		  one cannot name `reportServerError` in the lint output. That is the
+		  price of using a different rule id, which is what stops this block
+		  displacing the design-system selectors. The message still names the
+		  call and says which console methods remain allowed.
+		*/
+		expect(messages[0].message).toContain('console')
+	})
+
+	it('accepts reportServerError in a server-only module', async () => {
+		const messages = await messagesFor(
+			'import { reportServerError } from "../../observability/report-server-error.server"\n' +
+				'export function save() {\n\ttry {\n\t\treturn 1\n\t} catch (error) {\n' +
+				'\t\treportServerError(error)\n\t\treturn null\n\t}\n}\n',
+			SERVER_MODULE
+		)
+
+		expect(messages).toEqual([])
+	})
+
+	/*
+	  A malformed request body or an expired OAuth code answers with a 4xx and is
+	  the product working - the same judgement `buildErrorReport` makes at its
+	  status floor. Reporting those would bury real failures under client noise,
+	  so `console.warn` stays available and this asserts the rule leaves it alone.
+	*/
+	it('leaves console.warn alone', async () => {
+		const messages = await messagesFor(
+			'export function parse() {\n\ttry {\n\t\treturn 1\n\t} catch (error) {\n' +
+				'\t\tconsole.warn("bad input", error)\n\t\treturn null\n\t}\n}\n',
+			SERVER_MODULE
+		)
+
+		expect(messages).toEqual([])
+	})
+
+	it('rejects console.error inside a route loader', async () => {
+		const messages = await messagesFor(
+			'export async function loader() {\n\ttry {\n\t\treturn 1\n\t} catch (error) {\n' +
+				'\t\tconsole.error("failed", error)\n\t\treturn null\n\t}\n}\n',
+			ROUTE_MODULE
+		)
+
+		expect(messages).toHaveLength(1)
+	})
+
+	it('rejects console.error inside a route action', async () => {
+		const messages = await messagesFor(
+			'export async function action() {\n\ttry {\n\t\treturn 1\n\t} catch (error) {\n' +
+				'\t\tconsole.error("failed", error)\n\t\treturn null\n\t}\n}\n',
+			ROUTE_MODULE
+		)
+
+		expect(messages).toHaveLength(1)
+	})
+
+	/*
+	  The arrow form is not what this repo writes today, and that is exactly why
+	  it is pinned: a rule that only understands the current spelling stops
+	  working on the refactor that changes it, silently.
+	*/
+	it('rejects console.error in an arrow-function loader', async () => {
+		const messages = await messagesFor(
+			'export const loader = async () => {\n\ttry {\n\t\treturn 1\n\t} catch (error) {\n' +
+				'\t\tconsole.error("failed", error)\n\t\treturn null\n\t}\n}\n',
+			ROUTE_MODULE
+		)
+
+		expect(messages).toHaveLength(1)
+	})
+
+	/*
+	  The component half of a route runs in the browser, where the reporting path
+	  is `useErrorReport` and `error-boundary-reporting.spec.ts` is the ratchet.
+	  Banning it here would push people to disable the rule rather than move the
+	  call.
+	*/
+	it('leaves the component half of a route alone', async () => {
+		const messages = await messagesFor(
+			'export default function Page() {\n\tconsole.error("client side")\n\treturn null\n}\n',
+			ROUTE_MODULE
+		)
+
+		expect(messages).toEqual([])
+	})
+})
+
+
+/**
+ * The rules reach route modules too, and adding one did not turn the others off.
+ *
+ * This is a regression test for a defect in the change that added the
+ * `console.error` ban. Flat config does not merge rule options: the last
+ * matching block replaces them. Scoping a second `no-restricted-syntax` block
+ * to `apps/vectreal-platform/app/routes/**` therefore disabled cn(), the
+ * z-index scale and the inline-SVG ban for every route file, and lint stayed
+ * green because the only probe path in this file was under `app/components/`.
+ *
+ * A rule that has been switched off is indistinguishable from a codebase that
+ * complies, which is why the check is per-scope rather than global.
+ */
+describe('house rules apply in every scope', () => {
+	const CN_VIOLATION =
+		'export const A = ({ className }: { className?: string }) => (\n' +
+		'\t<div className={`space-y-4 ${className}`} />\n)\n'
+
+	it.each([
+		['a component', IN_SCOPE],
+		['a route module', ROUTE_MODULE]
+	])('still enforces cn() in %s', async (_, filePath) => {
+		expect(await messagesFor(CN_VIOLATION, filePath)).toHaveLength(1)
+	})
+
+	it.each([
+		['a component', IN_SCOPE],
+		['a route module', ROUTE_MODULE]
+	])('still enforces the z-index scale in %s', async (_, filePath) => {
+		const messages = await messagesFor(
+			'export const A = () => <div className="z-[999]" />\n',
+			filePath
+		)
+
+		expect(messages.length).toBeGreaterThanOrEqual(1)
 	})
 })

--- a/apps/vectreal-platform/tests/report-server-error.spec.ts
+++ b/apps/vectreal-platform/tests/report-server-error.spec.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The server sink, exercised rather than inspected.
+ *
+ * This is the half that carries the load. `posthog-js` is initialised opted out
+ * and stays that way until a visitor accepts analytics, so client-side
+ * reporting covers only consenting sessions - while every loader, action and
+ * resource route on the server reports unconditionally. If this path is broken
+ * the product is back to console logs in Fly with no grouping or alerting,
+ * which is the state this change exists to leave.
+ */
+
+const captureException = vi.fn()
+
+vi.mock('../app/lib/posthog/posthog-client.server', () => ({
+	getPosthogClient: () => ({ captureException }),
+	distinctIdFromRequest: (request: Request) =>
+		request.headers.get('X-POSTHOG-DISTINCT-ID') ?? undefined
+}))
+
+/*
+  Static, not a top-level `await import`. `vi.mock` is hoisted above every
+  import in the file, so the mock is already in place when this binding
+  resolves - and the spec tsconfig does not allow top-level await.
+*/
+import { reportServerError } from '../app/lib/observability/report-server-error.server'
+
+/** The context a call site inside a request handler passes. */
+const serving = (url: string, init?: RequestInit) => ({
+	request: new Request(url, init)
+})
+
+describe('reportServerError', () => {
+	/*
+	  Spied once and cleared per test, not re-spied per test: `vi.spyOn` on an
+	  already-spied method hands back the same mock with its history intact, so
+	  re-spying in `beforeEach` leaves earlier tests' calls in place and a
+	  call-count assertion counts the whole file.
+	*/
+	const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+	beforeEach(() => {
+		captureException.mockClear()
+		logged.mockClear()
+	})
+
+	it('captures an error thrown while serving a request', () => {
+		reportServerError(
+			new Error('the loader threw'),
+			serving('https://vectreal.io/api/scenes/s1')
+		)
+
+		expect(captureException).toHaveBeenCalledTimes(1)
+		expect(captureException.mock.calls[0][0]).toMatchObject({
+			message: 'the loader threw'
+		})
+	})
+
+	it('tags the request it happened on', () => {
+		reportServerError(
+			new Error('boom'),
+			serving('https://vectreal.io/api/scenes/s1/assets/a1', { method: 'GET' })
+		)
+
+		expect(captureException.mock.calls[0][2]).toMatchObject({
+			error_source: 'server',
+			on_critical_path: true,
+			critical_flows: ['publish-scene', 'authorize-embed'],
+			pathname: '/api/scenes/s1/assets/a1',
+			request_method: 'GET'
+		})
+	})
+
+	/*
+	  Ties the exception to the session that provoked it. `posthog-js` injects
+	  this header on same-origin requests, and without it a server-side error is
+	  an anonymous 500 with no way back to what the user was doing.
+	*/
+	it('attributes it to the reporting session', () => {
+		reportServerError(
+			new Error('boom'),
+			serving('https://vectreal.io/pricing', {
+				headers: { 'X-POSTHOG-DISTINCT-ID': 'visitor-9' }
+			})
+		)
+
+		expect(captureException.mock.calls[0][1]).toBe('visitor-9')
+	})
+
+	/*
+	  A client that navigated away mid-response is not a defect, and the abort
+	  reaches this function as an error. React Router's own default handler skips
+	  these for the same reason.
+	*/
+	it('ignores an aborted request', () => {
+		const controller = new AbortController()
+		controller.abort()
+
+		reportServerError(
+			new Error('aborted'),
+			serving('https://vectreal.io/api/scenes/s1', {
+				signal: controller.signal
+			})
+		)
+
+		expect(captureException).not.toHaveBeenCalled()
+	})
+
+	/*
+	  Exporting `handleError` replaces React Router's built-in handler, which
+	  logged and did nothing else. Losing the log would be a regression on the
+	  one signal the product already had.
+	*/
+	it('still logs, so Fly keeps what it always had', () => {
+		reportServerError(new Error('boom'), serving('https://vectreal.io/pricing'))
+		expect(logged).toHaveBeenCalledTimes(1)
+	})
+
+	/*
+	  Much of the code that swallows a failure is a repository or a service with
+	  no request in scope. An unattributed report is worth far more than none -
+	  and this is the path `stripe-subscription-sync.server.ts` reports through,
+	  where the alternative was a log asking an operator to reconcile a
+	  subscription that was still billing a deleted account.
+	*/
+	it('reports without a request at all', () => {
+		reportServerError(new Error('cancel failed'), {
+			properties: { organizationId: 'org-1' }
+		})
+
+		expect(captureException).toHaveBeenCalledTimes(1)
+		const [error, distinctId, properties] = captureException.mock.calls[0]
+		expect(error).toMatchObject({ message: 'cancel failed' })
+		expect(distinctId).toBeUndefined()
+		expect(properties).toMatchObject({
+			error_source: 'server',
+			organizationId: 'org-1',
+			on_critical_path: false
+		})
+		expect(properties).not.toHaveProperty('pathname')
+	})
+
+	/*
+	  The call sites this replaced logged `{ sceneId, assetId, userId }` beside
+	  the error, and that context is the difference between a stack and a lead.
+	*/
+	it('carries the call site\'s own context', () => {
+		reportServerError(new Error('boom'), {
+			...serving('https://vectreal.io/api/scenes/s1'),
+			properties: { sceneId: 's1', assetId: 'a1' }
+		})
+
+		expect(captureException.mock.calls[0][2]).toMatchObject({
+			sceneId: 's1',
+			assetId: 'a1',
+			pathname: '/api/scenes/s1'
+		})
+	})
+
+	/*
+	  A call site must not be able to shadow the keys alerts filter on, whether
+	  by accident or by copying the wrong example.
+	*/
+	it('does not let a call site overwrite the reserved keys', () => {
+		reportServerError(new Error('boom'), {
+			...serving('https://vectreal.io/api/scenes/s1'),
+			properties: { on_critical_path: false, error_source: 'client-boundary' }
+		})
+
+		expect(captureException.mock.calls[0][2]).toMatchObject({
+			on_critical_path: true,
+			error_source: 'server'
+		})
+	})
+
+	/*
+	  Adding `properties` added a second way for a live credential to leave, and
+	  it is the way the old code habitually used - `console.error('failed', { url })`.
+	*/
+	it('redacts an embed token passed as call site context', () => {
+		reportServerError(new Error('boom'), {
+			properties: { sourceUrl: '/embed/p/s?token=vk_live_secret' }
+		})
+
+		expect(JSON.stringify(captureException.mock.calls[0][2])).not.toContain(
+			'vk_live_secret'
+		)
+	})
+
+	/*
+	  A compile-time guarantee, asserted rather than assumed. `properties` takes
+	  scalars because `redactEmbedTokenFromProperties` returns a class instance
+	  untouched by design - so an `Error` smuggled in as a property would reach
+	  PostHog with its message and stack unredacted. If this stops being a type
+	  error, `tsconfig.spec.json` fails on the unused directive and says so.
+	*/
+	it('will not accept an error as a property', () => {
+		reportServerError(new Error('boom'), {
+			// @ts-expect-error properties are scalars; the error is the first argument
+			properties: { cause: new Error('token=vk_live_secret') }
+		})
+
+		expect(captureException).toHaveBeenCalledTimes(1)
+	})
+
+	/*
+	  An embed authenticates by a `token` query parameter, so a live API key is in
+	  the URL of every embed request. `posthog-node` has no `before_send` hook and
+	  serializes the message itself, so nothing but the redaction in
+	  `buildErrorReport` stands between that key and a third party - and #750 had
+	  to remove this exact leak from the client once already.
+	*/
+	it('never ships an embed token, to PostHog or to the log', () => {
+		reportServerError(
+			new Error('upstream failed for /embed/p/s?token=vk_live_secret'),
+			serving('https://vectreal.io/embed/p/s?token=vk_live_secret')
+		)
+
+		const [error, , properties] = captureException.mock.calls[0]
+		expect(JSON.stringify([error.message, error.stack, properties])).not.toContain(
+			'vk_live_secret'
+		)
+		expect(JSON.stringify(logged.mock.calls)).not.toContain(
+			'vk_live_secret'
+		)
+	})
+})

--- a/apps/vectreal-platform/tests/root-vitest-projects.spec.ts
+++ b/apps/vectreal-platform/tests/root-vitest-projects.spec.ts
@@ -1,0 +1,60 @@
+import { globSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import rootConfig from '../../../vitest.config.mts'
+
+/**
+ * Every project's suite is reachable from the repo root.
+ *
+ * `vitest.config.mts` lists its projects as globs so a project that gains a
+ * `vitest.config.ts` joins the root run by existing. That is the right default
+ * and it has one failure mode: a project added somewhere the globs do not
+ * reach - a new top-level directory, a nested workspace - is skipped in
+ * silence, and a suite nobody runs looks exactly like a suite that passes.
+ *
+ * This is the same shape of bug the root config was written to fix. Before it
+ * existed, `npx vitest run --root .` ran every spec under none of their
+ * configs and failed 53 of 100 files for reasons that were all artifacts. The
+ * command was still being quoted as a gate.
+ */
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+/** Config files a project's unit suite is defined by. */
+const PROJECT_CONFIGS = globSync('**/vitest.config.ts', {
+	cwd: REPO_ROOT,
+	exclude: (path) => path.includes('node_modules')
+}).sort()
+
+const PROJECT_GLOBS = rootConfig.test?.projects as string[]
+
+const REACHED = PROJECT_GLOBS.flatMap((pattern) =>
+	globSync(pattern, { cwd: REPO_ROOT })
+).sort()
+
+describe('root vitest config', () => {
+	/*
+	  Anti-tautology: both sides of the comparison below come from globs, so a
+	  discovery that quietly matched nothing would compare [] to [] and pass.
+	*/
+	it('finds the projects it is supposed to be checking', () => {
+		expect(PROJECT_CONFIGS.length).toBeGreaterThanOrEqual(5)
+	})
+
+	it('reaches every project that defines a unit suite', () => {
+		expect(REACHED).toEqual(PROJECT_CONFIGS)
+	})
+
+	/*
+	  Integration specs need a running local Supabase and are run through
+	  `vectreal-platform:test-integration`. Pulling them into the root run would
+	  make the default command fail for everyone without a database, which is
+	  the fastest way to get a gate ignored again.
+	*/
+	it('leaves the integration suite out', () => {
+		expect(REACHED.some((path) => path.includes('integration'))).toBe(false)
+	})
+})

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -9,6 +9,10 @@ import pluginReact from 'eslint-plugin-react'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
+/** `console.error(...)`, wherever it appears. Shared by the rules below. */
+const CONSOLE_ERROR_SELECTOR =
+	'CallExpression[callee.object.name="console"][callee.property.name="error"]'
+
 // Build tooling and test/story files are not part of what a consumer installs.
 const dependencyCheckOptions = {
 	buildTargets: ['build', 'build-ci', 'build-storybook'],
@@ -286,6 +290,37 @@ export default defineConfig(tseslint.configs.recommended, [
 				},
 				{
 					/*
+					  `console.error` in a route's server half.
+
+					  Route modules are not `.server.ts` - a page's loader, action
+					  and component share one file - so this is scoped by where the
+					  call sits rather than by filename, and lives in this array
+					  rather than its own block so it cannot displace the rules
+					  above. Both declaration forms are matched: `export async
+					  function loader` is what this repo writes today, and the arrow
+					  form is one refactor away from being right.
+
+					  A `console.error` in the component half is deliberately left
+					  alone. That runs in the browser, where the reporting path is
+					  `useErrorReport` and `error-boundary-reporting.spec.ts` is the
+					  ratchet.
+					*/
+					selector:
+						'ExportNamedDeclaration > FunctionDeclaration[id.name=/^(loader|action)$/] ' +
+						CONSOLE_ERROR_SELECTOR,
+					message:
+						'console.error inside a route loader or action. Call reportServerError(error, { request, properties }) from lib/observability instead - it logs and reports through one path. If this is a client mistake answered with a 4xx, use console.warn.'
+				},
+				{
+					/** The same rule for `export const loader = async () => {}`. */
+					selector:
+						'ExportNamedDeclaration > VariableDeclaration > VariableDeclarator[id.name=/^(loader|action)$/] ' +
+						CONSOLE_ERROR_SELECTOR,
+					message:
+						'console.error inside a route loader or action. Call reportServerError(error, { request, properties }) from lib/observability instead - it logs and reports through one path. If this is a client mistake answered with a 4xx, use console.warn.'
+				},
+				{
+					/*
 					  An SVG pasted into a feature component.
 
 					  Icons belong in `shared/components/src/assets/icons` as named
@@ -303,6 +338,49 @@ export default defineConfig(tseslint.configs.recommended, [
 					message:
 						'Inline SVG. Extract it to shared/components/src/assets/icons as a named component and import it. If this component exists to draw a graphic rather than an icon, disable this rule on the line with a comment saying so.'
 				}
+			]
+		}
+	},
+	{
+		/*
+		  Server-only modules do not get to invent their own error reporting.
+
+		  `handleError` in `entry.server.tsx` only ever sees what is thrown past
+		  it, so a service that catches its own failure and returns a fallback,
+		  an empty list or a 5xx envelope has consumed the error - and before
+		  this rule, 30-odd of them each answered that with a `console.error` of
+		  their own design, into a stream with no grouping, alerting or
+		  retention. `stripe-subscription-sync.server.ts` used one to ask an
+		  operator to reconcile a subscription that was still billing a deleted
+		  account, and no operator was ever told.
+
+		  `reportServerError` from `lib/observability` is the one path. It logs
+		  too, with the call site's own structured context, so nothing is lost by
+		  not writing the log by hand.
+
+		  `no-console` rather than a `no-restricted-syntax` selector, and that is
+		  load-bearing rather than taste. Flat config does not merge rule options
+		  - the last matching block replaces them - so a second
+		  `no-restricted-syntax` block over a subset of `apps/**` silently drops
+		  the design-system selectors for those files. The first version of this
+		  rule did exactly that and turned off cn(), the z-index scale and the
+		  inline-SVG ban for every route module while lint stayed green.
+
+		  The cost is the message: `no-console` has a fixed one, so the lint
+		  output here cannot name `reportServerError` the way the route rule
+		  below does. Worth it - a rule that fires with a plain message beats
+		  three rules that stopped firing with good ones.
+
+		  Everything except `error` stays allowed. `console.warn` is the right
+		  call for a malformed request body or an expired OAuth code: those
+		  answer with a 4xx and are the product working, which is the same
+		  judgement `buildErrorReport` makes at its status floor.
+		*/
+		files: ['apps/vectreal-platform/app/**/*.server.ts'],
+		rules: {
+			'no-console': [
+				'error',
+				{ allow: ['warn', 'log', 'info', 'debug', 'trace'] }
 			]
 		}
 	},

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * The root entry point, so that `vitest` run from the repo root means the same
+ * thing as the per-project targets Nx runs.
+ *
+ * Without this file there was no root configuration at all - `vitest.shared.mts`
+ * is a base that each project's own config merges, not something Vitest loads -
+ * so `npx vitest run --root .` fell back to Vitest's defaults: no `globals`, no
+ * tsconfig path resolution, no MDX plugin, no setup file, and the default
+ * `**\/*.{test,spec}.?(c|m)[jt]s?(x)` glob instead of any project's `include`.
+ * It collected every project's specs and ran them under none of their configs,
+ * so 53 of 100 spec files failed on a clean checkout with `describe is not
+ * defined` and `Cannot find package '@vctrl/core'`. None of those were real,
+ * which is worse than the command not working at all: it was quoted as a gate.
+ *
+ * Globs rather than a list, so a project that gains a `vitest.config.ts` joins
+ * the root run by existing. A list would have to be edited, and the failure
+ * mode of forgetting is silence - exactly the failure this file exists to fix.
+ * `tests/root-vitest-projects.spec.ts` asserts nothing is missed.
+ *
+ * `vitest.integration.config.ts` is deliberately not matched. Integration specs
+ * need a local Supabase and are run through their own Nx target.
+ */
+export default defineConfig({
+	test: {
+		projects: [
+			'apps/*/vitest.config.ts',
+			'packages/*/vitest.config.ts',
+			'shared/*/vitest.config.ts'
+		]
+	}
+})


### PR DESCRIPTION
## Summary

There was no error tracking in this product. One `captureException` existed, in root's `ErrorBoundary`, and React never rendered it. This adds a single reporting path that every boundary and the server entry call, a server-side sink, and reporting for the failures that were being caught and silently discarded.

## Root cause

Three, one per commit:

1. **The only error report sat in a component React never renders.** React Router composes the root error element as `<Layout><ErrorBoundary/></Layout>` ([`routes.js:37`](https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/dom/ssr/routes.ts)), and root's `Layout` returned its own fallback *without rendering `children`* whenever `useRouteError()` was set — so the rule "an error that reaches a boundary is reported" had no owner. That is how 28 route boundaries were added without anyone noticing that the 29th reported nothing either: a route boundary catches *before* the root one, so every one of them made the product quieter rather than safer.

2. **`handleError` only fires for errors that escape.** A route or service that catches its own failure and turns it into a response, a fallback or an empty list has consumed the error, and no framework hook sees it — so "a server-side failure is reported even when it never reached the user as a throw" had no owner either, and 30-odd sites each invented a `console.error`.

3. **There was never a `vitest.config` at the repo root.** `vitest.shared.mts` is a base each project's config merges, not something Vitest loads, so `npx vitest run --root .` ran on Vitest's defaults and failed 53 of 100 spec files for reasons that were all artifacts — while being quoted as a gate.

## Changes

- **`app/lib/observability/`** — the one path. `use-error-report.ts` is the hook every boundary calls (from an effect, so a re-render or StrictMode cannot double an event); `report-server-error.server.ts` is the server sink; `error-report.ts` holds the rules both share; `critical-flows.ts` owns the funnel list.
- **Server sink wired to `handleError`** — React Router's one hook for loader, action, resource-route and document-render failures, plus the streaming `onError` that `handleError` structurally cannot see. Exporting `handleError` *replaces* the framework's logger, so the sink keeps logging.
- **PostHog rather than a new vendor** — already a dependency, already has a client and shutdown hook in this process, already carries the session id the browser reports under, and needs no new DPA. Nothing about a dedicated tool outweighed that here.
- **Embed tokens stripped from message, stack and properties.** `posthog-node` has no `before_send` and serializes `message`/`stack` itself, so without this the reporter would have reintroduced the leak #750 removed.
- **Critical-flow instrumentation reuses the existing list.** `FUNNEL` moved out of `critical-path.spec.ts` into `critical-flows.ts`; the spec imports it. Errors carry `on_critical_path` (what you alert on) and `critical_flows` (what you filter by after).
- **30 swallowed failures now report**; 10 that answer with a 4xx became `console.warn`; 4 that rethrow had their duplicate log removed. See the commit body for the classification.
- **Root `vitest.config.mts`** declaring `test.projects` as globs.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated
- [ ] No tests required

`pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — 8 tasks green.
`npx vitest run --root .` — **99 files, 1231 tests**. `pnpm nx test vectreal-platform` — **92 files, 1092 tests**, run twice.

**Ratchets, not just tests.** `error-boundary-reporting.spec.ts` resolves every `ErrorBoundary` export through its re-export chain to the module that defines the component and requires that module to *call* the hook, so a boundary that renders a fallback and swallows the error fails on the commit that adds it. `error-boundary-reports.spec.tsx` renders throwing routes through the real router, because the whole defect here was code that looked wired and never ran — a grep would have called it covered. The `console.error` ban is an ESLint house rule with both directions asserted.

**24 mutations, each confirmed red and reverted.** Two of them caught tests of mine that could not fail: the boundary ratchet passed with the hook call deleted and the import left behind, and the dedupe test used a plain re-render, which never re-runs a stable-dependency effect.

## Reviewer notes

**Three concerns in one PR**, which is against the usual cut-by-concern rule — they are three commits and split cleanly if you would rather review them separately. Commit 3 is independent of the other two.

**A regression I introduced and caught, worth a second pair of eyes.** My first version of the `console.error` rule scoped a second `no-restricted-syntax` block to `app/routes/**`. Flat config *replaces* rule options rather than merging them, so that silently disabled `cn()`, the z-index scale and the inline-SVG ban for every route file, with lint green — the house-rules spec only probed `app/components/`. Fixed by using `no-console` for the server ban (a different rule id, so nothing can collide) and moving the loader/action selectors into the existing array. The cost is that `no-console`'s message is fixed and cannot name `reportServerError`; that trade is documented in the config.

The last commit fixes the *class* of it rather than the instance. My first guard was a per-scope spot check, which guessed at two scopes and two rules, and guessing which scopes are worth probing is what left the hole to begin with. It now resolves the real ESLint config for all 701 source files under `apps/**` and `shared/**` and asserts the shape of the answer: no file gets a partial rule set (which is exactly what a clobber produces), no file is exempt except through one of the four exceptions `ignores` declares (so switching a subset off entirely cannot pass as "exempt"), and each declared exception still exempts something. Three mutations cover it, including one that re-creates the broken config verbatim; each fails a different, specific assertion. It costs under a second, because ESLint caches config resolution per directory.

**Client-side reporting is consent-gated.** `posthog-js` is initialized `opt_out_capturing_by_default: true` and only opts in on analytics consent, so browser-side reports cover consenting sessions only. That is the privacy policy working as written, not a bug — and it is why the server sink is not optional and has its own runtime spec.

**A server-thrown loader error produces two events**, one `error_source: 'server'` and one `client-boundary`. Deliberate: the pair distinguishes "the server threw" from "a person saw a broken page", and the alternative heuristics for suppressing the client one were all fragile.

**Known cost.** Removing the two duplicate logs in `asset-storage.server.ts` means the rethrown wrapper is what gets reported. Its message interpolates the original's, but the original's stack is lost — a consequence of the deliberate "name, message, stack, checked" redaction rule. If you want cause chains reported, that is a change to `redactError` and needs its own redaction pass.

**Review was done inline rather than by subagent fan-out**, per this session's configuration. It found the flat-config regression above, a `window.location.pathname` read that should have been the router's location, a `JSON.stringify` that throws on circular thrown values *inside the error reporter*, and the two tautological tests.

