### PR TITLE
fix(a11y): give the info tooltip a real keyboard trigger, and bound tooltip copy to three lines

### DIFF
--- a/.agents/skills/vectreal-brand-ux-design/SKILL.md
+++ b/.agents/skills/vectreal-brand-ux-design/SKILL.md
@@ -75,6 +75,28 @@ keeps every surface of its own below 50, in its own ladder in
 Below 50 is component-local ordering and stays a plain number. Giving it a tier
 name would claim a relationship with the site chrome that it does not have.
 
+## Tooltip copy: 140 characters
+
+`TooltipContent` is `max-w-80` at `text-xs`, so 140 characters is three lines
+and a glance. Past that a tooltip becomes a paragraph hanging over the control
+the reader was trying to use; one optimization-catalog entry had reached 367
+characters, nine lines of it.
+
+`apps/vectreal-platform/tests/tooltip-copy-length.spec.ts` enforces the ceiling
+over every tooltip string in `app/`. It reads source rather than a render tree,
+so it only sees string literals, and a new prop name carrying help text has to
+be added to its `ATTRIBUTES` list.
+
+When copy no longer fits, the answer is a visible caption beside the control,
+the way the embed options panel resolved it, not a taller tooltip. Several
+controls already have that slot: the optimization catalog gives every step a
+`description` rendered under its label, so the tooltip only has to carry what
+the caption does not.
+
+The trigger is a real `<button>`, not the icon. Radix's `TooltipTrigger` adds no
+tabIndex of its own under `asChild`, and an `<svg>` is not a tab stop, so an
+icon handed straight to it cannot be reached or opened by keyboard at all.
+
 ## Motion
 
 Durations: `--duration-instant` 80ms, `--duration-fast` 150ms, `--duration-base`
@@ -191,6 +213,8 @@ present  shared/components/src/styles/globals.css                              -
 present  shared/components/src/styles/globals.css                              --z-index-select: 120
 present  eslint.config.mts                                                     z-index outside the named scale
 exists   apps/vectreal-platform/tests/documented-claims.spec.ts
+exists   apps/vectreal-platform/tests/tooltip-copy-length.spec.ts
+exists   apps/vectreal-platform/tests/info-tooltip.spec.tsx
 present  eslint.config.mts                                                     Build className with cn()
 present  eslint.config.mts                                                     Inline SVG
 present  apps/vectreal-platform/app/routes/layouts/dashboard-layout.tsx        h-svh

--- a/apps/vectreal-platform/app/components/info-tooltip.tsx
+++ b/apps/vectreal-platform/app/components/info-tooltip.tsx
@@ -20,14 +20,26 @@ interface InfoTooltipProps {
 
 /**
  * InfoTooltip component for displaying help information
+ *
+ * The trigger is a real button rather than the icon itself. Radix's
+ * TooltipTrigger is a `Primitive.button` that adds no tabIndex of its own, so
+ * under `asChild` it merges onto whatever it is given: an `<svg>` has no
+ * default tab stop, and the tooltip could not be opened by keyboard at all.
  */
 export const InfoTooltip = ({ content, className }: InfoTooltipProps) => (
 	<TooltipProvider>
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<Info
-					className={cn('text-muted-foreground size-4 cursor-help', className)}
-				/>
+				<button
+					type="button"
+					aria-label="More information"
+					className="focus-visible:ring-ring focus-visible:ring-offset-background inline-flex shrink-0 cursor-help items-center justify-center rounded-full focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+				>
+					<Info
+						aria-hidden
+						className={cn('text-muted-foreground size-4', className)}
+					/>
+				</button>
 			</TooltipTrigger>
 			<TooltipContent className="max-w-80">{content}</TooltipContent>
 		</Tooltip>

--- a/apps/vectreal-platform/app/components/publisher/optimization/model/optimization-catalog.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/model/optimization-catalog.ts
@@ -52,7 +52,7 @@ export const OPTIMIZATION_CATALOG: readonly OptimizationDefinition[] = [
 		title: 'Reduce polygon count',
 		description: 'Collapses triangles to lower the draw cost at runtime',
 		tooltip:
-			'Removes triangles until the mesh hits your target or the deviation limit stops it, whichever comes first. This rewrites topology: it can leave holes, shading seams, and distorted UVs, especially on hard-surface models. Reach for it when the triangle count itself is the problem, not the file size — geometry compression shrinks the download without touching the mesh.',
+			'Removes triangles until the mesh hits your target or the deviation limit stops it, whichever comes first. UVs and shading can distort.',
 		isDestructive: true
 	},
 	{
@@ -72,7 +72,7 @@ export const OPTIMIZATION_CATALOG: readonly OptimizationDefinition[] = [
 		title: 'Quantize vertices',
 		description: 'Stores vertex attributes at lower precision',
 		tooltip:
-			'Reduces the number of bits used to store vertex positions and attributes, producing smaller files at the cost of minor visual artifacts. Redundant when geometry compression is on, since Draco quantizes on its own.',
+			'Fewer bits per vertex position and attribute: smaller files, minor artifacts. Redundant when Draco is on, since it quantizes on its own.',
 		isDestructive: false
 	},
 	{
@@ -82,7 +82,7 @@ export const OPTIMIZATION_CATALOG: readonly OptimizationDefinition[] = [
 		title: 'Optimize normals',
 		description: 'Recomputes normal vectors for cleaner shading',
 		tooltip:
-			'Recalculates normal vectors to improve lighting appearance. Helpful on models exported with missing or broken normals; unnecessary otherwise.',
+			'Helpful on models exported with missing or broken normals; unnecessary otherwise.',
 		isDestructive: false
 	},
 	{
@@ -92,7 +92,7 @@ export const OPTIMIZATION_CATALOG: readonly OptimizationDefinition[] = [
 		title: 'Compress geometry (Draco)',
 		description: 'The largest size saving available, without altering the mesh',
 		tooltip:
-			'Applies Draco mesh compression, typically the single largest reduction in file size. Topology is preserved — only precision is reduced — so the model keeps its shape. Compression is applied when you publish, so the scene you edit stays at full precision. Draco quantizes vertex attributes itself, which is why "Quantize vertices" turns off alongside it.',
+			'Applied when you publish, so the scene you edit stays at full precision. Draco quantizes vertices itself, so Quantize vertices turns off.',
 		isDestructive: false
 	},
 	{
@@ -102,7 +102,7 @@ export const OPTIMIZATION_CATALOG: readonly OptimizationDefinition[] = [
 		title: 'Texture optimization',
 		description: 'Resizes and re-encodes images',
 		tooltip:
-			'Resizes and compresses textures to reduce file size. On texture-heavy models this usually outweighs every geometry saving combined. Smaller dimensions and lower quality reduce visual fidelity.',
+			'On texture-heavy models this usually outweighs every geometry saving combined. Smaller dimensions and lower quality cost visual fidelity.',
 		isDestructive: false
 	}
 ]
@@ -157,7 +157,5 @@ export function listEnabledGeometryKeys(
 export function listEnabledKeys(
 	optimizations: Optimizations
 ): OptimizationKey[] {
-	return OPTIMIZATION_KEYS.filter((key) =>
-		Boolean(optimizations[key]?.enabled)
-	)
+	return OPTIMIZATION_KEYS.filter((key) => Boolean(optimizations[key]?.enabled))
 }

--- a/apps/vectreal-platform/app/components/publisher/optimization/panels/fields/mesh-reduction-field.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/panels/fields/mesh-reduction-field.tsx
@@ -62,8 +62,8 @@ export const MeshReductionField: FC = () => {
 					</div>
 					<p className="text-muted-foreground text-sm leading-relaxed">
 						Destructive. Changes topology and can leave holes or shading seams.
-						Use it when the triangle count is the problem — geometry
-						compression already shrinks the download without touching the mesh.
+						Use it when the triangle count is the problem — geometry compression
+						already shrinks the download without touching the mesh.
 					</p>
 				</div>
 				<Switch
@@ -102,7 +102,7 @@ export const MeshReductionField: FC = () => {
 					<div className="flex items-center justify-between gap-2">
 						<div className="flex items-center gap-2">
 							<p className="text-sm font-semibold">Deviation limit</p>
-							<InfoTooltip content="The maximum shape deviation allowed. The simplifier stops as soon as further collapses would exceed this, even if the target has not been reached." />
+							<InfoTooltip content="The largest shape change allowed. Simplification stops as soon as a further collapse would exceed it, even if the target is unmet." />
 						</div>
 						<span className="text-orange text-xs font-medium">
 							{getClosestValue(DEVIATION_PRESETS, error).toFixed(3)}

--- a/apps/vectreal-platform/app/components/publisher/optimization/scene-normalization-notice.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/scene-normalization-notice.tsx
@@ -59,7 +59,7 @@ export const SceneNormalizationNotice: FC = () => {
 				<>
 					<div className="flex items-center gap-2">
 						<Label className="text-sm font-medium">Extreme model size</Label>
-						<InfoTooltip content="This model's dimensions are outside a workable range. Normalizing scales it uniformly so shadows, camera framing, and other features work correctly." />
+						<InfoTooltip content="This model's dimensions are outside a workable range. Normalizing scales it uniformly so shadows and camera framing work correctly." />
 					</div>
 					<Button
 						variant="outline"

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/constants.ts
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/constants.ts
@@ -138,7 +138,7 @@ export const SHADOW_ADVANCED_FIELDS: FieldConfig[] = [
 		max: 1.1,
 		step: 0.01,
 		tooltip:
-			'Advanced: nudge the auto cutoff. The shadow threshold is calibrated to the environment automatically; lower this to deepen, raise to lighten if the ground hazes.',
+			'Nudges the auto cutoff. The threshold is calibrated to the environment; lower it to deepen the shadow, raise it if the ground hazes.',
 		formatValue: (value) => `${Math.round(value * 100)}%`
 	}
 ]
@@ -199,7 +199,7 @@ export const SHADOW_CONTACT_FIELDS: FieldConfig[] = [
 		max: 1.5,
 		step: 0.05,
 		tooltip:
-			'How far up from the floor the shadow reaches. Lower confines it to where the model is closest to the ground (tighter, more accurate ambient occlusion — e.g. only under the wheels); higher reaches up the model for a broad grounding pool.',
+			'How far up from the floor the shadow reaches. Lower is tighter and more accurate; higher reaches up the model for a broad grounding pool.',
 		formatValue: (value) => `${Math.round(value * 100)}%`
 	}
 ]

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/shadow-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/shadow-settings/shadow-settings-panel.tsx
@@ -295,7 +295,7 @@ const ShadowSettingsPanel = () => {
 							label="Ground shadow"
 							action={
 								<div className="flex items-center gap-2">
-									<InfoTooltip content="A soft shadow pooled under the model that approximates the ambient occlusion it casts on the floor. It's independent of the directional light, so the model stays grounded even when the main shadow is cast off to the side. Raise Softness to keep it diffuse." />
+									<InfoTooltip content="A soft pool under the model approximating the ambient occlusion it casts on the floor. Independent of the light, so it stays grounded." />
 									<Switch
 										id="shadow-ground-toggle"
 										aria-label="Enable ground shadow"
@@ -337,7 +337,7 @@ const ShadowSettingsPanel = () => {
 										<Label htmlFor="shadow-ao-toggle" className="text-sm">
 											Ambient occlusion
 										</Label>
-										<InfoTooltip content="Darkens crevices and tight gaps on the model itself (screen-space). Higher quality but runs every frame, so it costs GPU — best for hero shots on capable devices." />
+										<InfoTooltip content="Darkens crevices and tight gaps on the model itself. Higher quality, but it runs every frame, so it costs GPU. Best for hero shots." />
 									</div>
 									<Switch
 										id="shadow-ao-toggle"

--- a/apps/vectreal-platform/app/constants/product-copy.ts
+++ b/apps/vectreal-platform/app/constants/product-copy.ts
@@ -390,7 +390,7 @@ export const LIMIT_DISPLAY_LABELS: Partial<Record<LimitKey, string>> = {
 export const STORAGE_USAGE_LABEL = 'Scene storage'
 
 export const STORAGE_USAGE_HINT =
-	'What your scenes keep, not what visitors download. Each scene stores an editable copy at full precision, plus the compressed file served when you publish, its thumbnail, and any baked shadow. The size shown in the publisher is the published file alone, so it is the smaller of the two.'
+	'What your scenes keep, not what visitors download: the editable copy, the published file, its thumbnail, and any baked shadow.'
 
 // ---------------------------------------------------------------------------
 // Upgrade success page: entitlement keys to highlight post-upgrade, in priority

--- a/apps/vectreal-platform/tests/info-tooltip.spec.tsx
+++ b/apps/vectreal-platform/tests/info-tooltip.spec.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+/**
+ * The reason this component has a button in it.
+ *
+ * Radix's `TooltipTrigger` is a `Primitive.button` that adds no tabIndex of
+ * its own, so under `asChild` it merges onto whatever it is handed. It used to
+ * be handed the lucide `<svg>` directly, and an `<svg>` is not a tab stop:
+ * every InfoTooltip in the app was unreachable by keyboard, and its content
+ * never entered the accessibility tree, because Radix only sets
+ * `aria-describedby` while the tooltip is open.
+ */
+
+import { act, render, screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { InfoTooltip } from '../app/components/info-tooltip'
+
+beforeAll(() => {
+	// Radix's popper measures the trigger with a ResizeObserver, which jsdom
+	// does not implement. Without this the content throws on open and React
+	// unmounts the whole tree, so every assertion below reads an empty body.
+	globalThis.ResizeObserver = class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	}
+})
+
+const focusTrigger = async (trigger: HTMLElement) => {
+	await act(async () => {
+		trigger.focus()
+	})
+}
+
+describe('InfoTooltip', () => {
+	it('exposes a focusable trigger with an accessible name', async () => {
+		render(<InfoTooltip content="Domains allowed to embed this scene." />)
+
+		const trigger = screen.getByRole('button', { name: 'More information' })
+		await focusTrigger(trigger)
+
+		expect(document.activeElement).toBe(trigger)
+		// A tab stop nobody can see is the same bug wearing a different hat.
+		expect(trigger.className).toContain('focus-visible:ring-2')
+	})
+
+	it('describes the trigger with the tooltip content once focused', async () => {
+		render(<InfoTooltip content="Domains allowed to embed this scene." />)
+
+		const trigger = screen.getByRole('button', { name: 'More information' })
+		await focusTrigger(trigger)
+
+		const describedBy = trigger.getAttribute('aria-describedby')
+
+		expect(describedBy).toBeTruthy()
+		expect(document.getElementById(describedBy!)?.textContent).toBe(
+			'Domains allowed to embed this scene.'
+		)
+	})
+
+	it('keeps the icon out of the accessibility tree so the name is the button’s', () => {
+		render(<InfoTooltip content="Help." className="size-3.5" />)
+
+		const icon = screen
+			.getByRole('button', { name: 'More information' })
+			.querySelector('svg')!
+
+		expect(icon).toHaveAttribute('aria-hidden', 'true')
+		expect(icon.getAttribute('class')).toContain('size-3.5')
+	})
+})

--- a/apps/vectreal-platform/tests/tooltip-copy-length.spec.ts
+++ b/apps/vectreal-platform/tests/tooltip-copy-length.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Tooltip copy has to fit in the tooltip.
+ *
+ * `TooltipContent` is `max-w-80` at `text-xs`: 320px of 12px DM Sans, minus
+ * `px-3` either side. Measured in the browser against that exact box, real
+ * English prose wraps to three lines at 140 characters and to four in the
+ * 150s. A tooltip is a glance, not a paragraph, so 140 is the ceiling.
+ *
+ * The rule exists because nothing bounded this. Copy that outgrew a glance
+ * kept being written as a tooltip anyway - one entry in the optimization
+ * catalog reached 367 characters, which is nine lines hanging over the panel
+ * the reader was trying to use. When copy no longer fits, the fix is a visible
+ * caption beside the control, the way the embed options panel resolved it, not
+ * a taller tooltip.
+ *
+ * The scan is deliberately literal: it reads source, not a render tree, so it
+ * sees only string literals. Copy assembled at runtime is not covered, and a
+ * new prop name carrying help text has to be added to ATTRIBUTES below.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const APP_DIR = join(dirname(fileURLToPath(import.meta.url)), '../app')
+
+/**
+ * 140 characters is three lines in the real tooltip box. Verified in the
+ * browser rather than estimated: the strings in this repo still measured three
+ * line boxes at 141 characters, and the fourth appears in the 150s.
+ */
+const MAX_LENGTH = 140
+
+/** A single- or double-quoted literal, escapes included. */
+const LITERAL = String.raw`'((?:[^'\\]|\\.)*)'|"((?:[^"\\]|\\.)*)"`
+
+/**
+ * Names that carry help text into a tooltip. `content` is not among them: it
+ * is far too common a prop name to match on, so InfoTooltip's own is read off
+ * the tag instead.
+ */
+const ATTRIBUTES = String.raw`tooltip|info|hint|\w+Help|\w+Hint|\w+_HINT|\w+_EXPLANATION`
+
+/** `name: 'copy'` and `name="copy"`, across the line break prettier inserts. */
+const ASSIGNED = String.raw`\b(?:${ATTRIBUTES})\s*[:=]\s*\{?\s*(?:${LITERAL})`
+
+/** `<InfoTooltip content="copy" />`, the only `content` that counts. */
+const INFO_TOOLTIP = String.raw`<InfoTooltip[^>]*?\bcontent=\{?\s*(?:${LITERAL})`
+
+interface TooltipCopy {
+	source: string
+	text: string
+}
+
+function collectSourceFiles(dir: string): string[] {
+	return readdirSync(dir).flatMap((entry) => {
+		const full = join(dir, entry)
+		if (statSync(full).isDirectory()) return collectSourceFiles(full)
+		return /(?<!\.spec)\.tsx?$/.test(entry) ? [full] : []
+	})
+}
+
+function collectTooltipCopy(): TooltipCopy[] {
+	const found: TooltipCopy[] = []
+
+	for (const file of collectSourceFiles(APP_DIR)) {
+		const source = readFileSync(file, 'utf8')
+		const where = relative(APP_DIR, file)
+
+		for (const pattern of [ASSIGNED, INFO_TOOLTIP]) {
+			for (const match of source.matchAll(new RegExp(pattern, 'g'))) {
+				const literal = match[0].match(new RegExp(LITERAL))
+				if (!literal) continue
+
+				const text = (literal[1] ?? literal[2] ?? '')
+					.replace(/\\(['"])/g, '$1')
+					.trim()
+
+				if (text) found.push({ source: where, text })
+			}
+		}
+	}
+
+	return found
+}
+
+describe('tooltip copy', () => {
+	const copy = collectTooltipCopy()
+
+	it('finds the tooltip strings it is meant to be guarding', () => {
+		// A collector that silently matches nothing is a green test that checks
+		// nothing, which is the only way this rule can fail quietly.
+		expect(copy.length).toBeGreaterThan(40)
+	})
+
+	it('stays within three lines of the tooltip box', () => {
+		const tooLong = copy
+			.filter(({ text }) => text.length > MAX_LENGTH)
+			.map(({ source, text }) => `${source}: ${text.length} chars - "${text}"`)
+			.sort()
+
+		expect(tooLong).toEqual([])
+	})
+})


### PR DESCRIPTION
## Summary

Every `InfoTooltip` in the app was invisible to keyboard and screen-reader users, because Radix was handed an `<svg>` as its trigger. This gives it a real button, and adds a rule bounding tooltip copy to three lines, with the strings that were over rewritten to fit.

## Root cause

Radix's `TooltipTrigger` is a `Primitive.button` that adds no `tabIndex` of its own, so under `asChild` its props merged onto the lucide `<svg>`, which has no default tab stop, and the tooltip could not be opened by keyboard at all. The fix belongs in `InfoTooltip` rather than at any call site because the trigger element is the component's own contract, and every one of its call sites inherited the defect from it.

## Changes

- `info-tooltip.tsx` renders a real `<button type="button" aria-label="More information">` wrapping an `aria-hidden` icon, with a focus ring from `--ring`. `className` still lands on the icon, so no call site changed.
- `tests/info-tooltip.spec.tsx` covers the focusable trigger, the visible focus ring, `aria-describedby` resolving to the content on focus, and the icon staying out of the accessibility tree.
- `tests/tooltip-copy-length.spec.ts` enforces a 140-character ceiling over every tooltip string in `app/`, plus a second test asserting the scan still finds what it is meant to guard.
- Twelve over-budget strings rewritten across the optimization catalog, the shadow settings, the normalization notice and `product-copy.ts`.
- The rule is documented in the `vectreal-brand-ux-design` skill, with claims lines that `documented-claims.spec.ts` enforces.

## Why 140

`TooltipContent` is `max-w-80` at `text-xs`: 320px of 12px DM Sans, minus `px-3` either side. Measured in the browser against that exact box rather than estimated, real English prose wraps to three lines at 141 characters and reaches a fourth in the 150s. The worst offender was 367 characters, about nine lines hanging over the panel the reader was trying to use.

Most of what came out was already on screen. The 367-character mesh-simplification tooltip duplicated the warning paragraph rendered directly beneath it, and four optimization-catalog entries repeated their own `description` field, which the panel already renders under the label.

## Rebase note

This branch was rebased onto `main` after #761. That PR rebuilt the embed panel around a key picker and deleted every `*Help` / `*Hint` key in `embed-snippet.ts` along with the panel's tooltips, so the three embed strings this branch had shortened no longer exist and `embed-snippet.ts` is out of the diff entirely. #761 is the precedent the rule points at: when copy outgrows a glance, it becomes a visible caption, not a taller tooltip. The shadow-settings panel was restructured on the same base, so main's structure was taken there and only the two copy changes re-applied.

## What reviewers should know

One fact did not survive the cut and has no visible home. Say if it should come back as a caption:

- `STORAGE_USAGE_HINT` no longer reconciles itself against the publisher's smaller number ("the size shown in the publisher is the published file alone").

The scan reads source rather than a render tree, so it sees only string literals. Copy assembled at runtime is not covered, and a new prop name carrying help text has to be added to its `ATTRIBUTES` list. It currently collects 52 strings against a guard threshold of 40.

Prettier also reflowed two unrelated lines in `optimization-catalog.ts` and `mesh-reduction-field.tsx`. Both files were already prettier-dirty on `main`; the reflow is whitespace only. `SKILL.md` is likewise already prettier-dirty on `main` and was deliberately left alone rather than reformatting 23 lines nobody here touched.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

Verified in the browser through Storybook's existing `UsageMeters` story, which renders `InfoTooltip` in both variants and both themes. The platform dev server cannot start in this worktree (no `.env.development`). One Tab reaches the trigger, `:focus-visible` matches, the ring renders in light and dark from the correct theme tokens, the tooltip opens on focus, and `aria-describedby` resolves to the full text. The button box measures exactly the icon box, so layout is untouched. The shortened storage hint measures three line boxes at 304px.

Mutation gate, four mutations, all red for the stated reason:

- Reverting the trigger to `<Info>` fails all three accessibility tests.
- Padding one string past 140 fails the length test, naming the file and string.
- Breaking the collector fails the guard test.
- Pointing a claims line at a missing file fails `documented-claims`.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [x] I updated documentation where needed
- [ ] I linked the related issue above

Re-run after the rebase: `vitest run --root .` green at 110 files and 1493 tests, `nx typecheck vectreal-platform` clean, `nx lint vectreal-platform` clean. The 43 `@nx/dependency-checks` errors noted in the first revision of this description were a stale-worktree artifact and are gone on the current base.
