### PR TITLE
docs(skills): bound the review loop so it terminates on behavior

### DIFF
--- a/.agents/skills/vectreal-iterative-delivery/SKILL.md
+++ b/.agents/skills/vectreal-iterative-delivery/SKILL.md
@@ -86,9 +86,35 @@ sat filed and untouched from the day before. Narrow was right; deep was wrong.
 2. **If the diff touches a file the scope line did not name**, stop. Either
    rename the scope out loud, or file the finding and leave the file alone.
 
+## When the loop does not run
+
+**A change whose whole purpose is to satisfy a mechanical gate - lint,
+typecheck, formatting, a renamed import - is reviewed by that gate.** One pass to
+confirm the gate is green and the change is minimal, then ship. No loop.
+
+The loop exists for changes where behavior is in question. Running it on a
+one-line lint fix does not make the fix safer; it makes the diff bigger, because
+each round has to find something and the only thing left to find is the prose the
+previous round produced.
+
 ## The loop, which is never skipped
 
 Findings are not the deliverable. **A clean review round is.**
+
+**What counts as a finding.** Something that changes what the code does, changes
+what a test can catch, or would lead the next reader to make a wrong change. That
+is the whole list. A comment that is merely less precise than it could be is not
+a finding - leave it. Reviewers asked to audit prose will always return
+something, so the loop only terminates if the bar is behavior.
+
+**A review round may not grow the diff.** A finding in a file the change does not
+already touch, a test for a gap that predates the change, a rewrite of code that
+was already reviewed: all of these are catalogue rows, not edits. A round that
+adds files or tests has created its own next round.
+
+**Two consecutive rounds that produce only comment rewrites means stop.** That is
+the signature of reviewing your own writing rather than the code, and it does not
+converge. Ship, and file whatever is left.
 
 1. **Review** - several subagents in parallel, each on one distinct dimension.
 2. **Map** - one subagent consolidates into a fix spec: dedupe, decide, and name
@@ -227,6 +253,9 @@ tests fail, say so with the output; if a step was skipped, say that.
 | Anti-pattern | Replacement |
 | --- | --- |
 | Review round skipped because the change looks small | Run the loop; #735's worst defect was in a 3-line hook |
+| The loop run on a change with no behavior in question | The gate is the review; one pass, then ship |
+| A round's findings are rewrites of the previous round's comments | Stop. Prose has no clean state; only behavior does |
+| A round fixes a pre-existing gap it happened to notice | Catalogue row. The round may not grow the diff |
 | Test written after the guard, never mutated | Mutate the line, watch it go red |
 | Third patch of one symptom | Find the cause |
 | Reviewers and fixers running concurrently | Phase barrier |


### PR DESCRIPTION
## Root cause

The review loop in `vectreal-iterative-delivery` exits when "a round comes back with nothing", but the skill never says what counts as a finding. Reviewers pointed at a diff will grade its comments, so as soon as one round rewrites prose the next round has fresh prose to grade — and prose has no clean state the way behavior does. The loop cannot terminate.

Observed on #760: a one-line lint fix (a `console[level]` call that #757's new `no-console` rule forbids in `.server.ts`) ran six review rounds. Rounds three onward produced only comment rewrites, and the loop pulled in a third file and added tests for gaps that predated the PR. The shipped fix is two files and 32 insertions; everything the loop added was discarded.

The fix belongs in the skill rather than in reviewer prompts, because the prompts were doing what the skill told them to.

## What changes

Three bounds in `.agents/skills/vectreal-iterative-delivery/SKILL.md`:

- **A change that exists to satisfy a mechanical gate is reviewed by that gate.** Lint, typecheck, formatting, a renamed import: one pass to confirm the gate is green and the change is minimal, then ship. No loop.
- **What counts as a finding** — changes what the code does, changes what a test can catch, or would lead the next reader to make a wrong change. A comment that is merely less precise than it could be is not a finding.
- **A round may not grow the diff**, and **two consecutive comment-only rounds means stop**.

Plus three anti-pattern rows, as a counterweight to the existing "Review round skipped because the change looks small → Run the loop", which had nothing pulling the other way.

## Verification

Documentation only — no code paths touched. `documented-claims.spec.ts` covers this file's ```claims``` block, which is unchanged.