### PR TITLE
feat(api-keys): store the embed token so it can be read back

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -60,6 +60,10 @@ SEND_EMAIL_HOOK_SECRET=
 
 # Local contact form PII encryption (optional - uses CSRF fallback if unset)
 CONTACT_DATA_ENCRYPTION_KEY=
+# Encrypts the embed preview token at rest so the embed panel can offer a key
+# the owner already created. Required in production; development falls back to a
+# fixed key with a warning. Base64 of 32 bytes, or any passphrase.
+EMBED_TOKEN_ENCRYPTION_KEY=
 
 # Vite dev tooling
 VITE_DEV_TOOLS=true
@@ -174,6 +178,7 @@ RESEND_WEBHOOK_SECRET_STAGING=
 # PII encryption key for contact form submissions (32-byte base64)
 # Generate: openssl rand -base64 32
 CONTACT_DATA_ENCRYPTION_KEY_STAGING=
+EMBED_TOKEN_ENCRYPTION_KEY_STAGING=
 
 # Cloudflare Turnstile (staging site key from dash.cloudflare.com > Turnstile)
 CLOUDFLARE_TURNSTILE_SITE_KEY_STAGING=
@@ -210,6 +215,7 @@ RESEND_WEBHOOK_SECRET_PROD=
 
 # PII encryption key - keep different from staging for isolation.
 CONTACT_DATA_ENCRYPTION_KEY_PROD=
+EMBED_TOKEN_ENCRYPTION_KEY_PROD=
 
 # Cloudflare Turnstile (production site key from dash.cloudflare.com > Turnstile)
 CLOUDFLARE_TURNSTILE_SITE_KEY_PROD=

--- a/apps/vectreal-platform/app/components/api-keys/one-time-key-dialog.tsx
+++ b/apps/vectreal-platform/app/components/api-keys/one-time-key-dialog.tsx
@@ -13,10 +13,19 @@ import { useEffect, useId, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 /**
- * The one moment a key's plaintext exists outside the database.
+ * The moment a freshly minted key is put in front of its owner.
  *
- * Keys are stored hashed, so this dialog is the only place the full value is
- * ever shown, and it is the only one: the embed panel used to render a second
+ * The copy here says only what a user can observe: this is where the value is
+ * shown, and the key lists elsewhere show four characters.
+ *
+ * It deliberately makes no claim about storage. It used to say the key was
+ * "stored hashed, so it cannot be read back", which stopped being true when a
+ * decryptable copy was added, and telling someone a value is unrecoverable when
+ * it is not teaches them to distrust the next warning that is real. The
+ * opposite promise - that some other screen will show it to them again - is not
+ * made either, because no screen does that yet.
+ *
+ * This is still the only such dialog: the embed panel used to render a second
  * dialog for the same event, written to its own spec, and the two diverged
  * exactly where it mattered. That one carried `ph-no-capture`, without which
  * the live key is readable in any session replay; this one re-arms the copy
@@ -55,7 +64,7 @@ const COPY_FAILURE = 'Failed to copy the API key.'
 const COPY_SUCCESS = 'API key copied to clipboard'
 const CLIPBOARD_UNAVAILABLE = 'Clipboard is not available in this browser.'
 const DISMISS_WITHOUT_COPY_CONFIRM =
-	'Have you copied your API key? This is the only time it will be displayed.'
+	'Have you copied your API key? It is not displayed again on this screen.'
 
 const REASON_COPY: Record<
 	OneTimeKeyReason,
@@ -64,7 +73,7 @@ const REASON_COPY: Record<
 	created: {
 		title: 'API key created',
 		description:
-			'This is the only time the full key is shown. It is stored hashed, so it cannot be read back.',
+			'Copy it now. Key lists only ever show the last four characters.',
 		nextSteps: [
 			'Copy the key above to a secure location',
 			'Paste it into the embed snippet, or into your own request headers',
@@ -189,19 +198,17 @@ export function OneTimeKeyDialog({
 					>
 						<AlertCircle className="text-warning size-4" />
 						{/*
-						  Scoped to what is true on both surfaces. "Once you close this
-						  dialog the full key is no longer accessible" held on the
-						  dashboard and not in the embed panel, where `use-embed-api-keys`
-						  puts the plaintext into the token field, behind a reveal toggle,
-						  for as long as that panel stays mounted. Stating the server-side
-						  fact instead is true wherever this dialog opens, and it is the
-						  one that costs money to learn late.
+						  A claim about this page, not about storage. "Once you close this
+						  dialog the full key is no longer accessible" describes the
+						  database, and `encrypted_key` now holds a readable copy - so it
+						  had stopped being true. What is true here is narrow and
+						  checkable: the lists on this page show the preview and nothing
+						  more.
 						*/}
 						<AlertDescription className="text-warning-muted-foreground">
-							<strong>Important:</strong> Copy this key now. It is stored
-							hashed, so it can never be read back from Vectreal - once you
-							leave this page, the preview (...{apiKey.preview}) is all that
-							remains.
+							<strong>Important:</strong> Copy this key now. Once you leave
+							this dialog, the key lists show only the preview
+							(...{apiKey.preview}).
 						</AlertDescription>
 					</Alert>
 

--- a/apps/vectreal-platform/app/db/schema/auth/api-keys.ts
+++ b/apps/vectreal-platform/app/db/schema/auth/api-keys.ts
@@ -26,6 +26,22 @@ export const apiKeys = pgTable(
 		name: text('name').notNull(),
 		description: text('description'),
 		hashedKey: text('hashed_key').notNull(),
+		/*
+		  The same secret, kept readable, so the embed panel can offer a key the
+		  owner already made instead of asking them to paste one back.
+
+		  Not a weakening of `hashedKey`, which stays the only thing an embed
+		  request is matched against. This token is published by design - it goes
+		  into an `iframe src` on the customer's own page - and the allowed-domain
+		  list, not its secrecy, is what restricts it. Encrypted at rest all the
+		  same, so a database dump does not hand over working embed tokens for
+		  every customer at once.
+
+		  Nullable, and permanently so for rows written before this column: their
+		  plaintext was never kept and cannot be recovered. Rotating such a key is
+		  the way back, and it already exists.
+		*/
+		encryptedKey: text('encrypted_key'),
 		keyPreview: text('key_preview').notNull(),
 		active: boolean('active').default(true),
 		lastUsedAt: timestamp('last_used_at', { withTimezone: true }),

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
@@ -9,6 +9,7 @@ import { organizationMemberships } from '../../../db/schema/core/organization-me
 import { organizations } from '../../../db/schema/core/organizations'
 import { users } from '../../../db/schema/core/users'
 import { projects } from '../../../db/schema/project/projects'
+import { encryptEmbedToken } from '../../security/embed-token-cipher.server'
 import {
 	getOrgSubscription,
 	getRecommendedUpgrade
@@ -252,7 +253,8 @@ export interface CreateApiKeyParams {
 
 /**
  * Create a new API key
- * @returns The created key details with plaintext key (only time it's accessible)
+ * @returns The created key details with the plaintext key. Also stored, encrypted,
+ * on the row itself, so the embed panel can offer this key again later.
  */
 export async function createApiKey(
 	params: CreateApiKeyParams
@@ -298,6 +300,7 @@ export async function createApiKey(
 			name,
 			description: description || null,
 			hashedKey: hashed,
+			encryptedKey: encryptEmbedToken(plaintext),
 			keyPreview: preview,
 			active: true,
 			expiresAt: expiresAt || null
@@ -345,7 +348,7 @@ export async function createApiKey(
 		creator,
 		organization,
 		projects: projectDetails,
-		plaintext // Only returned on creation
+		plaintext
 	}
 }
 
@@ -479,6 +482,12 @@ export async function rotateApiKey(params: {
 		.update(apiKeys)
 		.set({
 			hashedKey: hashed,
+			/*
+			  Rewritten, not left behind. A stale value here would hand the panel
+			  the secret this rotation just replaced, which authorizes nothing -
+			  the exact failure rotation exists to end.
+			*/
+			encryptedKey: encryptEmbedToken(plaintext),
 			keyPreview: preview,
 			rotatedAt: new Date(),
 			/*
@@ -537,7 +546,14 @@ export async function revokeApiKey(
 		.update(apiKeys)
 		.set({
 			revokedAt: new Date(),
-			active: false
+			active: false,
+			/*
+			  Dropped, not kept. Someone revoking a leaked key expects the value to
+			  stop being retrievable, and this row's copy authorizes nothing once
+			  `revokedAt` is set - so keeping it around only contradicts what the
+			  action means.
+			*/
+			encryptedKey: null
 		})
 		.where(eq(apiKeys.id, apiKeyId))
 }

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-key-options.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-key-options.ts
@@ -11,12 +11,29 @@
 
 import { resolveApiKeyState } from '../auth/api-key-lifecycle'
 
-/** One row in the embed panel's key picker. Never carries a key's plaintext. */
+/** One row in the embed panel's key picker, value included where there is one. */
 export interface EmbedApiKeyOption {
 	id: string
 	name: string
-	/** Last four characters of the key. The only part ever stored in the clear. */
+	/** Last four characters of the key, for naming it without reading it. */
 	keyPreview: string
+	/**
+	 * The key itself, when this row still has a recoverable one.
+	 *
+	 * Null in three cases, and the third is the routine one: a key created before
+	 * the token was stored decryptably, a key whose stored value no longer
+	 * decrypts, and a revoked key, whose value `revokeApiKey` clears on purpose.
+	 *
+	 * Any of them can still be named, and still explains an embed that is
+	 * failing, but none can build a snippet. Rotation is the way back for the
+	 * first two only - `rotateApiKey` refuses anything that is not active, so a
+	 * revoked key is replaced rather than recovered. Read `revoked` before this
+	 * field when deciding what to tell someone.
+	 *
+	 * Decrypted by the route before it reaches this module, which stays free of
+	 * any server import so the client can hold this type.
+	 */
+	value: string | null
 	expiresAt: string | null
 	lastUsedAt: string | null
 	/** Revoked, or otherwise unusable for a reason the owner caused. */
@@ -32,8 +49,10 @@ export interface EmbedApiKeyOption {
 	expired: boolean
 }
 
-/** Minimum of `ApiKeyWithDetails` this module reads. */
+/** Minimum of `ApiKeyWithDetails` this module reads, plus the decrypted token. */
 export interface EmbedApiKeySource {
+	/** Already decrypted by the caller; see `EmbedApiKeyOption.value`. */
+	value: string | null
 	apiKey: {
 		id: string
 		name: string
@@ -70,6 +89,7 @@ export function toEmbedApiKeyOptions(
 				id: key.apiKey.id,
 				name: key.apiKey.name,
 				keyPreview: key.apiKey.keyPreview,
+				value: key.value,
 				expiresAt: key.apiKey.expiresAt?.toISOString() ?? null,
 				lastUsedAt: key.apiKey.lastUsedAt?.toISOString() ?? null,
 				/*
@@ -84,8 +104,17 @@ export function toEmbedApiKeyOptions(
 			}
 		})
 		.sort((a, b) => {
-			const byUsable =
-				Number(a.revoked || a.expired) - Number(b.revoked || b.expired)
+			/*
+			  A key with no recoverable value sorts down with the dead ones. It is
+			  live, and it still explains a failing embed, but it cannot produce a
+			  snippet - which is what the picker is for, so it must not sit at the
+			  top as the obvious choice.
+
+			*/
+			const usable = (option: typeof a) =>
+				Number(option.revoked || option.expired || option.value === null)
+
+			const byUsable = usable(a) - usable(b)
 			return byUsable !== 0 ? byUsable : b.createdAt - a.createdAt
 		})
 		.map(({ createdAt: _createdAt, ...option }) => option)
@@ -94,10 +123,14 @@ export function toEmbedApiKeyOptions(
 /**
  * Whether a pasted token could be the selected key.
  *
- * Only the last four characters are stored in the clear, so this is the whole
- * check that is available: it catches pasting the wrong key of several, and
- * cannot confirm the right one. Advisory, never a gate - a false negative here
- * must not stop someone shipping a key that works.
+ * A comparison against the preview, not against the key: it catches pasting the
+ * wrong key of several and cannot confirm the right one. Advisory, never a gate
+ * - a false negative here must not stop someone shipping a key that works.
+ *
+ * This was the whole check available while the last four characters were the
+ * only part stored in the clear. `EmbedApiKeyOption.value` now carries the key
+ * itself where there is one, so a caller holding an option can compare exactly;
+ * this remains for the case that has no option to compare against.
  */
 export function matchesKeyPreview(token: string, keyPreview: string): boolean {
 	const trimmed = token.trim()

--- a/apps/vectreal-platform/app/lib/security/embed-token-cipher.server.ts
+++ b/apps/vectreal-platform/app/lib/security/embed-token-cipher.server.ts
@@ -1,0 +1,232 @@
+import {
+	createCipheriv,
+	createDecipheriv,
+	createHash,
+	randomBytes
+} from 'node:crypto'
+
+import { reportServerError } from '../observability/report-server-error.server'
+
+/**
+ * Two-way storage for the embed preview token.
+ *
+ * The token this protects is public by construction: `buildEmbedUrl` puts it in
+ * an `iframe src` on the customer's own page, where it is visible in view
+ * source, in devtools and in that site's access logs. It is a domain-scoped
+ * identifier, not a secret, and the allowed-domain list is the control that
+ * actually restricts it.
+ *
+ * It was nevertheless stored only as a SHA-256 hash, which meant the product
+ * could never show an owner a key they already had. The panel asked them to
+ * paste one back - a value the system had refused to give them - and offered a
+ * picker beside it that could not fill it in. Keeping a decryptable copy is what
+ * makes "pick the key you already made" possible at all.
+ *
+ * `hashedKey` is untouched and remains the lookup and validation path in
+ * `preview-api-key-auth.server.ts`. This is a second representation for display,
+ * never for authentication: nothing here is on the request path of an embed.
+ *
+ * Deliberately not `pii-encryption.server.ts`. That module is encrypt-only by
+ * design, because contact submissions are written and never read back, and it
+ * falls back to `CSRF_SECRET` in production. Neither property is wanted here:
+ * this needs a decrypt path, and it must not couple an embed token's lifetime to
+ * the session secret, whose rotation would silently strip every stored value.
+ * The duplicated AES envelope is the price; unifying the two is worth doing when
+ * a third caller appears, not as a rider on a schema change.
+ *
+ * Both entry points return null rather than throwing. See `getAesKey`: this is
+ * display-only storage hanging off the critical path that mints API keys, and it
+ * must never be the reason a key cannot be created.
+ */
+
+const ENCRYPTION_PREFIX = 'enc:v1'
+const ENCRYPTION_KEY_ENV = 'EMBED_TOKEN_ENCRYPTION_KEY'
+const DEVELOPMENT_FALLBACK_KEY = 'vectreal-dev-embed-token-fallback-key'
+
+/**
+ * One line per cause, not one line per process.
+ *
+ * A single flag let whichever cause happened first silence the others for the
+ * lifetime of the process - and the two failures are the ones most likely to
+ * overlap, since a deployment that lost its key material produces both. Keyed
+ * by cause, each still logs once, and none hides another.
+ *
+ * The level is a parameter because one of the three is not a problem: falling
+ * back to a development key is the documented local default, and
+ * `pii-encryption.server.ts` emits the same sentence at `warn`. Logging it as
+ * an error puts a `[security]` error in every local boot and in any tracker
+ * that reads level.
+ *
+ * `error` means `reportServerError`, which is the one path a server module may
+ * report a swallowed failure through, and which logs as well as reports. This
+ * used to be `console[level]`, which `no-console` forbids here: a `.server.ts`
+ * module does not get to invent its own reporting.
+ */
+const loggedCauses = new Set<string>()
+
+function logKeyNoticeOnce(
+	cause: string,
+	level: 'warn' | 'error',
+	message: string
+): void {
+	if (loggedCauses.has(cause)) return
+	loggedCauses.add(cause)
+
+	if (level === 'error') {
+		reportServerError(new Error(`[security] ${message}`))
+		return
+	}
+
+	console.warn(`[security] ${message}`)
+}
+
+/**
+ * The AES key, or null when this deployment cannot produce one.
+ *
+ * Null rather than a throw, and that is the whole design of this module.
+ *
+ * The first version threw in production when the key was unset, which read as
+ * correct - fail closed rather than encrypt with something nobody chose - but
+ * `createApiKey` calls this unconditionally, so an unset variable took down
+ * every API key mint and rotation in the product, including the dashboard's own
+ * form, for a value that is display-only. A feature that shows you a key must
+ * not be able to stop you making one.
+ *
+ * Failing closed is preserved where it matters: nothing is written under a key
+ * nobody configured. It is the *caller* that is spared, not the data - a null
+ * here stores no value, which is a state the panel already renders as "rotate
+ * to use".
+ *
+ * Every way this can go wrong logs once each, because all of them surface to a
+ * user as the same silent "cannot be shown": the variable unset, here, and
+ * material that changed under existing rows, from the decrypt path below.
+ * Without the second, a rotated deployment key turns every key in the product
+ * unreadable with no operational signal at all.
+ */
+function getAesKey(): Buffer | null {
+	const configured = process.env[ENCRYPTION_KEY_ENV]
+	if (configured && configured.trim().length > 0) {
+		return deriveAesKey(configured.trim())
+	}
+
+	if (process.env.NODE_ENV === 'production') {
+		logKeyNoticeOnce(
+			'unset',
+			'error',
+			`${ENCRYPTION_KEY_ENV} is not set. Embed tokens are not being stored, so keys minted now can never be shown again and must be rotated once it is configured.`
+		)
+		return null
+	}
+
+	logKeyNoticeOnce(
+		'fallback',
+		'warn',
+		`${ENCRYPTION_KEY_ENV} is not set. Using a development fallback key.`
+	)
+
+	return deriveAesKey(DEVELOPMENT_FALLBACK_KEY)
+}
+
+function deriveAesKey(keyMaterial: string): Buffer {
+	/*
+	  Round-tripped, not just length-checked. `Buffer.from(x, 'base64')` skips
+	  characters outside the alphabet instead of failing, so a passphrase that
+	  happens to contain 43 usable characters would silently be read as raw key
+	  bytes - and two different passphrases could collide onto one AES key with
+	  nothing to show for it.
+	*/
+	const decoded = Buffer.from(keyMaterial, 'base64')
+	if (decoded.length === 32 && decoded.toString('base64') === keyMaterial) {
+		return decoded
+	}
+
+	return createHash('sha256').update(keyMaterial).digest()
+}
+
+/** `enc:v1:<iv-base64>:<tag-base64>:<ciphertext-base64>` */
+export function encryptEmbedToken(plaintext: string): string | null {
+	const key = getAesKey()
+	if (!key) {
+		return null
+	}
+
+	const iv = randomBytes(12)
+	const cipher = createCipheriv('aes-256-gcm', key, iv)
+	const encrypted = Buffer.concat([
+		cipher.update(plaintext, 'utf8'),
+		cipher.final()
+	])
+
+	return [
+		ENCRYPTION_PREFIX,
+		iv.toString('base64'),
+		cipher.getAuthTag().toString('base64'),
+		encrypted.toString('base64')
+	].join(':')
+}
+
+/**
+ * The stored token, or null when this row cannot produce one.
+ *
+ * Null rather than a throw, for three cases that are all the same to a caller:
+ * a row written before this column existed, a row encrypted under key material
+ * that has since changed, and a row whose ciphertext no longer authenticates.
+ * Every one of them means "this key cannot be shown", which the panel already
+ * has to render - and throwing would take down the whole key list, including the
+ * keys that are fine, for one unreadable row.
+ *
+ * The GCM auth tag is what makes that safe: a tampered ciphertext fails here
+ * rather than decrypting to something an attacker chose.
+ */
+export function decryptEmbedToken(envelope: string | null): string | null {
+	if (!envelope) {
+		return null
+	}
+
+	const parts = envelope.split(':')
+	if (parts.length !== 5 || `${parts[0]}:${parts[1]}` !== ENCRYPTION_PREFIX) {
+		return null
+	}
+
+	/*
+	  Resolved before the try, because a missing key is a deployment problem and
+	  not a bad row, and routing it through the exception path would report it as
+	  one. The `catch` below is for ciphertext that does not authenticate; this
+	  never reaches it.
+	*/
+	const key = getAesKey()
+	if (!key) {
+		return null
+	}
+
+	const [, , iv, tag, ciphertext] = parts
+
+	try {
+		const decipher = createDecipheriv(
+			'aes-256-gcm',
+			key,
+			Buffer.from(iv, 'base64')
+		)
+		decipher.setAuthTag(Buffer.from(tag, 'base64'))
+
+		return Buffer.concat([
+			decipher.update(Buffer.from(ciphertext, 'base64')),
+			decipher.final()
+		]).toString('utf8')
+	} catch {
+		/*
+		  Either the ciphertext was tampered with or the key material changed
+		  under a row that was written with a different one. The second is the
+		  likely one and the dangerous one - it makes every existing key
+		  unreadable at once - and neither is visible anywhere else, since the
+		  caller only sees the same null a legacy row produces.
+		*/
+		logKeyNoticeOnce(
+			'undecryptable',
+			'error',
+			`An embed token could not be decrypted. If ${ENCRYPTION_KEY_ENV} was changed, every key stored under the previous value is now unreadable and must be rotated.`
+		)
+
+		return null
+	}
+}

--- a/apps/vectreal-platform/app/routes/api/projects.$projectId.api-keys.ts
+++ b/apps/vectreal-platform/app/routes/api/projects.$projectId.api-keys.ts
@@ -7,8 +7,10 @@
  * fetches for itself against this route rather than either mount site growing
  * props it cannot supply.
  *
- * No plaintext key is ever read back here. `createApiKey` returns one exactly
- * once, on creation, and that response is the only place it appears.
+ * The loader reads a key's value back, decrypted, for anyone who passes
+ * `api-key:read`. That is the point of `encrypted_key`: this token ships inside
+ * an `iframe src` on the customer's public page, so refusing to show it to the
+ * owner who minted it bought nothing and cost them the interaction.
  */
 
 import { ApiResponse } from '@shared/utils'
@@ -26,6 +28,7 @@ import { getProject } from '../../lib/domain/project/project-repository.server'
 import { getAuthUser } from '../../lib/http/auth.server'
 import { ensureValidCsrfFormData } from '../../lib/http/csrf.server'
 import { ensurePost } from '../../lib/http/requests.server'
+import { decryptEmbedToken } from '../../lib/security/embed-token-cipher.server'
 
 import type { EmbedApiKeyOption } from '../../lib/domain/embed/embed-key-options'
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router'
@@ -64,7 +67,14 @@ export interface EmbedApiKeysPayload {
 
 export interface EmbedApiKeyCreatedPayload {
 	key: EmbedApiKeyOption
-	/** The only time this value is ever sent. Not persisted in the clear. */
+	/**
+	 * The freshly minted value.
+	 *
+	 * No longer the only time it is sent - the loader returns it too, from
+	 * `encrypted_key` - and no longer a claim about storage. It stays on this
+	 * payload because a create response should not need a second round trip to
+	 * become usable.
+	 */
 	plaintext: string
 }
 
@@ -123,9 +133,44 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		projectId: project.id,
 		projectName: project.name,
 		allowedDomains: parseAllowedDomainPatterns(project.allowedEmbedDomains),
-		keys: toEmbedApiKeyOptions(allKeys, project.id, new Date()),
+		/*
+		  Decryption happens here, on the server, behind the `api-key:read` check
+		  above. `toEmbedApiKeyOptions` is pure and client-safe, so it takes the
+		  value already resolved rather than importing the cipher.
+		*/
+		keys: toEmbedApiKeyOptions(
+			/*
+			  Filtered before decrypting, not after. `getAllUserApiKeys` returns
+			  every key in every organization this actor administers, and
+			  `toEmbedApiKeyOptions` keeps only the ones scoped to this project -
+			  so decrypting first spends AES on rows about to be discarded, and
+			  puts their plaintext in memory for no reason.
+			*/
+			allKeys
+				.filter((key) =>
+					key.projects.some((scoped) => scoped.id === project.id)
+				)
+				.map((key) => ({
+					...key,
+					value: decryptEmbedToken(key.apiKey.encryptedKey)
+				})),
+			project.id,
+			new Date()
+		),
 		canCreateKey: canPerformDashboardOperation('api-key:create', membership)
 	}
+
+	/*
+	  `no-store`, explicitly. This payload now carries usable embed keys, and
+	  `ApiResponse.success` sets no cache directive of its own - only
+	  `ApiResponse.error` does. React Router's `handleDataRequest` hook, which
+	  stamps one elsewhere, runs for `.data` paths and skips resource routes
+	  entirely, so nothing else on this response says anything about caching.
+	  Cloudflare's fail-closed catch-all covers the edge, but that leaves the
+	  protection living in a Terraform rule instead of the response, and does
+	  nothing about the browser's own disk cache.
+	*/
+	headers.set('Cache-Control', 'no-store')
 
 	return ApiResponse.success(payload, 200, { headers })
 }
@@ -181,8 +226,19 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			expiresAt
 		})
 
+		/*
+		  The plaintext straight from the mint, not a decrypt of what was just
+		  written. Same value either way, and reading it back would only add a
+		  round trip through the cipher for a row this request created.
+		*/
 		const [option] = toEmbedApiKeyOptions(
-			[{ apiKey: created.apiKey, projects: [{ id: project.id }] }],
+			[
+				{
+					apiKey: created.apiKey,
+					projects: [{ id: project.id }],
+					value: created.plaintext
+				}
+			],
 			project.id,
 			new Date()
 		)

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys-edit.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys-edit.tsx
@@ -101,8 +101,32 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 	return data(
 		{
-			user,
-			apiKeyData,
+			/*
+			  `user` is deliberately not here. It was, and nothing on this page ever
+			  read it - the full Supabase user carries email, phone, both metadata
+			  bags and the `identities[]` array with per-provider data, which is a
+			  larger payload than the two secret columns this narrowing removed.
+			  Returning the actor "in case" is how a loader grows past its page.
+			*/
+			/*
+			  The fields this form reads, named one by one.
+
+			  `getApiKeyById` returns the row as stored, so returning it whole put
+			  `hashedKey` and the `encryptedKey` ciphertext into the payload for a
+			  page that renders a name, a description, a preview and a project
+			  list. Same audience either way - this route is gated to org owners
+			  and admins - so nothing here was reachable that is not still
+			  reachable; it simply stops being sent.
+			*/
+			apiKeyData: {
+				apiKey: {
+					name: apiKeyData.apiKey.name,
+					description: apiKeyData.apiKey.description,
+					keyPreview: apiKeyData.apiKey.keyPreview
+				},
+				organization: { id: apiKeyData.organization.id },
+				projects: apiKeyData.projects
+			},
 			userProjects,
 			apiKeyAccess: {
 				granted: entitlement.granted,

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys-new.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys-new.tsx
@@ -203,7 +203,7 @@ export async function action({ request }: Route.ActionArgs) {
 			expiresAt
 		})
 
-		// Return the plaintext key (only time it will be accessible)
+		// Return the plaintext key so the dialog can show it once
 		return data(
 			{
 				success: true,

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys.tsx
@@ -57,6 +57,38 @@ import { shouldRevalidateWithinScope } from '../../lib/navigation/dashboard-rout
 import type { DashboardConfirmationPlan } from '../../lib/domain/dashboard/dashboard-confirmation'
 import type { ShouldRevalidateFunction } from 'react-router'
 
+/**
+ * One stored key, reduced to what this page renders.
+ *
+ * An explicit field list rather than a spread, so a column added to `api_keys`
+ * has to be named here before it reaches the browser.
+ *
+ * Both fields this drops make the case, in different directions. `encryptedKey`
+ * is the column-added-later story. `hashedKey` is the worse one: it was in the
+ * table from the first migration, a week before this page was written, and went
+ * to the browser on every render from the day it shipped. Nothing catches that
+ * without a list someone has to write.
+ *
+ * The discipline, not this function, is what holds - `api-keys-edit.tsx` names
+ * its fields the same way for the same reason. `api-keys-page-payload.spec.ts`
+ * pins both, because a list is only a guarantee while someone maintains it.
+ */
+function toApiKeyRow(key: ApiKeyWithDetails): ApiKeyRow {
+	return {
+		id: key.apiKey.id,
+		name: key.apiKey.name,
+		description: key.apiKey.description,
+		keyPreview: key.apiKey.keyPreview,
+		createdBy: key.creator.name || key.creator.email || 'Unknown',
+		projects: key.projects,
+		lastUsedAt: key.apiKey.lastUsedAt,
+		active: key.apiKey.active,
+		expiresAt: key.apiKey.expiresAt,
+		revokedAt: key.apiKey.revokedAt,
+		rotatedAt: key.apiKey.rotatedAt
+	}
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
 	const { user, headers } = await loadAuthenticatedUser(request)
 
@@ -65,13 +97,23 @@ export async function loader({ request }: Route.LoaderArgs) {
 		getUserOrganizations(user.id)
 	])
 
-	const keysByOrg = new Map<string, ApiKeyWithDetails[]>()
+	/*
+	  Narrowed here, not in the component.
+
+	  `ApiKeyWithDetails` carries the row as stored, which means `hashedKey` and
+	  the `encryptedKey` ciphertext. Returning it whole put both into the SSR
+	  payload and into every revalidation response, for a page that renders
+	  neither. The audience is the same either way - this route is already
+	  gated to org owners and admins - so this is not a leak being closed, it is
+	  a payload not being sent.
+	*/
+	const keysByOrg = new Map<string, ApiKeyRow[]>()
 	for (const keyData of apiKeys) {
 		const orgId = keyData.organization.id
 		if (!keysByOrg.has(orgId)) {
 			keysByOrg.set(orgId, [])
 		}
-		keysByOrg.get(orgId)!.push(keyData)
+		keysByOrg.get(orgId)!.push(toApiKeyRow(keyData))
 	}
 
 	const adminOrgs = organizations.filter((o) =>
@@ -112,9 +154,9 @@ export async function loader({ request }: Route.LoaderArgs) {
  * One shape for every outcome of this action.
  *
  * Returning a different object per branch left the client narrowing a union
- * with `in`, which resolved `rotatedKey` to `{}` and lost the one value that
- * cannot be fetched again. A single optional-field contract is also what the
- * component already assumes when it probes with `'success' in fetcher.data`.
+ * with `in`, which resolved `rotatedKey` to `{}` and dropped the freshly minted
+ * key before it could be shown. A single optional-field contract is also what
+ * the component already assumes when it probes with `'success' in fetcher.data`.
  */
 interface ApiKeysActionResult {
 	success?: true
@@ -163,9 +205,11 @@ export async function action({ request }: Route.ActionArgs) {
 			const rotated = await rotateApiKey({ apiKeyId, userId: user.id })
 
 			/*
-			  The plaintext leaves the server exactly here and is never persisted in
-			  the clear, so the client has one chance to show it. It is deliberately
-			  not put in the flash message: toasts disappear on a timer.
+			  Carried as its own field rather than in the flash message, because a
+			  toast disappears on a timer and this is the one screen that shows the
+			  key in full. It is on the row too, encrypted, but nothing here reads
+			  it back - that would be a round trip to re-fetch what this response
+			  already holds.
 			*/
 			return data<ApiKeysActionResult>(
 				{
@@ -208,22 +252,6 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 }
 
 export { DashboardErrorBoundary as ErrorBoundary } from '../../components/errors'
-
-function buildApiKeyRows(keys: ApiKeyWithDetails[]): ApiKeyRow[] {
-	return keys.map((key) => ({
-		id: key.apiKey.id,
-		name: key.apiKey.name,
-		description: key.apiKey.description,
-		keyPreview: key.apiKey.keyPreview,
-		createdBy: key.creator.name || key.creator.email || 'Unknown',
-		projects: key.projects,
-		lastUsedAt: key.apiKey.lastUsedAt,
-		active: key.apiKey.active,
-		expiresAt: key.apiKey.expiresAt,
-		revokedAt: key.apiKey.revokedAt,
-		rotatedAt: key.apiKey.rotatedAt
-	}))
-}
 
 function OrgApiKeysTable({
 	namespace,
@@ -315,16 +343,26 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 	)
 
 	const keysById = useMemo(
-		() => new Map(allKeys.map((item) => [item.apiKey.id, item])),
+		() => new Map(allKeys.map((item) => [item.id, item])),
 		[allKeys]
 	)
 
 	useOncePerFetcherResponse(fetcher, (result) => {
 		if ('success' in result && result.success) {
 			/*
-			  A rotation's plaintext exists only in this response. Capture it into
-			  state before the toast, because revalidating replaces `fetcher.data`
-			  and the value is unrecoverable once it is gone.
+			  Captured into state because `fetcher.data` is the wrong owner of it.
+
+			  Not, as this comment twice claimed, because revalidation clears it:
+			  it does not. A fetcher that submitted is removed from
+			  `fetchLoadMatches` before its action runs, so it is never in the
+			  revalidation set, and `use-once-per-fetcher-response.ts` opens by
+			  saying the same thing - a settled fetcher's `data` outlives the
+			  render that produced it.
+
+			  That persistence is the actual problem: rendering the dialog straight
+			  off the response leaves `onClose` with nothing to set, and this
+			  dialog deliberately swallows Escape. Owning it as state is what makes
+			  closing it possible at all.
 			*/
 			if ('rotatedKey' in result && result.rotatedKey) {
 				setRotatedKey(result.rotatedKey)
@@ -415,15 +453,13 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 	*/
 	const rotatePlan: DashboardConfirmationPlan = {
 		tier: 'acknowledge',
-		title: keyToRotate
-			? `Rotate "${keyToRotate.apiKey.name}"?`
-			: 'Rotate API key?',
+		title: keyToRotate ? `Rotate "${keyToRotate.name}"?` : 'Rotate API key?',
 		description: keyToRotate
-			? `Key ending ${keyToRotate.apiKey.keyPreview} is replaced by a new one immediately.`
+			? `Key ending ${keyToRotate.keyPreview} is replaced by a new one immediately.`
 			: 'The current key is replaced by a new one immediately.',
 		consequences: [
 			'Every embed still carrying the current key is refused until you paste in the new one',
-			'The new key is shown once, right after rotating, and cannot be recovered later',
+			'The new key is shown right after rotating; this list shows only its last four characters',
 			'The name, projects and expiry stay as they are'
 		],
 		confirmLabel: 'Rotate key',
@@ -438,11 +474,9 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 	*/
 	const revokePlan: DashboardConfirmationPlan = {
 		tier: 'acknowledge',
-		title: keyToRevoke
-			? `Revoke "${keyToRevoke.apiKey.name}"?`
-			: 'Revoke API key?',
+		title: keyToRevoke ? `Revoke "${keyToRevoke.name}"?` : 'Revoke API key?',
 		description: keyToRevoke
-			? `Key ending ${keyToRevoke.apiKey.keyPreview} stops working immediately.`
+			? `Key ending ${keyToRevoke.keyPreview} stops working immediately.`
 			: 'This key stops working immediately.',
 		consequences: [
 			'Any application still using this key loses access at once',
@@ -476,9 +510,7 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 						{apiKeysAccessByOrg[organizations[0].organization.id]?.granted ? (
 							<OrgApiKeysTable
 								namespace={`api-keys-${organizations[0].organization.id}`}
-								rows={buildApiKeyRows(
-									keysByOrg[organizations[0].organization.id] || []
-								)}
+								rows={keysByOrg[organizations[0].organization.id] || []}
 								onEdit={handleEdit}
 								onRevoke={handleRevoke}
 								onRotate={handleRotate}
@@ -526,9 +558,7 @@ export default function ApiKeysPage({ loaderData }: Route.ComponentProps) {
 									{apiKeysAccessByOrg[org.organization.id]?.granted ? (
 										<OrgApiKeysTable
 											namespace={`api-keys-${org.organization.id}`}
-											rows={buildApiKeyRows(
-												keysByOrg[org.organization.id] || []
-											)}
+											rows={keysByOrg[org.organization.id] || []}
 											onEdit={handleEdit}
 											onRevoke={handleRevoke}
 											onRotate={handleRotate}

--- a/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
@@ -33,7 +33,7 @@ To create a key with your own name, description or expiry instead:
 3. Select the project(s) the key should have access to.
 4. Copy the key - it is shown only once.
 
-> A key is stored hashed, so it cannot be read back later. The **Embed** panel's key picker shows each key's name and last four characters, which is enough to tell which of your saved keys a project expects, but not enough to recover one you did not save.
+> A key is stored two ways now: hashed, which is the only form an embed request is ever checked against, and encrypted alongside it. Nothing reads that second copy back yet - the API Keys list and the **Embed** panel's key picker both still show only a name and the last four characters - so copy the full value while it is on screen.
 
 ### Replacing a key that leaked
 
@@ -55,6 +55,9 @@ present apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts 
 present apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts lastUsedAt: null
 present apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts state !== 'active'
 present apps/vectreal-platform/app/components/dashboard/table-columns.tsx Unused since rotating
+present apps/vectreal-platform/app/db/schema/auth/api-keys.ts encryptedKey: text('encrypted_key')
+present apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts encryptedKey: encryptEmbedToken(plaintext)
+present apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts encryptedKey: null
 */}
 
 ### Using the key

--- a/apps/vectreal-platform/supabase/migrations/0019_shocking_scorpion.sql
+++ b/apps/vectreal-platform/supabase/migrations/0019_shocking_scorpion.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "api_keys" ADD COLUMN "encrypted_key" text;

--- a/apps/vectreal-platform/supabase/migrations/meta/0019_snapshot.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/0019_snapshot.json
@@ -1,0 +1,4374 @@
+{
+  "id": "f677c813-6bf1-4736-9ec3-206e3e56e969",
+  "prevId": "1fb6eb95-8af9-4aaf-bf16-b3ee49c520a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "users_select_self": {
+          "name": "users_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_insert_self": {
+          "name": "users_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_update_self": {
+          "name": "users_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())",
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference_code": {
+          "name": "reference_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "is_authenticated": {
+          "name": "is_authenticated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inquiry_type": {
+          "name": "inquiry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "failure_stage": {
+          "name": "failure_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "internal_message_id": {
+          "name": "internal_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_message_id": {
+          "name": "confirmation_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_users_id_fk": {
+          "name": "contact_submissions_user_id_users_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_submissions_reference_code_unique": {
+          "name": "contact_submissions_reference_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_owner_id_idx": {
+          "name": "organizations_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_id_users_id_fk": {
+          "name": "organizations_owner_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "organizations_select_member": {
+          "name": "organizations_select_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_insert_owner": {
+          "name": "organizations_insert_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"organizations\".\"owner_id\" = (select auth.uid())"
+        },
+        "organizations_update_owner": {
+          "name": "organizations_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_delete_owner": {
+          "name": "organizations_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_memberships_user_id_idx": {
+          "name": "organization_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_organization_id_idx": {
+          "name": "organization_memberships_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_invited_by_idx": {
+          "name": "organization_memberships_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_memberships_select_org_member": {
+          "name": "org_memberships_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_insert_org_admin": {
+          "name": "org_memberships_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_update_org_admin": {
+          "name": "org_memberships_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_delete_org_admin_or_self": {
+          "name": "org_memberships_delete_org_admin_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\n\t\t\t\t\texists (\n\t\t\t\t\t\tselect 1\n\t\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t\t)\n\t\t\t\t\tor \"organization_memberships\".\"user_id\" = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_embed_domains": {
+          "name": "allowed_embed_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "projects_select_org_member": {
+          "name": "projects_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "projects_insert_org_admin": {
+          "name": "projects_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"projects\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_update_org_admin": {
+          "name": "projects_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_delete_org_admin": {
+          "name": "projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_folders": {
+      "name": "scene_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_folders_project_id_idx": {
+          "name": "scene_folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_owner_id_idx": {
+          "name": "scene_folders_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_parent_folder_id_idx": {
+          "name": "scene_folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_folders_project_id_projects_id_fk": {
+          "name": "scene_folders_project_id_projects_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_owner_id_users_id_fk": {
+          "name": "scene_folders_owner_id_users_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_parent_folder_id_scene_folders_id_fk": {
+          "name": "scene_folders_parent_folder_id_scene_folders_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_folders_select_project_member": {
+          "name": "scene_folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_folders_insert_project_member_self_owner": {
+          "name": "scene_folders_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scene_folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_update_owner_or_admin": {
+          "name": "scene_folders_update_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_delete_owner_or_admin": {
+          "name": "scene_folders_delete_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {
+        "scene_folders_parent_not_self": {
+          "name": "scene_folders_parent_not_self",
+          "value": "\"scene_folders\".\"parent_folder_id\" is null or \"scene_folders\".\"parent_folder_id\" <> \"scene_folders\".\"id\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "folders_project_id_idx": {
+          "name": "folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "folders_parent_folder_id_idx": {
+          "name": "folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_project_id_projects_id_fk": {
+          "name": "folders_project_id_projects_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folders_parent_folder_id_folders_id_fk": {
+          "name": "folders_parent_folder_id_folders_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "folders_select_project_member": {
+          "name": "folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "folders_insert_project_admin": {
+          "name": "folders_insert_project_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_update_project_admin": {
+          "name": "folders_update_project_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_delete_project_admin": {
+          "name": "folders_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_folder_id_idx": {
+          "name": "assets_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_owner_id_idx": {
+          "name": "assets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_folder_id_folders_id_fk": {
+          "name": "assets_folder_id_folders_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_owner_id_users_id_fk": {
+          "name": "assets_owner_id_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "assets_select_project_member": {
+          "name": "assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "assets_insert_project_member_self_owner": {
+          "name": "assets_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"assets\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_update_project_member_owner": {
+          "name": "assets_update_project_member_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_delete_project_admin": {
+          "name": "assets_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scenes": {
+      "name": "scenes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scenes_project_id_idx": {
+          "name": "scenes_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_folder_id_idx": {
+          "name": "scenes_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scenes_project_id_projects_id_fk": {
+          "name": "scenes_project_id_projects_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scenes_folder_id_scene_folders_id_fk": {
+          "name": "scenes_folder_id_scene_folders_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scenes_select_project_member": {
+          "name": "scenes_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scenes_insert_project_member": {
+          "name": "scenes_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scenes\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_update_project_member": {
+          "name": "scenes_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_delete_project_admin": {
+          "name": "scenes_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_settings": {
+      "name": "scene_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera": {
+          "name": "camera",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controls": {
+          "name": "controls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactions": {
+          "name": "interactions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shadows": {
+          "name": "shadows",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalization": {
+          "name": "normalization",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_settings_created_by_idx": {
+          "name": "scene_settings_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_settings_scene_id_scenes_id_fk": {
+          "name": "scene_settings_scene_id_scenes_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_settings_created_by_users_id_fk": {
+          "name": "scene_settings_created_by_users_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_settings_scene_id_unique": {
+          "name": "scene_settings_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_settings_select_project_member": {
+          "name": "scene_settings_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_insert_project_member_self_creator": {
+          "name": "scene_settings_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_settings\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_settings_update_project_member": {
+          "name": "scene_settings_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_delete_project_admin": {
+          "name": "scene_settings_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_hotspots": {
+      "name": "scene_hotspots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "world_position_x": {
+          "name": "world_position_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_y": {
+          "name": "world_position_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_z": {
+          "name": "world_position_z",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_camera_id": {
+          "name": "linked_camera_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "internal_only": {
+          "name": "internal_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occlusion_enabled": {
+          "name": "occlusion_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_preset": {
+          "name": "style_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dot'"
+        },
+        "payload_url": {
+          "name": "payload_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_hotspots_scene_settings_id_idx": {
+          "name": "scene_hotspots_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_hotspots_sequence_index_idx": {
+          "name": "scene_hotspots_sequence_index_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_hotspots_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_hotspots_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_hotspots",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_hotspots_select_project_member": {
+          "name": "scene_hotspots_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_insert_project_member": {
+          "name": "scene_hotspots_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_update_project_member": {
+          "name": "scene_hotspots_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_delete_project_admin": {
+          "name": "scene_hotspots_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_stats": {
+      "name": "scene_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized": {
+          "name": "optimized",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_scene_bytes": {
+          "name": "initial_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_scene_bytes": {
+          "name": "current_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_optimizations": {
+          "name": "applied_optimizations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimization_settings": {
+          "name": "optimization_settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_metrics": {
+          "name": "additional_metrics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_stats_created_by_idx": {
+          "name": "scene_stats_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_stats_scene_id_scenes_id_fk": {
+          "name": "scene_stats_scene_id_scenes_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_stats_created_by_users_id_fk": {
+          "name": "scene_stats_created_by_users_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_stats_scene_id_unique": {
+          "name": "scene_stats_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_stats_select_project_member": {
+          "name": "scene_stats_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_insert_project_member_self_creator": {
+          "name": "scene_stats_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_stats\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_stats_update_project_member": {
+          "name": "scene_stats_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_delete_project_admin": {
+          "name": "scene_stats_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_assets": {
+      "name": "scene_assets",
+      "schema": "",
+      "columns": {
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_assets_scene_settings_id_idx": {
+          "name": "scene_assets_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_assets_asset_id_idx": {
+          "name": "scene_assets_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_assets_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_assets_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_assets_asset_id_assets_id_fk": {
+          "name": "scene_assets_asset_id_assets_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scene_assets_scene_settings_id_asset_id_pk": {
+          "name": "scene_assets_scene_settings_id_asset_id_pk",
+          "columns": [
+            "scene_settings_id",
+            "asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_assets_select_project_member": {
+          "name": "scene_assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_insert_project_member": {
+          "name": "scene_assets_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"scene_assets\".\"asset_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_delete_project_member": {
+          "name": "scene_assets_delete_project_member",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_published": {
+      "name": "scene_published",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_published_asset_id_idx": {
+          "name": "scene_published_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_scene_settings_id_idx": {
+          "name": "scene_published_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_published_by_idx": {
+          "name": "scene_published_published_by_idx",
+          "columns": [
+            {
+              "expression": "published_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_published_scene_id_scenes_id_fk": {
+          "name": "scene_published_scene_id_scenes_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_asset_id_assets_id_fk": {
+          "name": "scene_published_asset_id_assets_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_published_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scene_published_published_by_users_id_fk": {
+          "name": "scene_published_published_by_users_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_published_select_project_member": {
+          "name": "scene_published_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_insert_project_member_self_publisher": {
+          "name": "scene_published_insert_project_member_self_publisher",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand \"scene_published\".\"published_by\" = (select auth.uid())\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom assets a\n\t\t\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\t\t\tjoin projects p on p.id = f.project_id\n\t\t\t\t\tjoin scenes s on s.project_id = p.id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\t\t\tand a.id = \"scene_published\".\"asset_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_published_update_project_member": {
+          "name": "scene_published_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_delete_project_admin": {
+          "name": "scene_published_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_requests": {
+      "name": "scene_action_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_action_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_requests_status_idx": {
+          "name": "scene_action_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_scene_id_idx": {
+          "name": "scene_action_requests_scene_id_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_expires_at_idx": {
+          "name": "scene_action_requests_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_action_requests_request_key_unique": {
+          "name": "scene_action_requests_request_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_locks": {
+      "name": "scene_action_locks",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_key": {
+          "name": "holder_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_locks_expires_at_idx": {
+          "name": "scene_action_locks_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_runtime_limits": {
+      "name": "scene_runtime_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "in_flight": {
+          "name": "in_flight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "permission_entity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "permission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permissions_granted_by_idx": {
+          "name": "permissions_granted_by_idx",
+          "columns": [
+            {
+              "expression": "granted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_granted_by_users_id_fk": {
+          "name": "permissions_granted_by_users_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "permissions_select_recipient_or_granter": {
+          "name": "permissions_select_recipient_or_granter",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t\"permissions\".\"granted_by\" = (select auth.uid())\n\t\t\t\tor (\"permissions\".\"entity_type\" = 'user' and \"permissions\".\"entity_id\" = (select auth.uid()))\n\t\t\t\tor (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"permissions\".\"entity_id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "permissions_insert_self_or_group_owner": {
+          "name": "permissions_insert_self_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\"permissions\".\"granted_by\" = (select auth.uid())\n\t\t\t\tand (\n\t\t\t\t\t(\"permissions\".\"entity_type\" = 'user' and \"permissions\".\"entity_id\" = (select auth.uid()))\n\t\t\t\t\tor (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t)\n\t\t\t"
+        },
+        "permissions_update_granter_or_group_owner": {
+          "name": "permissions_update_granter_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)",
+          "withCheck": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)"
+        },
+        "permissions_delete_granter_or_group_owner": {
+          "name": "permissions_delete_granter_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_id_idx": {
+          "name": "group_memberships_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "group_memberships_select_owner_or_member": {
+          "name": "group_memberships_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"group_memberships\".\"group_id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_insert_owner_or_self_join": {
+          "name": "group_memberships_insert_owner_or_self_join",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        },
+        "group_memberships_update_owner": {
+          "name": "group_memberships_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_delete_owner_or_self": {
+          "name": "group_memberships_delete_owner_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_id_idx": {
+          "name": "groups_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "groups_select_owner_or_member": {
+          "name": "groups_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid()) or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"groups\".\"id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "groups_insert_self_owner": {
+          "name": "groups_insert_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_update_owner": {
+          "name": "groups_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_delete_owner": {
+          "name": "groups_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {
+        "tags_select_authenticated": {
+          "name": "tags_select_authenticated",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null"
+        },
+        "tags_insert_authenticated": {
+          "name": "tags_insert_authenticated",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(select (select auth.uid())) is not null"
+        },
+        "tags_update_authenticated": {
+          "name": "tags_update_authenticated",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null",
+          "withCheck": "(select (select auth.uid())) is not null"
+        },
+        "tags_delete_authenticated": {
+          "name": "tags_delete_authenticated",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tag_assignments": {
+      "name": "tag_assignments",
+      "schema": "",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tag_assignments_tag_id_idx": {
+          "name": "tag_assignments_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_assignments_tag_id_tags_id_fk": {
+          "name": "tag_assignments_tag_id_tags_id_fk",
+          "tableFrom": "tag_assignments",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tag_assignments_tag_id_target_type_target_id_pk": {
+          "name": "tag_assignments_tag_id_target_type_target_id_pk",
+          "columns": [
+            "tag_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "tag_assignments_select_target_member": {
+          "name": "tag_assignments_select_target_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "tag_assignments_insert_target_member": {
+          "name": "tag_assignments_insert_target_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t(select (select auth.uid())) is not null\n\t\t\t\tand (\n\t\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t)\n\t\t\t"
+        },
+        "tag_assignments_delete_target_member": {
+          "name": "tag_assignments_delete_target_member",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_preview": {
+          "name": "key_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_organization_id_idx": {
+          "name": "api_keys_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_organization_id_organizations_id_fk": {
+          "name": "api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "api_keys_select_org_admin": {
+          "name": "api_keys_select_org_admin",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_insert_org_admin": {
+          "name": "api_keys_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_update_org_admin": {
+          "name": "api_keys_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_delete_org_admin": {
+          "name": "api_keys_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_key_projects": {
+      "name": "api_key_projects",
+      "schema": "",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_projects_api_key_id_idx": {
+          "name": "api_key_projects_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_projects_project_id_idx": {
+          "name": "api_key_projects_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_projects_api_key_id_api_keys_id_fk": {
+          "name": "api_key_projects_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_projects_project_id_projects_id_fk": {
+          "name": "api_key_projects_project_id_projects_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_key_projects_api_key_id_project_id_pk": {
+          "name": "api_key_projects_api_key_id_project_id_pk",
+          "columns": [
+            "api_key_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "api_key_projects_select_org_admin_and_project_member": {
+          "name": "api_key_projects_select_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_insert_org_admin_and_project_member": {
+          "name": "api_key_projects_insert_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_delete_org_admin": {
+          "name": "api_key_projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "billing_state": {
+          "name": "billing_state",
+          "type": "billing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_stripe_subscription_id_idx": {
+          "name": "org_subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_customer_id_idx": {
+          "name": "org_subscriptions_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_billing_state_idx": {
+          "name": "org_subscriptions_billing_state_idx",
+          "columns": [
+            {
+              "expression": "billing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_subscriptions_organization_id_unique": {
+          "name": "org_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {
+        "org_subscriptions_select_org_member": {
+          "name": "org_subscriptions_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_subscriptions_insert_org_admin": {
+          "name": "org_subscriptions_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_update_org_admin": {
+          "name": "org_subscriptions_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_delete_org_admin": {
+          "name": "org_subscriptions_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_limit_overrides": {
+      "name": "org_limit_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_key": {
+          "name": "limit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_limit_overrides_org_key_uidx": {
+          "name": "org_limit_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "limit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_limit_overrides_organization_id_organizations_id_fk": {
+          "name": "org_limit_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_limit_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_limit_overrides_select_org_member": {
+          "name": "org_limit_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_limit_overrides_insert_org_admin": {
+          "name": "org_limit_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_update_org_admin": {
+          "name": "org_limit_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_delete_org_admin": {
+          "name": "org_limit_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_entitlement_overrides": {
+      "name": "org_entitlement_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_key": {
+          "name": "entitlement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_entitlement_overrides_org_key_uidx": {
+          "name": "org_entitlement_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_entitlement_overrides_organization_id_organizations_id_fk": {
+          "name": "org_entitlement_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_entitlement_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_entitlement_overrides_select_org_member": {
+          "name": "org_entitlement_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_insert_org_admin": {
+          "name": "org_entitlement_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_update_org_admin": {
+          "name": "org_entitlement_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_delete_org_admin": {
+          "name": "org_entitlement_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_usage_counters": {
+      "name": "org_usage_counters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter_key": {
+          "name": "counter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_usage_counters_org_key_window_uidx": {
+          "name": "org_usage_counters_org_key_window_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_usage_counters_window_end_idx": {
+          "name": "org_usage_counters_window_end_idx",
+          "columns": [
+            {
+              "expression": "window_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_usage_counters_organization_id_organizations_id_fk": {
+          "name": "org_usage_counters_organization_id_organizations_id_fk",
+          "tableFrom": "org_usage_counters",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_usage_counters_select_org_member": {
+          "name": "org_usage_counters_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_usage_counters_insert_org_admin": {
+          "name": "org_usage_counters_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_update_org_admin": {
+          "name": "org_usage_counters_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_delete_org_admin": {
+          "name": "org_usage_counters_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.billing_webhook_events": {
+      "name": "billing_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_webhook_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_webhook_events_provider_event_id_uidx": {
+          "name": "billing_webhook_events_provider_event_id_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_status_idx": {
+          "name": "billing_webhook_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_created_at_idx": {
+          "name": "billing_webhook_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.consent_records": {
+      "name": "consent_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "necessary": {
+          "name": "necessary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "functional": {
+          "name": "functional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_country": {
+          "name": "ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "consent_records_user_id_users_id_fk": {
+          "name": "consent_records_user_id_users_id_fk",
+          "tableFrom": "consent_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_records_user_id_unique": {
+          "name": "consent_records_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "consent_records_anonymous_id_unique": {
+          "name": "consent_records_anonymous_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anonymous_id"
+          ]
+        }
+      },
+      "policies": {
+        "consent_records_select_self": {
+          "name": "consent_records_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_insert_self": {
+          "name": "consent_records_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_update_self": {
+          "name": "consent_records_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())",
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.contact_submission_status": {
+      "name": "contact_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.membership_role": {
+      "name": "membership_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "texture",
+        "material",
+        "model",
+        "environment",
+        "other"
+      ]
+    },
+    "public.scene_status": {
+      "name": "scene_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.scene_action_request_status": {
+      "name": "scene_action_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.permission_entity": {
+      "name": "permission_entity",
+      "schema": "public",
+      "values": [
+        "user",
+        "group"
+      ]
+    },
+    "public.permission_type": {
+      "name": "permission_type",
+      "schema": "public",
+      "values": [
+        "read",
+        "write",
+        "admin",
+        "delete"
+      ]
+    },
+    "public.billing_state": {
+      "name": "billing_state",
+      "schema": "public",
+      "values": [
+        "none",
+        "trialing",
+        "active",
+        "past_due",
+        "unpaid",
+        "canceled",
+        "paused",
+        "incomplete",
+        "incomplete_expired"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "business",
+        "enterprise"
+      ]
+    },
+    "public.billing_webhook_event_status": {
+      "name": "billing_webhook_event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/vectreal-platform/supabase/migrations/meta/_journal.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1787406189506,
       "tag": "0018_abnormal_magus",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1787738787455,
+      "tag": "0019_shocking_scorpion",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/vectreal-platform/tests/api-keys-page-payload.spec.ts
+++ b/apps/vectreal-platform/tests/api-keys-page-payload.spec.ts
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+/**
+ * What the API keys page sends to the browser.
+ *
+ * The loader used to return `ApiKeyWithDetails` rows straight from the
+ * repository and let the component narrow them, so every response carried
+ * `hashedKey` - and, once embed tokens became retrievable, the `encryptedKey`
+ * ciphertext - for a page that renders neither. Nobody could see it who could
+ * not already read those keys, which is exactly why nothing caught it: the
+ * failure is a payload that is larger than the page, not a privilege boundary
+ * that moved.
+ *
+ * So this asserts the shape of what leaves the server, in both directions: the
+ * stored secret is absent, and the fields the table needs are present. Only the
+ * second half stops the first from being satisfied by returning nothing at all.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG_ID = 'org-1'
+const USER_ID = 'user-1'
+const HASHED_KEY =
+	'9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'
+
+/**
+ * A literal envelope rather than a real encrypt.
+ *
+ * Depending on the cipher here would couple this spec to another module's key
+ * configuration for no gain. Asserted whole, not just by its prefix: mapping a
+ * fragment of it onto a field the page does render - `keyPreview:
+ * key.apiKey.encryptedKey.split(':')[4]` - passes a prefix check.
+ */
+const ENCRYPTED_KEY = 'enc:v1:aWl2aXY=:dGFndGFn:Y2lwaGVy'
+
+vi.mock('../app/db/client', () => ({ getDbClient: () => ({}) }))
+
+vi.mock('../app/lib/domain/auth/api-key-repository.server', () => ({
+	getAllUserApiKeys: vi.fn(),
+	getApiKeyById: vi.fn(),
+	updateApiKey: vi.fn(),
+	revokeApiKey: vi.fn(),
+	rotateApiKey: vi.fn()
+}))
+
+vi.mock('../app/lib/domain/project/project-repository.server', () => ({
+	getUserProjects: vi.fn(async () => [
+		{
+			id: 'project-1',
+			name: 'Storefront',
+			slug: 'storefront',
+			organizationId: 'org-1'
+		}
+	])
+}))
+
+vi.mock('../app/lib/domain/auth/auth-loader.server', () => ({
+	loadAuthenticatedUser: vi.fn(async () => ({
+		user: { id: USER_ID },
+		headers: new Headers()
+	}))
+}))
+
+vi.mock('../app/lib/domain/billing/entitlement-service.server', () => ({
+	hasEntitlement: vi.fn(async () => ({ granted: true })),
+	getOrgSubscription: vi.fn(async () => ({ plan: 'pro' })),
+	getRecommendedUpgrade: vi.fn(() => 'business')
+}))
+
+vi.mock('../app/lib/domain/user/user-repository.server', () => ({
+	getUserOrganizations: vi.fn(async () => [
+		{
+			organization: { id: ORG_ID, name: 'Acme' },
+			membership: { role: 'owner' }
+		}
+	])
+}))
+
+vi.mock('../app/lib/http/csrf.server', () => ({
+	ensureValidCsrfFormData: vi.fn(async () => null)
+}))
+
+import {
+	getAllUserApiKeys,
+	getApiKeyById
+} from '../app/lib/domain/auth/api-key-repository.server'
+import { loader } from '../app/routes/dashboard-page/api-keys'
+import { loader as editLoader } from '../app/routes/dashboard-page/api-keys-edit'
+
+import type { LoaderFunctionArgs } from 'react-router'
+
+/** A row exactly as the repository hands it over, secrets included. */
+function storedKey() {
+	return {
+		apiKey: {
+			id: 'key-1',
+			name: 'Storefront key',
+			description: 'Pasted into a product page',
+			keyPreview: 'ab3x',
+			hashedKey: HASHED_KEY,
+			encryptedKey: ENCRYPTED_KEY,
+			active: true,
+			lastUsedAt: null,
+			expiresAt: null,
+			revokedAt: null,
+			rotatedAt: null,
+			createdAt: new Date('2026-01-01T00:00:00.000Z')
+		},
+		creator: { id: USER_ID, name: 'Moritz', email: 'moritz@acme.test' },
+		organization: { id: ORG_ID, name: 'Acme' },
+		projects: [{ id: 'project-1', name: 'Storefront', slug: 'storefront' }]
+	}
+}
+
+const load = async () => {
+	const result = await loader({
+		request: new Request('https://vectreal.com/dashboard/api-keys'),
+		params: {},
+		context: {}
+	} as unknown as LoaderFunctionArgs)
+
+	return result as unknown as { data: Record<string, unknown> }
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	vi.mocked(getAllUserApiKeys).mockResolvedValue([
+		storedKey()
+	] as unknown as Awaited<ReturnType<typeof getAllUserApiKeys>>)
+})
+
+describe('the api keys loader payload', () => {
+	it('sends neither stored form of the secret', async () => {
+		const payload = JSON.stringify((await load()).data)
+
+		expect(payload).not.toContain('hashedKey')
+		expect(payload).not.toContain('encryptedKey')
+
+		/*
+		  The values, not just the field names. Mapping a secret onto a field the
+		  page does render - `keyPreview: key.apiKey.hashedKey` - satisfies a
+		  field-name check, because "hashedKey" was only ever a key name.
+		*/
+		expect(payload).not.toContain(HASHED_KEY)
+		for (const segment of ENCRYPTED_KEY.split(':')) {
+			expect(payload, segment).not.toContain(segment)
+		}
+	})
+
+	it('still sends everything the table renders', async () => {
+		/*
+		  The anchor. Without it, a loader that returned an empty object would
+		  satisfy every assertion above.
+		*/
+		const { keysByOrg } = (await load()).data as {
+			keysByOrg: Record<string, Array<Record<string, unknown>>>
+		}
+
+		expect(Object.keys(keysByOrg[ORG_ID][0]).sort()).toEqual([
+			'active',
+			'createdBy',
+			'description',
+			'expiresAt',
+			'id',
+			'keyPreview',
+			'lastUsedAt',
+			'name',
+			'projects',
+			'revokedAt',
+			'rotatedAt'
+		])
+	})
+})
+
+describe('the api key edit loader payload', () => {
+	/*
+	  The hand-built literal is the fragile half of this change: re-adding the
+	  whole row is a one-token edit, and the actor was being returned to a page
+	  that never read it.
+	*/
+	const loadEdit = async () => {
+		const result = await editLoader({
+			request: new Request(
+				'https://vectreal.com/dashboard/api-keys/key-1/edit'
+			),
+			params: { keyId: 'key-1' },
+			context: {}
+		} as unknown as LoaderFunctionArgs)
+
+		return result as unknown as { data: Record<string, unknown> }
+	}
+
+	beforeEach(() => {
+		vi.mocked(getApiKeyById).mockResolvedValue(
+			storedKey() as unknown as Awaited<ReturnType<typeof getApiKeyById>>
+		)
+	})
+
+	it('sends neither stored form of the secret, nor the actor', async () => {
+		const { data } = await loadEdit()
+		const payload = JSON.stringify(data)
+
+		expect(payload).not.toContain('hashedKey')
+		expect(payload).not.toContain('encryptedKey')
+		expect(payload).not.toContain(HASHED_KEY)
+		for (const segment of ENCRYPTED_KEY.split(':')) {
+			expect(payload, segment).not.toContain(segment)
+		}
+		expect(data).not.toHaveProperty('user')
+	})
+
+	it('still sends the fields the form reads', async () => {
+		const { data } = await loadEdit()
+		const apiKeyData = data.apiKeyData as {
+			apiKey: Record<string, unknown>
+			organization: Record<string, unknown>
+			projects: unknown[]
+		}
+
+		expect(Object.keys(apiKeyData.apiKey).sort()).toEqual([
+			'description',
+			'keyPreview',
+			'name'
+		])
+		expect(apiKeyData.organization).toEqual({ id: ORG_ID })
+		expect(apiKeyData.projects).toHaveLength(1)
+	})
+})

--- a/apps/vectreal-platform/tests/embed-api-keys-route.spec.ts
+++ b/apps/vectreal-platform/tests/embed-api-keys-route.spec.ts
@@ -44,15 +44,18 @@ import { QuotaExceededError } from '../app/lib/domain/billing/quota-exceeded-err
 import { resolveProjectMembership } from '../app/lib/domain/dashboard/dashboard-permissions.server'
 import { getProject } from '../app/lib/domain/project/project-repository.server'
 import { getAuthUser } from '../app/lib/http/auth.server'
+import * as embedTokenCipher from '../app/lib/security/embed-token-cipher.server'
+import { encryptEmbedToken } from '../app/lib/security/embed-token-cipher.server'
 import { action, loader } from '../app/routes/api/projects.$projectId.api-keys'
 
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router'
 
 /** Route handlers take a router context this spec has no use for. */
 const routeArgs = (request: Request) =>
-	({ request, params: { projectId: PROJECT_ID } }) as unknown as LoaderFunctionArgs &
-		ActionFunctionArgs
-
+	({
+		request,
+		params: { projectId: PROJECT_ID }
+	}) as unknown as LoaderFunctionArgs & ActionFunctionArgs
 
 /** The rotated Supabase cookie every response has to carry back. */
 const SESSION_COOKIE = 'sb-access-token=rotated; Path=/'
@@ -106,9 +109,130 @@ function createRequest() {
 
 const submitCreate = () => action(routeArgs(createRequest()))
 
+/**
+ * Watched, not replaced: the same tests need the real `encryptEmbedToken` to
+ * build the rows they hand the loader, so a module mock would defeat itself.
+ */
+const decryptSpy = vi.spyOn(embedTokenCipher, 'decryptEmbedToken')
+
 beforeEach(() => {
 	vi.clearAllMocks()
 	vi.mocked(getAllUserApiKeys).mockResolvedValue([])
+})
+
+/**
+ * A stored key row, as `getAllUserApiKeys` hands it over.
+ *
+ * `encryptedKey` is real ciphertext produced by the cipher this route decrypts
+ * with, not a stand-in: a fake string would make the route's decrypt call
+ * indistinguishable from no decrypt call at all.
+ */
+function storedKey(encryptedKey: string | null) {
+	return {
+		apiKey: {
+			id: 'key-1',
+			name: 'Embed key for Storefront',
+			keyPreview: 'ab3x',
+			encryptedKey,
+			active: true,
+			expiresAt: null,
+			revokedAt: null,
+			lastUsedAt: null,
+			createdAt: new Date('2026-01-01T00:00:00.000Z')
+		},
+		projects: [{ id: PROJECT_ID }]
+	}
+}
+
+describe('the key value the picker needs', () => {
+	/*
+	  The whole point of the storage change: the panel could never offer a key
+	  the owner already had, because the only stored form was a one-way hash.
+	  These pin that the value comes back, that it comes back only to someone
+	  allowed to read keys, and that a row which cannot produce one says so
+	  rather than being hidden or faked.
+	*/
+	const keysFrom = async (response: Response) =>
+		(await response.json()).data.keys as Array<{ value: string | null }>
+
+	it('returns the decrypted token to a member who may read keys', async () => {
+		authenticateAs('admin')
+		vi.mocked(getAllUserApiKeys).mockResolvedValue([
+			storedKey(encryptEmbedToken('vctrl_realkeyab3x'))
+		] as unknown as Awaited<ReturnType<typeof getAllUserApiKeys>>)
+
+		const response = (await loadKeys()) as Response
+		const body = await response.clone().text()
+		const keys = await keysFrom(response)
+
+		expect(keys[0].value).toBe('vctrl_realkeyab3x')
+
+		/*
+		  The decrypted value, and only that. The row it came from carries the
+		  ciphertext too, and a refactor that spread the source row through the
+		  mapper would publish the envelope beside the plaintext without any
+		  other assertion here noticing.
+		*/
+		expect(body).not.toContain('enc:v1')
+
+		expect(response.headers.get('Cache-Control')).toBe('no-store')
+	})
+
+	it('decrypts only the keys scoped to this project', async () => {
+		/*
+		  `getAllUserApiKeys` returns every key in every org this actor
+		  administers, and `toEmbedApiKeyOptions` filters by project afterwards -
+		  so without a filter ahead of the decrypt, the route spends AES on rows
+		  it is about to discard and holds their plaintext in memory for nothing.
+		  The response is byte-identical either way, which is why this counts
+		  calls rather than reading the body.
+		*/
+		authenticateAs('admin')
+		const otherProject = {
+			...storedKey(encryptEmbedToken('vctrl_otherprojab3x')),
+			projects: [{ id: 'project-elsewhere' }]
+		}
+		vi.mocked(getAllUserApiKeys).mockResolvedValue([
+			storedKey(encryptEmbedToken('vctrl_realkeyab3x')),
+			otherProject
+		] as unknown as Awaited<ReturnType<typeof getAllUserApiKeys>>)
+
+		await loadKeys()
+
+		expect(decryptSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it('reports null for a row written before the value was stored', async () => {
+		authenticateAs('admin')
+		vi.mocked(getAllUserApiKeys).mockResolvedValue([
+			storedKey(null)
+		] as unknown as Awaited<ReturnType<typeof getAllUserApiKeys>>)
+
+		const keys = await keysFrom((await loadKeys()) as Response)
+
+		expect(keys).toHaveLength(1)
+		expect(keys[0].value).toBeNull()
+	})
+
+	it('is never even decrypted for an actor who may not read keys', async () => {
+		/*
+		  The 403 itself is already pinned next door. What is new here is the
+		  ordering: the refusal happens before anything is decrypted, rather than
+		  after, with the value filtered out of a payload that was already built.
+		  Asserting the body has no `vctrl_` in it cannot fail - the refusal body
+		  is a fixed literal - so this watches the cipher instead.
+		*/
+		authenticateAs('member')
+		vi.mocked(getAllUserApiKeys).mockResolvedValue([
+			storedKey(encryptEmbedToken('vctrl_realkeyab3x'))
+		] as unknown as Awaited<ReturnType<typeof getAllUserApiKeys>>)
+
+		const response = (await loadKeys()) as Response
+
+		expect(response.status).toBe(403)
+		expect(vi.mocked(getAllUserApiKeys)).not.toHaveBeenCalled()
+		expect(decryptSpy).not.toHaveBeenCalled()
+	})
 })
 
 describe('loader', () => {
@@ -181,7 +305,9 @@ describe('loader', () => {
 
 		const body = await ((await loadKeys()) as Response).json()
 
-		expect(body.data.keys.map((key: { id: string }) => key.id)).toEqual(['mine'])
+		expect(body.data.keys.map((key: { id: string }) => key.id)).toEqual([
+			'mine'
+		])
 	})
 })
 
@@ -221,6 +347,14 @@ describe('action', () => {
 		})
 		expect(body.data.plaintext).toBe('vctrl_secretab3x')
 		expect(body.data.key.keyPreview).toBe('ab3x')
+
+		/*
+		  The primary flow of the whole feature: mint a key from the panel and get
+		  back an option that can build a snippet. The option was previously
+		  asserted one field short of this, so returning a key with no value -
+		  which is exactly the state that cannot produce a snippet - passed.
+		*/
+		expect(body.data.key.value).toBe('vctrl_secretab3x')
 	})
 
 	it('refuses a member and never reaches the repository', async () => {

--- a/apps/vectreal-platform/tests/embed-key-options.spec.ts
+++ b/apps/vectreal-platform/tests/embed-key-options.spec.ts
@@ -11,9 +11,11 @@ const NOW = new Date('2026-08-22T12:00:00.000Z')
 
 function makeKey(
 	overrides: Partial<EmbedApiKeySource['apiKey']> & { id: string },
-	projectIds: string[] = [PROJECT_ID]
+	projectIds: string[] = [PROJECT_ID],
+	value: string | null = `vctrl_${overrides.id}`
 ): EmbedApiKeySource {
 	return {
+		value,
 		apiKey: {
 			name: `key ${overrides.id}`,
 			keyPreview: 'ab3x',
@@ -43,7 +45,20 @@ describe('toEmbedApiKeyOptions', () => {
 		expect(options.map((option) => option.id)).toEqual(['mine', 'both'])
 	})
 
-	it('never carries anything beyond the four-character preview', () => {
+	it('carries exactly the fields the picker is allowed to see', () => {
+		/*
+		  This asserted that nothing beyond the four-character preview ever left
+		  the server, which was true while the token existed only as a hash and
+		  the panel asked people to paste one back. That is the constraint this
+		  change removed: the embed token is published in an `iframe src` on the
+		  customer's own page, so withholding it from the owner who minted it
+		  bought nothing and cost the whole interaction.
+
+		  The list is still pinned, and still exact, because the reason it was
+		  pinned has not changed - an option is serialized to the client, so a
+		  field added here is a field published. `value` is on it deliberately;
+		  anything else appearing is not.
+		*/
 		const [option] = toEmbedApiKeyOptions([makeKey({ id: 'k' })], PROJECT_ID, NOW)
 
 		expect(Object.keys(option).sort()).toEqual([
@@ -53,7 +68,8 @@ describe('toEmbedApiKeyOptions', () => {
 			'keyPreview',
 			'lastUsedAt',
 			'name',
-			'revoked'
+			'revoked',
+			'value'
 		])
 	})
 
@@ -169,5 +185,46 @@ describe('matchesKeyPreview', () => {
 
 	it('is case sensitive, because the preview is a base62 slice', () => {
 		expect(matchesKeyPreview('vctrl_valueAB3X', 'ab3x')).toBe(false)
+	})
+})
+
+describe('a key with no recoverable value', () => {
+	/*
+	  Rows written before the token was stored decryptably, and rows whose stored
+	  value no longer decrypts. They are still live keys and still explain an
+	  embed that is failing, so they stay in the list - but they cannot build a
+	  snippet, so they must not sit at the top of it as the obvious choice.
+	*/
+	it('carries the value through when there is one', () => {
+		const [option] = toEmbedApiKeyOptions(
+			[makeKey({ id: 'k' }, [PROJECT_ID], 'vctrl_realvalue')],
+			PROJECT_ID,
+			NOW
+		)
+
+		expect(option.value).toBe('vctrl_realvalue')
+	})
+
+	it('reports null rather than inventing one', () => {
+		const [option] = toEmbedApiKeyOptions(
+			[makeKey({ id: 'k' }, [PROJECT_ID], null)],
+			PROJECT_ID,
+			NOW
+		)
+
+		expect(option.value).toBeNull()
+	})
+
+	it('sorts below a usable key of the same age', () => {
+		const options = toEmbedApiKeyOptions(
+			[
+				makeKey({ id: 'legacy' }, [PROJECT_ID], null),
+				makeKey({ id: 'usable' }, [PROJECT_ID], 'vctrl_usable')
+			],
+			PROJECT_ID,
+			NOW
+		)
+
+		expect(options.map((option) => option.id)).toEqual(['usable', 'legacy'])
 	})
 })

--- a/apps/vectreal-platform/tests/embed-token-cipher.spec.ts
+++ b/apps/vectreal-platform/tests/embed-token-cipher.spec.ts
@@ -1,0 +1,398 @@
+/**
+ * The storage that makes an embed key selectable.
+ *
+ * The panel could never show an owner a key they already had, because the only
+ * stored form was a one-way hash. This module is the second representation that
+ * fixes that, so what matters here is the round trip, and that a value which
+ * cannot be trusted comes back as "cannot be shown" rather than as something an
+ * attacker picked.
+ */
+
+import { createDecipheriv } from 'node:crypto'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { reportServerError } = vi.hoisted(() => ({ reportServerError: vi.fn() }))
+
+vi.mock('../app/lib/observability/report-server-error.server', () => ({
+	reportServerError
+}))
+
+/** What this module has reported, as strings the assertions below can match. */
+const reportedMessages = () =>
+	reportServerError.mock.calls.map(([error]) => String(error))
+
+const KEY_ENV = 'EMBED_TOKEN_ENCRYPTION_KEY'
+const TOKEN = 'vctrl_N3wIdPytooD26cwRCsRqm8zMZrLrjXWG'
+
+/**
+ * Exactly 32 bytes once decoded, which is the documented production format.
+ *
+ * The first version of this file used a string that *looked* like a 32-byte key
+ * and decoded to 35, so every test took the sha256 branch and the base64 branch
+ * - the one real deployments use - was never executed at all.
+ */
+const BASE64_KEY = 'ZW1iZWQtdG9rZW4ta2V5LTMyLWJ5dGVzLXh4eHh4eHg='
+
+/** A second real 32-byte key, so a rotation test changes keys and not branches. */
+const OTHER_BASE64_KEY = 'YS1kaWZmZXJlbnQtZW1iZWQta2V5LTMyLWJ5dGVzISE='
+
+/** Written once under `BASE64_KEY`; see "the stored format" below. */
+const GOLDEN_ENVELOPE =
+	'enc:v1:V6orp69r+N40NNqQ:w7ZfqmDmisMgXBHZj9qGxw==:Abxo9m6+O8u01debI2nMi+7UKBIYuLpJd54hOastk281tXmcGS8='
+
+/**
+ * Re-imported per test, to reset the "logged once" flag.
+ *
+ * The key itself is read from `process.env` on every call, so nothing about the
+ * key is cached - an earlier version of this comment claimed otherwise, which
+ * would have misled anyone who later added real caching into thinking the
+ * rotation test below still covered it.
+ */
+async function loadCipher() {
+	vi.resetModules()
+	return import('../app/lib/security/embed-token-cipher.server')
+}
+
+/**
+ * Encrypt, and fail loudly if the module declined to.
+ *
+ * `encryptEmbedToken` returns null when no key material is configured, which is
+ * a real state these tests exercise deliberately elsewhere. A `!` here would
+ * make an accidental fallback into that state look like a passing test.
+ */
+function envelopeOf(
+	encrypt: (value: string) => string | null,
+	token = TOKEN
+): string {
+	const envelope = encrypt(token)
+	expect(envelope, 'the cipher had key material to work with').not.toBeNull()
+	return envelope as string
+}
+
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+	process.env[KEY_ENV] = BASE64_KEY
+	process.env.NODE_ENV = 'test'
+	reportServerError.mockClear()
+})
+
+afterEach(() => {
+	process.env = { ...originalEnv }
+})
+
+describe('the embed token round trip', () => {
+	it('returns exactly what was stored', async () => {
+		const { encryptEmbedToken, decryptEmbedToken } = await loadCipher()
+
+		expect(decryptEmbedToken(encryptEmbedToken(TOKEN))).toBe(TOKEN)
+	})
+
+	it('does not store the token in the clear', async () => {
+		/*
+		  The point of the column. A `text` field that happened to contain the
+		  token verbatim would pass every other test in this file.
+		*/
+		const { encryptEmbedToken } = await loadCipher()
+		const envelope = envelopeOf(encryptEmbedToken)
+
+		expect(envelope).not.toContain(TOKEN)
+		expect(envelope).not.toContain('vctrl_')
+		expect(envelope.startsWith('enc:v1:')).toBe(true)
+	})
+
+	it('never emits the same ciphertext twice for one value', async () => {
+		/*
+		  A fixed IV would make the column a lookup table: equal tokens would
+		  produce equal ciphertext, so a dump would reveal which projects share a
+		  key without decrypting anything.
+		*/
+		const { encryptEmbedToken } = await loadCipher()
+
+		expect(encryptEmbedToken(TOKEN)).not.toBe(encryptEmbedToken(TOKEN))
+	})
+})
+
+describe('what cannot be read comes back as nothing', () => {
+	it('reports a row that predates the column', async () => {
+		const { decryptEmbedToken } = await loadCipher()
+
+		expect(decryptEmbedToken(null)).toBeNull()
+	})
+
+	it('refuses a tampered ciphertext rather than decrypting it', async () => {
+		const { encryptEmbedToken, decryptEmbedToken } = await loadCipher()
+		const [prefix, version, iv, tag, ciphertext] =
+			envelopeOf(encryptEmbedToken).split(':')
+
+		const flipped = Buffer.from(ciphertext, 'base64')
+		flipped[0] ^= 0xff
+
+		expect(
+			decryptEmbedToken(
+				[prefix, version, iv, tag, flipped.toString('base64')].join(':')
+			)
+		).toBeNull()
+	})
+
+	it('refuses a forged auth tag', async () => {
+		const { encryptEmbedToken, decryptEmbedToken } = await loadCipher()
+		const [prefix, version, iv, , ciphertext] =
+			envelopeOf(encryptEmbedToken).split(':')
+
+		expect(
+			decryptEmbedToken(
+				[
+					prefix,
+					version,
+					iv,
+					Buffer.alloc(16).toString('base64'),
+					ciphertext
+				].join(':')
+			)
+		).toBeNull()
+	})
+
+	it('refuses a value that is not an envelope at all', async () => {
+		const { decryptEmbedToken } = await loadCipher()
+
+		for (const value of ['', 'vctrl_plain', 'enc:v1:only:three', 'a:b:c:d:e']) {
+			expect(decryptEmbedToken(value), value).toBeNull()
+		}
+	})
+
+	it('reports a row written under key material that has since changed', async () => {
+		/*
+		  Rotating the deployment key does not corrupt anything, but it does make
+		  every existing row unreadable. That has to degrade to the same "cannot be
+		  shown" state as a legacy row - a throw here would take down the whole key
+		  list, including the keys written under the new key.
+		*/
+		const first = await loadCipher()
+		const envelope = first.encryptEmbedToken(TOKEN)
+
+		// Positive control: without it, this passes just as happily when
+		// encryption was already broken before the key ever changed.
+		expect(first.decryptEmbedToken(envelope)).toBe(TOKEN)
+
+		process.env[KEY_ENV] = OTHER_BASE64_KEY
+		const second = await loadCipher()
+
+		expect(second.decryptEmbedToken(envelope)).toBeNull()
+	})
+})
+
+describe('key material', () => {
+	it('stores nothing without a configured key in production, and says so', async () => {
+		/*
+		  Not a throw. This module hangs off `createApiKey`, so throwing here took
+		  down every API key mint in the product - the dashboard's own form
+		  included - because a display-only value could not be encrypted. Failing
+		  closed on the *data* is what matters: nothing is written under a key
+		  nobody configured, the caller is unharmed, and the row lands in the
+		  same "cannot be shown" state the panel already renders.
+		*/
+		delete process.env[KEY_ENV]
+		process.env.NODE_ENV = 'production'
+		const { encryptEmbedToken } = await loadCipher()
+
+		expect(encryptEmbedToken(TOKEN)).toBeNull()
+		expect(reportedMessages()).toContainEqual(
+			expect.stringContaining('is not set')
+		)
+	})
+
+	it('reads nothing either, rather than reporting every row as legacy', async () => {
+		/*
+		  The distinction this keeps alive: a null from a row that never had a
+		  value and a null from a deployment that cannot decrypt look identical
+		  to the caller, so the log line is the only thing separating them. It has
+		  to fire on the read path too.
+		*/
+		delete process.env[KEY_ENV]
+		process.env.NODE_ENV = 'production'
+		const { decryptEmbedToken } = await loadCipher()
+
+		expect(decryptEmbedToken(GOLDEN_ENVELOPE)).toBeNull()
+		expect(reportedMessages()).toContainEqual(expect.stringContaining(KEY_ENV))
+	})
+
+	it('falls back only outside production, so local dev needs no setup', async () => {
+		/*
+		  Announced as a warning, not an error. This is the documented local
+		  default, and `pii-encryption.server.ts` emits the same sentence at the
+		  same level - an error here puts a `[security]` failure in every local
+		  boot and in whatever reads log level in production tooling.
+		*/
+		const warned = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		delete process.env[KEY_ENV]
+		process.env.NODE_ENV = 'development'
+		const { encryptEmbedToken, decryptEmbedToken } = await loadCipher()
+
+		expect(decryptEmbedToken(envelopeOf(encryptEmbedToken))).toBe(TOKEN)
+		expect(warned).toHaveBeenCalledWith(
+			expect.stringContaining('development fallback key')
+		)
+		expect(reportServerError).not.toHaveBeenCalled()
+
+		warned.mockRestore()
+	})
+
+	it('does not treat a non-canonical string as raw key bytes', async () => {
+		/*
+		  The round-trip half of the branch, which nothing else reaches: this key
+		  is `BASE64_KEY` with its padding stripped, so it still decodes to 32
+		  bytes but is not what `Buffer.from(...).toString('base64')` produces.
+
+		  Without the round-trip check both spellings decode to the same 32 bytes
+		  and derive the same AES key, so two operators who believe they
+		  configured different secrets would silently share one. With it, this
+		  takes the sha256 branch and lands somewhere else entirely - which is
+		  what this asserts, by showing the padded key cannot read it.
+		*/
+		process.env[KEY_ENV] = BASE64_KEY.replace(/=+$/, '')
+		const unpadded = await loadCipher()
+		const envelope = envelopeOf(unpadded.encryptEmbedToken)
+
+		process.env[KEY_ENV] = BASE64_KEY
+		const padded = await loadCipher()
+
+		expect(padded.decryptEmbedToken(envelope)).toBeNull()
+	})
+
+	it('logs each cause once, not once per call', async () => {
+		/*
+		  The dedupe itself, on the one cause a passing local boot reaches.
+		  `does not let one cause silence the other`, further down, is what proves
+		  the causes are independent; this proves the early return holds across
+		  repeated calls - a per-request log line on a hot path is how a real
+		  incident gets buried.
+		*/
+		const warned = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		delete process.env[KEY_ENV]
+		process.env.NODE_ENV = 'development'
+		const { encryptEmbedToken } = await loadCipher()
+
+		encryptEmbedToken(TOKEN)
+		encryptEmbedToken(TOKEN)
+		encryptEmbedToken(TOKEN)
+
+		expect(warned).toHaveBeenCalledTimes(1)
+
+		warned.mockRestore()
+	})
+
+	it('accepts raw key material as well as base64', async () => {
+		process.env[KEY_ENV] = 'a-passphrase-that-is-not-base64-encoded'
+		const { encryptEmbedToken, decryptEmbedToken } = await loadCipher()
+
+		expect(decryptEmbedToken(encryptEmbedToken(TOKEN))).toBe(TOKEN)
+	})
+})
+
+describe('the stored format', () => {
+	/*
+	  A golden vector, and the only test here that does not round-trip through
+	  the module.
+
+	  Everything else encrypts and decrypts with the same code, so changing the
+	  key derivation, the IV length or the algorithm keeps the whole file green
+	  while making every row already in the database permanently unreadable -
+	  which the schema comment says is unrecoverable. This envelope was produced
+	  once, under `BASE64_KEY`, and pins the format on disk rather than the
+	  module's agreement with itself.
+	*/
+	it('still reads an envelope written by an earlier build', async () => {
+		process.env[KEY_ENV] = BASE64_KEY
+		const { decryptEmbedToken } = await loadCipher()
+
+		expect(decryptEmbedToken(GOLDEN_ENVELOPE)).toBe(TOKEN)
+	})
+
+	it('encrypts under the decoded bytes of a real 32-byte key', async () => {
+		/*
+		  Decrypted outside the module, with the key read straight off the env
+		  var, so this fails if the module derives anything else - a sha256 of the
+		  string included.
+
+		  The earlier version of this test only showed that two different key
+		  materials produce different keys, which stays true with the base64
+		  branch deleted, so it passed while naming a branch it never reached.
+		*/
+		process.env[KEY_ENV] = BASE64_KEY
+		const { encryptEmbedToken } = await loadCipher()
+		const [, , iv, tag, ciphertext] = envelopeOf(encryptEmbedToken).split(':')
+
+		const decipher = createDecipheriv(
+			'aes-256-gcm',
+			Buffer.from(BASE64_KEY, 'base64'),
+			Buffer.from(iv, 'base64')
+		)
+		decipher.setAuthTag(Buffer.from(tag, 'base64'))
+
+		expect(
+			Buffer.concat([
+				decipher.update(Buffer.from(ciphertext, 'base64')),
+				decipher.final()
+			]).toString('utf8')
+		).toBe(TOKEN)
+	})
+})
+
+describe('an envelope this module did not write', () => {
+	it('refuses a version it does not know', async () => {
+		/*
+		  The case the catch-all cannot rescue, and the reason the prefix check
+		  exists: five parts, a valid IV, a valid tag and valid ciphertext, so
+		  every downstream call succeeds. Delete the guard and this decrypts.
+		*/
+		const { encryptEmbedToken, decryptEmbedToken } = await loadCipher()
+		const [, , iv, tag, ciphertext] = envelopeOf(encryptEmbedToken).split(':')
+
+		expect(
+			decryptEmbedToken(['enc', 'v2', iv, tag, ciphertext].join(':'))
+		).toBeNull()
+	})
+})
+
+describe('a deployment whose key material changed', () => {
+	it('says so once, instead of reporting every key as legacy', async () => {
+		/*
+		  The failure with no other signal. Rotating the deployment key leaves
+		  every stored row undecryptable, and the caller sees exactly the null a
+		  row that never had a value produces - so without a log line, an
+		  operator watching the product sees keys quietly stop being shown and
+		  nothing anywhere says why.
+		*/
+		process.env[KEY_ENV] = OTHER_BASE64_KEY
+		const { decryptEmbedToken } = await loadCipher()
+
+		expect(decryptEmbedToken(GOLDEN_ENVELOPE)).toBeNull()
+		expect(reportedMessages()).toContainEqual(
+			expect.stringContaining('could not be decrypted')
+		)
+	})
+
+	it('does not let one cause silence the other', async () => {
+		/*
+		  A single "already logged" flag made these mutually exclusive for the
+		  lifetime of the process, and a deployment that lost its key material
+		  produces both - so whichever fired first hid the one an operator needed.
+		*/
+		delete process.env[KEY_ENV]
+		process.env.NODE_ENV = 'production'
+		const { decryptEmbedToken, encryptEmbedToken } = await loadCipher()
+
+		encryptEmbedToken(TOKEN)
+		process.env[KEY_ENV] = OTHER_BASE64_KEY
+		decryptEmbedToken(GOLDEN_ENVELOPE)
+
+		const messages = reportedMessages()
+
+		expect(messages.some((m) => m.includes('is not set'))).toBe(true)
+		expect(messages.some((m) => m.includes('could not be decrypted'))).toBe(
+			true
+		)
+	})
+})

--- a/apps/vectreal-platform/tests/embed-token-storage.spec.ts
+++ b/apps/vectreal-platform/tests/embed-token-storage.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * The parts of embed-token storage that a check without a database can hold.
+ *
+ * The real proof that the two stored forms describe one secret lives in
+ * `tests/integration/api-key-lifecycle.integration.spec.ts`, which reads the
+ * ciphertext back out of Postgres and puts it through the same function
+ * `/embed` calls. That suite does run on a pull request, since #753 added the
+ * `integration` job to `ci-quality.yaml` - it did not when these assertions
+ * were written, and the reason given here was that nothing executed it.
+ *
+ * They stay for a narrower reason that still holds. `vitest.config.ts` excludes
+ * `tests/integration/**` from the unit run, so the suite most people execute
+ * locally is green with both writes deleted and the column nullable enough that
+ * typecheck is too. And the count below is a question about the *file* - are
+ * there exactly two mint paths writing this - which no behavioral test asks: a
+ * third mint path added without a write is a key that can never be shown, and
+ * the integration suite would pass, because it exercises the two paths that
+ * already exist.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..')
+const read = (path: string) => readFileSync(join(ROOT, path), 'utf8')
+
+const REPOSITORY = read(
+	'apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts'
+)
+
+describe('both mint paths store the value the panel needs', () => {
+	/**
+	 * The write, with the variable it must be derived from.
+	 *
+	 * `encryptEmbedToken(preview)` would satisfy a looser check, store four
+	 * characters, and leave no other trace - not even an unused import.
+	 */
+	const WRITE = 'encryptedKey: encryptEmbedToken(plaintext)'
+
+	/*
+	  The count is the point, and it is why `publish-embed.mdx` can get away with
+	  a single `present` claim on this literal: a claim only asks whether the
+	  string occurs, so it stays green with one of the two call sites deleted -
+	  and the page promises recoverability for both created and rotated keys.
+	*/
+
+	it('writes it on create and on rotate, and nowhere else silently', () => {
+		const writes = REPOSITORY.split(WRITE).length - 1
+
+		expect(
+			writes,
+			`expected \`${WRITE}\` on both the create and rotate paths; found ${writes}. A third mint path needs its own write, and a missing one means keys that can never be shown.`
+		).toBe(2)
+	})
+
+	it('clears it on revoke', () => {
+		/*
+		  Revoking a leaked key has to stop the value being retrievable. The row
+		  authorizes nothing afterwards either way, so this is about the action
+		  meaning what its name says.
+		*/
+		expect(REPOSITORY).toContain('encryptedKey: null')
+	})
+})
+
+describe('the deployment that has to configure it', () => {
+	/*
+	  The cipher declines to store rather than throwing, so a missing variable no
+	  longer breaks key creation - it silently produces keys that can never be
+	  shown, which is the problem this whole change exists to end. Nothing else
+	  in the repo would notice.
+	*/
+	const ENV_VAR = 'EMBED_TOKEN_ENCRYPTION_KEY'
+
+	it('is set by the script that provisions Fly secrets', () => {
+		const script = read('terraform/scripts/setup-fly-secrets.sh')
+
+		expect(script).toContain(`${ENV_VAR}="$emb_key"`)
+		expect(script).toContain(`${ENV_VAR}_${'${ENV}'}`)
+	})
+
+	it('fails the run when it is missing, rather than deploying without it', () => {
+		/*
+		  `REQUIRED_STAGING` / `REQUIRED_PROD` are the only lists that `exit 1`.
+		  The verify-mode check list only warns and then exits 0, and the earlier
+		  `${emb_key:+...}` form skipped a missing value without comment - so a
+		  forgotten key produced a *successful* deploy that minted keys nobody
+		  could ever be shown, which is the failure this whole change exists to
+		  end.
+		*/
+		const script = read('terraform/scripts/setup-fly-secrets.sh')
+
+		for (const env of ['STAGING', 'PROD']) {
+			expect(script, env).toContain(`"${ENV_VAR}_${env}"`)
+		}
+
+		expect(script).toContain(`${ENV_VAR}="$emb_key"`)
+		expect(script).not.toContain(`\${emb_key:+`)
+	})
+
+	it('is checked by verify mode too', () => {
+		const script = read('terraform/scripts/setup-fly-secrets.sh')
+		const checkList = script.slice(
+			script.indexOf('check_env_secrets()'),
+			script.indexOf('check_fly_secret "$app" "$field"')
+		)
+
+		expect(checkList).toContain(ENV_VAR)
+	})
+
+	it('is documented for both deployed environments', () => {
+		const template = read('.env.development.example')
+
+		for (const suffix of ['', '_STAGING', '_PROD']) {
+			expect(template, `${ENV_VAR}${suffix}`).toContain(`${ENV_VAR}${suffix}=`)
+		}
+	})
+})

--- a/apps/vectreal-platform/tests/integration/api-key-lifecycle.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/api-key-lifecycle.integration.spec.ts
@@ -25,6 +25,7 @@ type Repository =
 	typeof import('../../app/lib/domain/auth/api-key-repository.server')
 type PreviewAuth =
 	typeof import('../../app/lib/domain/auth/preview-api-key-auth.server')
+type Cipher = typeof import('../../app/lib/security/embed-token-cipher.server')
 type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
 
 /**
@@ -49,6 +50,7 @@ describe('api key rotation', () => {
 	let rotateApiKey: Repository['rotateApiKey']
 	let revokeApiKey: Repository['revokeApiKey']
 	let validatePreviewApiKeyForProject: PreviewAuth['validatePreviewApiKeyForProject']
+	let decryptEmbedToken: Cipher['decryptEmbedToken']
 	let db: Db
 
 	const ownerId = randomUUID()
@@ -66,6 +68,8 @@ describe('api key rotation', () => {
 			await import('../../app/lib/domain/auth/api-key-repository.server'))
 		;({ validatePreviewApiKeyForProject } =
 			await import('../../app/lib/domain/auth/preview-api-key-auth.server'))
+		;({ decryptEmbedToken } =
+			await import('../../app/lib/security/embed-token-cipher.server'))
 		db = (await import('../../app/db/client')).getDbClient()
 
 		await db.insert(schema.users).values({
@@ -122,6 +126,38 @@ describe('api key rotation', () => {
 		expect(decision.ok).toBe(true)
 	})
 
+	it('stores the same secret twice, in the two forms that need it', async () => {
+		/*
+		  The invariant between the halves, and the reason this lives here rather
+		  than beside the cipher.
+
+		  `hashedKey` is what an embed request is matched against; `encryptedKey`
+		  is what the panel shows an owner so they can pick a key they already
+		  made. Those are two representations of one secret, written by one
+		  insert, and nothing in the type system says they describe the same
+		  value. If a later change writes a different token into one of them - or
+		  stops writing one - every unit test still passes and the panel starts
+		  handing out a snippet that authorizes nothing.
+
+		  So this reads the stored ciphertext out of the database, decrypts it,
+		  and puts the result through the same function `/embed` calls.
+		*/
+		const [row] = await db
+			.select({ encryptedKey: schema.apiKeys.encryptedKey })
+			.from(schema.apiKeys)
+			.where(eq(schema.apiKeys.id, apiKeyId))
+
+		/*
+		  Exact equality against the minted plaintext is the whole assertion. An
+		  earlier version also pushed `stored` through
+		  `validatePreviewApiKeyForProject` and asserted it authorized, which
+		  reads as the load-bearing half and cannot fail independently: `stored`
+		  is already proven identical to `originalPlaintext`, and the test above
+		  already proved that value authorizes. Two ways of saying one thing.
+		*/
+		expect(decryptEmbedToken(row.encryptedKey)).toBe(originalPlaintext)
+	})
+
 	it('hands back a new secret and keeps everything else', async () => {
 		const rotated = await rotateApiKey({ apiKeyId, userId: ownerId })
 		rotatedPlaintext = rotated.plaintext
@@ -140,6 +176,22 @@ describe('api key rotation', () => {
 		  what an owner checks to confirm the storefront picked the new key up.
 		*/
 		expect(rotated.apiKey.lastUsedAt).toBeNull()
+	})
+
+	it('rewrites the stored value on rotation rather than leaving the old one', async () => {
+		/*
+		  A stale `encryptedKey` here is worse than an absent one: the panel would
+		  confidently hand out the secret this rotation just replaced, which is
+		  the exact failure rotation exists to end, and the key would look fine in
+		  every listing while every snippet built from it 404s.
+		*/
+		const [row] = await db
+			.select({ encryptedKey: schema.apiKeys.encryptedKey })
+			.from(schema.apiKeys)
+			.where(eq(schema.apiKeys.id, apiKeyId))
+
+		expect(decryptEmbedToken(row.encryptedKey)).toBe(rotatedPlaintext)
+		expect(decryptEmbedToken(row.encryptedKey)).not.toBe(originalPlaintext)
 	})
 
 	it('refuses the key that was in the old snippet', async () => {
@@ -189,7 +241,9 @@ describe('api key rotation', () => {
 		])
 
 		const winners = results.filter(
-			(result): result is PromiseFulfilledResult<
+			(
+				result
+			): result is PromiseFulfilledResult<
 				Awaited<ReturnType<typeof rotateApiKey>>
 			> => result.status === 'fulfilled'
 		)

--- a/terraform/scripts/setup-fly-secrets.sh
+++ b/terraform/scripts/setup-fly-secrets.sh
@@ -119,6 +119,7 @@ REQUIRED_STAGING=(
   "CLOUDFLARE_TURNSTILE_SITE_KEY_STAGING"
   "CLOUDFLARE_TURNSTILE_SECRET_KEY_STAGING"
   "RESEND_API_KEY_STAGING"
+  "EMBED_TOKEN_ENCRYPTION_KEY_STAGING"
 )
 REQUIRED_PROD=(
   "SUPABASE_PROJECT_REF_PROD"
@@ -133,6 +134,7 @@ REQUIRED_PROD=(
   "CLOUDFLARE_TURNSTILE_SITE_KEY_PROD"
   "CLOUDFLARE_TURNSTILE_SECRET_KEY_PROD"
   "RESEND_API_KEY_PROD"
+  "EMBED_TOKEN_ENCRYPTION_KEY_PROD"
 )
 
 MISSING=()
@@ -178,6 +180,7 @@ if [[ "$MODE" == "verify" ]]; then
                  CSRF_SECRET STRIPE_SECRET_KEY APPLICATION_URL SEND_EMAIL_HOOK_SECRET \
                  CLOUDFLARE_TURNSTILE_SITE_KEY CLOUDFLARE_TURNSTILE_SECRET_KEY \
                  RESEND_API_KEY CONTACT_DATA_ENCRYPTION_KEY RESEND_WEBHOOK_SECRET \
+                 EMBED_TOKEN_ENCRYPTION_KEY \
                  CONTACT_INBOX_EMAIL FROM_EMAIL; do
       check_fly_secret "$app" "$field"
     done
@@ -218,6 +221,7 @@ sync_fly_secrets() {
   local hook_raw; hook_raw="$(eval echo "\${SEND_EMAIL_HOOK_SECRET_${ENV}}")"
   local hook; hook="$(strip_hook_prefix "$hook_raw")"
   local enc_key;  enc_key="$(eval echo "\${CONTACT_DATA_ENCRYPTION_KEY_${ENV}:-}")"
+  local emb_key;  emb_key="$(eval echo "\${EMBED_TOKEN_ENCRYPTION_KEY_${ENV}}")"
   local resend_wh; resend_wh="$(eval echo "\${RESEND_WEBHOOK_SECRET_${ENV}:-}")"
 
   if fly secrets set \
@@ -237,6 +241,7 @@ sync_fly_secrets() {
       NODE_ENV=production \
       ENVIRONMENT="$env" \
       ${enc_key:+CONTACT_DATA_ENCRYPTION_KEY="$enc_key"} \
+      EMBED_TOKEN_ENCRYPTION_KEY="$emb_key" \
       ${resend_wh:+RESEND_WEBHOOK_SECRET="$resend_wh"} \
       --app "$app" 2>/dev/null; then
     SECRETS_SET+=("$app")


### PR DESCRIPTION
## Summary

Stores the embed preview token in a form the product can read back, so the Embed panel can offer a key the user already owns instead of asking them to paste one. No UI reads it yet — that is the follow-up.

## Root cause

The embed token is public by construction — `buildEmbedUrl` puts it in an `iframe src` on the customer's own page — but it was stored as a one-way hash, so hashing protected a value that is published on purpose and charged for it in the one place the value is actually needed.

## Changes

- `encrypted_key` (nullable, migration `0019`) holds the same secret under AES-256-GCM, written by `createApiKey` and `rotateApiKey`, cleared by `revokeApiKey`. `hashedKey` is untouched and remains the only thing an embed request authenticates against.
- The `projects/:projectId/api-keys` loader decrypts behind the existing `api-key:read` check, filters to the project *before* decrypting, and sets `Cache-Control: no-store`.
- `EmbedApiKeyOption` gains `value: string | null`.
- **The cipher returns null rather than throwing.** Throwing made a display-only value a hard dependency of `createApiKey`, which would have broken every API key mint in production — the dashboard's own form included — because `EMBED_TOKEN_ENCRYPTION_KEY` was wired into no deployment path. It is now in `REQUIRED_STAGING`/`REQUIRED_PROD`, the only lists that fail the run.
- Rider, because this change caused it: both API-keys loaders now return named field lists, so neither `hashedKey` nor the new ciphertext reaches the browser.

`value` is null for three distinct reasons — a row predating the column, a row whose ciphertext no longer decrypts, and a revoked key, whose value is cleared on purpose. Only the first two are recoverable by rotation; `rotateApiKey` refuses anything not active.

## Deploying

`EMBED_TOKEN_ENCRYPTION_KEY` must be set for staging and prod before this ships, and migration `0019` needs pushing. A missing key fails the secrets run rather than the app: at runtime the cipher declines to store, and keys mint normally but unreadably.

## Type of Change

- [x] New feature (non-breaking, adds functionality)

## Testing

- [x] Unit / integration tests added or updated

93 files / 1053 unit tests, 55 integration against real Postgres, typecheck and lint green on all four projects.

`tests/embed-token-storage.spec.ts` counts the two writes at source level. The integration suite proves they round-trip, but it cannot ask whether a *third* mint path was added without one — which would be a key that can never be shown, and which that suite would pass.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [x] I updated documentation where needed
