### PR TITLE
fix(publisher): rebuild the hotspot panel on the shell's own surfaces

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 /**
- * When the panel gives up the click-to-place arming it took.
+ * The panel's two contracts with state that outlives it: the click-to-place
+ * arming it takes from an atom, and the playback order it writes back.
  *
  * The arming lives in an atom, which outlives the panel that set it. Switching
  * compose tools unmounts the panel without deselecting anything, so the canvas
@@ -9,7 +10,7 @@
  * editing.
  */
 
-import { act, render } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { getDefaultStore } from 'jotai'
 import { describe, expect, it, beforeEach } from 'vitest'
 
@@ -51,13 +52,38 @@ const arrange = () => {
 	store.set(isClickToPlaceActiveAtom, true)
 }
 
-describe('HotspotsSettingsPanel arming', () => {
-	beforeEach(() => {
-		store.set(hotspotsAtom, [])
-		store.set(activeHotspotIdAtom, null)
-		store.set(isClickToPlaceActiveAtom, false)
-	})
+/** A sequence of `count` markers, all in the playback order, numbered from zero. */
+const sequence = (count: number): HotspotDefinition[] =>
+	Array.from({ length: count }, (_, index) => ({
+		...hotspot,
+		id: `0000000${index}-0000-4000-8000-000000000001`,
+		name: `Marker ${index + 1}`,
+		sequenceIndex: index,
+		linkedCameraId: undefined
+	}))
 
+const orderOfNames = () =>
+	store.get(hotspotsAtom)
+		.filter((entry) => entry.sequenceIndex !== undefined)
+		.sort((a, b) => (a.sequenceIndex as number) - (b.sequenceIndex as number))
+		.map((entry) => entry.name)
+
+const handleFor = (name: string) =>
+	screen.getByRole('button', { name: `Reorder ${name}` })
+
+const rowTriggers = () =>
+	screen
+		.getAllByRole('button')
+		.filter((element) => element.hasAttribute('aria-expanded'))
+
+beforeEach(() => {
+	store.set(hotspotsAtom, [])
+	store.set(activeHotspotIdAtom, null)
+	store.set(isClickToPlaceActiveAtom, false)
+	store.set(cameraAtom, { cameras: [] })
+})
+
+describe('HotspotsSettingsPanel arming', () => {
 	it('disarms click-to-place when the panel unmounts', () => {
 		arrange()
 		const { unmount } = render(<HotspotsSettingsPanel />)
@@ -67,6 +93,24 @@ describe('HotspotsSettingsPanel arming', () => {
 		unmount()
 
 		expect(store.get(isClickToPlaceActiveAtom)).toBe(false)
+	})
+
+	/**
+	 * The selection is the other half of the same defect the arming cleanup was
+	 * written for, one atom over: `activeHotspotIdAtom` is what puts the transform
+	 * gizmo on the canvas, and it outlives the panel too. Closing the tool drawer
+	 * left a gizmo floating over the model with no panel to explain it and no way
+	 * to dismiss it short of reopening the tool.
+	 */
+	it('drops the selection when the panel unmounts', () => {
+		arrange()
+		const { unmount } = render(<HotspotsSettingsPanel />)
+
+		expect(store.get(activeHotspotIdAtom)).toBe(hotspot.id)
+
+		unmount()
+
+		expect(store.get(activeHotspotIdAtom)).toBeNull()
 	})
 
 	/**
@@ -97,5 +141,185 @@ describe('HotspotsSettingsPanel arming', () => {
 		act(() => {})
 
 		expect(store.get(isClickToPlaceActiveAtom)).toBe(true)
+	})
+})
+
+describe('HotspotsSettingsPanel selection', () => {
+	/**
+	 * Being open is being selected. Nothing else marks the row, so a disclosure
+	 * that does not reach the atom leaves the canvas gizmo pointed elsewhere.
+	 */
+	it('selects the hotspot whose row is expanded', () => {
+		store.set(hotspotsAtom, sequence(2))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.click(rowTriggers()[1])
+		})
+
+		expect(store.get(activeHotspotIdAtom)).toBe(sequence(2)[1].id)
+	})
+
+	it('opens at most one row at a time', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.click(rowTriggers()[0])
+		})
+		act(() => {
+			fireEvent.click(rowTriggers()[2])
+		})
+
+		expect(
+			rowTriggers().filter(
+				(trigger) => trigger.getAttribute('aria-expanded') === 'true'
+			)
+		).toHaveLength(1)
+	})
+
+	/**
+	 * `DynamicSidebar` already draws "Hotspots" and the tool's description above
+	 * this panel, so a section of the same name printed the word twice.
+	 */
+	it('draws no heading of its own repeating the tool name', () => {
+		store.set(hotspotsAtom, sequence(1))
+		render(<HotspotsSettingsPanel />)
+
+		expect(screen.queryByRole('heading', { name: 'Hotspots' })).toBeNull()
+		expect(screen.getByRole('heading', { name: 'Markers' })).toBeTruthy()
+	})
+
+	it('offers the asset field only for a preset that needs one', () => {
+		store.set(hotspotsAtom, [{ ...hotspot, sequenceIndex: 0 }])
+		store.set(activeHotspotIdAtom, hotspot.id)
+		const { rerender } = render(<HotspotsSettingsPanel />)
+
+		expect(screen.queryByLabelText('Asset URL')).toBeNull()
+
+		act(() => {
+			store.set(hotspotsAtom, [
+				{ ...hotspot, sequenceIndex: 0, stylePreset: 'image' }
+			])
+		})
+		rerender(<HotspotsSettingsPanel />)
+
+		expect(screen.getByLabelText('Asset URL')).toBeTruthy()
+	})
+})
+
+describe('HotspotsSettingsPanel ordering', () => {
+	it('moves a marker one step down the sequence', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 1'), { key: 'ArrowDown' })
+		})
+
+		expect(orderOfNames()).toEqual(['Marker 2', 'Marker 1', 'Marker 3'])
+	})
+
+	it('moves a marker one step up the sequence', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 3'), { key: 'ArrowUp' })
+		})
+
+		expect(orderOfNames()).toEqual(['Marker 1', 'Marker 3', 'Marker 2'])
+	})
+
+	it('leaves the order alone at the ends', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 1'), { key: 'ArrowUp' })
+		})
+
+		expect(orderOfNames()).toEqual(['Marker 1', 'Marker 2', 'Marker 3'])
+		expect(screen.getByRole('status').textContent).toBe('')
+	})
+
+	it('sends a marker to the end of the sequence', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 1'), { key: 'End' })
+		})
+
+		expect(orderOfNames()).toEqual(['Marker 2', 'Marker 3', 'Marker 1'])
+	})
+
+	/**
+	 * A reorder that leaves focus on the document body strands a keyboard user
+	 * mid-sequence: the next arrow press goes nowhere and the list has to be
+	 * tabbed back into. React keeps the node only while the key is the id.
+	 */
+	it('keeps focus on the handle it was moved with', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		const handle = handleFor('Marker 1')
+		handle.focus()
+
+		act(() => {
+			fireEvent.keyDown(handle, { key: 'ArrowDown' })
+		})
+
+		expect(document.activeElement).toBe(handleFor('Marker 1'))
+	})
+
+	it('announces where the marker landed', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 1'), { key: 'ArrowDown' })
+		})
+
+		expect(screen.getByRole('status').textContent).toBe(
+			'Marker 1 moved to step 2 of 3.'
+		)
+	})
+
+	/**
+	 * The step on the row is the step a visitor is shown, and `@vctrl/viewer`
+	 * ranks among the markers a visitor can reach rather than printing the
+	 * stored index. A hidden marker holding slot 0 must not push the first
+	 * reachable one to "2".
+	 */
+	it('numbers the steps a visitor will actually see', () => {
+		const [first, second] = sequence(2)
+		store.set(hotspotsAtom, [{ ...first, visible: false }, second])
+		render(<HotspotsSettingsPanel />)
+
+		const rows = screen.getAllByRole('listitem')
+
+		expect(within(rows[0]).queryByText('1')).toBeNull()
+		expect(within(rows[1]).getByText('1')).toBeTruthy()
+	})
+
+	it('closes the gap a deleted marker leaves in the sequence', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.click(
+				screen.getByRole('button', { name: 'Delete Marker 2' })
+			)
+		})
+
+		expect(
+			store
+				.get(hotspotsAtom)
+				.map((entry) => [entry.name, entry.sequenceIndex])
+		).toEqual([
+			['Marker 1', 0],
+			['Marker 3', 1]
+		])
 	})
 })

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
@@ -63,10 +63,23 @@ const sequence = (count: number): HotspotDefinition[] =>
 	}))
 
 const orderOfNames = () =>
-	store.get(hotspotsAtom)
+	store
+		.get(hotspotsAtom)
 		.filter((entry) => entry.sequenceIndex !== undefined)
 		.sort((a, b) => (a.sequenceIndex as number) - (b.sequenceIndex as number))
 		.map((entry) => entry.name)
+
+/**
+ * The live announcement. Two regions are rendered and used alternately so a
+ * repeated message still counts as a change, so the live one is whichever has
+ * text.
+ */
+const announcement = () =>
+	screen
+		.getAllByRole('status')
+		.map((region) => region.textContent)
+		.filter(Boolean)
+		.join('')
 
 const handleFor = (name: string) =>
 	screen.getByRole('button', { name: `Reorder ${name}` })
@@ -231,7 +244,11 @@ describe('HotspotsSettingsPanel ordering', () => {
 		expect(orderOfNames()).toEqual(['Marker 1', 'Marker 3', 'Marker 2'])
 	})
 
-	it('leaves the order alone at the ends', () => {
+	/**
+	 * Silence at an end is indistinguishable from a key that does nothing, so
+	 * the refusal is spoken rather than swallowed.
+	 */
+	it('refuses a move at the ends, and says so', () => {
 		store.set(hotspotsAtom, sequence(3))
 		render(<HotspotsSettingsPanel />)
 
@@ -240,7 +257,25 @@ describe('HotspotsSettingsPanel ordering', () => {
 		})
 
 		expect(orderOfNames()).toEqual(['Marker 1', 'Marker 2', 'Marker 3'])
-		expect(screen.getByRole('status').textContent).toBe('')
+		expect(announcement()).toBe('Marker 1 is already first.')
+	})
+
+	/**
+	 * "Position", not "step". The badge on a row is what a visitor is shown, and
+	 * `resolveHotspotMarkers` ranks that over the markers a visitor can reach.
+	 * This list is the authoring order and counts hidden members too, so one
+	 * word for both would announce a number that is on screen nowhere.
+	 */
+	it('announces a move in authoring positions, not visitor steps', () => {
+		const [first, second, third] = sequence(3)
+		store.set(hotspotsAtom, [{ ...first, visible: false }, second, third])
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 3'), { key: 'ArrowUp' })
+		})
+
+		expect(announcement()).toBe('Marker 3 moved to position 2 of 3.')
 	})
 
 	it('sends a marker to the end of the sequence', () => {
@@ -281,9 +316,109 @@ describe('HotspotsSettingsPanel ordering', () => {
 			fireEvent.keyDown(handleFor('Marker 1'), { key: 'ArrowDown' })
 		})
 
-		expect(screen.getByRole('status').textContent).toBe(
-			'Marker 1 moved to step 2 of 3.'
-		)
+		expect(announcement()).toBe('Marker 1 moved to position 2 of 3.')
+	})
+
+	/**
+	 * A hidden marker is still in the sequence; it just carries no step, which
+	 * is why its badge is a dash. Announcing that as "not in the sequence"
+	 * contradicted both the group it sits in and its own switch.
+	 */
+	it('keeps a hidden marker in the sequence it belongs to', () => {
+		const [first, second] = sequence(2)
+		store.set(hotspotsAtom, [{ ...first, visible: false }, second])
+		render(<HotspotsSettingsPanel />)
+
+		const rows = screen.getAllByRole('listitem')
+
+		expect(
+			within(rows[0]).getByText(
+				/in the sequence, no step in the published scene/
+			)
+		).toBeTruthy()
+		expect(within(rows[0]).queryByText(/, not in the sequence/)).toBeNull()
+	})
+
+	/**
+	 * "Hidden" is not the only reason a step is withheld: `resolveHotspotMarkers`
+	 * also drops an editor-only marker. Saying "while hidden" for one whose
+	 * "Visible to viewers" switch is on contradicts the switch.
+	 */
+	it('does not call an editor-only marker hidden', () => {
+		const [first, second] = sequence(2)
+		store.set(hotspotsAtom, [{ ...first, internalOnly: true }, second])
+		render(<HotspotsSettingsPanel />)
+
+		const rows = screen.getAllByRole('listitem')
+
+		expect(within(rows[0]).getByText(/editor only/)).toBeTruthy()
+		expect(within(rows[0]).queryByText(/hidden/)).toBeNull()
+	})
+
+	/**
+	 * A live region speaks on mutation, and React bails out of an identical
+	 * `setState`, so a refusal repeated verbatim used to speak once and then go
+	 * quiet - the silence the refusal message exists to remove.
+	 */
+	it('repeats a refusal rather than falling silent', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		const slots = () =>
+			screen.getAllByRole('status').map((region) => region.textContent)
+
+		// Three, not two: the first attempt at this alternated a trailing
+		// zero-width space, which saturates on the third repeat and goes silent
+		// again. A two-press test could not see that.
+		const seen: string[][] = []
+		for (let press = 0; press < 3; press += 1) {
+			act(() => {
+				fireEvent.keyDown(handleFor('Marker 1'), { key: 'ArrowUp' })
+			})
+			seen.push(slots())
+			expect(announcement()).toBe('Marker 1 is already first.')
+		}
+
+		// Each press must land in a region that was empty, so every one of them
+		// is an insertion rather than an unchanged node.
+		expect(seen[0]).not.toEqual(seen[1])
+		expect(seen[1]).not.toEqual(seen[2])
+	})
+
+	/**
+	 * With one member `from` is always 0, so reading the end off the index
+	 * announced "already first" for a press asking to go last.
+	 */
+	it('names the end the press was aiming for', () => {
+		store.set(hotspotsAtom, sequence(1))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 1'), { key: 'ArrowDown' })
+		})
+
+		expect(announcement()).toBe('Marker 1 is already last.')
+	})
+
+	/**
+	 * Two genuine moves that happen to cancel out. Both are edits, so both are
+	 * announced - the drag-released-where-it-began case, which is not reachable
+	 * from the keyboard, is pinned on `applySequenceMove` instead.
+	 */
+	it('returns a marker to where it started, announcing each leg', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 1'), { key: 'ArrowDown' })
+		})
+		expect(announcement()).toBe('Marker 1 moved to position 2 of 3.')
+
+		act(() => {
+			fireEvent.keyDown(handleFor('Marker 1'), { key: 'ArrowUp' })
+		})
+		expect(announcement()).toBe('Marker 1 moved to position 1 of 3.')
+		expect(orderOfNames()).toEqual(['Marker 1', 'Marker 2', 'Marker 3'])
 	})
 
 	/**
@@ -303,20 +438,34 @@ describe('HotspotsSettingsPanel ordering', () => {
 		expect(within(rows[1]).getByText('1')).toBeTruthy()
 	})
 
+	/**
+	 * Deleting removes a row, drops focus and renumbers every later step. A
+	 * reorder one row up announces itself; saying nothing here read as an
+	 * oversight rather than a decision.
+	 */
+	it('announces a deletion and what it left behind', () => {
+		store.set(hotspotsAtom, sequence(3))
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.click(screen.getByRole('button', { name: 'Delete Marker 2' }))
+		})
+
+		expect(announcement()).toBe(
+			'Marker 2 deleted. 2 markers left in the sequence.'
+		)
+	})
+
 	it('closes the gap a deleted marker leaves in the sequence', () => {
 		store.set(hotspotsAtom, sequence(3))
 		render(<HotspotsSettingsPanel />)
 
 		act(() => {
-			fireEvent.click(
-				screen.getByRole('button', { name: 'Delete Marker 2' })
-			)
+			fireEvent.click(screen.getByRole('button', { name: 'Delete Marker 2' }))
 		})
 
 		expect(
-			store
-				.get(hotspotsAtom)
-				.map((entry) => [entry.name, entry.sequenceIndex])
+			store.get(hotspotsAtom).map((entry) => [entry.name, entry.sequenceIndex])
 		).toEqual([
 			['Marker 1', 0],
 			['Marker 3', 1]

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -1,7 +1,19 @@
 import { Badge } from '@shared/components/ui/badge'
 import { Button } from '@shared/components/ui/button'
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger
+} from '@shared/components/ui/collapsible'
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle
+} from '@shared/components/ui/empty'
 import { Input } from '@shared/components/ui/input'
-import { Label } from '@shared/components/ui/label'
 import {
 	Select,
 	SelectContent,
@@ -9,11 +21,23 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@shared/components/ui/select'
-import { Switch } from '@shared/components/ui/switch'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@shared/components/ui/tooltip'
 import { cn } from '@shared/utils'
+import { resolveHotspotMarkers } from '@vctrl/viewer'
+import { AnimatePresence, Reorder, motion, useDragControls, useReducedMotion } from 'framer-motion'
 import { useAtom, useSetAtom } from 'jotai/react'
-import { Crosshair, Eye, EyeOff, Plus, Trash2 } from 'lucide-react'
-import { memo, useCallback, useEffect, useMemo } from 'react'
+import {
+	ChevronDown,
+	Crosshair,
+	EyeOff,
+	GripVertical,
+	Locate,
+	Plus,
+	SquarePen,
+	Trash2
+} from 'lucide-react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
 
 import {
 	PAIRED_HOTSPOT_CAMERA_ID_PREFIX,
@@ -25,7 +49,10 @@ import {
 	removeHotspot,
 	renameHotspot
 } from '../../../../lib/domain/scene/scene-hotspot-camera-links'
-import { assignSequenceIndex } from '../../../../lib/domain/scene/scene-hotspot-sequence'
+import {
+	reorderSequence,
+	setSequenceMembership
+} from '../../../../lib/domain/scene/scene-hotspot-sequence'
 import { isClickToPlaceActiveAtom } from '../../../../lib/stores/publisher-config-store'
 import {
 	activeHotspotIdAtom,
@@ -33,13 +60,9 @@ import {
 	hotspotsAtom,
 	selectedCameraIdAtom
 } from '../../../../lib/stores/scene-settings-store'
-import { ToggleButtonGroup } from '../../settings-components'
-import {
-	SidebarSection,
-	SidebarSectionContent,
-	SettingRow,
-	SettingGroup
-} from '../sidebar-section'
+import { InlineNotice } from '../../../layout-components'
+import { SettingToggle, ToggleButtonGroup } from '../../settings-components'
+import { SidebarSection, SidebarSectionContent, SettingGroup } from '../sidebar-section'
 
 import type { ToggleButtonGroupOption } from '../../settings-components'
 import type {
@@ -47,6 +70,8 @@ import type {
 	HotspotDefinition,
 	HotspotStylePreset
 } from '@vctrl/core'
+import type { DragControls } from 'framer-motion'
+import type { ReactNode } from 'react'
 
 /**
  * `scene_hotspots.id` is a uuid primary key, so the hotspot id has to be a real
@@ -84,6 +109,284 @@ const STYLE_PRESET_OPTIONS: ToggleButtonGroupOption<HotspotStylePreset>[] = [
 	{ value: 'svg', label: 'SVG' }
 ]
 
+const AXES = ['X', 'Y', 'Z'] as const
+
+const sequencedFirst = (hotspots: readonly HotspotDefinition[]) => {
+	const inSequence = hotspots
+		.filter((hotspot) => hotspot.sequenceIndex !== undefined)
+		.sort((a, b) => (a.sequenceIndex as number) - (b.sequenceIndex as number))
+
+	return {
+		inSequence,
+		rest: hotspots.filter((hotspot) => hotspot.sequenceIndex === undefined)
+	}
+}
+
+/**
+ * One axis of the world-space position.
+ *
+ * The label is a prefix inside the well rather than a line above it: three
+ * stacked label lines cost about 54px in a 304px column where everything below
+ * the style presets is already off screen. The focus ring moves to the well so
+ * the affordance still reads at the size the input ends up.
+ *
+ * `SettingRow`'s label is a sibling with no `htmlFor`, so it names nothing to a
+ * screen reader. Until that is fixed in its owner, every field here carries its
+ * own `aria-label`.
+ */
+const AxisField = memo(
+	({
+		axis,
+		value,
+		onChange
+	}: {
+		axis: (typeof AXES)[number]
+		value: number
+		onChange: (raw: string) => void
+	}) => (
+		<div className="publisher-shell-nested focus-within:ring-ring flex items-center rounded-lg pl-2 focus-within:ring-2">
+			<span
+				aria-hidden
+				className="text-muted-foreground text-label-xs w-3 shrink-0 font-medium"
+			>
+				{axis}
+			</span>
+			<Input
+				type="number"
+				step="0.1"
+				aria-label={`${axis} position`}
+				value={value}
+				onChange={(event) => onChange(event.target.value)}
+				className="h-8 border-0 bg-transparent px-2 font-mono text-xs shadow-none focus-visible:ring-0"
+			/>
+		</div>
+	)
+)
+
+AxisField.displayName = 'AxisField'
+
+interface HotspotRowProps {
+	hotspot: HotspotDefinition
+	/** The step a visitor is shown, or null when this marker is outside the sequence. */
+	step: number | null
+	isOpen: boolean
+	reduceMotion: boolean
+	/** Present only for a marker in the sequence, which is the only one that reorders. */
+	dragControls?: DragControls
+	onOpenChange: (open: boolean) => void
+	onDelete: () => void
+	onMove?: (delta: number | 'first' | 'last') => void
+	children: ReactNode
+}
+
+/**
+ * One marker: a header row that is always visible, and its editor underneath.
+ *
+ * Being open *is* being selected. The panel used to fill the selected row with
+ * brand at 80% and print its coordinates on top in `--muted-foreground`, around
+ * 1.1:1 in dark. Expressing selection by disclosure instead means the state
+ * needs no colour at all, which is also what the surface ladder asks for:
+ * `globals.css` separates surfaces by value, never by an outline.
+ */
+const HotspotRow = memo(
+	({
+		hotspot,
+		step,
+		isOpen,
+		reduceMotion,
+		dragControls,
+		onOpenChange,
+		onDelete,
+		onMove,
+		children
+	}: HotspotRowProps) => {
+		const name = hotspot.name || 'Unnamed hotspot'
+		const hiddenFromViewers = !hotspot.visible || hotspot.internalOnly
+
+		return (
+			<Collapsible
+				open={isOpen}
+				onOpenChange={onOpenChange}
+				className="overflow-hidden rounded-xl"
+			>
+				<div className="publisher-shell-nested-interactive flex items-center gap-1 pr-1">
+					{dragControls && onMove ? (
+						<button
+							type="button"
+							aria-label={`Reorder ${name}`}
+							aria-keyshortcuts="ArrowUp ArrowDown Home End"
+							onPointerDown={(event) => dragControls.start(event)}
+							onKeyDown={(event) => {
+								const move = {
+									ArrowUp: -1,
+									ArrowDown: 1,
+									Home: 'first',
+									End: 'last'
+								}[event.key] as number | 'first' | 'last' | undefined
+
+								if (move === undefined) return
+								event.preventDefault()
+								onMove(move)
+							}}
+							className="publisher-shell-focus text-muted-foreground hover:text-foreground ml-1 flex size-6 shrink-0 cursor-grab touch-none items-center justify-center rounded-md active:cursor-grabbing"
+						>
+							<GripVertical aria-hidden className="size-3.5" />
+						</button>
+					) : (
+						<span aria-hidden className="ml-1 size-6 shrink-0" />
+					)}
+
+					{step === null ? (
+						<span
+							aria-hidden
+							className="text-muted-foreground/60 text-label-xs flex size-5 shrink-0 items-center justify-center"
+						>
+							&mdash;
+						</span>
+					) : (
+						<Badge
+							variant="secondary"
+							aria-hidden
+							className="text-label-xs flex size-5 shrink-0 justify-center px-0 tabular-nums"
+						>
+							{step}
+						</Badge>
+					)}
+
+					<CollapsibleTrigger asChild>
+						<button
+							type="button"
+							className="publisher-shell-focus flex min-w-0 flex-1 items-center gap-2 rounded-lg py-2 pr-1 pl-1 text-left"
+						>
+							<span className="min-w-0 flex-1">
+							<span
+								className={cn(
+									'block truncate text-sm leading-tight font-medium',
+									hiddenFromViewers && 'opacity-60'
+								)}
+							>
+								{name}
+							</span>
+							<span className="text-muted-foreground text-label-xs block font-mono tabular-nums">
+								{hotspot.worldPosition.map((axis) => axis.toFixed(2)).join(', ')}
+							</span>
+							<span className="sr-only">
+								{step === null ? ', not in the sequence' : `, step ${step}`}
+								{hotspot.internalOnly
+									? ', editor only'
+									: hotspot.visible
+										? ''
+										: ', hidden from viewers'}
+							</span>
+							</span>
+							<ChevronDown
+								aria-hidden
+								className={cn(
+									'text-muted-foreground size-3.5 shrink-0 transition-transform duration-150',
+									isOpen && 'rotate-180',
+									reduceMotion && 'transition-none'
+								)}
+							/>
+						</button>
+					</CollapsibleTrigger>
+
+					{!hotspot.visible && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<EyeOff
+									aria-hidden
+									className="text-muted-foreground size-3.5 shrink-0"
+								/>
+							</TooltipTrigger>
+							<TooltipContent>Hidden from viewers</TooltipContent>
+						</Tooltip>
+					)}
+					{hotspot.internalOnly && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<SquarePen
+									aria-hidden
+									className="text-muted-foreground size-3.5 shrink-0"
+								/>
+							</TooltipTrigger>
+							<TooltipContent>Editor only</TooltipContent>
+						</Tooltip>
+					)}
+
+					<Button
+						variant="ghost"
+						size="icon"
+						aria-label={`Delete ${name}`}
+						onClick={onDelete}
+						className="publisher-shell-focus text-muted-foreground hover:text-destructive size-7 shrink-0"
+					>
+						<Trash2 aria-hidden className="size-3.5" />
+					</Button>
+
+				</div>
+
+				<CollapsibleContent
+					className={cn(
+						'publisher-shell-nested overflow-hidden',
+						'data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down',
+						'motion-reduce:animate-none'
+					)}
+				>
+					<div className="space-y-4 px-3 pt-3 pb-4">{children}</div>
+				</CollapsibleContent>
+			</Collapsible>
+		)
+	}
+)
+
+HotspotRow.displayName = 'HotspotRow'
+
+/**
+ * A marker in the sequence, wrapped so it can be dragged.
+ *
+ * `useDragControls` is a hook, so it cannot be called inside the `map` that
+ * renders the list; one row owning one controller is what lets the drag start
+ * from the handle alone rather than from anywhere on the row, which would make
+ * the row impossible to click.
+ */
+const SequencedRow = ({
+	id,
+	reduceMotion,
+	onDragStart,
+	onDragEnd,
+	...rowProps
+}: Omit<HotspotRowProps, 'dragControls'> & {
+	id: string
+	onDragStart: () => void
+	onDragEnd: () => void
+}) => {
+	const dragControls = useDragControls()
+
+	return (
+		<Reorder.Item
+			value={id}
+			dragListener={false}
+			dragControls={dragControls}
+			onDragStart={onDragStart}
+			onDragEnd={onDragEnd}
+			layout={reduceMotion ? undefined : 'position'}
+			transition={
+				reduceMotion
+					? { duration: 0 }
+					: { type: 'spring', stiffness: 600, damping: 40 }
+			}
+			whileDrag={reduceMotion ? undefined : { scale: 1.02 }}
+			className="rounded-xl"
+		>
+			<HotspotRow
+				{...rowProps}
+				reduceMotion={reduceMotion}
+				dragControls={dragControls}
+			/>
+		</Reorder.Item>
+	)
+}
+
 const HotspotsSettingsPanel = memo(() => {
 	const [hotspots, setHotspots] = useAtom(hotspotsAtom)
 	const [camera, setCamera] = useAtom(cameraAtom)
@@ -93,6 +396,8 @@ const HotspotsSettingsPanel = memo(() => {
 		isClickToPlaceActiveAtom
 	)
 
+	const reduceMotion = useReducedMotion() ?? false
+	const [announcement, setAnnouncement] = useState('')
 	const allCameras = camera.cameras ?? []
 
 	/**
@@ -109,11 +414,104 @@ const HotspotsSettingsPanel = memo(() => {
 		}
 	}, [selectedId, setIsClickToPlaceActive])
 
+	/**
+	 * Both pieces of canvas state this panel takes are handed back when it goes.
+	 *
+	 * The selection is not bookkeeping: `activeHotspotIdAtom` is what puts the
+	 * transform gizmo on the model, and `DynamicSidebar` unmounts the panel when
+	 * the drawer closes. Keeping it left a gizmo floating over the scene with no
+	 * panel to explain it and nothing to dismiss it with, under a tool that was
+	 * no longer open.
+	 */
 	useEffect(
 		() => () => {
 			setIsClickToPlaceActive(false)
+			setSelectedId(null)
 		},
-		[setIsClickToPlaceActive]
+		[setIsClickToPlaceActive, setSelectedId]
+	)
+
+	const { inSequence, rest } = useMemo(
+		() => sequencedFirst(hotspots),
+		[hotspots]
+	)
+
+	/**
+	 * The step a visitor is actually shown.
+	 *
+	 * `resolveHotspotMarkers` owns this rule in `@vctrl/viewer`, and it ranks
+	 * among reachable markers rather than printing `sequenceIndex + 1`. Computing
+	 * an ordinal here instead would put a number on the row that nobody browsing
+	 * the published scene ever sees — a hidden marker holding a slot shifts every
+	 * step after it.
+	 */
+	const stepById = useMemo(() => {
+		const steps = new Map<string, number>()
+		for (const marker of resolveHotspotMarkers(hotspots)) {
+			if (marker.step !== null) steps.set(marker.id, marker.step)
+		}
+		return steps
+	}, [hotspots])
+
+	/**
+	 * The order the list shows while a drag is in flight.
+	 *
+	 * `Reorder.Group` fires `onReorder` on every adjacent swap, and `hotspotsAtom`
+	 * is read by the editor scene, so committing each one would re-render the 3D
+	 * view for every pixel of the drag. The atom is written once, on release —
+	 * the same shape `shadow-settings-panel` uses for its sliders, and the one
+	 * the hotspot gizmo itself landed on.
+	 */
+	const sequencedIds = useMemo(
+		() => inSequence.map((hotspot) => hotspot.id),
+		[inSequence]
+	)
+	const [draftOrder, setDraftOrder] = useState<string[]>(sequencedIds)
+	const isDraggingRef = useRef(false)
+
+	useEffect(() => {
+		if (isDraggingRef.current) return
+		setDraftOrder(sequencedIds)
+	}, [sequencedIds])
+
+	const commitOrder = useCallback(
+		(order: string[], movedId: string, movedName: string) => {
+			setHotspots((prev) => reorderSequence(prev, order))
+			setAnnouncement(
+				`${movedName} moved to step ${order.indexOf(movedId) + 1} of ${order.length}.`
+			)
+		},
+		[setHotspots]
+	)
+
+	const handleReorderEnd = useCallback(
+		(id: string, name: string) => {
+			isDraggingRef.current = false
+			commitOrder(draftOrder, id, name)
+		},
+		[commitOrder, draftOrder]
+	)
+
+	const handleKeyboardMove = useCallback(
+		(id: string, name: string, delta: number | 'first' | 'last') => {
+			const from = draftOrder.indexOf(id)
+			if (from < 0) return
+
+			const to =
+				delta === 'first'
+					? 0
+					: delta === 'last'
+						? draftOrder.length - 1
+						: from + delta
+
+			if (to < 0 || to >= draftOrder.length || to === from) return
+
+			const next = [...draftOrder]
+			next.splice(to, 0, ...next.splice(from, 1))
+			setDraftOrder(next)
+			commitOrder(next, id, name)
+		},
+		[commitOrder, draftOrder]
 	)
 
 	const selectedHotspot = useMemo(
@@ -139,11 +537,21 @@ const HotspotsSettingsPanel = memo(() => {
 		setSelectedId(ids.hotspotId)
 	}, [camera, hotspots, setCamera, setHotspots, setSelectedId])
 
+	/**
+	 * Deleting renumbers what is left.
+	 *
+	 * Removing step 2 of 3 used to leave indices 0 and 2. That was invisible
+	 * while a number field owned the display; now that the list *is* the order,
+	 * a gap would show as steps 1 and 3 with nothing between them.
+	 */
 	const handleDelete = useCallback(
 		(id: string) => {
 			const next = removeHotspot({ camera, hotspots }, id)
+			const survivingOrder = sequencedFirst(next.hotspots).inSequence.map(
+				(hotspot) => hotspot.id
+			)
 
-			setHotspots(next.hotspots)
+			setHotspots(reorderSequence(next.hotspots, survivingOrder))
 			setCamera(next.camera)
 			setSelectedCameraId((prev) =>
 				survivingSelectedCameraId(next.camera.cameras, prev)
@@ -197,296 +605,297 @@ const HotspotsSettingsPanel = memo(() => {
 		[selectedHotspot, updateHotspot]
 	)
 
-	/**
-	 * The server rejects duplicate sequence indices outright, with a message
-	 * naming the number and neither hotspot. Typing an index another hotspot
-	 * already holds swaps the two rather than creating that collision, which
-	 * is also what someone reordering a sequence expects.
-	 */
-	const handleSequenceChange = useCallback(
-		(raw: string) => {
-			if (!selectedHotspot) return
-
-			if (raw === '') {
-				setHotspots((prev) =>
-					assignSequenceIndex(prev, selectedHotspot.id, undefined)
-				)
-				return
-			}
-
-			const parsed = parseInt(raw, 10)
-			if (isNaN(parsed) || parsed < 0) return
-
-			setHotspots((prev) =>
-				assignSequenceIndex(prev, selectedHotspot.id, parsed)
-			)
+	const handleMembershipChange = useCallback(
+		(id: string, memberOfSequence: boolean) => {
+			setHotspots((prev) => setSequenceMembership(prev, id, memberOfSequence))
 		},
-		[selectedHotspot, setHotspots]
+		[setHotspots]
 	)
 
-	return (
-		<div className="space-y-8">
-			{/* Hotspots List */}
-			<SidebarSection
-				title="Hotspots"
-				tooltip="Hotspots mark interactive points in 3D space. They can trigger camera transitions or display custom overlays."
-			>
-				<SidebarSectionContent>
-					{hotspots.length === 0 ? (
-						<div className="py-6 text-center">
-							<p className="text-muted-foreground text-sm">No hotspots yet.</p>
-							<p className="text-muted-foreground mt-1 mb-4 text-xs">
-								Add one to create a point of interest for viewers.
-							</p>
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={handleAdd}
-								className="gap-1.5"
-							>
-								<Plus className="h-3.5 w-3.5" />
-								Add Hotspot
-							</Button>
-						</div>
-					) : (
-						<div className="space-y-1.5">
-							{hotspots.map((hotspot) => (
-								<div
-									key={hotspot.id}
-									className={cn(
-										'flex cursor-pointer items-center gap-3 rounded-md px-3 py-2 transition-colors',
-										selectedId === hotspot.id
-											? 'bg-orange/80'
-											: 'hover:bg-orange/40'
-									)}
-									onClick={() =>
-										setSelectedId((prev) =>
-											prev === hotspot.id ? null : hotspot.id
-										)
-									}
-								>
-									<div className="min-w-0 flex-1">
-										<p className="truncate text-sm leading-tight font-medium">
-											{hotspot.name || 'Unnamed Hotspot'}
-										</p>
-										<p className="text-muted-foreground font-mono text-xs">
-											{hotspot.worldPosition
-												.map((v) => v.toFixed(2))
-												.join(', ')}
-										</p>
-									</div>
-									<div className="flex shrink-0 items-center gap-1.5">
-										{hotspot.internalOnly && (
-											<Badge variant="secondary" className="text-xs">
-												Editor only
-											</Badge>
-										)}
-										{!hotspot.visible && (
-											<EyeOff className="text-muted-foreground h-3.5 w-3.5" />
-										)}
-										<Button
-											variant="ghost"
-											size="icon"
-											className="h-6 w-6"
-											onClick={(e) => {
-												e.stopPropagation()
-												handleDelete(hotspot.id)
-											}}
-											title="Delete hotspot"
-										>
-											<Trash2 className="h-3.5 w-3.5" />
-										</Button>
-									</div>
-								</div>
-							))}
-							<Button
-								variant="outline"
-								size="sm"
-								className="mt-3 w-full gap-1.5"
-								onClick={handleAdd}
-								title="Add hotspot"
-							>
-								<Plus className="h-3.5 w-3.5" />
-								Add Hotspot
-							</Button>
-						</div>
-					)}
-				</SidebarSectionContent>
-			</SidebarSection>
+	const renderEditor = useCallback(
+		(hotspot: HotspotDefinition) => (
+			<>
+				<InlineNotice tone={isClickToPlaceActive ? 'warning' : 'neutral'}>
+					{isClickToPlaceActive
+						? 'Click anywhere on the model to move this marker there.'
+						: 'Drag the marker in the scene, or place it from here.'}
+				</InlineNotice>
 
-			{/* Selected Hotspot Editor */}
-			{selectedHotspot && (
-				<SidebarSection title={`Edit: ${selectedHotspot.name || 'Unnamed'}`}>
-					<SidebarSectionContent>
-						{/* Click to Place Info */}
-						{isClickToPlaceActive && (
-							<div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2">
-								<p className="text-xs text-amber-700 dark:text-amber-400">
-									Click anywhere on the model to move this hotspot there.
-								</p>
-							</div>
+				<Button
+					variant={isClickToPlaceActive ? 'secondary' : 'outline'}
+					size="sm"
+					aria-pressed={isClickToPlaceActive}
+					onClick={() => setIsClickToPlaceActive((active) => !active)}
+					className="publisher-shell-focus w-full gap-1.5"
+				>
+					<Crosshair
+						aria-hidden
+						className={cn(
+							'size-3.5',
+							isClickToPlaceActive && 'animate-pulse motion-reduce:animate-none'
 						)}
+					/>
+					{isClickToPlaceActive ? 'Click the model…' : 'Place on model'}
+				</Button>
 
-						{/* Click to Place Button */}
-						<Button
-							variant={isClickToPlaceActive ? 'default' : 'outline'}
-							size="sm"
-							className="w-full gap-1.5"
-							onClick={() => setIsClickToPlaceActive((v) => !v)}
-							title="Click on the model to move this hotspot"
-						>
-							<Crosshair className="h-3.5 w-3.5" />
-							{isClickToPlaceActive ? 'Placing...' : 'Click to Place'}
-						</Button>
-
-						{/* Name */}
-						<SettingRow label="Name">
-							<Input
-								value={selectedHotspot.name}
-								onChange={(e) =>
-									handleRename(selectedHotspot.id, e.target.value)
-								}
-								placeholder="Hotspot name"
-								className="text-sm"
-							/>
-						</SettingRow>
-
-						{/* World Position */}
-						<SettingGroup
-							label="World Position"
-							description="3D world-space coordinates (X, Y, Z)"
-						>
-							<div className="grid grid-cols-3 gap-1.5">
-								{(['X', 'Y', 'Z'] as const).map((axis, idx) => (
-									<div key={axis} className="space-y-1">
-										<Label className="text-muted-foreground text-xs font-medium">
-											{axis}
-										</Label>
-										<Input
-											type="number"
-											step="0.1"
-											value={selectedHotspot.worldPosition[idx]}
-											onChange={(e) =>
-												handlePositionChange(idx as 0 | 1 | 2, e.target.value)
-											}
-											className="h-8 font-mono text-xs"
-										/>
-									</div>
-								))}
-							</div>
-						</SettingGroup>
-
-						{/* Style Preset */}
-						<SettingGroup label="Style">
-							<ToggleButtonGroup
-								options={STYLE_PRESET_OPTIONS}
-								value={selectedHotspot.stylePreset}
-								onChange={(v) =>
-									updateHotspot(selectedHotspot.id, { stylePreset: v })
+				<SettingGroup label="Position">
+					<div className="grid grid-cols-3 gap-1.5">
+						{AXES.map((axis, index) => (
+							<AxisField
+								key={axis}
+								axis={axis}
+								value={hotspot.worldPosition[index]}
+								onChange={(raw) =>
+									handlePositionChange(index as 0 | 1 | 2, raw)
 								}
 							/>
-						</SettingGroup>
+						))}
+					</div>
+				</SettingGroup>
 
-						{selectedHotspot.stylePreset !== 'dot' && (
-							<SettingRow label="Asset URL">
+				<SettingGroup label="Name">
+					<Input
+						aria-label="Marker name"
+						value={hotspot.name}
+						onChange={(event) => handleRename(hotspot.id, event.target.value)}
+						placeholder="Hotspot name"
+						className="text-sm"
+					/>
+				</SettingGroup>
+
+				<SettingGroup label="Style">
+					<ToggleButtonGroup
+						options={STYLE_PRESET_OPTIONS}
+						value={hotspot.stylePreset}
+						onChange={(preset) =>
+							updateHotspot(hotspot.id, { stylePreset: preset })
+						}
+					/>
+				</SettingGroup>
+
+				<AnimatePresence initial={false}>
+					{hotspot.stylePreset !== 'dot' && (
+						<motion.div
+							key="payload-url"
+							initial={{ height: 0, opacity: 0 }}
+							animate={{ height: 'auto', opacity: 1 }}
+							exit={{ height: 0, opacity: 0 }}
+							transition={{ duration: reduceMotion ? 0 : 0.15 }}
+							className="overflow-hidden"
+						>
+							<SettingGroup label="Asset URL">
 								<Input
-									value={selectedHotspot.payloadUrl ?? ''}
-									onChange={(e) =>
-										updateHotspot(selectedHotspot.id, {
-											payloadUrl: e.target.value || undefined
+									aria-label="Asset URL"
+									value={hotspot.payloadUrl ?? ''}
+									onChange={(event) =>
+										updateHotspot(hotspot.id, {
+											payloadUrl: event.target.value || undefined
 										})
 									}
 									placeholder="https://…"
 									className="text-sm"
 								/>
-							</SettingRow>
-						)}
+							</SettingGroup>
+						</motion.div>
+					)}
+				</AnimatePresence>
 
-						{/* Linked Camera */}
-						<SettingGroup
-							label="Linked Camera"
-							description="Viewers transition to this camera when clicking the hotspot"
+				<SettingGroup
+					label="Linked camera"
+					description="Viewers transition to this camera when they click the marker."
+				>
+					<Select
+						value={hotspot.linkedCameraId ?? 'none'}
+						onValueChange={(value) =>
+							handleRelink(hotspot.id, value === 'none' ? undefined : value)
+						}
+					>
+						<SelectTrigger aria-label="Linked camera" className="w-full">
+							<SelectValue placeholder="None" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="none">None</SelectItem>
+							{allCameras.map((entry) => (
+								<SelectItem key={entry.cameraId} value={entry.cameraId}>
+									{entry.name || entry.cameraId}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</SettingGroup>
+
+				<SettingToggle
+					enabled={hotspot.sequenceIndex !== undefined}
+					onToggle={(enabled) => handleMembershipChange(hotspot.id, enabled)}
+					title="In the sequence"
+					description="Include this marker in the order viewers step through."
+				/>
+
+				<SettingToggle
+					enabled={hotspot.visible}
+					onToggle={(enabled) =>
+						updateHotspot(hotspot.id, { visible: enabled })
+					}
+					title="Visible to viewers"
+					description="Show this marker in the published scene."
+				/>
+
+				<SettingToggle
+					enabled={hotspot.internalOnly}
+					onToggle={(enabled) =>
+						updateHotspot(hotspot.id, { internalOnly: enabled })
+					}
+					title="Editor only"
+					description="Keep the marker in the publisher and leave it out of the embed."
+				/>
+
+				<SettingToggle
+					enabled={hotspot.occlusionEnabled ?? true}
+					onToggle={(enabled) =>
+						updateHotspot(hotspot.id, { occlusionEnabled: enabled })
+					}
+					title="Hide behind geometry"
+					description="Fade the marker when part of the model is in front of it."
+				/>
+			</>
+		),
+		[
+			allCameras,
+			handleMembershipChange,
+			handlePositionChange,
+			handleRelink,
+			handleRename,
+			isClickToPlaceActive,
+			reduceMotion,
+			setIsClickToPlaceActive,
+			updateHotspot
+		]
+	)
+
+	if (hotspots.length === 0) {
+		return (
+			<Empty className="publisher-shell-nested gap-4 rounded-xl px-4 py-8">
+				<EmptyHeader>
+					<EmptyMedia variant="icon">
+						<Locate aria-hidden />
+					</EmptyMedia>
+					<EmptyTitle className="text-h4">No markers yet</EmptyTitle>
+					<EmptyDescription>
+						Add one, then click the model to place it.
+					</EmptyDescription>
+				</EmptyHeader>
+				<EmptyContent>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={handleAdd}
+						className="gap-1.5"
+					>
+						<Plus aria-hidden className="size-3.5" />
+						Add marker
+					</Button>
+				</EmptyContent>
+			</Empty>
+		)
+	}
+
+	const rowProps = (hotspot: HotspotDefinition) => ({
+		hotspot,
+		step: stepById.get(hotspot.id) ?? null,
+		isOpen: selectedId === hotspot.id,
+		reduceMotion,
+		onOpenChange: (open: boolean) => setSelectedId(open ? hotspot.id : null),
+		onDelete: () => handleDelete(hotspot.id)
+	})
+
+	return (
+		<SidebarSection
+			title="Markers"
+			tooltip="Markers call out a point on the model. Drag one to set the order viewers step through; a marker without a number is not in that order."
+			action={
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={handleAdd}
+					className="publisher-shell-focus -my-1 h-7 gap-1.5 px-2"
+				>
+					<Plus aria-hidden className="size-3.5" />
+					Add
+				</Button>
+			}
+		>
+			<SidebarSectionContent>
+				<span role="status" aria-live="polite" className="sr-only">
+					{announcement}
+				</span>
+				<p id="hotspot-reorder-hint" className="sr-only">
+					Use the up and down arrow keys to move a marker through the sequence.
+				</p>
+
+				<div className="space-y-1">
+					<p className="text-muted-foreground text-label-xs px-1">
+						In the sequence
+					</p>
+					{inSequence.length === 0 ? (
+						<p className="text-muted-foreground/75 text-label-xs px-1 pb-1">
+							Turn on “In the sequence” for a marker below to add it.
+						</p>
+					) : (
+						<Reorder.Group
+							axis="y"
+							role="list"
+							values={draftOrder}
+							onReorder={setDraftOrder}
+							className="space-y-1"
 						>
-							<Select
-								value={selectedHotspot.linkedCameraId ?? 'none'}
-								onValueChange={(v) =>
-									handleRelink(selectedHotspot.id, v === 'none' ? undefined : v)
-								}
-							>
-								<SelectTrigger className="w-full">
-									<SelectValue placeholder="None" />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="none">None</SelectItem>
-									{allCameras.map((c) => (
-										<SelectItem key={c.cameraId} value={c.cameraId}>
-											{c.name || c.cameraId}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</SettingGroup>
+							{draftOrder.map((id) => {
+								const hotspot = inSequence.find((entry) => entry.id === id)
+								if (!hotspot) return null
+								return (
+									<SequencedRow
+										key={id}
+										id={id}
+										onDragStart={() => {
+											isDraggingRef.current = true
+										}}
+										onDragEnd={() =>
+											handleReorderEnd(id, hotspot.name || 'Unnamed hotspot')
+										}
+										onMove={(delta) =>
+											handleKeyboardMove(
+												id,
+												hotspot.name || 'Unnamed hotspot',
+												delta
+											)
+										}
+										{...rowProps(hotspot)}
+									>
+										{renderEditor(hotspot)}
+									</SequencedRow>
+								)
+							})}
+						</Reorder.Group>
+					)}
+				</div>
 
-						{/* Sequence Index */}
-						<SettingRow label="Sequence Order">
-							<Input
-								type="number"
-								min={0}
-								step={1}
-								placeholder="Not in sequence"
-								value={
-									selectedHotspot.sequenceIndex !== undefined
-										? selectedHotspot.sequenceIndex
-										: ''
-								}
-								onChange={(e) => handleSequenceChange(e.target.value)}
-								className="h-8 font-mono text-sm"
-							/>
-						</SettingRow>
-
-						{/* Toggles */}
-						<div className="space-y-3 border-t pt-4">
-							<div className="flex items-center justify-between">
-								<div className="flex items-center gap-2">
-									<Label className="text-sm font-medium">
-										{selectedHotspot.visible ? (
-											<Eye className="mr-1 inline h-4 w-4" />
-										) : (
-											<EyeOff className="mr-1 inline h-4 w-4" />
-										)}
-										Visible
-									</Label>
-								</div>
-								<Switch
-									checked={selectedHotspot.visible}
-									onCheckedChange={(v) =>
-										updateHotspot(selectedHotspot.id, { visible: v })
-									}
-								/>
-							</div>
-							<div className="flex items-center justify-between">
-								<Label className="text-sm font-medium">Editor Only</Label>
-								<Switch
-									checked={selectedHotspot.internalOnly}
-									onCheckedChange={(v) =>
-										updateHotspot(selectedHotspot.id, { internalOnly: v })
-									}
-								/>
-							</div>
-							<div className="flex items-center justify-between">
-								<Label className="text-sm font-medium">Depth Occlusion</Label>
-								<Switch
-									checked={selectedHotspot.occlusionEnabled ?? true}
-									onCheckedChange={(v) =>
-										updateHotspot(selectedHotspot.id, { occlusionEnabled: v })
-									}
-								/>
-							</div>
-						</div>
-					</SidebarSectionContent>
-				</SidebarSection>
-			)}
-		</div>
+				{rest.length > 0 && (
+					<div className="space-y-1">
+						<p className="text-muted-foreground text-label-xs px-1">
+							Not in the sequence
+						</p>
+						<ul role="list" className="space-y-1">
+							{rest.map((hotspot) => (
+								<li key={hotspot.id}>
+									<HotspotRow {...rowProps(hotspot)}>
+										{renderEditor(hotspot)}
+									</HotspotRow>
+								</li>
+							))}
+						</ul>
+					</div>
+				)}
+			</SidebarSectionContent>
+		</SidebarSection>
 	)
 })
 

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -21,10 +21,15 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@shared/components/ui/select'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@shared/components/ui/tooltip'
 import { cn } from '@shared/utils'
-import { resolveHotspotMarkers } from '@vctrl/viewer'
-import { AnimatePresence, Reorder, motion, useDragControls, useReducedMotion } from 'framer-motion'
+import { resolveHotspotMarkers } from '@vctrl/viewer/hotspots'
+import {
+	AnimatePresence,
+	Reorder,
+	motion,
+	useDragControls,
+	useReducedMotion
+} from 'framer-motion'
 import { useAtom, useSetAtom } from 'jotai/react'
 import {
 	ChevronDown,
@@ -38,7 +43,6 @@ import {
 } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-
 import {
 	PAIRED_HOTSPOT_CAMERA_ID_PREFIX,
 	resolveDefaultSceneCameraId
@@ -50,6 +54,7 @@ import {
 	renameHotspot
 } from '../../../../lib/domain/scene/scene-hotspot-camera-links'
 import {
+	applySequenceMove,
 	reorderSequence,
 	setSequenceMembership
 } from '../../../../lib/domain/scene/scene-hotspot-sequence'
@@ -62,8 +67,13 @@ import {
 } from '../../../../lib/stores/scene-settings-store'
 import { InlineNotice } from '../../../layout-components'
 import { SettingToggle, ToggleButtonGroup } from '../../settings-components'
-import { SidebarSection, SidebarSectionContent, SettingGroup } from '../sidebar-section'
+import {
+	SidebarSection,
+	SidebarSectionContent,
+	SettingGroup
+} from '../sidebar-section'
 
+import type { SequenceMove } from '../../../../lib/domain/scene/scene-hotspot-sequence'
 import type { ToggleButtonGroupOption } from '../../settings-components'
 import type {
 	CameraProps,
@@ -147,7 +157,7 @@ const AxisField = memo(
 		<div className="publisher-shell-nested focus-within:ring-ring flex items-center rounded-lg pl-2 focus-within:ring-2">
 			<span
 				aria-hidden
-				className="text-muted-foreground text-label-xs w-3 shrink-0 font-medium"
+				className="text-muted-foreground w-3 shrink-0 text-xs font-medium"
 			>
 				{axis}
 			</span>
@@ -215,6 +225,7 @@ const HotspotRow = memo(
 							type="button"
 							aria-label={`Reorder ${name}`}
 							aria-keyshortcuts="ArrowUp ArrowDown Home End"
+							aria-describedby="hotspot-reorder-hint"
 							onPointerDown={(event) => dragControls.start(event)}
 							onKeyDown={(event) => {
 								const move = {
@@ -239,7 +250,7 @@ const HotspotRow = memo(
 					{step === null ? (
 						<span
 							aria-hidden
-							className="text-muted-foreground/60 text-label-xs flex size-5 shrink-0 items-center justify-center"
+							className="text-muted-foreground text-label-xs flex size-5 shrink-0 items-center justify-center"
 						>
 							&mdash;
 						</span>
@@ -259,25 +270,40 @@ const HotspotRow = memo(
 							className="publisher-shell-focus flex min-w-0 flex-1 items-center gap-2 rounded-lg py-2 pr-1 pl-1 text-left"
 						>
 							<span className="min-w-0 flex-1">
-							<span
-								className={cn(
-									'block truncate text-sm leading-tight font-medium',
-									hiddenFromViewers && 'opacity-60'
-								)}
-							>
-								{name}
-							</span>
-							<span className="text-muted-foreground text-label-xs block font-mono tabular-nums">
-								{hotspot.worldPosition.map((axis) => axis.toFixed(2)).join(', ')}
-							</span>
-							<span className="sr-only">
-								{step === null ? ', not in the sequence' : `, step ${step}`}
-								{hotspot.internalOnly
-									? ', editor only'
-									: hotspot.visible
-										? ''
-										: ', hidden from viewers'}
-							</span>
+								<span
+									className={cn(
+										'block truncate text-sm leading-tight font-medium',
+										hiddenFromViewers && 'opacity-60'
+									)}
+								>
+									{name}
+								</span>
+								<span className="text-muted-foreground text-label-xs block font-mono tabular-nums">
+									{hotspot.worldPosition
+										.map((axis) => axis.toFixed(2))
+										.join(', ')}
+								</span>
+								{/*
+							  Membership and step are two different facts. A marker the
+							  author hid is still in the sequence, but
+							  `resolveHotspotMarkers` ranks steps over the markers a
+							  visitor can reach, so it carries no step - which is why
+							  the badge shows a dash. Announcing that as "not in the
+							  sequence" contradicted both the group it sits in and its
+							  own switch.
+							*/}
+								<span className="sr-only">
+									{hotspot.sequenceIndex === undefined
+										? ', not in the sequence'
+										: step === null
+											? ', in the sequence, no step in the published scene'
+											: `, step ${step}`}
+									{hotspot.internalOnly
+										? ', editor only'
+										: hotspot.visible
+											? ''
+											: ', hidden from viewers'}
+								</span>
 							</span>
 							<ChevronDown
 								aria-hidden
@@ -290,27 +316,26 @@ const HotspotRow = memo(
 						</button>
 					</CollapsibleTrigger>
 
+					{/*
+					  Bare glyphs, not tooltip triggers. Radix `asChild` merged the
+					  trigger onto a lucide `<svg>`, which takes no focus and is
+					  `aria-hidden`, so the tooltip was unreachable by keyboard and
+					  dead on touch - and its `aria-describedby` landed on a node
+					  outside the accessibility tree. Both states are already in the
+					  trigger's own `sr-only` text, so the icon is the visual cue and
+					  nothing is missing.
+					*/}
 					{!hotspot.visible && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<EyeOff
-									aria-hidden
-									className="text-muted-foreground size-3.5 shrink-0"
-								/>
-							</TooltipTrigger>
-							<TooltipContent>Hidden from viewers</TooltipContent>
-						</Tooltip>
+						<EyeOff
+							aria-hidden
+							className="text-muted-foreground size-3.5 shrink-0"
+						/>
 					)}
 					{hotspot.internalOnly && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<SquarePen
-									aria-hidden
-									className="text-muted-foreground size-3.5 shrink-0"
-								/>
-							</TooltipTrigger>
-							<TooltipContent>Editor only</TooltipContent>
-						</Tooltip>
+						<SquarePen
+							aria-hidden
+							className="text-muted-foreground size-3.5 shrink-0"
+						/>
 					)}
 
 					<Button
@@ -322,7 +347,6 @@ const HotspotRow = memo(
 					>
 						<Trash2 aria-hidden className="size-3.5" />
 					</Button>
-
 				</div>
 
 				<CollapsibleContent
@@ -369,7 +393,18 @@ const SequencedRow = ({
 			dragControls={dragControls}
 			onDragStart={onDragStart}
 			onDragEnd={onDragEnd}
-			layout={reduceMotion ? undefined : 'position'}
+			/*
+			  `layout` stays on whatever the motion preference is, and the
+			  preference is honoured by the transition instead.
+
+			  `undefined` was the bug: framer defaults the prop to `true`, so the
+			  reduced-motion branch was asking for *more* animation than the other
+			  one. `Reorder.Item` also registers with its group only from
+			  `onLayoutMeasure`, so turning layout off here is not obviously safe
+			  either - and there is no reason to, since the transition already
+			  carries the preference.
+			*/
+			layout="position"
 			transition={
 				reduceMotion
 					? { duration: 0 }
@@ -397,7 +432,32 @@ const HotspotsSettingsPanel = memo(() => {
 	)
 
 	const reduceMotion = useReducedMotion() ?? false
-	const [announcement, setAnnouncement] = useState('')
+	/**
+	 * Two regions, used alternately, so a message can repeat.
+	 *
+	 * A live region speaks when its content changes, and React bails out of an
+	 * identical `setState`, so saying the same thing twice produced no DOM change
+	 * and no announcement - which is how "already first" spoke on the first
+	 * ArrowUp at the top of the list and went quiet on every one after it.
+	 *
+	 * Alternating a trailing zero-width space was the first attempt and does not
+	 * work: it saturates on the third repeat, and even before that it only
+	 * mutates one text node, which some screen readers report as an insertion of
+	 * the delta - here, an inaudible character. Writing each message into a region
+	 * that was empty makes every announcement an unambiguous insertion, which is
+	 * the technique `react-aria`'s announcer settled on for the same reason.
+	 */
+	const [announcement, setAnnouncement] = useState<{
+		message: string
+		slot: 0 | 1
+	}>({ message: '', slot: 0 })
+
+	const announce = useCallback((message: string) => {
+		setAnnouncement((previous) => ({
+			message,
+			slot: previous.slot === 0 ? 1 : 0
+		}))
+	}, [])
 	const allCameras = camera.cameras ?? []
 
 	/**
@@ -467,29 +527,83 @@ const HotspotsSettingsPanel = memo(() => {
 		[inSequence]
 	)
 	const [draftOrder, setDraftOrder] = useState<string[]>(sequencedIds)
-	const isDraggingRef = useRef(false)
+	const draftOrderRef = useRef(sequencedIds)
+	/**
+	 * State, not a ref, so the re-seed below can see a drag end.
+	 *
+	 * As a ref it was invisible to the effect's dependencies: a write to the
+	 * store during a drag - the canvas gizmo under a second touch point, or a
+	 * scene load - ran the effect once, hit the guard, and nothing afterwards
+	 * could make it run again, so the draft stayed diverged from the store for
+	 * the life of the panel. One render at drag start is the whole cost.
+	 */
+	const [isDragging, setIsDragging] = useState(false)
+
+	/** Keeps the ref beside the state, so a commit outside React can read it. */
+	const applyDraftOrder = useCallback((order: string[]) => {
+		draftOrderRef.current = order
+		setDraftOrder(order)
+	}, [])
 
 	useEffect(() => {
-		if (isDraggingRef.current) return
+		if (isDragging) return
+		draftOrderRef.current = sequencedIds
 		setDraftOrder(sequencedIds)
-	}, [sequencedIds])
+	}, [isDragging, sequencedIds])
 
+	/**
+	 * Writes a new order, and says so once it is actually new.
+	 *
+	 * "Position" rather than "step": the step on a row is what a visitor is
+	 * shown, and `resolveHotspotMarkers` ranks that over the markers a visitor
+	 * can reach. This list is the authoring order and counts hidden members too,
+	 * so calling both of them "step" would announce a number that appears
+	 * nowhere on screen.
+	 */
 	const commitOrder = useCallback(
 		(order: string[], movedId: string, movedName: string) => {
-			setHotspots((prev) => reorderSequence(prev, order))
-			setAnnouncement(
-				`${movedName} moved to step ${order.indexOf(movedId) + 1} of ${order.length}.`
+			/*
+			  The annotated return type is load-bearing. TypeScript cannot see the
+			  updater run, so a value captured from inside it narrows to `never`
+			  after its own null guard and the announcement below silently stops
+			  being type-checked. Declaring the type at the boundary keeps it.
+
+			  Capturing at all is safe because `hotspotsAtom` is a jotai primitive:
+			  its write runs the updater once, synchronously, before the next
+			  statement. A derived atom would break that, which is why the whole
+			  decision lives in `applySequenceMove` rather than here. Do not copy
+			  the shape to a React `useState` updater, which StrictMode invokes
+			  twice in development - an impure one would then run twice too.
+
+			  If the assumption ever does break, `applied` stays null and only the
+			  announcement is skipped; the reorder still commits.
+			*/
+			const move = ((): SequenceMove | null => {
+				let applied: SequenceMove | null = null
+
+				setHotspots((prev) => {
+					applied = applySequenceMove(prev, order, movedId)
+					return applied ? applied.hotspots : prev
+				})
+
+				return applied
+			})()
+
+			if (!move) return
+
+			announce(
+				`${movedName} moved to position ${move.position} of ${move.total}.`
 			)
 		},
-		[setHotspots]
+		[announce, setHotspots]
 	)
 
 	const handleReorderEnd = useCallback(
 		(id: string, name: string) => {
-			isDraggingRef.current = false
-			commitOrder(draftOrder, id, name)
+			setIsDragging(false)
+			commitOrder(draftOrderRef.current, id, name)
 		},
-		[commitOrder, draftOrder]
+		[commitOrder]
 	)
 
 	const handleKeyboardMove = useCallback(
@@ -504,19 +618,23 @@ const HotspotsSettingsPanel = memo(() => {
 						? draftOrder.length - 1
 						: from + delta
 
-			if (to < 0 || to >= draftOrder.length || to === from) return
+			// Silence at the ends is indistinguishable from a key that does
+			// nothing, so a refused move is announced rather than swallowed.
+			if (to < 0 || to >= draftOrder.length || to === from) {
+				// Named from the direction asked for, not from the index it started
+				// at: in a one-marker sequence `from` is always 0, so reading the
+				// index announced "already first" for a press asking to go last.
+				const towardsEnd = delta === 'last' || delta === 1
+				announce(`${name} is already ${towardsEnd ? 'last' : 'first'}.`)
+				return
+			}
 
 			const next = [...draftOrder]
 			next.splice(to, 0, ...next.splice(from, 1))
-			setDraftOrder(next)
+			applyDraftOrder(next)
 			commitOrder(next, id, name)
 		},
-		[commitOrder, draftOrder]
-	)
-
-	const selectedHotspot = useMemo(
-		() => hotspots.find((h) => h.id === selectedId) ?? null,
-		[hotspots, selectedId]
+		[applyDraftOrder, commitOrder, draftOrder]
 	)
 
 	const updateHotspot = useCallback(
@@ -545,7 +663,7 @@ const HotspotsSettingsPanel = memo(() => {
 	 * a gap would show as steps 1 and 3 with nothing between them.
 	 */
 	const handleDelete = useCallback(
-		(id: string) => {
+		(id: string, name: string) => {
 			const next = removeHotspot({ camera, hotspots }, id)
 			const survivingOrder = sequencedFirst(next.hotspots).inSequence.map(
 				(hotspot) => hotspot.id
@@ -557,8 +675,25 @@ const HotspotsSettingsPanel = memo(() => {
 				survivingSelectedCameraId(next.camera.cameras, prev)
 			)
 			setSelectedId((prev) => (prev === id ? null : prev))
+
+			/*
+			  Deleting is the loudest thing this panel does and it was the only one
+			  that said nothing: the row goes, focus falls to the document body,
+			  and every later step silently renumbers. A reorder one row up
+			  announces itself, so this looked like an oversight rather than a
+			  decision - because it was.
+			*/
+			const wasSequenced = hotspots.some(
+				(hotspot) => hotspot.id === id && hotspot.sequenceIndex !== undefined
+			)
+			announce(
+				wasSequenced
+					? `${name} deleted. ${survivingOrder.length} ${survivingOrder.length === 1 ? 'marker' : 'markers'} left in the sequence.`
+					: `${name} deleted.`
+			)
 		},
 		[
+			announce,
 			camera,
 			hotspots,
 			setCamera,
@@ -591,18 +726,28 @@ const HotspotsSettingsPanel = memo(() => {
 		[camera, hotspots, setCamera, setHotspots, setSelectedCameraId]
 	)
 
+	/**
+	 * Takes the hotspot it is editing, like every other handler here.
+	 *
+	 * Reading the selection instead was wrong for as long as two editors are
+	 * mounted at once, which is the whole of a row's collapse animation: Radix
+	 * keeps closing content mounted until it finishes, so for those ~200ms the
+	 * outgoing row still shows live fields that would have written to the
+	 * incoming one.
+	 */
 	const handlePositionChange = useCallback(
-		(axis: 0 | 1 | 2, raw: string) => {
-			if (!selectedHotspot) return
+		(hotspot: HotspotDefinition, axis: 0 | 1 | 2, raw: string) => {
 			const value = parseFloat(raw)
 			if (isNaN(value)) return
-			const next: [number, number, number] = [
-				...selectedHotspot.worldPosition
-			] as [number, number, number]
+			const next: [number, number, number] = [...hotspot.worldPosition] as [
+				number,
+				number,
+				number
+			]
 			next[axis] = value
-			updateHotspot(selectedHotspot.id, { worldPosition: next })
+			updateHotspot(hotspot.id, { worldPosition: next })
 		},
-		[selectedHotspot, updateHotspot]
+		[updateHotspot]
 	)
 
 	const handleMembershipChange = useCallback(
@@ -646,7 +791,7 @@ const HotspotsSettingsPanel = memo(() => {
 								axis={axis}
 								value={hotspot.worldPosition[index]}
 								onChange={(raw) =>
-									handlePositionChange(index as 0 | 1 | 2, raw)
+									handlePositionChange(hotspot, index as 0 | 1 | 2, raw)
 								}
 							/>
 						))}
@@ -805,7 +950,7 @@ const HotspotsSettingsPanel = memo(() => {
 		isOpen: selectedId === hotspot.id,
 		reduceMotion,
 		onOpenChange: (open: boolean) => setSelectedId(open ? hotspot.id : null),
-		onDelete: () => handleDelete(hotspot.id)
+		onDelete: () => handleDelete(hotspot.id, hotspot.name || 'Unnamed hotspot')
 	})
 
 	return (
@@ -826,10 +971,14 @@ const HotspotsSettingsPanel = memo(() => {
 		>
 			<SidebarSectionContent>
 				<span role="status" aria-live="polite" className="sr-only">
-					{announcement}
+					{announcement.slot === 0 ? announcement.message : ''}
+				</span>
+				<span role="status" aria-live="polite" className="sr-only">
+					{announcement.slot === 1 ? announcement.message : ''}
 				</span>
 				<p id="hotspot-reorder-hint" className="sr-only">
-					Use the up and down arrow keys to move a marker through the sequence.
+					Use the up and down arrow keys to move a marker through the sequence,
+					or Home and End to send it to either end.
 				</p>
 
 				<div className="space-y-1">
@@ -837,7 +986,7 @@ const HotspotsSettingsPanel = memo(() => {
 						In the sequence
 					</p>
 					{inSequence.length === 0 ? (
-						<p className="text-muted-foreground/75 text-label-xs px-1 pb-1">
+						<p className="text-muted-foreground text-label-xs px-1 pb-1">
 							Turn on “In the sequence” for a marker below to add it.
 						</p>
 					) : (
@@ -845,7 +994,7 @@ const HotspotsSettingsPanel = memo(() => {
 							axis="y"
 							role="list"
 							values={draftOrder}
-							onReorder={setDraftOrder}
+							onReorder={applyDraftOrder}
 							className="space-y-1"
 						>
 							{draftOrder.map((id) => {
@@ -855,9 +1004,7 @@ const HotspotsSettingsPanel = memo(() => {
 									<SequencedRow
 										key={id}
 										id={id}
-										onDragStart={() => {
-											isDraggingRef.current = true
-										}}
+										onDragStart={() => setIsDragging(true)}
 										onDragEnd={() =>
 											handleReorderEnd(id, hotspot.name || 'Unnamed hotspot')
 										}

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/interaction-controls-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/interaction-controls-settings-panel.tsx
@@ -2,19 +2,25 @@ import {
 	Collapsible,
 	CollapsibleContent
 } from '@shared/components/ui/collapsible'
-import { Separator } from '@shared/components/ui/separator'
 import { useAtom } from 'jotai/react'
 import { memo, useCallback, useState } from 'react'
 
 import { controlsAtom } from '../../../../lib/stores/scene-settings-store'
-import { InfoTooltip } from '../../../info-tooltip'
 import {
 	EnhancedSettingSlider,
-	SettingToggle
+	SettingToggle,
+	ToggleButtonGroup
 } from '../../settings-components'
-import { PresetButton } from '../../settings-components/preset-button'
 import { CollapsibleSectionTrigger } from '../accordion-components'
-import { CAMERA_CONTROLS_FIELDS, defaultControlsOptions } from './camera-controls-settings/constants'
+import {
+	SettingGroup,
+	SidebarSection,
+	SidebarSectionContent
+} from '../sidebar-section'
+import {
+	CAMERA_CONTROLS_FIELDS,
+	defaultControlsOptions
+} from './camera-controls-settings/constants'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -76,121 +82,68 @@ const InteractionControlsSettingsPanel = memo(() => {
 	return (
 		<div className="space-y-6">
 			{/* ── Enable toggles ──────────────────────────────────────── */}
-			<div className="space-y-3">
-				<div className="flex items-center gap-2">
-					<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-						Controls
-					</p>
-					<InfoTooltip content="Configure which interactions viewers can use with the 3D scene." />
-				</div>
-				<Separator />
+			<SidebarSection
+				title="Controls"
+				tooltip="Configure which interactions viewers can use with the 3D scene."
+			>
+				<SidebarSectionContent>
+					<SettingToggle
+						enabled={!!controls.enableZoom}
+						onToggle={(enabled) => handleToggle('enableZoom', enabled)}
+						title="Enable Zoom"
+						description="Allow viewers to zoom in and out."
+					/>
 
-				<SettingToggle
-					enabled={!!controls.enableZoom}
-					onToggle={(enabled) => handleToggle('enableZoom', enabled)}
-					title="Enable Zoom"
-					description="Allow viewers to zoom in and out."
-				/>
-
-				<SettingToggle
-					enabled={!!controls.autoRotate}
-					onToggle={(enabled) => handleToggle('autoRotate', enabled)}
-					title="Auto Rotate"
-					description="Continuously orbit the camera around the model."
-				/>
-			</div>
+					<SettingToggle
+						enabled={!!controls.autoRotate}
+						onToggle={(enabled) => handleToggle('autoRotate', enabled)}
+						title="Auto Rotate"
+						description="Continuously orbit the camera around the model."
+					/>
+				</SidebarSectionContent>
+			</SidebarSection>
 
 			{/* ── Movement feel ───────────────────────────────────────── */}
-			<div className="space-y-3">
-				<div className="flex items-center gap-2">
-					<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-						Feel
-					</p>
-					<InfoTooltip content="Controls how the camera decelerates when you release the mouse. Lower values feel floatier; higher values snap to a stop." />
-				</div>
-				<Separator />
-
-				<div className="space-y-1.5">
-					<p className="text-xs text-muted-foreground">Movement Feel</p>
-					<div className="grid grid-cols-3 gap-1.5">
-						{SMOOTHNESS_PRESETS.map((preset) => (
-							<PresetButton
-								key={preset.label}
-								label={preset.label}
-								isActive={closestSmoothness === preset.value}
-								onClick={() => handleUpdate('dampingFactor', preset.value)}
-							/>
-						))}
-					</div>
-				</div>
-			</div>
+			<SidebarSection
+				title="Feel"
+				tooltip="Controls how the camera decelerates when you release the mouse. Lower values feel floatier; higher values snap to a stop."
+			>
+				<SidebarSectionContent>
+					<SettingGroup label="Movement Feel">
+						<ToggleButtonGroup
+							options={SMOOTHNESS_PRESETS}
+							isActive={(value) => closestSmoothness === value}
+							onChange={(value) => handleUpdate('dampingFactor', value)}
+						/>
+					</SettingGroup>
+				</SidebarSectionContent>
+			</SidebarSection>
 
 			{/* ── Interaction speeds ──────────────────────────────────── */}
-			<div className="space-y-3">
-				<div className="flex items-center gap-2">
-					<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-						Speeds
-					</p>
-					<InfoTooltip content="Fine-tune the speed of each interaction type. Speeds for disabled controls are greyed out." />
-				</div>
-				<Separator />
+			<SidebarSection
+				title="Speeds"
+				tooltip="Fine-tune the speed of each interaction type. Speeds for disabled controls are greyed out."
+			>
+				<SidebarSectionContent>
+					{speedFields.map((config) => {
+						const isEnabled =
+							config.key === 'autoRotateSpeed'
+								? !!controls.autoRotate
+								: config.key === 'zoomSpeed'
+									? !!controls.enableZoom
+									: true
 
-				{speedFields.map((config) => {
-					const isEnabled =
-						config.key === 'autoRotateSpeed'
-							? !!controls.autoRotate
-							: config.key === 'zoomSpeed'
-								? !!controls.enableZoom
-								: true
-
-					return (
-						<EnhancedSettingSlider
-							key={config.key}
-							enabled={isEnabled}
-							id={config.key}
-							sliderProps={{
-								min: config.min,
-								max: config.max,
-								step: config.step,
-								value:
-									(controls[
-										config.key as keyof typeof controls
-									] as number) ??
-									(defaultControlsOptions[
-										config.key as keyof typeof defaultControlsOptions
-									] as number),
-								onChange: (value) => handleUpdate(config.key, value)
-							}}
-							label={config.label}
-							tooltip={config.tooltip}
-							labelProps={{
-								low: `${config.min} – Slow`,
-								high: `${config.max} – Fast`
-							}}
-							formatValue={config.formatValue}
-							valueMapping={config.valueMapping}
-							allowDirectInput
-						/>
-					)
-				})}
-
-				<Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
-					<CollapsibleSectionTrigger isOpen={advancedOpen}>
-						Advanced
-					</CollapsibleSectionTrigger>
-					<CollapsibleContent className="space-y-4 pt-3">
-						{advancedFields.map((config) => (
+						return (
 							<EnhancedSettingSlider
 								key={config.key}
+								enabled={isEnabled}
 								id={config.key}
 								sliderProps={{
 									min: config.min,
 									max: config.max,
 									step: config.step,
 									value:
-										(controls[
-											config.key as keyof typeof controls
-										] as number) ??
+										(controls[config.key as keyof typeof controls] as number) ??
 										(defaultControlsOptions[
 											config.key as keyof typeof defaultControlsOptions
 										] as number),
@@ -199,21 +152,58 @@ const InteractionControlsSettingsPanel = memo(() => {
 								label={config.label}
 								tooltip={config.tooltip}
 								labelProps={{
-									low: `${config.min}`,
-									high: `${((config.max * 180) / Math.PI).toFixed(0)}°`
+									low: `${config.min} – Slow`,
+									high: `${config.max} – Fast`
 								}}
 								formatValue={config.formatValue}
 								valueMapping={config.valueMapping}
 								allowDirectInput
 							/>
-						))}
-					</CollapsibleContent>
-				</Collapsible>
-			</div>
+						)
+					})}
+
+					<Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+						<CollapsibleSectionTrigger isOpen={advancedOpen}>
+							Advanced
+						</CollapsibleSectionTrigger>
+						<CollapsibleContent className="space-y-4 pt-3">
+							{advancedFields.map((config) => (
+								<EnhancedSettingSlider
+									key={config.key}
+									id={config.key}
+									sliderProps={{
+										min: config.min,
+										max: config.max,
+										step: config.step,
+										value:
+											(controls[
+												config.key as keyof typeof controls
+											] as number) ??
+											(defaultControlsOptions[
+												config.key as keyof typeof defaultControlsOptions
+											] as number),
+										onChange: (value) => handleUpdate(config.key, value)
+									}}
+									label={config.label}
+									tooltip={config.tooltip}
+									labelProps={{
+										low: `${config.min}`,
+										high: `${((config.max * 180) / Math.PI).toFixed(0)}°`
+									}}
+									formatValue={config.formatValue}
+									valueMapping={config.valueMapping}
+									allowDirectInput
+								/>
+							))}
+						</CollapsibleContent>
+					</Collapsible>
+				</SidebarSectionContent>
+			</SidebarSection>
 		</div>
 	)
 })
 
-InteractionControlsSettingsPanel.displayName = 'InteractionControlsSettingsPanel'
+InteractionControlsSettingsPanel.displayName =
+	'InteractionControlsSettingsPanel'
 
 export default InteractionControlsSettingsPanel

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/shadow-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/shadow-settings-panel.tsx
@@ -1,12 +1,9 @@
-import { Button } from '@shared/components/ui/button'
 import {
 	Collapsible,
 	CollapsibleContent
 } from '@shared/components/ui/collapsible'
 import { Label } from '@shared/components/ui/label'
-import { Separator } from '@shared/components/ui/separator'
 import { Switch } from '@shared/components/ui/switch'
-import { cn } from '@shared/utils'
 import { useAtom } from 'jotai/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
@@ -23,10 +20,38 @@ import {
 } from './constants'
 import { shadowsAtom } from '../../../../../lib/stores/scene-settings-store'
 import { InfoTooltip } from '../../../../info-tooltip'
-import { EnhancedSettingSlider } from '../../../settings-components'
+import { InlineNotice } from '../../../../layout-components'
+import {
+	EnhancedSettingSlider,
+	SettingToggle,
+	ToggleButtonGroup
+} from '../../../settings-components'
 import { CollapsibleSectionTrigger } from '../../accordion-components'
+import {
+	SettingGroup,
+	SidebarSection,
+	SidebarSectionContent
+} from '../../sidebar-section'
+
+/**
+ * The presets as `ToggleButtonGroup` wants them.
+ *
+ * The grid these replaced expressed "active" as a solid `bg-primary` fill — a
+ * fourth selection language in the compose panels, and the same defect as the
+ * hotspot row this change started from. `description` was a `title=` hover
+ * tooltip, invisible on touch and to the keyboard; as `subLabel` it is simply
+ * on screen.
+ */
+const PRESET_OPTIONS: ToggleButtonGroupOption<string>[] = SHADOW_PRESETS.map(
+	(preset) => ({
+		value: preset.id,
+		label: preset.label,
+		subLabel: preset.description
+	})
+)
 
 import type { FieldConfig } from '../../../../../types/settings-field'
+import type { ToggleButtonGroupOption } from '../../../settings-components'
 import type { ShadowsProps } from '@vctrl/core'
 
 interface ShadowFieldProps {
@@ -219,145 +244,122 @@ const ShadowSettingsPanel = () => {
 	}
 
 	return (
-		<div className="space-y-4">
-			<div className="flex items-center justify-between gap-2">
-				<p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-					Shadows
-				</p>
-				<div className="flex items-center gap-2">
-					<InfoTooltip content="Configure shadow quality in your scene." />
-					<Label htmlFor="shadows-enabled-toggle" className="text-sm">
-						Enabled
-					</Label>
-					<Switch
-						id="shadows-enabled-toggle"
-						checked={shadowsEnabled}
-						onCheckedChange={handleToggleShadows}
-					/>
-				</div>
-			</div>
-			<Separator />
+		/*
+		  Titleless on purpose. `DynamicSidebar` already draws "Shadows" and the
+		  tool's description above this panel, so a section of the same name printed
+		  the word twice - the defect the Hotspots panel was rebuilt to remove.
+		  The master switch is a setting rather than section chrome, so it says so.
+		*/
+		<SidebarSection>
+			<SidebarSectionContent>
+				<SettingToggle
+					enabled={shadowsEnabled}
+					onToggle={handleToggleShadows}
+					title="Cast shadows"
+					description="Ground the model with a directional shadow."
+					info="Configure shadow quality in your scene."
+				/>
 
-			{!shadowsEnabled && (
-				<p className="text-muted-foreground py-2 text-xs">
-					Enable shadows to configure shadow quality.
-				</p>
-			)}
+				{!shadowsEnabled && (
+					<InlineNotice tone="neutral">
+						Turn on shadows to configure their quality.
+					</InlineNotice>
+				)}
 
-			{shadowsEnabled && (
-				<div className="space-y-4">
-					<div className="space-y-2">
-						<p className="text-muted-foreground text-xs font-medium">Presets</p>
-						<div className="grid grid-cols-3 gap-2">
-							{SHADOW_PRESETS.map((preset) => (
-								<Button
-									key={preset.id}
-									type="button"
-									variant={
-										activePresetId === preset.id ? 'default' : 'secondary'
-									}
-									size="sm"
-									className={cn(
-										'h-auto py-2 text-xs font-medium',
-										activePresetId !== preset.id && 'text-muted-foreground'
-									)}
-									title={preset.description}
-									onClick={() => handleApplyPreset(preset)}
-								>
-									{preset.label}
-								</Button>
-							))}
-						</div>
-					</div>
-
-					<Separator />
-
+				{shadowsEnabled && (
 					<div className="space-y-4">
-						<p className="text-muted-foreground text-xs font-medium">
-							Directional shadow
-						</p>
-						{SHADOW_PRIMARY_FIELDS.map((field) => (
-							<ShadowField
-								key={field.key}
-								field={field}
-								idPrefix="shadow"
-								value={getFieldValue(field.key)}
-								onChange={handleFieldChange}
+						<SettingGroup label="Presets">
+							<ToggleButtonGroup
+								options={PRESET_OPTIONS}
+								isActive={(id) => activePresetId === id}
+								onChange={(id) => {
+									const preset = SHADOW_PRESETS.find((entry) => entry.id === id)
+									if (preset) handleApplyPreset(preset)
+								}}
 							/>
-						))}
-					</div>
+						</SettingGroup>
 
-					<Separator />
-
-					<div className="space-y-4">
-						<div className="flex items-center justify-between gap-2">
-							<div className="flex items-center gap-2">
-								<p className="text-muted-foreground text-xs font-medium">
-									Ground shadow
-								</p>
-								<InfoTooltip content="A soft shadow pooled under the model that approximates the ambient occlusion it casts on the floor. It's independent of the directional light, so the model stays grounded even when the main shadow is cast off to the side. Raise Softness to keep it diffuse." />
-							</div>
-							<Switch
-								id="shadow-ground-toggle"
-								checked={draft.contact?.enabled ?? false}
-								onCheckedChange={handleToggleContact}
-							/>
-						</div>
-
-						{(draft.contact?.enabled ?? false) &&
-							SHADOW_CONTACT_FIELDS.map((field) => (
+						<SettingGroup label="Directional shadow">
+							{SHADOW_PRIMARY_FIELDS.map((field) => (
 								<ShadowField
 									key={field.key}
 									field={field}
-									idPrefix="shadow-contact"
+									idPrefix="shadow"
 									value={getFieldValue(field.key)}
 									onChange={handleFieldChange}
 								/>
 							))}
-					</div>
+						</SettingGroup>
 
-					<Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
-						<CollapsibleSectionTrigger isOpen={advancedOpen}>
-							Advanced
-						</CollapsibleSectionTrigger>
-						<CollapsibleContent className="space-y-4 pt-3">
-							{SHADOW_ADVANCED_FIELDS.map((field) => (
-								<ShadowField
-									key={field.key}
-									field={field}
-									idPrefix="shadow-adv"
-									value={getFieldValue(field.key)}
-									onChange={handleFieldChange}
-								/>
-							))}
-
-							<div className="flex items-center justify-between gap-2">
+						<SettingGroup
+							label="Ground shadow"
+							action={
 								<div className="flex items-center gap-2">
-									<Label htmlFor="shadow-ao-toggle" className="text-sm">
-										Ambient occlusion
-									</Label>
-									<InfoTooltip content="Darkens crevices and tight gaps on the model itself (screen-space). Higher quality but runs every frame, so it costs GPU — best for hero shots on capable devices." />
+									<InfoTooltip content="A soft shadow pooled under the model that approximates the ambient occlusion it casts on the floor. It's independent of the directional light, so the model stays grounded even when the main shadow is cast off to the side. Raise Softness to keep it diffuse." />
+									<Switch
+										id="shadow-ground-toggle"
+										aria-label="Enable ground shadow"
+										checked={draft.contact?.enabled ?? false}
+										onCheckedChange={handleToggleContact}
+									/>
 								</div>
-								<Switch
-									id="shadow-ao-toggle"
-									checked={draft.ao ?? false}
-									onCheckedChange={handleToggleAo}
-								/>
-							</div>
+							}
+						>
+							{(draft.contact?.enabled ?? false) &&
+								SHADOW_CONTACT_FIELDS.map((field) => (
+									<ShadowField
+										key={field.key}
+										field={field}
+										idPrefix="shadow-contact"
+										value={getFieldValue(field.key)}
+										onChange={handleFieldChange}
+									/>
+								))}
+						</SettingGroup>
 
-							{(draft.ao ?? false) && (
-								<ShadowField
-									field={SHADOW_AO_INTENSITY_FIELD}
-									idPrefix="shadow-adv"
-									value={getFieldValue(SHADOW_AO_INTENSITY_FIELD.key)}
-									onChange={handleFieldChange}
-								/>
-							)}
-						</CollapsibleContent>
-					</Collapsible>
-				</div>
-			)}
-		</div>
+						<Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+							<CollapsibleSectionTrigger isOpen={advancedOpen}>
+								Advanced
+							</CollapsibleSectionTrigger>
+							<CollapsibleContent className="space-y-4 pt-3">
+								{SHADOW_ADVANCED_FIELDS.map((field) => (
+									<ShadowField
+										key={field.key}
+										field={field}
+										idPrefix="shadow-adv"
+										value={getFieldValue(field.key)}
+										onChange={handleFieldChange}
+									/>
+								))}
+
+								<div className="flex items-center justify-between gap-2">
+									<div className="flex items-center gap-2">
+										<Label htmlFor="shadow-ao-toggle" className="text-sm">
+											Ambient occlusion
+										</Label>
+										<InfoTooltip content="Darkens crevices and tight gaps on the model itself (screen-space). Higher quality but runs every frame, so it costs GPU — best for hero shots on capable devices." />
+									</div>
+									<Switch
+										id="shadow-ao-toggle"
+										checked={draft.ao ?? false}
+										onCheckedChange={handleToggleAo}
+									/>
+								</div>
+
+								{(draft.ao ?? false) && (
+									<ShadowField
+										field={SHADOW_AO_INTENSITY_FIELD}
+										idPrefix="shadow-adv"
+										value={getFieldValue(SHADOW_AO_INTENSITY_FIELD.key)}
+										onChange={handleFieldChange}
+									/>
+								)}
+							</CollapsibleContent>
+						</Collapsible>
+					</div>
+				)}
+			</SidebarSectionContent>
+		</SidebarSection>
 	)
 }
 

--- a/apps/vectreal-platform/app/components/publisher/sidebars/sidebar-section.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/sidebar-section.tsx
@@ -24,15 +24,30 @@ import { DetailPanelSection } from '../../layout-components'
 interface SidebarSectionProps {
 	title?: string
 	tooltip?: string
+	/**
+	 * A control belonging to the section as a whole, sitting on the heading row
+	 * beside the tooltip: an Add button, the switch that turns the section off.
+	 *
+	 * It follows `tooltip` in needing a title, because a heading row that draws
+	 * no heading has nowhere to put it.
+	 */
+	action?: ReactNode
 	children: ReactNode
 	className?: string
 }
 
 export const SidebarSection = memo(
-	({ title, tooltip, children, className = '' }: SidebarSectionProps) => (
+	({ title, tooltip, action, children, className = '' }: SidebarSectionProps) => (
 		<DetailPanelSection
 			title={title}
-			action={title && tooltip ? <InfoTooltip content={tooltip} /> : undefined}
+			action={
+				title && (tooltip || action) ? (
+					<div className="flex items-center gap-2">
+						{tooltip && <InfoTooltip content={tooltip} />}
+						{action}
+					</div>
+				) : undefined
+			}
 			divider={Boolean(title)}
 			className={cn('space-y-4', className)}
 			contentClassName="space-y-4"
@@ -97,17 +112,32 @@ SettingRow.displayName = 'SettingRow'
 interface SettingGroupProps {
 	label: string
 	description?: string
+	/**
+	 * A control for the group as a whole, on the label row.
+	 *
+	 * The row was already a `justify-between` wrapping a single child — a slot
+	 * drawn and never wired, which is why Shadow's per-group switches sat in
+	 * hand-rolled rows beside it instead.
+	 */
+	action?: ReactNode
 	children: ReactNode
 	className?: string
 }
 
 export const SettingGroup = memo(
-	({ label, description, children, className = '' }: SettingGroupProps) => (
+	({
+		label,
+		description,
+		action,
+		children,
+		className = ''
+	}: SettingGroupProps) => (
 		<div className={cn('space-y-2', className)}>
 			<div className="flex items-center justify-between gap-2">
 				<label className="text-muted-foreground text-xs font-medium">
 					{label}
 				</label>
+				{action}
 			</div>
 			{description && (
 				<p className="text-muted-foreground/75 text-xs">{description}</p>

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-camera-links.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-camera-links.ts
@@ -167,9 +167,15 @@ export function removeCamera(
 /**
  * Retires the camera the hotspot owns along with it.
  *
- * Sequence indices are left exactly as the author set them: the server takes
- * any distinct non-negative integers, gaps included, so closing the order up
- * would rewrite numbers nobody asked to change.
+ * Sequence indices are left exactly as the author set them, because the server
+ * takes any distinct non-negative integers, gaps included.
+ *
+ * That makes this function's output legal but not necessarily what an author
+ * should see. The publisher's list *is* the playback order now, so a gap there
+ * would read as a missing step; the hotspot panel pipes the survivors through
+ * `reorderSequence` after calling this. Renumbering here instead would put the
+ * decision in the wrong place: this module owns the hotspot/camera link, and a
+ * caller that does not display the order has no reason to have it rewritten.
  */
 export function removeHotspot(
 	state: CameraHotspotState,

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-sequence.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-sequence.spec.ts
@@ -1,4 +1,9 @@
-import { reorderSequence, setSequenceMembership } from './scene-hotspot-sequence'
+import {
+	applySequenceMove,
+	reorderSequence,
+	resolveSequenceOrder,
+	setSequenceMembership
+} from './scene-hotspot-sequence'
 
 import type { HotspotDefinition } from '@vctrl/core'
 
@@ -173,5 +178,152 @@ describe('setSequenceMembership', () => {
 		expect(indices(setSequenceMembership(list, 'gone', true))).toEqual([
 			['a', 0]
 		])
+	})
+})
+
+describe('applySequenceMove', () => {
+	const stored = () => [
+		hotspot('a', { sequenceIndex: 0 }),
+		hotspot('b', { sequenceIndex: 1 }),
+		hotspot('c', { sequenceIndex: 2 })
+	]
+
+	it('renumbers and reports where the marker landed', () => {
+		const move = applySequenceMove(stored(), ['c', 'a', 'b'], 'a')
+
+		expect(move).not.toBeNull()
+		expect(indices(move!.hotspots)).toEqual([
+			['a', 1],
+			['b', 2],
+			['c', 0]
+		])
+		expect(move!.position).toBe(2)
+		expect(move!.total).toBe(3)
+	})
+
+	/**
+	 * A drag released where it began. Applying it is harmless, announcing it is
+	 * not: it tells a screen reader something moved when nothing did.
+	 */
+	it('refuses an order that resolves to the sequence already stored', () => {
+		expect(applySequenceMove(stored(), ['a', 'b', 'c'], 'a')).toBeNull()
+	})
+
+	/**
+	 * The order a drag was holding when the panel went away, against whatever
+	 * scene loaded after it. Applying it would clear a sequence nobody touched.
+	 */
+	it('refuses an order naming no hotspot in the list', () => {
+		expect(
+			applySequenceMove(stored(), ['gone', 'also-gone'], 'gone')
+		).toBeNull()
+	})
+
+	/**
+	 * The position announced has to come from the order actually assigned, not
+	 * from the raw list: a stale id left in would say "position 4 of 4" for a
+	 * three-marker sequence.
+	 */
+	it('counts positions from the order it assigned, not the order it was given', () => {
+		const move = applySequenceMove(stored(), ['b', 'ghost', 'c', 'a'], 'a')
+
+		expect(move!.position).toBe(3)
+		expect(move!.total).toBe(3)
+		expect(indices(move!.hotspots)).toEqual([
+			['a', 2],
+			['b', 0],
+			['c', 1]
+		])
+	})
+
+	/**
+	 * The mirror of leaving, and the case an element-wise comparison gets wrong
+	 * without a length check: every stored id still matches by position, so the
+	 * order reads as unchanged and the join is refused.
+	 */
+	it('accepts a marker joining the sequence', () => {
+		const list = [hotspot('a', { sequenceIndex: 0 }), hotspot('b')]
+		const move = applySequenceMove(list, ['a', 'b'], 'b')
+
+		expect(move).not.toBeNull()
+		expect(indices(move!.hotspots)).toEqual([
+			['a', 0],
+			['b', 1]
+		])
+		expect(move!.position).toBe(2)
+		expect(move!.total).toBe(2)
+	})
+
+	it('accepts a marker leaving the sequence', () => {
+		const move = applySequenceMove(stored(), ['a', 'b'], 'a')
+
+		expect(indices(move!.hotspots)).toEqual([
+			['a', 0],
+			['b', 1],
+			['c', undefined]
+		])
+	})
+
+	/**
+	 * The marker being dragged, deleted from elsewhere before the drop. The rest
+	 * may genuinely have moved, but there is nothing left to announce and the
+	 * position would read as zero.
+	 */
+	it('refuses a move whose own marker is no longer in the order', () => {
+		expect(applySequenceMove(stored(), ['c', 'b'], 'a')).toBeNull()
+	})
+
+	it('does not mutate the input', () => {
+		const list = stored()
+		applySequenceMove(list, ['c', 'b', 'a'], 'c')
+
+		expect(indices(list)).toEqual([
+			['a', 0],
+			['b', 1],
+			['c', 2]
+		])
+	})
+})
+
+describe('resolveSequenceOrder', () => {
+	it('keeps the ids that name a hotspot, in the order given', () => {
+		const list = [hotspot('a'), hotspot('b')]
+
+		expect(resolveSequenceOrder(list, ['b', 'a'])).toEqual(['b', 'a'])
+	})
+
+	/**
+	 * A drag list can name a hotspot deleted since it was built. Letting it
+	 * through inflates every position the panel announces: "position 3 of 3" for
+	 * a two-member sequence, alongside a commit that changed nothing.
+	 */
+	it('drops an id naming no hotspot', () => {
+		const list = [hotspot('a'), hotspot('b')]
+
+		expect(resolveSequenceOrder(list, ['a', 'ghost', 'b'])).toEqual(['a', 'b'])
+	})
+
+	it('drops a repeated id', () => {
+		const list = [hotspot('a'), hotspot('b')]
+
+		expect(resolveSequenceOrder(list, ['a', 'a', 'b'])).toEqual(['a', 'b'])
+	})
+
+	/** What `reorderSequence` assigns and what this returns cannot disagree. */
+	it('agrees with the indices reorderSequence assigns', () => {
+		const list = [hotspot('a'), hotspot('b')]
+		const order = ['b', 'ghost', 'a', 'b']
+
+		const assigned = reorderSequence(list, order)
+			.filter((h) => h.sequenceIndex !== undefined)
+			.sort((a, b) => (a.sequenceIndex as number) - (b.sequenceIndex as number))
+			.map((h) => h.id)
+
+		expect(assigned).toEqual(resolveSequenceOrder(list, order))
+	})
+
+	/** A stale order naming nothing must not read as a legal empty sequence. */
+	it('is empty when no id names a hotspot', () => {
+		expect(resolveSequenceOrder([hotspot('a')], ['gone'])).toEqual([])
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-sequence.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-sequence.spec.ts
@@ -1,4 +1,4 @@
-import { assignSequenceIndex } from './scene-hotspot-sequence'
+import { reorderSequence, setSequenceMembership } from './scene-hotspot-sequence'
 
 import type { HotspotDefinition } from '@vctrl/core'
 
@@ -15,56 +15,92 @@ const hotspot = (
 	...overrides
 })
 
-describe('assignSequenceIndex', () => {
-	it('sets an index nobody holds', () => {
-		const result = assignSequenceIndex([hotspot('a')], 'a', 3)
-		expect(result[0].sequenceIndex).toBe(3)
+const indices = (hotspots: readonly HotspotDefinition[]) =>
+	hotspots.map((h) => [h.id, h.sequenceIndex])
+
+describe('reorderSequence', () => {
+	it('numbers the listed hotspots from zero, in the order given', () => {
+		const result = reorderSequence(
+			[hotspot('a'), hotspot('b'), hotspot('c')],
+			['c', 'a']
+		)
+
+		expect(indices(result)).toEqual([
+			['a', 1],
+			['b', undefined],
+			['c', 0]
+		])
 	})
 
-	// A duplicate index is a hard 400 on save, naming the number and neither
-	// hotspot, so the collision is resolved rather than created.
-	it('swaps with the hotspot already holding the index', () => {
-		const result = assignSequenceIndex(
+	/**
+	 * The list is the order, so a hotspot left out of it is out of the sequence.
+	 * Keeping its old index would leave a step no reorder can reach.
+	 */
+	it('takes an unlisted hotspot out of the sequence', () => {
+		const result = reorderSequence(
 			[hotspot('a', { sequenceIndex: 0 }), hotspot('b', { sequenceIndex: 1 })],
-			'a',
-			1
+			['b']
 		)
-		expect(result.map((h) => [h.id, h.sequenceIndex])).toEqual([
-			['a', 1],
+
+		expect(indices(result)).toEqual([
+			['a', undefined],
 			['b', 0]
 		])
 	})
 
-	// A hotspot joining the sequence has no slot to hand over. The displaced
-	// one must not be dropped out of the sequence to make room, since that
-	// silently changes playback.
-	it('moves the displaced hotspot to the next free index when the target had none', () => {
-		const result = assignSequenceIndex(
-			[hotspot('a'), hotspot('b', { sequenceIndex: 1 })],
-			'a',
-			1
+	/**
+	 * The gaps this closes are the ones `resolve-hotspot-markers.ts` in the
+	 * viewer works around: it ranks rather than printing `sequenceIndex + 1`
+	 * precisely because the old swap left scenes holding 0, 1 and 4. Emitting a
+	 * dense range removes the cause; the viewer's rank stays as hardening for
+	 * consumers that never pass through this panel.
+	 */
+	it('closes gaps left by the indices it is given', () => {
+		const result = reorderSequence(
+			[hotspot('a', { sequenceIndex: 3 }), hotspot('b', { sequenceIndex: 7 })],
+			['a', 'b']
 		)
-		expect(result.map((h) => [h.id, h.sequenceIndex])).toEqual([
-			['a', 1],
-			['b', 2]
-		])
-	})
 
-	it('takes a hotspot out of the sequence without disturbing anyone', () => {
-		const result = assignSequenceIndex(
-			[hotspot('a', { sequenceIndex: 0 }), hotspot('b', { sequenceIndex: 1 })],
-			'a',
-			undefined
-		)
-		expect(result.map((h) => [h.id, h.sequenceIndex])).toEqual([
-			['a', undefined],
+		expect(indices(result)).toEqual([
+			['a', 0],
 			['b', 1]
 		])
 	})
 
-	it('is a no-op when the id is not present', () => {
-		const list = [hotspot('a', { sequenceIndex: 0 })]
-		expect(assignSequenceIndex(list, 'gone', 4)).toEqual(list)
+	it('consumes no index for an id naming no hotspot', () => {
+		const result = reorderSequence([hotspot('a')], ['ghost', 'a'])
+
+		expect(indices(result)).toEqual([['a', 0]])
+	})
+
+	it('consumes no index for a repeated id', () => {
+		const result = reorderSequence(
+			[hotspot('a'), hotspot('b')],
+			['a', 'a', 'b']
+		)
+
+		expect(indices(result)).toEqual([
+			['a', 0],
+			['b', 1]
+		])
+	})
+
+	/**
+	 * `scene-hotspot-comparison.ts` matches by id and does not store list order,
+	 * and the panel renders from its own sort. Reordering the array here would
+	 * make the return value's shape a second, competing source of order.
+	 */
+	it('returns the hotspots in the order they arrived', () => {
+		const result = reorderSequence([hotspot('b'), hotspot('a')], ['a', 'b'])
+
+		expect(result.map((h) => h.id)).toEqual(['b', 'a'])
+	})
+
+	it('leaves a hotspot whose index is already correct untouched by reference', () => {
+		const settled = hotspot('a', { sequenceIndex: 0 })
+		const result = reorderSequence([settled], ['a'])
+
+		expect(result[0]).toBe(settled)
 	})
 
 	it('does not mutate the input', () => {
@@ -72,7 +108,70 @@ describe('assignSequenceIndex', () => {
 			hotspot('a', { sequenceIndex: 0 }),
 			hotspot('b', { sequenceIndex: 1 })
 		]
-		assignSequenceIndex(list, 'a', 1)
-		expect(list.map((h) => h.sequenceIndex)).toEqual([0, 1])
+
+		reorderSequence(list, ['b', 'a'])
+
+		expect(indices(list)).toEqual([
+			['a', 0],
+			['b', 1]
+		])
+	})
+
+	it('is empty for an empty list', () => {
+		expect(reorderSequence([], [])).toEqual([])
+	})
+})
+
+describe('setSequenceMembership', () => {
+	it('appends a hotspot to the end of the sequence', () => {
+		const result = setSequenceMembership(
+			[hotspot('a', { sequenceIndex: 0 }), hotspot('b')],
+			'b',
+			true
+		)
+
+		expect(indices(result)).toEqual([
+			['a', 0],
+			['b', 1]
+		])
+	})
+
+	it('closes the gap when a hotspot leaves the sequence', () => {
+		const result = setSequenceMembership(
+			[
+				hotspot('a', { sequenceIndex: 0 }),
+				hotspot('b', { sequenceIndex: 1 }),
+				hotspot('c', { sequenceIndex: 2 })
+			],
+			'b',
+			false
+		)
+
+		expect(indices(result)).toEqual([
+			['a', 0],
+			['b', undefined],
+			['c', 1]
+		])
+	})
+
+	it('leaves a hotspot that is already a member where it is', () => {
+		const result = setSequenceMembership(
+			[hotspot('a', { sequenceIndex: 0 }), hotspot('b', { sequenceIndex: 1 })],
+			'a',
+			true
+		)
+
+		expect(indices(result)).toEqual([
+			['a', 0],
+			['b', 1]
+		])
+	})
+
+	it('is a no-op for an id naming no hotspot', () => {
+		const list = [hotspot('a', { sequenceIndex: 0 })]
+
+		expect(indices(setSequenceMembership(list, 'gone', true))).toEqual([
+			['a', 0]
+		])
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-sequence.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-sequence.ts
@@ -3,44 +3,93 @@
  *
  * No camera is involved, so these take the hotspot list on its own rather than
  * the paired state `scene-hotspot-camera-links` works in.
+ *
+ * The list is the order. Both functions here emit a dense `0..n-1` range rather
+ * than an arbitrary set of unique integers, which is all the server enforces.
+ * Density is not decoration: `resolve-hotspot-markers.ts` in `@vctrl/viewer`
+ * numbers steps by rank instead of by `sequenceIndex + 1` specifically because
+ * the swap these replaced left scenes holding 0, 1 and 4, and printing those
+ * would tell a visitor there are steps they cannot find. Emitting a dense range
+ * removes that cause. The viewer keeps its rank as hardening for consumers that
+ * never pass through the publisher at all.
  */
 
 import type { HotspotDefinition } from '@vctrl/core'
 
-const nextFreeSequenceIndex = (
-	hotspots: readonly HotspotDefinition[]
-): number =>
-	hotspots.reduce(
-		(next, h) =>
-			h.sequenceIndex === undefined
-				? next
-				: Math.max(next, h.sequenceIndex + 1),
-		0
-	)
+/** Applies a new index to a hotspot, or returns it untouched when it already holds one. */
+const withSequenceIndex = (
+	hotspot: HotspotDefinition,
+	sequenceIndex: number | undefined
+): HotspotDefinition =>
+	hotspot.sequenceIndex === sequenceIndex
+		? hotspot
+		: { ...hotspot, sequenceIndex }
 
 /**
- * Puts one hotspot at `sequenceIndex`, swapping with whoever already held it.
+ * Renumbers the playback order from the ids, in the order given.
  *
- * Swapping rather than refusing keeps every index unique, which is what the
- * server requires, and matches what someone reordering a sequence expects. A
- * hotspot joining the sequence has no slot to hand over, so the displaced one
- * takes the next free index rather than dropping out of the sequence, which
- * would quietly change playback the author never asked to change.
+ * This is what dragging a row asks for: a splice, not the swap the retired
+ * `assignSequenceIndex` performed. Expressing a splice as a run of swaps
+ * renumbers hotspots the author never touched.
+ *
+ * `orderedIds` is the whole sequence, so a hotspot missing from it leaves the
+ * sequence. Ids naming no hotspot, and ids repeated in the list, consume no
+ * index; both are reachable from a stale drag list, and letting either take a
+ * slot would leave a step nothing occupies.
+ *
+ * The returned array keeps the order it arrived in. `scene-hotspot-comparison`
+ * matches by id and stores no list order, and the panel sorts for display, so
+ * reordering here would make the return value a second, competing claim about
+ * what the order is.
  */
-export function assignSequenceIndex(
+export function reorderSequence(
+	hotspots: readonly HotspotDefinition[],
+	orderedIds: readonly string[]
+): HotspotDefinition[] {
+	const assigned = new Map<string, number>()
+
+	for (const id of orderedIds) {
+		if (assigned.has(id)) continue
+		if (!hotspots.some((hotspot) => hotspot.id === id)) continue
+		assigned.set(id, assigned.size)
+	}
+
+	return hotspots.map((hotspot) =>
+		withSequenceIndex(hotspot, assigned.get(hotspot.id))
+	)
+}
+
+/**
+ * Adds a hotspot to the playback order, or takes it out and closes the gap.
+ *
+ * Joining appends rather than inserting: the author asked to include the
+ * hotspot, not to decide where it belongs, and the list is right there to drag.
+ * Asking for the state a hotspot is already in leaves its position alone — the
+ * switch is idempotent, so re-affirming membership must not quietly move a step
+ * to the end of the sequence.
+ */
+export function setSequenceMembership(
 	hotspots: readonly HotspotDefinition[],
 	id: string,
-	sequenceIndex: number | undefined
+	inSequence: boolean
 ): HotspotDefinition[] {
-	const target = hotspots.find((h) => h.id === id)
+	const target = hotspots.find((hotspot) => hotspot.id === id)
 	if (!target) return [...hotspots]
 
-	const displacedTo = target.sequenceIndex ?? nextFreeSequenceIndex(hotspots)
+	const ordered = hotspots
+		.filter((hotspot) => hotspot.sequenceIndex !== undefined)
+		.sort((a, b) => (a.sequenceIndex as number) - (b.sequenceIndex as number))
+		.map((hotspot) => hotspot.id)
 
-	return hotspots.map((h) => {
-		if (h.id === id) return { ...h, sequenceIndex }
-		return sequenceIndex !== undefined && h.sequenceIndex === sequenceIndex
-			? { ...h, sequenceIndex: displacedTo }
-			: h
-	})
+	if (!inSequence) {
+		return reorderSequence(
+			hotspots,
+			ordered.filter((memberId) => memberId !== id)
+		)
+	}
+
+	return reorderSequence(
+		hotspots,
+		ordered.includes(id) ? ordered : [...ordered, id]
+	)
 }

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-sequence.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-sequence.ts
@@ -26,6 +26,36 @@ const withSequenceIndex = (
 		: { ...hotspot, sequenceIndex }
 
 /**
+ * The ids that will actually take a place in the order, in the order they take.
+ *
+ * A drag list is not trustworthy input: it can name a hotspot that has since
+ * been deleted, and it can repeat one. Neither may consume a slot, or the
+ * sequence ends up with a step nothing occupies.
+ *
+ * Exported because `reorderSequence` and `applySequenceMove` both have to agree
+ * on it: one assigns the indices, the other compares against the stored order
+ * and counts the position it announces. When only the first used it, an order
+ * carrying a single stale id announced "position 3 of 3" for a two-member
+ * sequence and committed no change at all.
+ */
+export function resolveSequenceOrder(
+	hotspots: readonly HotspotDefinition[],
+	orderedIds: readonly string[]
+): string[] {
+	const seen = new Set<string>()
+	const resolved: string[] = []
+
+	for (const id of orderedIds) {
+		if (seen.has(id)) continue
+		if (!hotspots.some((hotspot) => hotspot.id === id)) continue
+		seen.add(id)
+		resolved.push(id)
+	}
+
+	return resolved
+}
+
+/**
  * Renumbers the playback order from the ids, in the order given.
  *
  * This is what dragging a row asks for: a splice, not the swap the retired
@@ -46,13 +76,9 @@ export function reorderSequence(
 	hotspots: readonly HotspotDefinition[],
 	orderedIds: readonly string[]
 ): HotspotDefinition[] {
-	const assigned = new Map<string, number>()
-
-	for (const id of orderedIds) {
-		if (assigned.has(id)) continue
-		if (!hotspots.some((hotspot) => hotspot.id === id)) continue
-		assigned.set(id, assigned.size)
-	}
+	const assigned = new Map(
+		resolveSequenceOrder(hotspots, orderedIds).map((id, index) => [id, index])
+	)
 
 	return hotspots.map((hotspot) =>
 		withSequenceIndex(hotspot, assigned.get(hotspot.id))
@@ -92,4 +118,66 @@ export function setSequenceMembership(
 		hotspots,
 		ordered.includes(id) ? ordered : [...ordered, id]
 	)
+}
+
+/**
+ * One move through the playback order: the new list, and where the marker
+ * landed, or `null` when the move is not one.
+ *
+ * The decision and the numbers travel together on purpose. They were three
+ * separate calls in the panel - is this applicable, resolve it, renumber it -
+ * wired inside a state updater that no test can reach, because the only caller
+ * that can produce an inapplicable order is a pointer drag. Two of the three
+ * could be broken with the whole suite still green. Here the same three steps
+ * are one unit with one specced contract.
+ *
+ * Two orders are not moves, and both arrive by drag:
+ *
+ * - one that resolves to the sequence already stored. A drag released where it
+ *   began is not an edit, and announcing it would tell a screen reader that
+ *   something moved when nothing did.
+ * - one naming no hotspot in the list. framer deliberately keeps a drag session
+ *   alive across unmount and still fires `onDragEnd`, so if a different scene
+ *   loaded meanwhile, applying it would clear the sequence of a scene the
+ *   author never touched.
+ * - one that survives without the marker it was moving, which happens when that
+ *   marker is deleted from elsewhere mid-drag. The rest may well have moved, but
+ *   there is nothing left to announce and the position would read as zero.
+ */
+export interface SequenceMove {
+	hotspots: HotspotDefinition[]
+	/** 1-based place the marker landed in, for an announcement. */
+	position: number
+	/** How many markers the order ended up holding. */
+	total: number
+}
+
+export function applySequenceMove(
+	hotspots: readonly HotspotDefinition[],
+	orderedIds: readonly string[],
+	movedId: string
+): SequenceMove | null {
+	const resolved = resolveSequenceOrder(hotspots, orderedIds)
+	if (resolved.length === 0) return null
+
+	const stored = hotspots
+		.filter((hotspot) => hotspot.sequenceIndex !== undefined)
+		.sort((a, b) => (a.sequenceIndex as number) - (b.sequenceIndex as number))
+		.map((hotspot) => hotspot.id)
+
+	// Element-wise rather than comparing joined strings. Ids are uuids, so a
+	// separator cannot appear inside one and both spellings agree today - but
+	// that is a rule the save parser enforces two layers away, and this module
+	// should not need it to be correct.
+	const unchanged =
+		stored.length === resolved.length &&
+		stored.every((id, index) => id === resolved[index])
+	if (unchanged) return null
+	if (!resolved.includes(movedId)) return null
+
+	return {
+		hotspots: reorderSequence(hotspots, resolved),
+		position: resolved.indexOf(movedId) + 1,
+		total: resolved.length
+	}
 }

--- a/apps/vectreal-platform/vite.config.ts
+++ b/apps/vectreal-platform/vite.config.ts
@@ -215,6 +215,48 @@ export default defineConfig(({ command }) => {
 						}
 
 						if (id.includes('/packages/viewer/')) {
+							/*
+							  The hotspot list rules are the one part of the viewer a
+							  surface can want without the viewer.
+
+							  `@vctrl/viewer/hotspots` exists so the publisher's sidebar
+							  can number sequence steps the same way the renderer does
+							  without importing React, three and drei behind it. That
+							  buys nothing here unless this predicate agrees: it buckets
+							  by path, so a dependency-free module under `packages/viewer`
+							  still lands in a chunk that statically imports
+							  `vendor-react-three`, which imports `vendor-postprocessing`.
+							  Left in, one `resolveHotspotMarkers` call in a compose panel
+							  put the 62KB viewer chunk into the shared `components-*`
+							  chunk, which the marketing home page imports statically.
+
+							  Measured on the emitted graph, not estimated. Note what it
+							  does *not* fix: three, R3F and postprocessing are eager on
+							  `/` regardless, through `components-*` →
+							  `vendor-three-examples` → `vendor-postprocessing`, which
+							  `@vctrl/core`'s glTF exporter pulls in. That is a separate
+							  and much larger problem, filed on its own.
+
+							  Its own bucket rather than none: the module is imported by
+							  the viewer's own barrel too, so leaving it unbucketed lets
+							  rollup hoist the shared copy straight back into the chunk
+							  this is trying to keep it out of.
+							*/
+							/*
+							  Matched exactly. A looser `includes` would also catch a
+							  future `src/hotspots/` directory or a `.tsx` of the same
+							  name, and quietly put an R3F-importing module into the
+							  bucket the marketing home page imports eagerly.
+							*/
+							if (
+								id.endsWith('/packages/viewer/src/hotspots.ts') ||
+								id.endsWith(
+									'/packages/viewer/src/components/scene/resolve-hotspot-markers.ts'
+								)
+							) {
+								return 'vendor-vectreal-hotspots'
+							}
+
 							return 'vendor-vectreal-viewer'
 						}
 					}

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -41,6 +41,11 @@
 			"import": "./index.js",
 			"require": "./index.cjs"
 		},
+		"./hotspots": {
+			"types": "./hotspots.d.ts",
+			"import": "./hotspots.js",
+			"require": "./hotspots.cjs"
+		},
 		"./css": "./style.css"
 	},
 	"dependencies": {

--- a/packages/viewer/src/hotspots.ts
+++ b/packages/viewer/src/hotspots.ts
@@ -1,0 +1,24 @@
+/**
+ * The hotspot list rules, without the renderer.
+ *
+ * Which hotspots are drawn, in what order, and what step number each one shows
+ * is decided here rather than in the marker component, and an authoring surface
+ * has to agree with a viewing one about all three: a publisher that numbered its
+ * own rows would print a step nobody browsing the published scene ever sees.
+ *
+ * A separate entry point because the package root pulls in the viewer itself -
+ * React, three, and drei - and its stylesheet, so a consumer that only wants the
+ * numbering would drag all of that into whatever bundle it lands in. This module
+ * imports nothing at runtime.
+ *
+ * A bundler that chunks by path needs telling as well. The platform's
+ * `manualChunks` bucketed everything under `packages/viewer` together, so this
+ * module still landed in the viewer's chunk - three and R3F behind it - until it
+ * was given a bucket of its own.
+ */
+
+export {
+	resolveHotspotMarkers,
+	type HotspotMarker,
+	type ResolveHotspotMarkersOptions
+} from './components/scene/resolve-hotspot-markers'

--- a/packages/viewer/vite.config.ts
+++ b/packages/viewer/vite.config.ts
@@ -27,9 +27,17 @@ export default defineConfig({
 		},
 
 		lib: {
-			entry: 'src/index.ts',
+			entry: {
+				index: path.resolve(import.meta.dirname, 'src/index.ts'),
+				// Dependency-free, so a consumer that only needs the hotspot list
+				// rules does not pull React, three and drei in behind them.
+				hotspots: path.resolve(import.meta.dirname, 'src/hotspots.ts')
+			},
 			name: '@vctrl/viewer',
-			fileName: 'index',
+			// Spelled out rather than taking the default, which appends the format
+			// to every name: `index.js` and `index.cjs` are what `exports` already
+			// points at, and renaming them would break every installed consumer.
+			fileName: (format, entry) => `${entry}.${format === 'es' ? 'js' : 'cjs'}`,
 			cssFileName: 'style',
 			// Don't forget to update your package.json as well.
 			formats: ['es', 'cjs']

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,6 +34,7 @@
 				"packages/hooks/src/use-optimize-model/index.ts"
 			],
 			"@vctrl/viewer": ["packages/viewer/src/index.ts"],
+			"@vctrl/viewer/hotspots": ["packages/viewer/src/hotspots.ts"],
 			"@vctrl/core": ["packages/core/src/index.ts"],
 			"@vctrl/core/model-loader": ["packages/core/src/model-loader/index.ts"],
 			"@vctrl/core/model-optimizer": [


### PR DESCRIPTION
## Summary

Rebuilds the publisher's hotspot compose panel on the surfaces and components the publisher shell already owns, puts every compose panel on one section idiom, and closes five rounds of review on both.

The panel's selected row was `bg-orange/80` carrying `text-muted-foreground` coordinates on top — about **1.1:1 in dark, 1.9:1 in light**. That contrast failure is what started this; the rest is what the surrounding code turned out to need once the panel stopped hand-rolling its own vocabulary.

## Root cause

The hotspot panel predates the publisher shell's surface vocabulary and was never brought onto it, so it separated surfaces with a brand fill and a raw `amber-500` outline where the rule stated in `globals.css` is that "Vectreal separates surfaces by value, not by outlines", and where `publisher-shell-nested`, `Collapsible`, `InlineNotice` and `SettingToggle` already own every job it did by hand.

## Changes

**The panel is a disclosure list.** The list and the `Edit: <name>` section were two things describing one hotspot; now a row expands in place. **Being open is being selected**, so selection needs no colour at all — which is why the shell ladder's missing "selected" rung is a non-problem rather than a reason to add one. `--orange` does not appear anywhere in the panel.

**The list is the playback order.** The `sequenceIndex` number field is gone; markers drag to reorder, with a keyboard path on each handle. `assignSequenceIndex` (a swap) is replaced by `applySequenceMove` and `reorderSequence` (a splice, emitting a dense `0..n-1`).

That last part removes a cause rather than adding a check: `resolve-hotspot-markers.ts` in `@vctrl/viewer` numbers steps by *rank* rather than `sequenceIndex + 1` precisely because the old swap left scenes holding 0, 1 and 4. The panel now reads its step numbers from that same function, so the number on a row is the number a visitor sees, and the gaps stop being produced. The viewer keeps its rank as hardening for consumers that never pass through the publisher.

**Closing the tool drawer releases the selection.** `activeHotspotIdAtom` is what puts the transform gizmo on the model and it outlived the panel, so closing the drawer left a gizmo floating over the scene with nothing to dismiss it — the same defect the click-to-place cleanup was written for, one atom over.

**One section idiom.** Interaction and Shadow move off a hand-rolled uppercase `text-xs` heading onto `SidebarSection`. Shadow's preset grid comes off a solid `bg-primary` fill onto `ToggleButtonGroup` — a fourth selection language, and the same defect as the hotspot row. `SidebarSection` and `SettingGroup` gain an `action` slot.

**A dependency-free `@vctrl/viewer/hotspots` entry point**, so a surface that wants the list rules does not pull React, three and drei behind them.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required

1175 platform tests, 91 viewer tests, typecheck and lint green on `vctrl/core`, `vctrl/hooks`, `vctrl/viewer` and `vectreal-platform`, prettier clean on every changed file.

Every guard added was mutation-tested: the production line was broken and a named test watched to go red. Two guards resisted that at first and are worth naming, because the fix was structural rather than a new test. Deciding whether a drag was a move, and counting the position it announced, sat inside a state updater jsdom cannot reach — both could be deleted with the whole suite green. They are now one `applySequenceMove` in the domain module, specced directly.

Verified in the browser in both themes: the list, an expanded row, armed placement, a hidden marker, and the drawer closing without leaving a gizmo behind.

The bundle claim is measured on the emitted chunk graph rather than asserted. The panel's chunk imported one binding from the 62KB viewer chunk, and both `publisher-layout-*` and `home-page-*` import that chunk statically; it now imports 1122 bytes that import nothing, and the viewer chunk is out of the home page's static closure.

**Residual risk.** `publisher-editor-scene.tsx` has no component-level test coverage and this branch does not add any, so the gizmo drag, click-to-place and the view-cube withdrawal are covered by the manual pass and nothing else. The `isDragging` re-seed guard is likewise unpinned — it is React lifecycle and cannot be lifted into a pure function the way the arithmetic was.

## Filed rather than fixed

Each of these is a catalogue row, not a line in this diff:

- **The home page eagerly loads ~1.5MB of three and R3F it never renders**, through `components-* → vendor-three-examples → vendor-postprocessing`. Predates this branch; found while chasing the 62KB above. The guard that would catch this class is a CI assertion on the emitted chunk graph — nothing in the build reports it today, and the `onwarn` branch that looks like it should is dead code, because rolldown does not emit that warning at all.
- **The publisher draws its own hotspot marker** instead of the one `@vctrl/viewer` ships, so an author composes against a marker no visitor sees, and both stylesheets define `@keyframes vctrl-hotspot-pulse` differently. `@vctrl/viewer` also needs editing affordances before the publisher can drop its copy.
- **The shell ladder has surface rungs but no foreground rung**, so `--muted-foreground` on a nested block is ~4.0:1 in light. Two opacity modifiers this branch introduced are gone, but the underlying gap is what leaves the rest marginal.
- **An X/Y/Z field cannot be cleared**, so a negative coordinate cannot be typed after clearing one. Pre-existing; React rewrites a controlled `type="number"` input when the handler declines to set state.
- `ToggleButtonGroup` carries its selected state in colour alone, with no `aria-pressed` — pre-existing, but this branch took it from one call site to three.
- `@vctrl/viewer` ships `.d.ts` files importing paths outside the published package.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [ ] I updated documentation where needed
- [ ] I linked the related issue above
