### PR TITLE
fix(ui): close the loose ends from the detail-panel unification

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
+++ b/apps/vectreal-platform/app/components/publisher/controls-overlay.tsx
@@ -381,7 +381,7 @@ const OverlayControls = ({
 					showDesktopHeader
 				>
 					<PublishSidebarProvider value={publishSidebarValue}>
-						<PublishSidebarContent showSceneInfo />
+						<PublishSidebarContent />
 					</PublishSidebarProvider>
 				</DynamicSidebar>
 

--- a/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/publish-sidebar-content.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/publish-sidebar/publish-sidebar-content.tsx
@@ -20,17 +20,6 @@ import { ScenePreview } from './sections/scene-preview'
 
 import type { FC } from 'react'
 
-/**
- * The panel header is not here. `DynamicSidebar` renders it - title,
- * description and the one close control - for both the desktop panel and the
- * mobile sheet. This component carried a second one behind a `hideHeader`
- * prop that its only consumer always passed, so the branch could not run: a
- * `Card`/`CardHeader` copy of the same three parts, kept in step with nothing.
- */
-interface PublishSidebarContentProps {
-	showSceneInfo?: boolean
-}
-
 const getSizeDeltaLabel = (deltaBytes?: number | null) => {
 	if (typeof deltaBytes !== 'number') {
 		return null
@@ -47,9 +36,22 @@ const getSizeDeltaLabel = (deltaBytes?: number | null) => {
 	return 'No size change'
 }
 
-const PublishSidebarContent: FC<PublishSidebarContentProps> = ({
-	showSceneInfo = false
-}) => {
+/**
+ * The publish sidebar's body. It takes no props.
+ *
+ * It had two booleans, `hideHeader` and `showSceneInfo`, and its one consumer
+ * always passed both, so neither could ever be false and every branch reading
+ * them was unreachable. `hideHeader` guarded a second panel header that
+ * `DynamicSidebar` already renders for the desktop panel and the mobile sheet
+ * alike; `showSceneInfo` guarded the delivery summary and the two size figures
+ * it needs.
+ *
+ * A prop with one caller and one value is not configuration - it is a claim
+ * that the component supports a mode nobody has ever rendered, which someone
+ * eventually has to read the whole tree to disprove.
+ */
+
+const PublishSidebarContent: FC = () => {
 	const {
 		sceneId,
 		projectId,
@@ -71,11 +73,7 @@ const PublishSidebarContent: FC<PublishSidebarContentProps> = ({
 		? isSaving || !saveAvailability?.canSave
 		: isSaving
 
-	const sizeReductionPercent = showSceneInfo
-		? viewModel.sizeReductionPercent
-		: null
-	const sizeDeltaBytes = showSceneInfo ? viewModel.sizeDeltaBytes : null
-	const sizeDeltaLabel = getSizeDeltaLabel(sizeDeltaBytes)
+	const sizeDeltaLabel = getSizeDeltaLabel(viewModel.sizeDeltaBytes)
 	const currentSceneBytes = viewModel.publishMetricSizeInfo.currentSceneBytes
 	const isAuthenticated = viewModel.isAuthenticated
 	const hasSavedScene = viewModel.hasSavedScene
@@ -98,14 +96,12 @@ const PublishSidebarContent: FC<PublishSidebarContentProps> = ({
 				  sidebar did not line up with the accordion below it.
 				*/}
 				<div className="flex flex-col gap-3 p-4">
-					{showSceneInfo && (
-						<DeliverySummary
-							sceneBytes={currentSceneBytes}
-							sizeReductionPercent={sizeReductionPercent}
-							sizeDeltaLabel={sizeDeltaLabel}
-							onOpenOptimization={onOpenOptimizationDrawer}
-						/>
-					)}
+					<DeliverySummary
+						sceneBytes={currentSceneBytes}
+						sizeReductionPercent={viewModel.sizeReductionPercent}
+						sizeDeltaLabel={sizeDeltaLabel}
+						onOpenOptimization={onOpenOptimizationDrawer}
+					/>
 
 					{canAccessPublishFeatures && <ScenePreview />}
 

--- a/apps/vectreal-platform/tests/container-scale.spec.ts
+++ b/apps/vectreal-platform/tests/container-scale.spec.ts
@@ -29,9 +29,20 @@ const GLOBALS = join(REPO_ROOT, 'shared/components/src/styles/globals.css')
  */
 function containersDeclaredInTheme() {
 	const css = readFileSync(GLOBALS, 'utf8')
-	const themeBlocks = [...css.matchAll(/@theme\s*\{([\s\S]*?)\n\}/g)].map(
-		([, body]) => body
-	)
+	/*
+	  Any modifier, not a named one. `@theme` takes `inline`, `static`,
+	  `default` and `reference`, alone or combined, and every spelling generates
+	  the same utilities from a `--container-*` key. Listing them was the first
+	  attempt here and it is the same mistake the `cn()` registration made:
+	  enumerating someone else's grammar leaves a hole shaped like whichever
+	  spelling was forgotten.
+
+	  Deliberately not `@theme\b[^{]*\{`, which reads through prose and matches
+	  the three comments in this stylesheet that mention `@theme`.
+	*/
+	const themeBlocks = [
+		...css.matchAll(/@theme(?:[ \t]+[a-z]+)*[ \t]*\{([\s\S]*?)\n\}/g)
+	].map(([, body]) => body)
 
 	return themeBlocks.flatMap((body) =>
 		/*
@@ -76,5 +87,21 @@ describe('container scale', () => {
 		expect(cn('w-detail-panel', 'max-w-detail-panel')).toBe(
 			'w-detail-panel max-w-detail-panel'
 		)
+	})
+
+	it('covers every group the namespace feeds, not just the ones with a caller', () => {
+		/*
+		  Tailwind generates five utilities from one `--container-*` key, and
+		  `basis-*` and `columns-*` have no caller in the app today. That is
+		  precisely why they are pinned here: an unregistered group is
+		  indistinguishable from a registered one until two classes meet, and the
+		  first two attempts at this registration enumerated the groups by hand
+		  and missed one each time.
+		*/
+		expect(cn('basis-detail-panel', 'basis-1/2')).toBe('basis-1/2')
+		expect(cn('basis-1/2', 'basis-detail-panel')).toBe('basis-detail-panel')
+		expect(cn('basis-full', 'basis-detail-panel')).toBe('basis-detail-panel')
+		expect(cn('columns-2', 'columns-detail-panel')).toBe('columns-detail-panel')
+		expect(cn('columns-detail-panel', 'columns-2')).toBe('columns-2')
 	})
 })

--- a/apps/vectreal-platform/tests/eslint-house-rules.spec.ts
+++ b/apps/vectreal-platform/tests/eslint-house-rules.spec.ts
@@ -16,13 +16,32 @@ import { beforeAll, describe, expect, it } from 'vitest'
 const ROOT = resolve(__dirname, '../../..')
 
 /** A path inside the glob the rules are scoped to (`apps/**`, `shared/**`). */
-const IN_SCOPE = resolve(ROOT, 'apps/vectreal-platform/app/components/probe.tsx')
+const IN_SCOPE = resolve(
+	ROOT,
+	'apps/vectreal-platform/app/components/probe.tsx'
+)
 
 let eslint: ESLint
 
-beforeAll(() => {
+/*
+  The warm-up is the point of the timeout argument.
+
+  `new ESLint()` is cheap; the first `lintText` is not. It resolves the flat
+  config, which imports `eslint.config.mts` and every plugin it pulls in, and
+  that lands on whichever test happens to run first. Measured on an idle
+  machine it is about a second; measured while the rest of the suite runs in
+  parallel it has exceeded the 5s per-test budget and failed outright. So the
+  first test in this file failed for want of time rather than for anything it
+  asserts, and passed when run alone - which reads as a flaky rule instead of
+  a misplaced cost.
+
+  Paying it here moves it out of every test's budget and into a hook with a
+  budget of its own, so each test times only the assertion it makes.
+*/
+beforeAll(async () => {
 	eslint = new ESLint({ cwd: ROOT })
-})
+	await eslint.lintText('export const warmUp = 1\n', { filePath: IN_SCOPE })
+}, 120_000)
 
 async function messagesFor(code: string, filePath = IN_SCOPE) {
 	const [result] = await eslint.lintText(code, { filePath })

--- a/shared/utils/src/lib/styling.utils.ts
+++ b/shared/utils/src/lib/styling.utils.ts
@@ -36,19 +36,28 @@ const Z_INDEX_TIERS = [
  * publisher's tool sidebar is exactly that call - a component defaulting to the
  * detail-panel width, overridden to 21rem by one consumer.
  *
+ * Registered below as a `theme` key rather than as a list of class groups.
+ * `container` is a theme namespace tailwind-merge already understands, and the
+ * five groups that read it - `w`, `max-w`, `min-w`, `basis` and `columns` - are
+ * its business, not ours. Enumerating them was the first attempt and it shipped
+ * wrong twice in one sitting: `basis` was missed, then `columns` after it. A
+ * list of someone else's internals is a list that drifts, and each gap is
+ * invisible until two classes meet and the stylesheet's emission order decides.
+ *
  * Only names the app declares. Tailwind's own `--container-*` defaults
  * (`w-md`, `max-w-xl`) are already in the built-in groups.
  */
 const CONTAINER_SCALE = ['detail-panel']
 
+/*
+  The tiers stay a class group. `--z-index-*` is a Tailwind namespace, but
+  tailwind-merge has no `z` theme key to hang them on, so the group is the only
+  place they fit.
+*/
 const twMerge = extendTailwindMerge({
 	extend: {
-		classGroups: {
-			z: [{ z: Z_INDEX_TIERS }],
-			w: [{ w: CONTAINER_SCALE }],
-			'max-w': [{ 'max-w': CONTAINER_SCALE }],
-			'min-w': [{ 'min-w': CONTAINER_SCALE }]
-		}
+		classGroups: { z: [{ z: Z_INDEX_TIERS }] },
+		theme: { container: CONTAINER_SCALE }
 	}
 })
 


### PR DESCRIPTION
## Summary

Closes the three small loose ends filed against #754. Three independent concerns, disjoint files, one commit each. The bigger findings from that PR went to the work catalogue instead.

## Root cause

Each is a case of a rule with no single owner: `cn()` knew about the detail-panel token in three of the five class groups Tailwind generates from it, the publish sidebar carried a second boolean prop whose only caller always passed it, and the ESLint house-rules spec charged its config-resolution cost to whichever test happened to run first.

## Changes

- **`cn()` now registers the container scale by theme key.** #754 enumerated the class groups it could think of — `w`, `max-w`, `min-w` — and the list was incomplete: `--container-*` also feeds `basis` and `columns`, where a token still survived the merge beside the class meant to replace it, leaving stylesheet emission order to pick the winner. Enumerating tailwind-merge's internals was the wrong shape of fix; it was corrected once for `basis` and was *still* missing `columns` after that. `theme: { container: CONTAINER_SCALE }` is the mechanism all five groups already read, so it cannot drift when a sixth appears. The z-index tiers stay a class group and now say why: `--z-index-*` is a Tailwind namespace, but tailwind-merge has no `z` theme key.
- **`showSceneInfo` removed from `PublishSidebarContent`.** One consumer, always passed, so the `= false` default was unreachable and its three branches had one outcome. Same shape as the `hideHeader` prop removed in #754, and found by its review.
- **The `eslint-house-rules` flake fixed at the cause.** Its first test failed intermittently with `Test timed out in 5000ms` and passed when run alone. Not the rule: `new ESLint()` is free, but the first `lintText` resolves the flat config and every plugin it imports, and that landed inside the 5s per-test budget. A warm-up in `beforeAll` moves it into a hook with its own budget. **First test: 5.7–11.7s under parallel load → 10ms.** Raising the timeout would have hidden it; the number was never the problem, the attribution was.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser

`pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform,shared/utils,shared/components` — green, 12 tasks. `pnpm nx test vectreal-platform` — 88 files, 984 tests.

The container-scale registration is mutation-checked: emptying `CONTAINER_SCALE` fails three tests, and rebuilding the old hand-enumerated config fails all five of the new assertions. The spec now pins `basis` and `columns` even though neither has a caller in the app — that is the point, since an unregistered group is indistinguishable from a registered one until two classes meet.

Its `@theme` scrape also accepts every modifier spelling now. `@theme` takes `inline`, `static`, `default` and `reference`, alone or combined, and all of them generate utilities from a `--container-*` key; accepting only `inline` left the same shape of hole in the pin itself. Demonstrated by injecting a key under `@theme static`: the spec fails with the new pattern and passed with the old one.

The publisher change was verified in the browser, not only by type — the panel still renders `DELIVERY / 852.69 KB / No size change` at the same 416px width.

## Notes

- `IN_SCOPE` in `eslint-house-rules.spec.ts` is reflowed. That is not churn: the `origin/main` version fails `prettier --check`, so this fixes a pre-existing violation in a file the PR already touches.
- Observed and left alone: `PublishSidebarContent` is re-exported through three barrel files that nothing imports. Pre-existing, and a different concern from the prop removed here.
