### PR TITLE
feat(viewer): give hotspots one renderer, and wire it to every surface

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
@@ -1,26 +1,16 @@
-import { Html, TransformControls } from '@react-three/drei'
-import { useFrame, useThree } from '@react-three/fiber'
+import { TransformControls } from '@react-three/drei'
+import { useThree } from '@react-three/fiber'
 import { useModelContext } from '@vctrl/hooks/use-load-model'
 import { useAtom, useAtomValue } from 'jotai/react'
-import {
-	memo,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-	type FC
-} from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 
 import { PublisherViewCube } from './publisher-view-cube'
 import { usePublisherViewerCapture } from './publisher-viewer-capture-context'
 import {
-	isHotspotOccluded,
 	isHotspotPlacementGesture,
 	prepareHotspotRaycaster,
-	resolveHotspotAnchor,
-	resolveHotspotOcclusionTolerance
+	resolveHotspotAnchor
 } from '../../lib/domain/scene/scene-hotspot-placement'
 import {
 	isClickToPlaceActiveAtom,
@@ -28,234 +18,11 @@ import {
 } from '../../lib/stores/publisher-config-store'
 import {
 	activeHotspotIdAtom,
-	hotspotsAtom,
-	normalizationAtom,
-	selectedCameraIdAtom
+	hotspotsAtom
 } from '../../lib/stores/scene-settings-store'
 
 import type { HotspotDefinition } from '@vctrl/core'
 import type { Object3D } from 'three'
-
-// ---------------------------------------------------------------------------
-// Inject CSS keyframes for the pulsing dot animation (once per document)
-// ---------------------------------------------------------------------------
-
-function useHotspotStyles() {
-	useEffect(() => {
-		const id = 'vctrl-hotspot-styles'
-		if (document.getElementById(id)) return
-		const el = document.createElement('style')
-		el.id = id
-		el.textContent = `
-      @keyframes vctrl-hotspot-pulse {
-        0%   { box-shadow: 0 0 0 0px currentColor; }
-        55%  { box-shadow: 0 0 0 8px transparent; }
-        100% { box-shadow: 0 0 0 0px transparent; }
-      }
-      .vctrl-hp          { animation: vctrl-hotspot-pulse 2.2s ease-out infinite; }
-      .vctrl-hp-selected { animation: vctrl-hotspot-pulse 1.3s ease-out infinite; }
-    `
-		document.head.appendChild(el)
-	}, [])
-}
-
-/**
- * The gizmo's live position during a drag, shared with the marker that follows
- * it.
- *
- * Refs rather than state on purpose: a drag emits a position every frame, and
- * routing that through React is what this exists to stop.
- */
-interface HotspotDragState {
-	hotspotId: React.MutableRefObject<null | string>
-	position: React.MutableRefObject<THREE.Vector3>
-}
-
-// ---------------------------------------------------------------------------
-// 2-D hotspot dot rendered via drei Html (no 3-D geometry)
-// ---------------------------------------------------------------------------
-
-interface HotspotDotProps {
-	hotspot: HotspotDefinition
-	isSelected: boolean
-	isHotspotToolActive: boolean
-	activeCameraId?: string
-	modelRoot: Object3D | null
-	/**
-	 * World-unit occlusion slack for this model, held by the owner and refreshed
-	 * when the model or its transform changes.
-	 */
-	occlusionTolerance: React.MutableRefObject<number>
-	/**
-	 * Where the gizmo is while a drag is in flight, and whose drag it is. The
-	 * dragged marker reads this instead of its stored position, so the drag can
-	 * keep the marker glued to the gizmo without writing the scene settings on
-	 * every frame.
-	 */
-	drag: HotspotDragState
-	onSelect: (id: string) => void
-	onActivateCamera: (cameraId: string) => void
-}
-
-const HotspotDot: FC<HotspotDotProps> = memo(
-	({
-		hotspot,
-		isSelected,
-		isHotspotToolActive,
-		activeCameraId,
-		modelRoot,
-		occlusionTolerance,
-		drag,
-		onSelect,
-		onActivateCamera
-	}) => {
-		const [hovered, setHovered] = useState(false)
-		const wrapperRef = useRef<HTMLDivElement>(null)
-		const anchorRef = useRef<THREE.Group>(null)
-		const posVec = useRef(new THREE.Vector3(...hotspot.worldPosition))
-		const { camera } = useThree()
-		// Private, so the per-frame occlusion test cannot leave R3F's own pointer
-		// raycaster aimed at a hotspot.
-		const occlusionRay = useMemo(
-			() => prepareHotspotRaycaster(new THREE.Raycaster()),
-			[]
-		)
-		const occlusionDir = useRef(new THREE.Vector3())
-
-		// Keep position in sync with atom changes (e.g. after gizmo drag or click-to-place)
-		useEffect(() => {
-			posVec.current.set(...hotspot.worldPosition)
-			anchorRef.current?.position.copy(posVec.current)
-		}, [hotspot.worldPosition])
-
-		// Occlusion: raycast from camera toward hotspot every frame, mutate opacity
-		// directly. Priority -1 so this writes the group's position before drei's
-		// `Html` projects from it: at equal priority `Html` subscribes first, being
-		// a child, and the marker would trail the gizmo by a frame. Negative
-		// priorities sort early without taking rendering over, which only `> 0` does.
-		useFrame(() => {
-			// A drag moves the gizmo directly and commits once, on release, so the
-			// dragged marker tracks the gizmo from here rather than from a stored
-			// position that is deliberately not being rewritten yet.
-			if (drag.hotspotId.current === hotspot.id) {
-				posVec.current.copy(drag.position.current)
-				anchorRef.current?.position.copy(posVec.current)
-			}
-
-			if (!wrapperRef.current) return
-
-			if (hotspot.occlusionEnabled === false) {
-				wrapperRef.current.style.opacity = '1'
-				return
-			}
-
-			const origin = camera.position
-			const target = posVec.current
-			const distance = origin.distanceTo(target)
-
-			occlusionRay.set(
-				origin,
-				occlusionDir.current.subVectors(target, origin).normalize()
-			)
-
-			const occluded = isHotspotOccluded(
-				occlusionRay,
-				modelRoot,
-				distance,
-				occlusionTolerance.current
-			)
-			wrapperRef.current.style.opacity = occluded ? '0.18' : '1'
-		}, -1)
-
-		const isLinkedCameraActive =
-			!isHotspotToolActive &&
-			!!hotspot.linkedCameraId &&
-			hotspot.linkedCameraId === activeCameraId
-		const accentColor =
-			isSelected && isHotspotToolActive
-				? '#f97316'
-				: isLinkedCameraActive
-					? 'var(--success)'
-					: hotspot.visible
-						? '#3b82f6'
-						: '#6b7280'
-
-		const showLabel = isSelected || hovered
-
-		return (
-			<group
-				ref={anchorRef}
-				position={hotspot.worldPosition as [number, number, number]}
-			>
-				<Html center zIndexRange={[100, 0]} style={{ pointerEvents: 'none' }}>
-					<div
-						ref={wrapperRef}
-						style={{
-							pointerEvents: 'auto',
-							transition: 'opacity 0.35s ease',
-							position: 'relative',
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center'
-						}}
-						onClick={(e) => {
-							e.stopPropagation()
-							if (isHotspotToolActive) {
-								onSelect(hotspot.id)
-							} else if (hotspot.linkedCameraId) {
-								onActivateCamera(hotspot.linkedCameraId)
-							}
-						}}
-						onMouseEnter={() => setHovered(true)}
-						onMouseLeave={() => setHovered(false)}
-					>
-						{/* Pulsing circle */}
-						<div
-							className={isSelected ? 'vctrl-hp-selected' : 'vctrl-hp'}
-							style={{
-								width: 13,
-								height: 13,
-								borderRadius: '50%',
-								background: accentColor,
-								color: accentColor,
-								border: '2px solid rgba(255,255,255,0.55)',
-								boxSizing: 'border-box',
-								cursor: 'pointer',
-								flexShrink: 0
-							}}
-						/>
-
-						{/* Floating label above the dot */}
-						{showLabel && (
-							<div
-								style={{
-									position: 'absolute',
-									bottom: 'calc(100% + 7px)',
-									left: '50%',
-									transform: 'translateX(-50%)',
-									fontSize: 11,
-									lineHeight: 1.4,
-									padding: '2px 8px',
-									whiteSpace: 'nowrap',
-									borderRadius: 4,
-									background: 'rgba(0,0,0,0.82)',
-									color: '#fff',
-									backdropFilter: 'blur(6px)',
-									border: '1px solid rgba(255,255,255,0.13)',
-									pointerEvents: 'none',
-									userSelect: 'none'
-								}}
-							>
-								{hotspot.name || 'Hotspot'}
-							</div>
-						)}
-					</div>
-				</Html>
-			</group>
-		)
-	}
-)
-HotspotDot.displayName = 'HotspotDot'
 
 // ---------------------------------------------------------------------------
 // TransformControls gizmo for the active hotspot
@@ -270,17 +37,50 @@ interface HotspotGizmoProps {
 	 * reads as a placement aimed at whatever the arrow tip covers.
 	 */
 	grabbedRef: React.MutableRefObject<boolean>
-	drag: HotspotDragState
 	onMove: (id: string, position: [number, number, number]) => void
 }
 
 const HotspotGizmo = memo(
-	({ hotspot, grabbedRef, drag, onMove }: HotspotGizmoProps) => {
+	({ hotspot, grabbedRef, onMove }: HotspotGizmoProps) => {
 		const meshRef = useRef<THREE.Mesh>(null)
 		const isDraggingRef = useRef(false)
-		const { commandExecutor } = usePublisherViewerCapture()
+		/**
+		 * The last position published to the viewer during the drag.
+		 *
+		 * The interrupted path cannot read the mesh: React detaches a callback ref in
+		 * the mutation phase and the cleanup that finishes the drag runs in the
+		 * passive phase after it, so `meshRef.current` is already null by then and the
+		 * author's drag used to be discarded in silence.
+		 */
+		const lastPublished = useRef<[number, number, number] | null>(null)
+		const { commandExecutor, hotspotPositionSetter } =
+			usePublisherViewerCapture()
 		// TransformControls `object` prop requires the mesh to already be in the scene
 		const [meshMounted, setMeshMounted] = useState(false)
+
+		/**
+		 * Tells the viewer where this hotspot's marker should be drawn right now.
+		 *
+		 * The marker belongs to `@vctrl/viewer`, which draws every hotspot on every
+		 * surface; the gizmo is all the publisher still owns. The viewer applies this
+		 * to the marker's own anchor group inside a frame callback, so a drag never
+		 * touches React state - which is what it cost when this component committed
+		 * to `hotspotsAtom` on every frame instead: the settings object rebuilt from
+		 * that atom is the memo key for the unsaved-changes check, so a drag ran two
+		 * full canonical serializations of every scene setting twice per frame while
+		 * every marker and the sidebar re-rendered.
+		 */
+		const publishDragPosition = useCallback(() => {
+			const p = meshRef.current?.position
+			if (!p) return
+			lastPublished.current = [p.x, p.y, p.z]
+			hotspotPositionSetter.current?.(hotspot.id, lastPublished.current)
+		}, [hotspot.id, hotspotPositionSetter])
+
+		/** Hands the marker back to its stored position. Commit before releasing. */
+		const releaseDragPosition = useCallback(() => {
+			hotspotPositionSetter.current?.(hotspot.id, null)
+		}, [hotspot.id, hotspotPositionSetter])
 
 		// Imperatively sync position when the atom changes (e.g. after click-to-place).
 		// Guarded so we don't fight TransformControls while the user is dragging.
@@ -294,21 +94,20 @@ const HotspotGizmo = memo(
 		const handleDragStart = useCallback(() => {
 			isDraggingRef.current = true
 			grabbedRef.current = true
-			// Seeded before the id is published. three-stdlib dispatches `mouseDown`
-			// with no `objectChange` - the first of those comes from a pointermove,
-			// many frames later - so a marker that began following an unseeded
-			// vector would sit at the world origin until the pointer moved.
-			if (meshRef.current) drag.position.current.copy(meshRef.current.position)
-			drag.hotspotId.current = hotspot.id
+			lastPublished.current = null
+			// Published before the first `objectChange`. three-stdlib dispatches
+			// `mouseDown` with no `objectChange` of its own - the first of those comes
+			// from a pointermove, many frames later - so a marker whose override began
+			// life empty would have nowhere to be drawn until the pointer moved.
+			publishDragPosition()
 			commandExecutor.current?.execute({
 				type: 'set_controls_enabled',
 				enabled: false
 			})
-		}, [commandExecutor, drag, grabbedRef, hotspot.id])
+		}, [commandExecutor, grabbedRef, publishDragPosition])
 
 		const handleDragEnd = useCallback(() => {
 			isDraggingRef.current = false
-			drag.hotspotId.current = null
 			commandExecutor.current?.execute({
 				type: 'set_controls_enabled',
 				enabled: true
@@ -317,22 +116,18 @@ const HotspotGizmo = memo(
 				const p = meshRef.current.position
 				onMove(hotspot.id, [p.x, p.y, p.z])
 			}
-		}, [commandExecutor, drag, hotspot.id, onMove])
+			// Release after the commit, in the same task. `setHotspots` schedules the
+			// update rather than applying it, so the release still runs first in wall
+			// time; what the ordering buys is that the commit is already queued when
+			// the viewer sees the release, so the marker settles on the new position
+			// rather than being put back on the old one.
+			releaseDragPosition()
+		}, [commandExecutor, hotspot.id, onMove, releaseDragPosition])
 
-		/**
-		 * Publishes the drag rather than committing it.
-		 *
-		 * Committing here wrote `hotspotsAtom` on every frame, and the settings
-		 * object rebuilt from that atom is the memo key for the unsaved-changes
-		 * check - two full canonical serializations of every scene setting, twice
-		 * per frame at 60fps, while every marker and the sidebar re-rendered. The
-		 * position reaches the marker through a ref instead, and the atom is
-		 * written once, on release.
-		 */
 		const handleObjectChange = useCallback(() => {
 			if (!meshRef.current || !isDraggingRef.current) return
-			drag.position.current.copy(meshRef.current.position)
-		}, [drag])
+			publishDragPosition()
+		}, [publishDragPosition])
 
 		/**
 		 * Finishes a drag the gizmo is about to be torn away from.
@@ -345,16 +140,21 @@ const HotspotGizmo = memo(
 		const finishInterruptedDrag = useCallback(() => {
 			if (!isDraggingRef.current) return
 			isDraggingRef.current = false
-			drag.hotspotId.current = null
 			commandExecutor.current?.execute({
 				type: 'set_controls_enabled',
 				enabled: true
 			})
-			// Read the mesh, as `handleDragEnd` does: the published vector is a frame
-			// old at best and never written at worst.
+			// The mesh first, then the last vector published to the viewer. Running as
+			// an unmount cleanup the ref is already detached, and the fallback is the
+			// difference between keeping the author's drag and throwing it away because
+			// they switched tools without letting go.
 			const p = meshRef.current?.position
-			if (p) onMove(hotspot.id, [p.x, p.y, p.z])
-		}, [commandExecutor, drag, hotspot.id, onMove])
+			const position = p ? [p.x, p.y, p.z] : lastPublished.current
+			if (position) {
+				onMove(hotspot.id, [position[0], position[1], position[2]])
+			}
+			releaseDragPosition()
+		}, [commandExecutor, hotspot.id, onMove, releaseDragPosition])
 
 		/**
 		 * Hands the gizmo the release it is waiting for when a gesture is cancelled.
@@ -535,75 +335,28 @@ function ClickToPlace({
 // Main editor scene
 // ---------------------------------------------------------------------------
 
+/**
+ * What the publisher adds on top of the viewer, and nothing more.
+ *
+ * The markers themselves belong to `@vctrl/viewer`: the route passes the scene's
+ * hotspots straight through, so an author composes against exactly the marker a
+ * visitor will see. This component owns only the affordances that make no sense
+ * outside an editor - the transform gizmo, click-to-place, and getting the view
+ * cube out of the way while placement is armed.
+ */
 export const PublisherEditorScene = memo(() => {
-	useHotspotStyles()
-
 	const [hotspots, setHotspots] = useAtom(hotspotsAtom)
-	const [activeHotspotId, setActiveHotspotId] = useAtom(activeHotspotIdAtom)
+	const activeHotspotId = useAtomValue(activeHotspotIdAtom)
 	const [isClickToPlaceActive, setIsClickToPlaceActive] = useAtom(
 		isClickToPlaceActiveAtom
 	)
 	const process = useAtomValue(processAtom)
-	const [selectedCameraId, setSelectedCameraId] = useAtom(selectedCameraIdAtom)
 	const isHotspotToolActive = process.activeComposeTool === 'hotspots'
 	const isPlacementArmed = isClickToPlaceActive && isHotspotToolActive
 	// The object the viewer renders, and the only thing a hotspot anchors to.
 	const { file } = useModelContext()
 	const modelRoot = file?.model ?? null
 	const gizmoGrabbedRef = useRef(false)
-	const dragHotspotIdRef = useRef<null | string>(null)
-	const dragPositionRef = useRef(new THREE.Vector3())
-	const drag = useMemo<HotspotDragState>(
-		() => ({ hotspotId: dragHotspotIdRef, position: dragPositionRef }),
-		[]
-	)
-	/**
-	 * Walks the whole model, so it is resolved once here rather than per marker
-	 * per frame - and in a frame rather than in a memo.
-	 *
-	 * Normalization rescales an ancestor group without touching the model, so the
-	 * size this measures changes without `modelRoot` doing so. A render-phase
-	 * `useMemo` keyed on the normalization settings looks like it covers that and
-	 * does not: R3F applies the new scale in the commit phase, after every
-	 * render-phase memo in the same update, so the memo measures the previous
-	 * scale and nothing recomputes it afterwards. On a large model clamped to a
-	 * small one that leaves a slack wider than the whole model, and occlusion
-	 * stops firing entirely. `SceneModel` solves its clipping sphere the same way,
-	 * one file over.
-	 *
-	 * Priority -2 so the refresh lands before the markers read it at -1.
-	 */
-	const normalization = useAtomValue(normalizationAtom)
-	const occlusionTolerance = useRef(0)
-	const occlusionToleranceStale = useRef(true)
-
-	useEffect(() => {
-		occlusionToleranceStale.current = true
-	}, [modelRoot, normalization])
-
-	useFrame(() => {
-		if (!occlusionToleranceStale.current) return
-		const tolerance = resolveHotspotOcclusionTolerance(modelRoot)
-		// Zero means the model has no geometry in the graph yet. Leave the slack as
-		// it was and try again next frame rather than latching onto nothing.
-		if (tolerance <= 0) return
-		occlusionTolerance.current = tolerance
-		occlusionToleranceStale.current = false
-	}, -2)
-
-	const handleSelectHotspot = useCallback(
-		(id: string) => {
-			setActiveHotspotId((prev) => (prev === id ? null : id))
-		},
-		[setActiveHotspotId]
-	)
-
-	const handleActivateHotspotCamera = useCallback(
-		(cameraId: string) => {
-			setSelectedCameraId(cameraId)
-		},
-		[setSelectedCameraId]
-	)
 
 	const handleMoveHotspot = useCallback(
 		(id: string, position: [number, number, number]) => {
@@ -633,27 +386,11 @@ export const PublisherEditorScene = memo(() => {
 
 	return (
 		<>
-			{hotspots.map((hotspot) => (
-				<HotspotDot
-					key={hotspot.id}
-					hotspot={hotspot}
-					isSelected={hotspot.id === activeHotspotId}
-					isHotspotToolActive={isHotspotToolActive}
-					activeCameraId={selectedCameraId ?? undefined}
-					modelRoot={modelRoot}
-					occlusionTolerance={occlusionTolerance}
-					drag={drag}
-					onSelect={handleSelectHotspot}
-					onActivateCamera={handleActivateHotspotCamera}
-				/>
-			))}
-
 			{isHotspotToolActive && activeHotspot && (
 				<HotspotGizmo
 					key={activeHotspot.id}
 					hotspot={activeHotspot}
 					grabbedRef={gizmoGrabbedRef}
-					drag={drag}
 					onMove={handleMoveHotspot}
 				/>
 			)}

--- a/apps/vectreal-platform/app/components/publisher/publisher-viewer-capture-context.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-viewer-capture-context.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 
 import type {
+	HotspotPositionSetter,
 	SceneCameraSnapshot,
 	SceneCameraSnapshotCapture,
 	SceneScreenshotCapture,
@@ -33,6 +34,16 @@ interface PublisherViewerCaptureContextValue {
 	requestShadowBake: () => Promise<null | ShadowBakeResult>
 	registerCommandExecutor: (executor: null | ViewerCommandExecutor) => void
 	commandExecutor: MutableRefObject<null | ViewerCommandExecutor>
+	/**
+	 * The viewer's handle for moving a hotspot marker during a drag.
+	 *
+	 * Here for the same reason `commandExecutor` is: the prop lives on the route,
+	 * and the only consumer is the transform gizmo, which mounts inside the
+	 * Canvas. A ref rather than state because a drag publishes a position every
+	 * frame and none of them may re-render anything.
+	 */
+	registerHotspotPositionSetter: (setter: null | HotspotPositionSetter) => void
+	hotspotPositionSetter: MutableRefObject<null | HotspotPositionSetter>
 }
 
 const PublisherViewerCaptureContext =
@@ -46,6 +57,7 @@ export function PublisherViewerCaptureProvider({
 		null
 	)
 	const commandExecutorRef = useRef<null | ViewerCommandExecutor>(null)
+	const hotspotPositionSetterRef = useRef<null | HotspotPositionSetter>(null)
 
 	const registerSceneScreenshotCapture = useCallback(
 		(capture: null | SceneScreenshotCapture) => {
@@ -96,6 +108,13 @@ export function PublisherViewerCaptureProvider({
 		[]
 	)
 
+	const registerHotspotPositionSetter = useCallback(
+		(setter: null | HotspotPositionSetter) => {
+			hotspotPositionSetterRef.current = setter
+		},
+		[]
+	)
+
 	const value = useMemo<PublisherViewerCaptureContextValue>(
 		() => ({
 			registerSceneScreenshotCapture,
@@ -105,7 +124,9 @@ export function PublisherViewerCaptureProvider({
 			registerShadowBakeCapture,
 			requestShadowBake,
 			registerCommandExecutor,
-			commandExecutor: commandExecutorRef
+			commandExecutor: commandExecutorRef,
+			registerHotspotPositionSetter,
+			hotspotPositionSetter: hotspotPositionSetterRef
 		}),
 		[
 			registerSceneScreenshotCapture,
@@ -114,7 +135,8 @@ export function PublisherViewerCaptureProvider({
 			requestSceneCameraSnapshot,
 			registerShadowBakeCapture,
 			requestShadowBake,
-			registerCommandExecutor
+			registerCommandExecutor,
+			registerHotspotPositionSetter
 		]
 	)
 

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
@@ -18,7 +18,11 @@ import type { ReactNode } from 'react'
 
 /** What an overlay needs from the running viewer. */
 export interface SceneEmbedViewerControl {
-	/** Scene cameras only; hotspots and the like are navigational. */
+	/**
+	 * Scene cameras only. A hotspot's own camera is reachable by clicking its
+	 * marker, which the viewer draws, so listing it here as well would put the
+	 * same viewpoint in the chrome's switcher twice.
+	 */
 	cameras: { cameraId: string; name?: null | string }[]
 	activeCameraId: null | string
 	activateCamera: (cameraId: string) => void
@@ -136,7 +140,9 @@ const SceneEmbedPage = ({
 		return (
 			<div className="bg-background flex h-dvh w-full items-center justify-center p-6">
 				<div className="border-border bg-card w-full max-w-lg space-y-4 rounded-2xl border p-6">
-					<h1 className="text-lg font-semibold">Unable to Load Scene Preview</h1>
+					<h1 className="text-lg font-semibold">
+						Unable to Load Scene Preview
+					</h1>
 					<p className="text-muted-foreground text-sm">{loadError.message}</p>
 					<div className="flex gap-2">
 						<Button type="button" onClick={() => void retrySceneLoad()}>

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-viewer.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-viewer.tsx
@@ -64,6 +64,21 @@ const SceneEmbedViewer = memo(
 					controlsOptions={sceneData?.controls}
 					envOptions={sceneData?.environment}
 					normalizationOptions={sceneData?.normalization}
+					/*
+					  Straight from the scene's own settings, and never with
+					  `showInternalHotspots` or `showHiddenHotspots` beside it.
+
+					  That omission is load-bearing rather than tidy. Two of the three
+					  surfaces rendering this component are served the *unredacted*
+					  manifest - the dashboard's scene detail panel, and `/preview` of a
+					  scene that has no published model row yet - so hotspots the author
+					  marked `internalOnly` genuinely do arrive in this array, and the
+					  viewer's own default is the only thing that stops them being
+					  drawn. On the published `/embed` path `redactSettingsForEmbed` has
+					  already stripped them server-side; these are two independent
+					  gates, and this surface must never open either.
+					*/
+					hotspots={sceneData?.hotspots}
 					shadowsOptions={shadowsOptions}
 					staticShadowBake
 					bakedShadow={bakedShadow}

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.spec.ts
@@ -1,5 +1,4 @@
 import {
-	BoxGeometry,
 	BufferGeometry,
 	DoubleSide,
 	Float32BufferAttribute,
@@ -20,11 +19,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	HOTSPOT_PLACEMENT_DRAG_TOLERANCE_PX,
-	isHotspotOccluded,
 	isHotspotPlacementGesture,
 	prepareHotspotRaycaster,
-	resolveHotspotAnchor,
-	resolveHotspotOcclusionTolerance
+	resolveHotspotAnchor
 } from './scene-hotspot-placement'
 
 const WIDTH = 800
@@ -101,24 +98,11 @@ function editorScene() {
 		return raycaster
 	}
 
-	const rayTowards = (marker: Vector3) => {
-		camera.updateMatrixWorld(true)
-		scene.updateMatrixWorld(true)
-		const raycaster = prepareHotspotRaycaster(new Raycaster())
-		raycaster.set(
-			camera.position,
-			marker.clone().sub(camera.position).normalize()
-		)
-		return raycaster
-	}
-
 	return {
-		camera,
 		model,
 		normalizationScale,
 		parkGizmoAt,
 		rayThrough,
-		rayTowards,
 		scene
 	}
 }
@@ -244,181 +228,6 @@ describe('resolveHotspotAnchor', () => {
 
 		expect(anchor).not.toBeNull()
 		expect(distanceFromModelSurface(anchor!)).toBeLessThan(ON_THE_SURFACE)
-	})
-})
-
-describe('isHotspotOccluded', () => {
-	it('reports occluded when the root is widened past the model', () => {
-		const { model, parkGizmoAt, rayTowards, scene } = editorScene()
-
-		const marker = new Vector3(0, 1, 1)
-		// The gizmo belongs to another hotspot, one the author dragged off to the
-		// side. It is three units clear of this marker and still covers it, because
-		// the plane is 100,000 units wide - which is why every marker in the scene
-		// dimmed no matter where the gizmo sat.
-		parkGizmoAt(new Vector3(3, 1, 2))
-		const distance = 4
-		const tolerance = resolveHotspotOcclusionTolerance(model)
-
-		expect(
-			isHotspotOccluded(rayTowards(marker), scene, distance, tolerance)
-		).toBe(true)
-		expect(
-			isHotspotOccluded(rayTowards(marker), model, distance, tolerance)
-		).toBe(false)
-	})
-
-	/**
-	 * Pins the tolerance's lower bound. Half a percent of the radius stands in for
-	 * the gizmo nudge, the largest of the three drifts the slack exists for and
-	 * the one that sets this bound - storage rounding and Draco re-quantization
-	 * are orders of magnitude smaller. Without slack the face the marker sits on
-	 * reads as covering it.
-	 */
-	it('does not dim a marker sitting just inside the face it was placed on', () => {
-		const { camera, model, rayThrough, rayTowards } = editorScene()
-
-		const placed = resolveHotspotAnchor(rayThrough(...OVER_THE_MODEL), model)!
-		const marker = new Vector3(...placed).lerp(new Vector3(0, 1, 0), 0.005)
-
-		expect(
-			isHotspotOccluded(
-				rayTowards(marker),
-				model,
-				camera.position.distanceTo(marker),
-				resolveHotspotOcclusionTolerance(model)
-			)
-		).toBe(false)
-	})
-
-	/**
-	 * Pins the ceiling. A twentieth of the radius behind the near face is sunk,
-	 * not seated, and slack wide enough to forgive that would stop a marker
-	 * dimming when it is genuinely inside the model.
-	 */
-	it('dims a marker sunk a twentieth of the radius behind the near face', () => {
-		const { camera, model, rayTowards } = editorScene()
-
-		const marker = new Vector3(0, 1, 0.95)
-
-		expect(
-			isHotspotOccluded(
-				rayTowards(marker),
-				model,
-				camera.position.distanceTo(marker),
-				resolveHotspotOcclusionTolerance(model)
-			)
-		).toBe(true)
-	})
-
-	it('still reports geometry that genuinely covers the marker', () => {
-		const { camera, model, rayTowards } = editorScene()
-
-		// The far side of the sphere: the near face is in the way.
-		const marker = new Vector3(0, 1, -1)
-
-		expect(
-			isHotspotOccluded(
-				rayTowards(marker),
-				model,
-				camera.position.distanceTo(marker),
-				resolveHotspotOcclusionTolerance(model)
-			)
-		).toBe(true)
-	})
-
-	/**
-	 * `modelRoot` is `file?.model ?? null` and is genuinely null until the model
-	 * loads. Answering `true` there would dim every marker permanently.
-	 */
-	it('reports nothing occluded before a model is loaded', () => {
-		const { rayTowards } = editorScene()
-
-		expect(
-			isHotspotOccluded(rayTowards(new Vector3(0, 1, 1)), null, 4, 0.01)
-		).toBe(false)
-	})
-})
-
-describe('resolveHotspotOcclusionTolerance', () => {
-	it('is nothing before a model is loaded', () => {
-		expect(resolveHotspotOcclusionTolerance(null)).toBe(0)
-	})
-
-	/**
-	 * A root carrying no geometry measures as an empty box, whose min is
-	 * +Infinity and max -Infinity. Left alone that yields a negative slack, which
-	 * widens the occlusion test instead of narrowing it.
-	 */
-	it('is nothing for a root with no geometry in it', () => {
-		expect(resolveHotspotOcclusionTolerance(new Group())).toBe(0)
-	})
-
-	/**
-	 * Pins the measure itself, not just how it scales. Without this the suite
-	 * cannot tell the bounding-box diagonal from twice or half of it.
-	 */
-	it('is a fixed fraction of the bounding-box diagonal', () => {
-		const cube = new Group()
-		cube.add(new Mesh(new BoxGeometry(2, 4, 4), new MeshBasicMaterial()))
-
-		// 2 x 4 x 4 has a diagonal of 6, and the slack is half a percent of it.
-		// Spelled as a literal: writing the constant on both sides would pin the
-		// shape of the measure while saying nothing about its value, and the two
-		// behavioural tests either side only bracket it within a factor of ten.
-		expect(resolveHotspotOcclusionTolerance(cube)).toBeCloseTo(0.03, 10)
-	})
-
-	it('measures the model as the world sees it, through every ancestor', () => {
-		const { model, normalizationScale } = editorScene()
-
-		const unscaled = resolveHotspotOcclusionTolerance(model)
-		normalizationScale.scale.setScalar(3)
-
-		expect(resolveHotspotOcclusionTolerance(model)).toBeCloseTo(unscaled * 3, 8)
-	})
-
-	/**
-	 * The reason the slack is derived from the model rather than written in world
-	 * units. Nothing bounds the size a scene arrives at - runtime normalization is
-	 * off by default - so a constant that seats a marker on a unit model swallows
-	 * a tenth of a model a tenth that size.
-	 */
-	it('scales with the model, so a tenth-size scene judges the same', () => {
-		const small = editorScene()
-		small.normalizationScale.scale.setScalar(0.1)
-		small.camera.position.set(0, 1, 0.5)
-		small.camera.lookAt(0, 1, 0)
-
-		const tolerance = resolveHotspotOcclusionTolerance(small.model)
-		expect(tolerance).toBeCloseTo(
-			resolveHotspotOcclusionTolerance(editorScene().model) * 0.1,
-			6
-		)
-
-		const seated = new Vector3(
-			...resolveHotspotAnchor(small.rayThrough(...OVER_THE_MODEL), small.model)!
-		).lerp(new Vector3(0, 1, 0), 0.005)
-		// A twentieth of this model's radius, which is a two-hundredth of a unit.
-		const sunk = new Vector3(0, 1, 0.095)
-
-		expect(
-			isHotspotOccluded(
-				small.rayTowards(seated),
-				small.model,
-				small.camera.position.distanceTo(seated),
-				tolerance
-			)
-		).toBe(false)
-
-		expect(
-			isHotspotOccluded(
-				small.rayTowards(sunk),
-				small.model,
-				small.camera.position.distanceTo(sunk),
-				tolerance
-			)
-		).toBe(true)
 	})
 })
 

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-placement.ts
@@ -19,8 +19,6 @@
  * runs under the node test environment like its siblings.
  */
 
-import { Box3, Vector3 } from 'three'
-
 import type { Object3D, Raycaster } from 'three'
 
 /**
@@ -33,64 +31,6 @@ import type { Object3D, Raycaster } from 'three'
  * pixel or two, and at zero almost none of them would register.
  */
 export const HOTSPOT_PLACEMENT_DRAG_TOLERANCE_PX = 4
-
-/**
- * How far in front of a marker geometry has to be before it counts as covering
- * it, as a fraction of the model's bounding-box diagonal.
- *
- * What it forgives is drift, not geometry: `resolveHotspotAnchor` returns an
- * exact point on a triangle, so a clean round trip is exact. A stored position
- * moves off the surface for three reasons, in ascending size. `scene_hotspots`
- * holds it in `real` columns, worth about 1e-7 of the value. Draco re-quantizes
- * vertices on the next save, worth about 1e-4 of the model. And an author can
- * nudge a marker inward with the gizmo, which is the term that actually sets
- * this floor - it is a screen-space gesture, so unlike the other two it does
- * not scale with the model at all. Without the slack a marker would read as
- * occluded by the very face it sits on.
- *
- * Measured against the model because nothing bounds the size a scene arrives
- * at: runtime normalization is off by default. The literal this replaced was
- * 0.05 world units, a tenth of a half-unit model and a ten-thousandth of a
- * 500-unit one - the same setting meaning "forgive the surface" on one scene
- * and "ignore the model" on another.
- *
- * Camera distance would be the easier reference and is the wrong one: nothing
- * bounds the dolly, so zooming out would widen the slack until markers behind
- * real geometry stopped dimming.
- *
- * The diagonal is the same measure the viewer normalizes on. It is
- * axis-aligned, so rotating a model changes it somewhat - which is tolerable
- * because this is a floor under a rounding error, not a threshold anything is
- * calibrated to.
- */
-export const HOTSPOT_OCCLUSION_TOLERANCE_FRACTION = 0.005
-
-/**
- * The slack in world units for a given model, for a caller to hold and refresh.
- *
- * Separate from `isHotspotOccluded` because that runs once per marker per frame
- * and this walks the whole model. It has to be recomputed when the model
- * changes and when anything rescales it: normalization moves an ancestor group,
- * so the size this reads changes without the model itself doing so. Read it
- * after the transform is live - a render-phase memo runs before React commits
- * the new scale, and would measure the previous one.
- */
-export function resolveHotspotOcclusionTolerance(
-	modelRoot: Object3D | null
-): number {
-	if (!modelRoot) return 0
-
-	modelRoot.updateWorldMatrix(true, false)
-
-	// Size rather than bounding sphere: `Box3.getSize` answers zero for a root
-	// with no geometry in it, where `getBoundingSphere` answers a radius of -1
-	// and would hand back negative slack, widening the occlusion test instead of
-	// narrowing it.
-	return (
-		new Box3().setFromObject(modelRoot).getSize(new Vector3()).length() *
-		HOTSPOT_OCCLUSION_TOLERANCE_FRACTION
-	)
-}
 
 export interface HotspotPlacementGesture {
 	/** `PointerEvent.button`: 0 is the primary button. */
@@ -172,24 +112,4 @@ export function resolveHotspotAnchor(
 	// reading anything local would land the marker at an unscaled, un-offset
 	// position.
 	return [hit.point.x, hit.point.y, hit.point.z]
-}
-
-/**
- * Whether the model stands between `origin` and a marker `distance` away.
- *
- * Reads the same subtree as `resolveHotspotAnchor` so the two cannot disagree
- * about what counts as geometry: while this walked the whole scene, the gizmo's
- * 100,000-unit plane covered every marker from every angle and dimmed them all.
- */
-export function isHotspotOccluded(
-	raycaster: Raycaster,
-	modelRoot: Object3D | null,
-	distance: number,
-	tolerance: number
-): boolean {
-	if (!modelRoot) return false
-
-	const hit = raycaster.intersectObject(modelRoot, true)[0]
-
-	return !!hit && hit.distance < distance - tolerance
 }

--- a/apps/vectreal-platform/app/lib/observability/critical-flows.ts
+++ b/apps/vectreal-platform/app/lib/observability/critical-flows.ts
@@ -171,6 +171,40 @@ export const CRITICAL_FLOWS: CriticalFlow[] = [
 				pattern: /^\/publisher(\/[^/]+)?$/
 			}
 		]
+	},
+	{
+		/*
+		  The funnel used to stop at "serve the manifest", and that gap is exactly
+		  how a finished hotspot renderer shipped with nothing calling it: the
+		  server had been handing the settings over correctly for months while the
+		  component that turns them into pixels was never given them. Serving a
+		  payload nobody draws is not a served scene, so the last hop belongs on
+		  the list too.
+		*/
+		id: 'render-embed-scene',
+		step: 'draw the published scene the manifest described',
+		module: 'app/components/scene-embed/scene-embed-viewer.tsx',
+		routes: [
+			{
+				file: './routes/embed-page/embed-scene.tsx',
+				pattern: /^\/embed\/[^/]+\/[^/]+$/
+			},
+			{
+				file: './routes/preview-page/preview-scene.tsx',
+				pattern: /^\/preview\/[^/]+\/[^/]+$/
+			},
+			/*
+			  The dashboard's scene detail panel renders this component as well, so
+			  it belongs here by the rule this list is built on: routes come from the
+			  module's actual importers, not from what the step sounds like it should
+			  serve. Same lookaheads as `copy-snippet` above, and for the same reason
+			  - the edit drawer shares this URL shape.
+			*/
+			{
+				file: './routes/dashboard-page/projects/scene.tsx',
+				pattern: /^\/dashboard\/projects\/(?!edit\/)[^/]+\/(?!edit$)[^/]+$/
+			}
+		]
 	}
 ]
 

--- a/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
+++ b/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
@@ -2,7 +2,7 @@ import { LoadingSpinner } from '@shared/components/ui/loading-spinner'
 import { SpinnerWrapper } from '@shared/components/ui/spinner-wrapper'
 import { useModelContext } from '@vctrl/hooks/use-load-model'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useAtomValue, useSetAtom } from 'jotai/react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import CenteredSpinner from '../../components/centered-spinner'
@@ -15,6 +15,7 @@ import {
 	toolSidebarStateAtom
 } from '../../lib/stores/publisher-config-store'
 import {
+	activeHotspotIdAtom,
 	bakedShadowSourceAtom,
 	rawModelDiagonalAtom,
 	sceneViewerSettingsAtom,
@@ -23,6 +24,7 @@ import {
 } from '../../lib/stores/scene-settings-store'
 import { toViewerLoadingThumbnail } from '../../lib/viewer/viewer-loading-thumbnail'
 
+import type { ViewerInteractionEvent } from '@vctrl/viewer'
 import type { ShouldRevalidateFunction } from 'react-router'
 
 export const shouldRevalidate: ShouldRevalidateFunction = ({
@@ -111,7 +113,7 @@ const PublisherPage = () => {
 	const { file } = useModelContext()
 	const setRawDiagonal = useSetAtom(rawModelDiagonalAtom)
 	const setShadows = useSetAtom(shadowsAtom)
-	const { bounds, camera, controls, env, shadows, normalization } =
+	const { bounds, camera, controls, env, shadows, normalization, hotspots } =
 		useAtomValue(sceneViewerSettingsAtom)
 
 	// Persist drags of the in-scene shadow light handle. Debounced so a drag
@@ -144,7 +146,8 @@ const PublisherPage = () => {
 		[]
 	)
 
-	const selectedCameraId = useAtomValue(selectedCameraIdAtom)
+	const [selectedCameraId, setSelectedCameraId] = useAtom(selectedCameraIdAtom)
+	const [activeHotspotId, setActiveHotspotId] = useAtom(activeHotspotIdAtom)
 	const sceneMeta = useAtomValue(sceneMetaAtom)
 	const { activeComposeTool, showSidebar } = useAtomValue(toolSidebarStateAtom)
 	// The in-scene light handle only belongs to the shadow tool, so show it only
@@ -159,14 +162,55 @@ const PublisherPage = () => {
 		registerSceneScreenshotCapture,
 		registerSceneCameraSnapshotCapture,
 		registerShadowBakeCapture,
-		registerCommandExecutor
+		registerCommandExecutor,
+		registerHotspotPositionSetter
 	} = usePublisherViewerCapture()
 
 	// Persisted shadow bake resolved from the loaded scene's inlined asset data
 	// (a data URL, no separate request). The viewer ignores it once the bake inputs
 	// change during editing (signature mismatch) and re-bakes live.
 	const bakedShadow = useAtomValue(bakedShadowSourceAtom) ?? undefined
-	const handleInteractionEvent = useAutomaticOpeningView()
+	const captureOpeningView = useAutomaticOpeningView()
+
+	/**
+	 * Mirrors the viewer's own camera changes back into the atom the sidebar
+	 * reads.
+	 *
+	 * Clicking a hotspot activates its linked camera inside the viewer, through
+	 * the same command path an embed uses, and that path writes the viewer's
+	 * internal selection directly. Without this the atom never learns: the camera
+	 * sidebar would highlight the wrong entry, and the next unrelated edit to the
+	 * camera list would see the two disagree and fly the camera back to the stale
+	 * value.
+	 *
+	 * It cannot loop. The write re-runs the viewer's selection effect, which
+	 * recomputes the identical key and signature the command path already stored
+	 * and returns before animating or re-emitting. `selectedCameraIdAtom` is not
+	 * part of `sceneViewerSettingsAtom`, so it also cannot mark the scene dirty.
+	 */
+	const handleInteractionEvent = useCallback(
+		(event: ViewerInteractionEvent) => {
+			if (event.type === 'camera_changed' && event.cameraId) {
+				setSelectedCameraId(event.cameraId)
+			}
+			captureOpeningView(event)
+		},
+		[captureOpeningView, setSelectedCameraId]
+	)
+
+	/**
+	 * Selection is offered only while the hotspot tool is armed, and passing it is
+	 * exactly what makes a marker select rather than fly its camera. Outside the
+	 * tool the publisher wants the embed's behaviour, so it passes nothing.
+	 */
+	const handleHotspotSelect = useMemo(
+		() =>
+			activeComposeTool === 'hotspots'
+				? (id: string) =>
+						setActiveHotspotId((previous) => (previous === id ? null : id))
+				: undefined,
+		[activeComposeTool, setActiveHotspotId]
+	)
 
 	// Memoized: a fresh object here re-creates the viewer's screenshot capture on
 	// every render, which would de-register it for the frame a save runs in.
@@ -195,6 +239,26 @@ const PublisherPage = () => {
 					bakedShadow={bakedShadow}
 					onShadowBakeReady={registerShadowBakeCapture}
 					shadowLightEditable={isShadowToolActive}
+					hotspots={hotspots}
+					/*
+					  The publisher is the surface those two flags exist for: it is where
+					  `internalOnly` hotspots are authored, and where a hidden one has to
+					  stay findable so it can be switched back on. Neither changes a step
+					  number - the viewer ranks those over the published set - so the
+					  numbers here are the numbers a visitor gets.
+					*/
+					showInternalHotspots
+					showHiddenHotspots
+					/*
+					  Gated on the tool, like `onHotspotSelect` below it. Left ungated
+					  the ring stayed on after switching to the shadow or camera tool,
+					  where there is no gizmo and no way to clear it from the canvas.
+					*/
+					selectedHotspotId={
+						activeComposeTool === 'hotspots' ? activeHotspotId : null
+					}
+					onHotspotSelect={handleHotspotSelect}
+					onHotspotPositionSetterReady={registerHotspotPositionSetter}
 					onShadowLightChange={handleShadowLightChange}
 					normalizationOptions={normalization}
 					boundsOptions={bounds}

--- a/apps/vectreal-platform/tests/embed-scene-hotspots.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-scene-hotspots.spec.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+/**
+ * The last hop of the funnel: the published scene draws the hotspots the
+ * manifest carried, and never the ones it was not supposed to.
+ *
+ * This is a seam test, and it is here because the seam is what broke. A
+ * complete hotspot renderer shipped in `@vctrl/viewer`, the server persisted
+ * and redacted hotspots correctly, and every one of those halves had tests -
+ * but nothing passed `hotspots` from one to the other, so a published scene
+ * showed nothing at all and no suite noticed.
+ *
+ * `ClientVectrealViewer` is stubbed rather than `@vctrl/viewer` itself: it is
+ * one level below the package, so no viewer internals (or WebGL) load, and what
+ * we care about is the props this component hands over.
+ */
+import { render } from '@testing-library/react'
+import { resolveHotspotMarkers } from '@vctrl/viewer/hotspots'
+import { describe, expect, it, vi } from 'vitest'
+
+import SceneEmbedViewer from '../app/components/scene-embed/scene-embed-viewer'
+
+import type { HotspotDefinition } from '@vctrl/core'
+import type { ServerSceneData } from '@vctrl/hooks/use-load-model'
+import type { VectrealViewerProps } from '@vctrl/viewer'
+
+/*
+  An array rather than a `let`. A module-level mutable assigned only inside a
+  callback narrows to its initializer, so `if (!lastProps) throw` left every
+  later read typed `never`; reading the last element gives a fresh const that
+  narrows the ordinary way.
+*/
+const captured: VectrealViewerProps[] = []
+
+vi.mock('../app/components/viewer/client-vectreal-viewer', () => ({
+	ClientVectrealViewer: (props: VectrealViewerProps) => {
+		captured.push(props)
+		return null
+	}
+}))
+
+const hotspot = (
+	overrides: Partial<HotspotDefinition> & Pick<HotspotDefinition, 'id'>
+): HotspotDefinition => ({
+	name: overrides.id,
+	worldPosition: [0, 1, 2],
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot',
+	...overrides
+})
+
+const HOTSPOTS = [
+	hotspot({ id: 'public', sequenceIndex: 0 }),
+	hotspot({ id: 'internal', internalOnly: true }),
+	hotspot({ id: 'hidden', visible: false })
+]
+
+function renderEmbed(sceneData?: Partial<ServerSceneData>) {
+	captured.length = 0
+	render(
+		<SceneEmbedViewer
+			file={null}
+			sceneData={sceneData as ServerSceneData | undefined}
+		/>
+	)
+	const props = captured.at(-1)
+	if (!props) throw new Error('the viewer was never rendered')
+	return props
+}
+
+describe('the published scene draws its hotspots', () => {
+	it('hands the scene’s hotspots to the viewer', () => {
+		expect(renderEmbed({ hotspots: HOTSPOTS }).hotspots).toEqual(HOTSPOTS)
+	})
+
+	it('passes nothing at all when the scene carries none', () => {
+		expect(renderEmbed({}).hotspots).toBeUndefined()
+	})
+
+	it('never asks the viewer for internal or hidden hotspots', () => {
+		/*
+		  Two of the three surfaces rendering this component are served the
+		  unredacted manifest - the dashboard's scene detail panel, and `/preview`
+		  of a scene with no published model row - so `internalOnly` hotspots
+		  really do arrive here, and this omission is the only thing stopping them
+		  being drawn on those two.
+		*/
+		const props = renderEmbed({ hotspots: HOTSPOTS })
+
+		expect(props.showInternalHotspots).toBeFalsy()
+		expect(props.showHiddenHotspots).toBeFalsy()
+	})
+
+	it('draws the public hotspot and neither the internal nor the hidden one', () => {
+		// The claim that matters, made across the seam rather than either side of
+		// it: these are the props this component actually passes, resolved by the
+		// renderer that actually receives them.
+		const props = renderEmbed({ hotspots: HOTSPOTS })
+
+		const drawn = resolveHotspotMarkers(props.hotspots, {
+			includeInternal: props.showInternalHotspots,
+			includeHidden: props.showHiddenHotspots
+		})
+
+		expect(drawn.map((marker) => marker.id)).toEqual(['public'])
+	})
+})

--- a/apps/vectreal-platform/tests/error-boundary-reports.spec.tsx
+++ b/apps/vectreal-platform/tests/error-boundary-reports.spec.tsx
@@ -63,16 +63,19 @@ const BOUNDARIES: [string, ComponentType][] = [
 ]
 
 describe('a rendered boundary reports', () => {
-	it.each(BOUNDARIES)('%s captures the error it catches', async (_, Boundary) => {
-		const posthog = renderThrowing(Boundary, new Error('render blew up'))
+	it.each(BOUNDARIES)(
+		'%s captures the error it catches',
+		async (_, Boundary) => {
+			const posthog = renderThrowing(Boundary, new Error('render blew up'))
 
-		await waitFor(() => {
-			expect(posthog.captureException).toHaveBeenCalledTimes(1)
-		})
-		expect(posthog.captureException.mock.calls[0][0]).toMatchObject({
-			message: 'render blew up'
-		})
-	})
+			await waitFor(() => {
+				expect(posthog.captureException).toHaveBeenCalledTimes(1)
+			})
+			expect(posthog.captureException.mock.calls[0][0]).toMatchObject({
+				message: 'render blew up'
+			})
+		}
+	)
 
 	it('still renders its fallback', async () => {
 		renderThrowing(DashboardErrorBoundary, new Error('render blew up'))
@@ -91,7 +94,9 @@ describe('a rendered boundary reports', () => {
 		expect(posthog.captureException.mock.calls[0][1]).toMatchObject({
 			error_source: 'client-boundary',
 			on_critical_path: true,
-			critical_flows: ['copy-snippet']
+			// The scene detail panel offers the embed snippet and draws the scene,
+			// so a boundary there is attributable to both funnel steps.
+			critical_flows: ['copy-snippet', 'render-embed-scene']
 		})
 	})
 

--- a/apps/vectreal-platform/tests/error-report.spec.ts
+++ b/apps/vectreal-platform/tests/error-report.spec.ts
@@ -48,15 +48,18 @@ describe('critical flow attribution', () => {
 	})
 
 	it.each([
-		['/api/scenes/abc', ['save-scene', 'publish-scene', 'authorize-embed', 'serve-manifest']],
+		[
+			'/api/scenes/abc',
+			['save-scene', 'publish-scene', 'authorize-embed', 'serve-manifest']
+		],
 		['/api/scenes/abc/assets/xyz', ['publish-scene', 'authorize-embed']],
 		['/api/scenes/abc/thumbnail/xyz', ['publish-scene']],
 		['/api/projects/p1/api-keys', ['mint-api-key', 'allow-domain']],
 		['/dashboard/api-keys/new', ['mint-api-key']],
 		['/dashboard/projects/edit/p1', ['allow-domain']],
 		['/dashboard/projects/p1/edit', ['allow-domain']],
-		['/embed/p1/s1', ['authorize-embed']],
-		['/preview/p1/s1', ['copy-snippet']],
+		['/embed/p1/s1', ['authorize-embed', 'render-embed-scene']],
+		['/preview/p1/s1', ['copy-snippet', 'render-embed-scene']],
 		['/publisher/s1', ['serve-manifest']],
 		// Off the funnel entirely. Reported, but not as a critical-path failure.
 		['/pricing', []],
@@ -73,15 +76,18 @@ describe('critical flow attribution', () => {
 	  wrong attribution, which is worse than none because it is believed.
 	*/
 	it('does not confuse the scene page with the edit drawer', () => {
+		// The scene detail panel both offers the snippet and draws the scene, so
+		// an error there is attributable to either step.
 		expect(criticalFlowsForPathname('/dashboard/projects/p1/s1')).toEqual([
-			'copy-snippet'
+			'copy-snippet',
+			'render-embed-scene'
 		])
-		expect(criticalFlowsForPathname('/dashboard/projects/edit/p1')).not.toContain(
-			'copy-snippet'
-		)
-		expect(criticalFlowsForPathname('/dashboard/projects/p1/edit')).not.toContain(
-			'copy-snippet'
-		)
+		expect(
+			criticalFlowsForPathname('/dashboard/projects/edit/p1')
+		).not.toContain('copy-snippet')
+		expect(
+			criticalFlowsForPathname('/dashboard/projects/p1/edit')
+		).not.toContain('copy-snippet')
 	})
 })
 

--- a/packages/viewer-e2e/src/consumer-template/src/App.tsx
+++ b/packages/viewer-e2e/src/consumer-template/src/App.tsx
@@ -2,6 +2,43 @@ import { useLoadModel } from '@vctrl/hooks'
 import { VectrealViewer } from '@vctrl/viewer'
 import { Component, useEffect, type ReactNode } from 'react'
 
+/*
+  Three hotspots covering the visibility contract, so a real browser proves what
+  a jsdom seam test only asserts: a public marker draws, and the two a visitor
+  must never see do not. `showInternalHotspots` is deliberately not passed - the
+  viewer's own gate is the second of two, and it is the only one a consumer of
+  this package gets, since nothing here went through the platform's redaction.
+*/
+const E2E_HOTSPOTS = [
+	{
+		id: 'public-hotspot',
+		name: 'Public marker',
+		worldPosition: [1.5, 0, 0] as [number, number, number],
+		visible: true,
+		internalOnly: false,
+		stylePreset: 'dot' as const,
+		occlusionEnabled: false
+	},
+	{
+		id: 'internal-hotspot',
+		name: 'Internal marker',
+		worldPosition: [-1.5, 0, 0] as [number, number, number],
+		visible: true,
+		internalOnly: true,
+		stylePreset: 'dot' as const,
+		occlusionEnabled: false
+	},
+	{
+		id: 'hidden-hotspot',
+		name: 'Hidden marker',
+		worldPosition: [0, 1.5, 0] as [number, number, number],
+		visible: false,
+		internalOnly: false,
+		stylePreset: 'dot' as const,
+		occlusionEnabled: false
+	}
+]
+
 // Reusable error boundary: a render-time crash would otherwise be swallowed by
 // React. We mirror it onto a window flag the e2e polls, and swap in a marker node.
 class CrashBoundary extends Component<
@@ -59,6 +96,7 @@ export default function App() {
 				<VectrealViewer
 					theme="dark"
 					controlsOptions={{ autoRotate: false }}
+					hotspots={E2E_HOTSPOTS}
 					onCommandExecutorReady={() => {
 						// Viewer scene graph is live and the imperative API is wired up.
 						window.__VIEWER_E2E__ = { status: 'mounted' }

--- a/packages/viewer-e2e/tests/viewer-render.spec.ts
+++ b/packages/viewer-e2e/tests/viewer-render.spec.ts
@@ -44,6 +44,16 @@ test('viewer mounts without a runtime crash', async ({ page }) => {
 	const hooksFlag = await page.evaluate(() => window.__HOOKS_E2E__)
 	expect(hooksFlag?.status, hooksFlag?.error).toBe('ok')
 
+	// Hotspots, in a real browser, from the published tarball. The seam test in
+	// the platform app asserts which props are handed over; this asserts what the
+	// package actually draws when it gets them - and that the two markers a
+	// visitor must never see are not among them.
+	const markers = page.locator('.vctrl-viewer-hotspot')
+	await expect(markers).toHaveCount(1)
+	await expect(page.getByRole('img', { name: 'Public marker' })).toBeVisible()
+	await expect(page.getByLabel('Internal marker')).toHaveCount(0)
+	await expect(page.getByLabel('Hidden marker')).toHaveCount(0)
+
 	expect(pageErrors, pageErrors.join('\n')).toEqual([])
 })
 

--- a/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
@@ -55,12 +55,12 @@ describe('resolveHotspotInteraction', () => {
 	it('refuses to activate an occluded marker', () => {
 		expect(
 			resolveHotspotInteraction(linked, { occluded: true, canActivate: true })
-				.activatable
-		).toBe(false)
+				.action
+		).toBe('none')
 		expect(
 			resolveHotspotInteraction(linked, { occluded: false, canActivate: true })
-				.activatable
-		).toBe(true)
+				.action
+		).toBe('activate')
 	})
 
 	it('drops an occluded marker out of the tab order', () => {
@@ -72,5 +72,93 @@ describe('resolveHotspotInteraction', () => {
 			resolveHotspotInteraction(linked, { occluded: false, canActivate: true })
 				.focusable
 		).toBe(true)
+	})
+
+	describe('an editing surface that can select', () => {
+		it('is a button when the surface can select it, with or without a camera', () => {
+			// The whole point of drawing a camera-less marker in an editor is being
+			// able to pick it, so selection cannot borrow the camera's gate.
+			expect(
+				resolveHotspotInteraction(unlinked, {
+					occluded: false,
+					canActivate: false,
+					canSelect: true
+				}).role
+			).toBe('button')
+		})
+
+		it('selects rather than activates when a surface offers both', () => {
+			// Selecting is local and reversible; flying the camera throws away the
+			// viewpoint the author was working from.
+			expect(
+				resolveHotspotInteraction(linked, {
+					occluded: false,
+					canActivate: true,
+					canSelect: true
+				}).action
+			).toBe('select')
+		})
+
+		it('activates when the surface is not offering selection', () => {
+			expect(
+				resolveHotspotInteraction(linked, {
+					occluded: false,
+					canActivate: true,
+					canSelect: false
+				}).action
+			).toBe('activate')
+			expect(
+				resolveHotspotInteraction(unlinked, {
+					occluded: false,
+					canActivate: true,
+					canSelect: false
+				}).action
+			).toBe('none')
+		})
+
+		it('does nothing on an occluded marker, whichever action it would have had', () => {
+			expect(
+				resolveHotspotInteraction(linked, {
+					occluded: true,
+					canActivate: true,
+					canSelect: true
+				}).action
+			).toBe('none')
+		})
+
+		it('keeps a selectable marker in the tab order, and drops it when occluded', () => {
+			expect(
+				resolveHotspotInteraction(unlinked, {
+					occluded: false,
+					canActivate: false,
+					canSelect: true
+				}).focusable
+			).toBe(true)
+			expect(
+				resolveHotspotInteraction(unlinked, {
+					occluded: true,
+					canActivate: false,
+					canSelect: true
+				}).focusable
+			).toBe(false)
+		})
+
+		it('goes on announcing a selectable marker as a toggle while occluded', () => {
+			// `aria-pressed` appearing and disappearing as the model turns would
+			// change what the control claims to be under a screen reader.
+			expect(
+				resolveHotspotInteraction(unlinked, {
+					occluded: true,
+					canActivate: false,
+					canSelect: true
+				}).toggles
+			).toBe(true)
+			expect(
+				resolveHotspotInteraction(linked, {
+					occluded: false,
+					canActivate: true
+				}).toggles
+			).toBe(false)
+		})
 	})
 })

--- a/packages/viewer/src/components/scene/hotspot-interaction.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.ts
@@ -3,16 +3,30 @@ import type { HotspotMarker } from './resolve-hotspot-markers'
 /** How a marker behaves once the depth test has had its say. */
 export interface HotspotInteraction {
 	/**
-	 * `button` for a hotspot that can move the camera, `image` for one that only
-	 * labels a point.
+	 * `button` for a hotspot a click can do something with, `image` for one that
+	 * only labels a point.
 	 *
 	 * Deliberately independent of occlusion. Swapping the element type mid-orbit
 	 * unmounts the focused button, which drops keyboard focus to the document
 	 * body and restarts the tab order.
 	 */
 	role: 'button' | 'image'
-	/** False while occluded: see `pointerEvents`. */
-	activatable: boolean
+	/**
+	 * What a click does. `none` while occluded, and for a marker that offers
+	 * nothing.
+	 *
+	 * Selecting beats activating wherever a surface offers both. Selecting is
+	 * local and reversible; activating throws away the viewpoint the author was
+	 * working from, so the cheap one has to be what a click gets. A surface that
+	 * wants the camera instead says so by not passing a select handler.
+	 */
+	action: 'select' | 'activate' | 'none'
+	/**
+	 * True when this button is a selection toggle, so it can carry
+	 * `aria-pressed`. Independent of occlusion for the same reason `role` is: a
+	 * marker must not change what it announces itself to be mid-orbit.
+	 */
+	toggles: boolean
 	/**
 	 * False while occluded, so an invisible marker is not a tab stop. Focus that
 	 * is already on it survives, which `disabled` would not allow.
@@ -30,18 +44,36 @@ export function resolveHotspotInteraction(
 	marker: Pick<HotspotMarker, 'linkedCameraId'>,
 	{
 		occluded,
-		canActivate
+		canActivate,
+		canSelect = false
 	}: {
 		occluded: boolean
 		/** Whether the viewer was given somewhere to send an activation. */
 		canActivate: boolean
+		/**
+		 * Whether the viewer was given somewhere to send a selection. An editing
+		 * surface passes a select handler only while its own tool is armed, so
+		 * "the tool decides" collapses into this one flag and the precedence rule
+		 * below stays a plain, testable thing.
+		 */
+		canSelect?: boolean
 	}
 ): HotspotInteraction {
-	const isButton = marker.linkedCameraId !== null && canActivate
+	const canFly = marker.linkedCameraId !== null && canActivate
+	// Selection needs no camera: an editing surface has to be able to pick a
+	// marker that names none, which is the whole point of drawing it.
+	const isButton = canSelect || canFly
 
 	return {
 		role: isButton ? 'button' : 'image',
-		activatable: isButton && !occluded,
+		action: occluded
+			? 'none'
+			: canSelect
+				? 'select'
+				: canFly
+					? 'activate'
+					: 'none',
+		toggles: canSelect,
 		focusable: isButton && !occluded,
 		pointerEvents: occluded ? 'none' : 'auto'
 	}

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -6,6 +6,7 @@ import { resolveHotspotInteraction } from './hotspot-interaction'
 
 import type { HotspotMarker as HotspotMarkerModel } from './resolve-hotspot-markers'
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react'
+import type { Group } from 'three'
 
 /**
  * Under the viewer's own overlay chrome, which sits at 100 (the animation
@@ -24,6 +25,9 @@ const HOTSPOT_Z_INDEX_RANGE = [40, 0]
  * read it.
  */
 const TOUCH_LABEL_DURATION_MS = 2500
+
+/** Hoisted so drei's `styles` memo is not defeated by a fresh object per render. */
+const HTML_WRAPPER_STYLE = { pointerEvents: 'none' } as const
 
 /**
  * A hairline edge and a soft shadow, on every preset.
@@ -61,7 +65,12 @@ const markerClasses = {
 	// A 24px floor on the box that takes the pointer, which then grows to fit
 	// whatever is inside it. The plain dot is 12px: well under the minimum target
 	// size, and missed by a thumb on a touch screen.
-	body: 'relative m-0 flex min-h-6 min-w-6 appearance-none items-center justify-center rounded-full border-0 bg-transparent p-0 leading-none',
+	// `vctrl-hotspot-body` carries no styles of its own. It is the hook the
+	// selected and hidden rules in styles.css reach for, and they have to land on
+	// a descendant of the root: `hotspotColor` writes `--vctrl-hotspot-fill` as an
+	// inline style on the root itself, and an inline declaration beats any
+	// stylesheet rule for the same property on the same element.
+	body: 'vctrl-hotspot-body relative m-0 flex min-h-6 min-w-6 appearance-none items-center justify-center rounded-full border-0 bg-transparent p-0 leading-none',
 	live: 'pointer-events-auto',
 	inert: 'pointer-events-none',
 	interactive: 'cursor-pointer',
@@ -96,10 +105,19 @@ export interface HotspotMarkerProps {
 	marker: HotspotMarkerModel
 	/** Computed by `SceneHotspots`, which owns the depth test for every marker. */
 	occluded: boolean
+	/** Drawn as the one an editing surface has picked out. */
+	selected?: boolean
 	/** Overrides the marker fill. Any CSS colour; undefined keeps the default. */
 	color?: string
 	/** Runs when a hotspot carrying a `linkedCameraId` is activated. */
 	onActivate?: (cameraId: string) => void
+	/** Runs when a marker is picked on a surface that selects rather than flies. */
+	onSelect?: (id: string) => void
+	/**
+	 * Hands `SceneHotspots` the anchor group it moves during a drag, and `null`
+	 * on unmount. See the group below.
+	 */
+	onAnchorRef: (id: string, node: Group | null) => void
 }
 
 /**
@@ -113,16 +131,31 @@ export interface HotspotMarkerProps {
 const HotspotMarker = ({
 	marker,
 	occluded,
+	selected = false,
 	color,
-	onActivate
+	onActivate,
+	onSelect,
+	onAnchorRef
 }: HotspotMarkerProps) => {
 	const [labelVisible, setLabelVisible] = useState(false)
 	const touchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
 	const interaction = resolveHotspotInteraction(marker, {
 		occluded,
-		canActivate: !!onActivate
+		canActivate: !!onActivate,
+		canSelect: !!onSelect
 	})
+
+	// A block body, not a concise one. React 19 treats a *function* returned from
+	// a callback ref as its cleanup and then stops calling `ref(null)`, so a
+	// concise body forwarding the registrar's return value is one refactor of that
+	// registrar away from silently leaking every anchor. Nothing warns.
+	const anchorRef = useCallback(
+		(node: Group | null) => {
+			onAnchorRef(marker.id, node)
+		},
+		[marker.id, onAnchorRef]
+	)
 
 	const clearTouchTimeout = () => {
 		if (touchTimeout.current !== null) {
@@ -169,10 +202,18 @@ const HotspotMarker = ({
 	)
 
 	const handleClick = useCallback(() => {
-		if (interaction.activatable && marker.linkedCameraId) {
+		if (interaction.action === 'select') {
+			onSelect?.(marker.id)
+		} else if (interaction.action === 'activate' && marker.linkedCameraId) {
 			onActivate?.(marker.linkedCameraId)
 		}
-	}, [interaction.activatable, marker.linkedCameraId, onActivate])
+	}, [
+		interaction.action,
+		marker.id,
+		marker.linkedCameraId,
+		onActivate,
+		onSelect
+	])
 
 	// Set on the marker root rather than the viewer container: drei portals every
 	// Html separately, so there is no shared ancestor inside the marker layer.
@@ -217,47 +258,81 @@ const HotspotMarker = ({
 		)
 
 	return (
-		<Html center position={marker.position} zIndexRange={HOTSPOT_Z_INDEX_RANGE}>
-			<div
-				className={cn(markerClasses.root, occluded && markerClasses.occluded)}
-				style={colorStyle}
-				onPointerEnter={handlePointerEnter}
-				onPointerLeave={handlePointerLeave}
+		/*
+		  The anchor `SceneHotspots` writes to while this marker is being dragged.
+		  drei's `Html` renders a group of its own and does not forward a ref to it,
+		  so following a gizmo at 60fps needs a group of ours to mutate.
+
+		  Unconditional, never gated on whether an editing surface is attached:
+		  wrapping conditionally would remount the `Html` the moment editing turned
+		  on, tearing down drei's portal and dropping keyboard focus with it. The
+		  `position` prop stays here so a marker is correct with zero frames
+		  elapsed - a consumer may be running `frameloop="demand"` - and so React
+		  keeps handling every update that is not a drag.
+		*/
+		<group ref={anchorRef} position={marker.position}>
+			{/*
+			  `pointerEvents: 'none'` on the wrapper, not just on the body.
+
+			  drei's non-transform branch renders `{position, transform, ...style}`
+			  and nothing else, so without this its div defaults to `auto` and
+			  shrink-wraps the marker - a 24px box that takes the pointer even when
+			  the body inside it has refused it. Two things break without it: the
+			  `pointerEvents: 'none'` an occluded marker asks for is overruled one
+			  level up, so a marker faded to 15% still swallows clicks and blocks an
+			  orbit started on top of it; and an authoring surface listening on the
+			  canvas never sees a press that lands here at all. Its `pointerEvents`
+			  prop is no use - that one only reaches the inner div in transform mode.
+			*/}
+			<Html
+				center
+				zIndexRange={HOTSPOT_Z_INDEX_RANGE}
+				style={HTML_WRAPPER_STYLE}
 			>
-				<span aria-hidden="true" className={markerClasses.pulse} />
+				<div
+					className={cn(markerClasses.root, occluded && markerClasses.occluded)}
+					style={colorStyle}
+					data-selected={selected || undefined}
+					data-hidden={marker.hidden || undefined}
+					onPointerEnter={handlePointerEnter}
+					onPointerLeave={handlePointerLeave}
+				>
+					<span aria-hidden="true" className={markerClasses.pulse} />
 
-				{interaction.role === 'button' ? (
-					<button
-						type="button"
-						className={cn(
-							bodyClasses,
-							FOCUS_RING,
-							interaction.activatable && markerClasses.interactive
-						)}
-						aria-label={marker.accessibleName}
-						aria-disabled={interaction.activatable ? undefined : true}
-						tabIndex={interaction.focusable ? undefined : -1}
-						onClick={handleClick}
-						onFocus={showLabel}
-						onBlur={hideLabel}
-					>
-						{body}
-					</button>
-				) : (
-					<div
-						className={bodyClasses}
-						role="img"
-						aria-label={marker.accessibleName}
-					>
-						{body}
-					</div>
-				)}
+					{interaction.role === 'button' ? (
+						<button
+							type="button"
+							className={cn(
+								bodyClasses,
+								FOCUS_RING,
+								interaction.action !== 'none' && markerClasses.interactive
+							)}
+							aria-label={marker.accessibleName}
+							aria-pressed={interaction.toggles ? selected : undefined}
+							aria-disabled={interaction.action === 'none' ? true : undefined}
+							tabIndex={interaction.focusable ? undefined : -1}
+							onClick={handleClick}
+							onFocus={showLabel}
+							onBlur={hideLabel}
+						>
+							{body}
+						</button>
+					) : (
+						<div
+							className={bodyClasses}
+							role="img"
+							aria-label={marker.accessibleName}
+						>
+							{body}
+						</div>
+					)}
 
-				{labelVisible && (
-					<span className={markerClasses.label}>{marker.name}</span>
-				)}
-			</div>
-		</Html>
+					{labelVisible && (
+						<span className={markerClasses.label}>{marker.name}</span>
+					)}
+				</div>
+			</Html>
+		</group>
 	)
 }
 

--- a/packages/viewer/src/components/scene/index.ts
+++ b/packages/viewer/src/components/scene/index.ts
@@ -14,9 +14,11 @@ export {
 	defaultEnvOptions
 } from './scene-environment'
 export { default as SceneHotspots } from './scene-hotspots'
+export type { HotspotPositionSetter } from './scene-hotspots'
 export {
 	resolveHotspotMarkers,
-	type HotspotMarker
+	type HotspotMarker,
+	type ResolveHotspotMarkersOptions
 } from './resolve-hotspot-markers'
 export { default as SceneModel } from './scene-model'
 export { default as ScenePostProcessing } from './scene-postprocessing'

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
@@ -304,6 +304,139 @@ describe('resolveHotspotMarkers', () => {
 		})
 	})
 
+	describe('an editing surface drawing more than a visitor sees', () => {
+		it('draws a hotspot the author hid, and marks it as hidden', () => {
+			const markers = resolveHotspotMarkers(
+				[hotspot({ id: 'shown' }), hotspot({ id: 'hidden', visible: false })],
+				{ includeHidden: true }
+			)
+
+			expect(ids(markers)).toEqual(['shown', 'hidden'])
+			expect(markers.map((marker) => marker.hidden)).toEqual([false, true])
+		})
+
+		it('still drops a hidden hotspot when nobody asked for it', () => {
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'shown' }),
+				hotspot({ id: 'hidden', visible: false })
+			])
+
+			expect(ids(markers)).toEqual(['shown'])
+		})
+
+		it('gives a hidden marker no step number', () => {
+			const markers = resolveHotspotMarkers(
+				[
+					hotspot({ id: 'a', sequenceIndex: 0 }),
+					hotspot({ id: 'b', sequenceIndex: 1, visible: false }),
+					hotspot({ id: 'c', sequenceIndex: 2 })
+				],
+				{ includeHidden: true }
+			)
+
+			expect(ids(markers)).toEqual(['a', 'b', 'c'])
+			expect(markers.map((marker) => marker.step)).toEqual([1, null, 2])
+		})
+
+		it('gives an internalOnly marker no step number either', () => {
+			const markers = resolveHotspotMarkers(
+				[
+					hotspot({ id: 'internal', sequenceIndex: 0, internalOnly: true }),
+					hotspot({ id: 'public', sequenceIndex: 1 })
+				],
+				{ includeInternal: true }
+			)
+
+			expect(markers.map((marker) => marker.step)).toEqual([null, 1])
+		})
+
+		it('leaves every step number exactly where the visitor sees it', () => {
+			// The rule this pins: an author composes against these numbers in the
+			// sidebar, which ranks over the published set. If drawing extra markers
+			// on the canvas renumbered them, the canvas and the sidebar would
+			// disagree from the first hidden hotspot onwards.
+			const stored = [
+				hotspot({ id: 'a', sequenceIndex: 0 }),
+				hotspot({ id: 'hidden', sequenceIndex: 1, visible: false }),
+				hotspot({ id: 'internal', sequenceIndex: 2, internalOnly: true }),
+				hotspot({ id: 'b', sequenceIndex: 3 })
+			]
+
+			const visitor = new Map(
+				resolveHotspotMarkers(stored).map((marker) => [marker.id, marker.step])
+			)
+			const editor = resolveHotspotMarkers(stored, {
+				includeHidden: true,
+				includeInternal: true
+			})
+
+			expect(visitor).toEqual(
+				new Map([
+					['a', 1],
+					['b', 2]
+				])
+			)
+			for (const marker of editor) {
+				expect([marker.id, marker.step]).toEqual([
+					marker.id,
+					visitor.get(marker.id) ?? null
+				])
+				expect(marker.stepCount).toBe(2)
+			}
+		})
+
+		it('resolves a duplicate id the same way on every surface', () => {
+			// The id is claimed before any option is consulted, so drawing extra
+			// markers cannot change which of two hotspots sharing an id survives.
+			// While it was claimed after the filters, the hidden one won in the
+			// editor and the published one won for a visitor, and the two surfaces
+			// disagreed about both the marker and its step.
+			const stored = [
+				hotspot({
+					id: 'x',
+					name: 'Hidden X',
+					sequenceIndex: 0,
+					visible: false
+				}),
+				hotspot({ id: 'x', name: 'Public X', sequenceIndex: 1 }),
+				hotspot({ id: 'y', name: 'Y', sequenceIndex: 2 })
+			]
+
+			const editor = resolveHotspotMarkers(stored, {
+				includeHidden: true,
+				includeInternal: true
+			})
+
+			expect(editor.map((m) => [m.name, m.step])).toEqual([
+				['Public X', 1],
+				['Y', 2]
+			])
+			expect(
+				resolveHotspotMarkers(stored).map((m) => [m.name, m.step])
+			).toEqual(editor.map((m) => [m.name, m.step]))
+		})
+
+		it('lets a published hotspot take a duplicate id from a hidden one', () => {
+			// Claiming strictly-first would drop the published hotspot entirely and
+			// cost a visitor a marker they had been seeing.
+			const markers = resolveHotspotMarkers([
+				hotspot({ id: 'x', name: 'Hidden X', visible: false }),
+				hotspot({ id: 'x', name: 'Public X' })
+			])
+
+			expect(markers.map((m) => m.name)).toEqual(['Public X'])
+		})
+
+		it('announces that a marker is hidden', () => {
+			const markers = resolveHotspotMarkers(
+				[hotspot({ id: 'a', name: 'Handle', visible: false })],
+				{ includeHidden: true }
+			)
+
+			expect(markers[0].accessibleName).toBe('Handle, hidden')
+		})
+	})
+
 	it('does not mutate the settings it was given', () => {
 		const stored = [
 			hotspot({ id: 'b', sequenceIndex: 1 }),

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
@@ -28,6 +28,16 @@ export interface HotspotMarker {
 	step: number | null
 	/** How many steps the sequence has, for the same reason. */
 	stepCount: number
+	/**
+	 * Drawn, but `visible: false` - an editing surface asked to see it so the
+	 * author can find it and unhide it. Never true on a public surface, which
+	 * drops these entirely.
+	 *
+	 * Deliberately not set for `internalOnly`. That is a different fact with a
+	 * different remedy: a hidden hotspot is one the author switched off, an
+	 * internal one is one they meant to keep backstage.
+	 */
+	hidden: boolean
 	/** Never `image` or `svg` without a `payloadUrl` to go with it. */
 	preset: HotspotStylePreset
 	payloadUrl: string | null
@@ -41,6 +51,12 @@ export interface ResolveHotspotMarkersOptions {
 	 * `internalOnly`. Public and embedded viewers never do - see below.
 	 */
 	includeInternal?: boolean
+	/**
+	 * Editing surfaces pass true to draw hotspots the author hid
+	 * (`visible: false`), so they can be found and switched back on. Neither this
+	 * nor `includeInternal` changes a single step number - see below.
+	 */
+	includeHidden?: boolean
 }
 
 /** A trimmed string, or null for anything that is not a usable string. */
@@ -63,14 +79,29 @@ function drawablePosition(position: unknown): [number, number, number] | null {
 	return [position[0], position[1], position[2]]
 }
 
+/** What survived the filters, and whether a visitor would have seen it. */
+interface DrawableEntry {
+	hotspot: HotspotDefinition
+	id: string
+	position: [number, number, number]
+	hidden: boolean
+	internal: boolean
+	/**
+	 * True when a visitor to the published scene would see this hotspot, which
+	 * is the only set step numbers are ranked over.
+	 */
+	published: boolean
+}
+
 /**
  * Turns a scene's stored hotspots into the list the viewer draws, in order.
  *
  * Three rules, all of them the author's:
  *
- * - `visible: false` is never drawn. Only an explicit false hides: the field is
- *   required by the type, so an absent one is malformed data, and dropping a
- *   hotspot someone placed is the worse failure of the two.
+ * - `visible: false` is drawn only where someone can switch it back on, which
+ *   an editing surface asks for with `includeHidden`. Only an explicit false
+ *   hides: the field is required by the type, so an absent one is malformed
+ *   data, and dropping a hotspot someone placed is the worse failure of the two.
  * - `internalOnly` is only drawn on an editing surface. The published payload is
  *   already stripped of these server-side (`redactSettingsForEmbed`), so this is
  *   the second of two independent gates rather than the only one: the viewer is
@@ -78,6 +109,20 @@ function drawablePosition(position: unknown): [number, number, number] | null {
  *   including one that never passed through that redaction.
  * - Sequenced hotspots come first, in sequence order, then the rest in the order
  *   the author stored them. Order is what `sequenceIndex` means.
+ *
+ * **Step rank and `stepCount` are computed over the published set, always.**
+ * Every option here decides only what gets *drawn*; a marker a visitor would
+ * never see carries `step: null` and is counted by nothing. Without that rule an
+ * editing surface and the sidebar beside it disagree the moment a hidden or
+ * internal hotspot sits in the sequence: the canvas would print "step 2 of 4"
+ * where the visitor gets "step 1 of 3", and every later marker would be off by
+ * one. The numbers an author composes against have to be the numbers that ship.
+ *
+ * A hidden marker keeps its place in this list even though it takes no number,
+ * so it is drawn among the steps it sits between rather than pushed to the end.
+ * (Only the list order: drei portals each marker into a container it appends on
+ * mount and never reorders, so document order - and with it tab order - follows
+ * whichever order the markers first mounted in.)
  *
  * Everything else here is hardening. The platform's own parser validates most of
  * these fields on save, but it never sees `payloadUrl`, and a direct consumer of
@@ -87,34 +132,66 @@ function drawablePosition(position: unknown): [number, number, number] | null {
  */
 export function resolveHotspotMarkers(
 	hotspots: readonly HotspotDefinition[] | undefined,
-	{ includeInternal = false }: ResolveHotspotMarkersOptions = {}
+	{
+		includeInternal = false,
+		includeHidden = false
+	}: ResolveHotspotMarkersOptions = {}
 ): HotspotMarker[] {
 	if (!Array.isArray(hotspots)) return []
 
-	const seen = new Set<string>()
-	const drawable: {
-		hotspot: HotspotDefinition
-		id: string
-		position: [number, number, number]
-	}[] = []
+	/*
+	  One entry per id, chosen before any option is consulted.
+
+	  Two markers sharing an id would collide on React's key and one would inherit
+	  the other's occlusion state, so one of them has to go. Which one cannot be
+	  left to the options: while the id was claimed after the visibility filters, a
+	  hidden hotspot took it on an editing surface while the published one took it
+	  for a visitor, and the two surfaces then disagreed about both the marker and
+	  its step - the exact divergence the numbering rule below exists to rule out.
+
+	  First entry wins, except that a published one takes the id from an
+	  unpublished one. Both halves are load-bearing. The first makes the choice a
+	  pure function of the stored array; the second stops a hidden or internal
+	  duplicate from costing a visitor a marker they would otherwise have seen,
+	  which claiming strictly-first would do. A Map keeps the position of the first
+	  occurrence even when a later entry replaces the value, so the author's
+	  ordering survives either way.
+
+	  Only reachable from a direct consumer of this package - the platform's
+	  parser rejects duplicate ids on save.
+	*/
+	const claimed = new Map<string, DrawableEntry>()
 
 	for (const hotspot of hotspots) {
 		if (!hotspot) continue
 
 		const id = text(hotspot.id)
-		// Two markers sharing an id would collide on React's key and one of them
-		// would inherit the other's occlusion state.
-		if (!id || seen.has(id)) continue
+		if (!id) continue
 
 		const position = drawablePosition(hotspot.worldPosition)
 		if (!position) continue
 
-		if (hotspot.visible === false) continue
-		if (!includeInternal && hotspot.internalOnly === true) continue
+		const hidden = hotspot.visible === false
+		const internal = hotspot.internalOnly === true
+		const entry: DrawableEntry = {
+			hotspot,
+			id,
+			position,
+			hidden,
+			internal,
+			published: !hidden && !internal
+		}
 
-		seen.add(id)
-		drawable.push({ hotspot, id, position })
+		const existing = claimed.get(id)
+		if (!existing || (!existing.published && entry.published)) {
+			claimed.set(id, entry)
+		}
 	}
+
+	const drawable = [...claimed.values()].filter(
+		(entry) =>
+			(!entry.hidden || includeHidden) && (!entry.internal || includeInternal)
+	)
 
 	const sequenced = drawable
 		.flatMap((entry) =>
@@ -128,26 +205,22 @@ export function resolveHotspotMarkers(
 		({ hotspot }) => !Number.isFinite(hotspot.sequenceIndex)
 	)
 
-	const stepCount = sequenced.length
+	const stepCount = sequenced.filter(({ entry }) => entry.published).length
 
-	return [
-		...sequenced.map(({ entry }, index) =>
-			toMarker(entry, index + 1, stepCount)
-		),
-		...unsequenced.map((entry) => toMarker(entry, null, stepCount))
-	]
+	const markers: HotspotMarker[] = []
+	let step = 0
+	for (const { entry } of sequenced) {
+		markers.push(toMarker(entry, entry.published ? ++step : null, stepCount))
+	}
+	for (const entry of unsequenced) {
+		markers.push(toMarker(entry, null, stepCount))
+	}
+
+	return markers
 }
 
 function toMarker(
-	{
-		hotspot,
-		id,
-		position
-	}: {
-		hotspot: HotspotDefinition
-		id: string
-		position: [number, number, number]
-	},
+	{ hotspot, id, position, hidden }: DrawableEntry,
 	step: number | null,
 	stepCount: number
 ): HotspotMarker {
@@ -157,11 +230,11 @@ function toMarker(
 	return {
 		id,
 		name,
-		accessibleName:
-			step === null ? name : `${name}, step ${step} of ${stepCount}`,
+		accessibleName: accessibleName(name, step, stepCount, hidden),
 		position,
 		step,
 		stepCount,
+		hidden,
 		// Both payload presets fall back to the dot rather than rendering a broken
 		// image: `payloadUrl` is optional on the type, so an author can pick a
 		// preset and save before choosing the artwork.
@@ -177,4 +250,19 @@ function toMarker(
 		// carries no value at all.
 		occlusionEnabled: hotspot.occlusionEnabled !== false
 	}
+}
+
+/**
+ * A hidden marker only exists on an editing surface, and there the one thing
+ * its name has to carry is that a visitor will not see it. It never has a step
+ * to announce, so the two branches cannot collide.
+ */
+function accessibleName(
+	name: string,
+	step: number | null,
+	stepCount: number,
+	hidden: boolean
+): string {
+	if (hidden) return `${name}, hidden`
+	return step === null ? name : `${name}, step ${step} of ${stepCount}`
 }

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -1,5 +1,5 @@
 import { useFrame, useThree } from '@react-three/fiber'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Raycaster, Vector3 } from 'three'
 
 import HotspotMarker from './hotspot-marker'
@@ -10,9 +10,26 @@ import {
 import { resolveHotspotMarkers } from './resolve-hotspot-markers'
 
 import type { HotspotDefinition } from '@vctrl/core'
-import type { Object3D } from 'three'
+import type { Group, Object3D } from 'three'
 
 const NO_OCCLUSIONS: ReadonlySet<string> = new Set()
+
+/**
+ * Moves a hotspot's marker without moving the hotspot.
+ *
+ * World space, the same frame `worldPosition` is stored in. Passing `null`
+ * releases that hotspot's override; the marker then returns to whatever
+ * `hotspots` says, whether or not the caller committed anything.
+ *
+ * The id and the position are published together, by one call, which is what
+ * makes an override that names a hotspot but has nowhere to put it impossible
+ * to express. Releasing is scoped to an id for the matching reason: a gizmo
+ * torn down after a newer drag has already begun must not cancel that drag.
+ */
+export type HotspotPositionSetter = (
+	id: string,
+	position: [number, number, number] | null
+) => void
 
 export interface SceneHotspotsProps {
 	hotspots?: HotspotDefinition[]
@@ -24,9 +41,15 @@ export interface SceneHotspotsProps {
 	model?: Object3D
 	/** Draws `internalOnly` hotspots. Editing surfaces only. */
 	includeInternal?: boolean
+	/** Draws hotspots the author hid, greyed. Editing surfaces only. */
+	includeHidden?: boolean
 	/** Overrides the marker fill for every hotspot in this viewer. */
 	color?: string
+	/** The marker drawn as the current one. */
+	selectedId?: string | null
 	onActivateCamera?: (cameraId: string) => void
+	onSelect?: (id: string) => void
+	onPositionSetterReady?: (setter: null | HotspotPositionSetter) => void
 }
 
 /**
@@ -48,17 +71,153 @@ const SceneHotspots = ({
 	hotspots,
 	model,
 	includeInternal,
+	includeHidden,
 	color,
-	onActivateCamera
+	selectedId,
+	onActivateCamera,
+	onSelect,
+	onPositionSetterReady
 }: SceneHotspotsProps) => {
 	const camera = useThree((state) => state.camera)
+	const invalidate = useThree((state) => state.invalidate)
 	const [occludedIds, setOccludedIds] =
 		useState<ReadonlySet<string>>(NO_OCCLUSIONS)
 
 	const markers = useMemo(
-		() => resolveHotspotMarkers(hotspots, { includeInternal }),
-		[hotspots, includeInternal]
+		() => resolveHotspotMarkers(hotspots, { includeInternal, includeHidden }),
+		[hotspots, includeInternal, includeHidden]
 	)
+
+	/**
+	 * Where the gizmo is while a drag is in flight, and whose drag it is.
+	 *
+	 * Refs rather than state, and the whole reason this path exists: a drag emits
+	 * a position every frame, and routing sixty of those a second through React
+	 * would re-render every marker's portal and, on the platform's publisher,
+	 * re-serialize every scene setting twice per frame.
+	 */
+	const overrideId = useRef<string | null>(null)
+	const overridePosition = useRef(new Vector3())
+	/**
+	 * A released hotspot whose anchor still has to be put back where stored state
+	 * says, handled on the next frame rather than inside the release itself.
+	 *
+	 * Both halves matter. Without it, releasing leaves the anchor wherever the
+	 * drag left it: R3F skips `applyProps` when a `position` array is
+	 * element-wise equal to the last one it rendered, and it diffs against that
+	 * remembered prop rather than against the object, so a position the caller
+	 * never changed can never pull an imperatively-moved anchor back. The
+	 * re-seat effect below covers the case where the list changes; a release that
+	 * commits nothing changes nothing, and that is exactly what an interrupted
+	 * drag does when the gizmo's mesh is detached before its cleanup runs.
+	 *
+	 * Deferring to the next frame is what keeps the ordinary path from flickering:
+	 * a commit is scheduled before the release but flushed after it, so reading
+	 * stored state during the release would find the pre-drag position and snap
+	 * the marker back to it for a beat. By the next frame it has landed, and the
+	 * frame callback reads `markers` from its own closure - R3F refreshes that in
+	 * a layout effect, so it is never behind a passive one.
+	 */
+	const pendingReseat = useRef(new Set<string>())
+
+	/**
+	 * The anchor group each drawn marker registers by callback ref. A marker that
+	 * unmounts mid-drag deregisters itself, and the frame write below then finds
+	 * nothing - which is the correct thing for it to find.
+	 */
+	const anchors = useRef(new Map<string, Group>())
+
+	const registerAnchor = useCallback((id: string, node: Group | null) => {
+		if (node) anchors.current.set(id, node)
+		else anchors.current.delete(id)
+	}, [])
+
+	const setHotspotPosition = useCallback<HotspotPositionSetter>(
+		(id, position) => {
+			if (position === null) {
+				if (overrideId.current === id) {
+					overrideId.current = null
+					pendingReseat.current.add(id)
+				}
+				// Under `frameloop="demand"` nothing else would ask for the frame that
+				// puts this marker back: a release that commits nothing produces no
+				// React update, so no render is scheduled either.
+				invalidate()
+				return
+			}
+			overrideId.current = id
+			overridePosition.current.set(position[0], position[1], position[2])
+			pendingReseat.current.delete(id)
+			invalidate()
+		},
+		[invalidate]
+	)
+
+	useEffect(() => {
+		onPositionSetterReady?.(setHotspotPosition)
+		return () => onPositionSetterReady?.(null)
+	}, [onPositionSetterReady, setHotspotPosition])
+
+	/**
+	 * Re-seats every anchor from stored state whenever the drawn list changes.
+	 *
+	 * A drag writes these positions outside React, and R3F only re-applies a
+	 * `position` prop it sees change between renders - so a commit that happens
+	 * to land on the value the anchor already holds would leave it stuck at the
+	 * drag position for good.
+	 *
+	 * The marker being dragged is skipped: an unrelated edit landing mid-drag, a
+	 * rename typed in a sidebar, would otherwise snap it back to wherever the
+	 * author picked it up.
+	 */
+	useEffect(() => {
+		// A hotspot that leaves the list mid-drag takes its override with it.
+		// Otherwise a marker that later remounts under the same id - a consumer
+		// toggling `includeHidden`, say - would be yanked to the stale position on
+		// its first frame.
+		if (
+			overrideId.current &&
+			!markers.some((marker) => marker.id === overrideId.current)
+		) {
+			pendingReseat.current.delete(overrideId.current)
+			overrideId.current = null
+		}
+
+		for (const marker of markers) {
+			if (marker.id === overrideId.current) continue
+			anchors.current.get(marker.id)?.position.set(...marker.position)
+		}
+	}, [markers])
+
+	/**
+	 * Puts the dragged marker where the gizmo is, before anything projects from
+	 * it.
+	 *
+	 * Priority -1 is load-bearing. drei's `Html` subscribes at priority 0 and
+	 * calls `updateWorldMatrix(true, false)`, which recomputes each ancestor's
+	 * local matrix from its `position` - so a plain `.position.copy()` on this
+	 * group lands in the same frame, provided it happened first. R3F sorts
+	 * subscribers ascending and, at equal priority, a child subscribes before its
+	 * parent, so at 0 the `Html` would project before this write and the marker
+	 * would trail the gizmo by a frame. Only a positive priority takes the render
+	 * loop over, so a negative one costs nothing.
+	 */
+	useFrame(() => {
+		const id = overrideId.current
+		if (id) anchors.current.get(id)?.position.copy(overridePosition.current)
+
+		// Deliberately not behind the `if` above: a marker released while a
+		// different one is being dragged would otherwise wait for that drag to end,
+		// and the single slot this used to be would have lost it by then.
+		for (const released of pendingReseat.current) {
+			// Picked up again before this ran; its override owns the anchor now.
+			if (released === id) continue
+			pendingReseat.current.delete(released)
+			const marker = markers.find((entry) => entry.id === released)
+			if (marker)
+				anchors.current.get(released)?.position.set(...marker.position)
+		}
+	}, -1)
 
 	const raycaster = useMemo(() => {
 		const instance = new Raycaster()
@@ -77,6 +236,7 @@ const SceneHotspots = ({
 	// Forces the next frame to re-test instead of waiting out the interval, so a
 	// changed hotspot list or a swapped model never renders against stale state.
 	const stale = useRef(true)
+	const lastOverrideId = useRef<string | null>(null)
 
 	// Keyed on what the pass actually reads, not on array identity: a caller that
 	// rebuilds its hotspot array each render - which is the normal shape for
@@ -94,6 +254,14 @@ const SceneHotspots = ({
 	}, [inputs, model])
 
 	useFrame((_state, delta) => {
+		// Both edges of a drag re-test on the next frame rather than waiting out
+		// the interval. The release edge is usually covered by `inputs` changing,
+		// but not for a drag that ends exactly where it started.
+		if (overrideId.current !== lastOverrideId.current) {
+			lastOverrideId.current = overrideId.current
+			stale.current = true
+		}
+
 		elapsed.current += delta
 		if (!stale.current && elapsed.current < OCCLUSION_INTERVAL_SECONDS) return
 		const forced = stale.current
@@ -110,6 +278,18 @@ const SceneHotspots = ({
 
 			for (const marker of markers) {
 				if (!marker.occlusionEnabled) continue
+				/*
+				  The marker being dragged is left un-occluded for the whole gesture.
+
+				  Its stored position is deliberately not being rewritten yet, so the
+				  only point this pass could test is the one the author already
+				  dragged away from. There is no true answer mid-gesture, and the
+				  useful rendering of "unknown" is "visible": the author is looking
+				  straight at the thing they are dragging, and fading it to 15% under
+				  a `TransformControls` gizmo that stays fully drawn is the worst
+				  reading available. Truth returns on the frame after release.
+				*/
+				if (marker.id === overrideId.current) continue
 
 				target.current.set(...marker.position)
 				direction.current.subVectors(target.current, camera.position)
@@ -149,8 +329,11 @@ const SceneHotspots = ({
 					key={marker.id}
 					marker={marker}
 					occluded={occludedIds.has(marker.id)}
+					selected={marker.id === selectedId}
 					color={color}
 					onActivate={onActivateCamera}
+					onSelect={onSelect}
+					onAnchorRef={registerAnchor}
 				/>
 			))}
 		</>

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -53,6 +53,13 @@
 	*/
 	--vctrl-hotspot-fill: #ffffff;
 	--vctrl-hotspot-ink: #18181b;
+	/*
+	  A hotspot the author switched off, drawn only where somebody can switch it
+	  back on. Grey rather than a faded copy of the fill, because opacity is
+	  already spoken for here - occlusion owns it - and a hidden marker sitting
+	  behind the model has to be able to say both things at once.
+	*/
+	--vctrl-hotspot-hidden-fill: #a1a1aa;
 
 	font-family: 'DM Sans Variable', sans-serif;
 }
@@ -160,6 +167,73 @@
 	.vctrl-hotspot-pulse {
 		animation: none;
 	}
+}
+
+/*
+  The marker an editing surface has picked out.
+
+  A ring rather than a colour, and that is not a taste call: `hotspotColor`
+  writes `--vctrl-hotspot-fill` as an inline style on the marker root, and an
+  inline declaration beats any stylesheet rule for the same property on the same
+  element - so a colour-based selection would simply not exist on a viewer that
+  had been given a brand. A ring composes with any fill at all.
+
+  Never the accent (`#f97316` is what this replaced when the platform's publisher
+  stopped drawing its own marker). The argument the fill tokens make above holds
+  twice as hard for a state the author stares at while dragging: a hotspot sits
+  on top of somebody's product.
+
+  White inside a dark halo, so it carries on a dark scene and on a light one.
+
+  This rule outranks the focus utility's own `box-shadow`, so the focused case
+  is spelled out separately below rather than left to the cascade - without it a
+  marker that was both selected and focused lost the dark halo entirely and the
+  focus outline landed exactly where that halo used to be.
+*/
+.vctrl-viewer-hotspot[data-selected] .vctrl-hotspot-body {
+	border-radius: 9999px;
+	box-shadow:
+		0 0 0 2px #ffffff,
+		0 0 0 4px rgb(0 0 0 / 0.55);
+}
+
+/*
+  Selected *and* focused. The selection ring keeps the inner 2px; the halo moves
+  out past the focus outline (2px wide at `outline-offset: 2px`) instead of
+  sitting under it, so the marker reads as a white band with a dark edge around
+  it rather than as a white band alone.
+*/
+.vctrl-viewer-hotspot[data-selected] .vctrl-hotspot-body:focus-visible {
+	box-shadow:
+		0 0 0 2px #ffffff,
+		0 0 0 6px rgb(0 0 0 / 0.5);
+}
+
+/* Faster, not different - and killed outright by the reduced-motion rule above,
+   which the ring deliberately does not depend on. */
+.vctrl-viewer-hotspot[data-selected] .vctrl-hotspot-pulse {
+	animation-duration: 1.4s;
+}
+
+/*
+  A hotspot the author hid. Declared on the body rather than the root so it wins
+  over a `hotspotColor` inherited from the root.
+
+  The pulse stops and goes dashed: a moving ring means "touch this", and nobody
+  browsing the published scene ever will - this marker exists so its author can
+  find it again. `filter` carries the image and svg presets, whose artwork no
+  token here can reach.
+*/
+.vctrl-viewer-hotspot[data-hidden] .vctrl-hotspot-body {
+	--vctrl-hotspot-fill: var(--vctrl-hotspot-hidden-fill);
+	--vctrl-hotspot-ink: #18181b;
+	filter: grayscale(1);
+}
+
+.vctrl-viewer-hotspot[data-hidden] .vctrl-hotspot-pulse {
+	color: var(--vctrl-hotspot-hidden-fill);
+	border-style: dashed;
+	animation: none;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/packages/viewer/src/vectreal-viewer.stories.tsx
+++ b/packages/viewer/src/vectreal-viewer.stories.tsx
@@ -215,7 +215,15 @@ const styleHotspots: StoryHotspot[] = [
 		...base('no-payload', 'Image preset, no artwork yet', [-1.1, 0.15, 0.7]),
 		stylePreset: 'image'
 	},
-	{ ...base('hidden', 'Hidden by the author', [0, 0.6, 0.7]), visible: false },
+	{
+		// Sequenced *and* hidden, which is what makes the numbering rule visible:
+		// an editing surface draws it between steps 1 and 2, and it still takes no
+		// number, so the steps either side of it read the same as they do for a
+		// visitor.
+		...base('hidden', 'Hidden by the author', [0, 0.6, 0.7]),
+		visible: false,
+		sequenceIndex: 2
+	},
 	{ ...base('internal', 'Internal only', [0, -0.35, 0.7]), internalOnly: true }
 ]
 
@@ -270,15 +278,62 @@ export const HotspotStyles: Story = {
 /**
  * Colour is opt-in. The default marker is neutral so it does not compete with
  * the product; a caller that wants the hotspots to carry a brand passes one.
+ *
+ * One marker is also drawn as selected, because this is the story that proves
+ * selection had to be a ring rather than a colour: `hotspotColor` writes the
+ * fill as an inline style on the marker root, and an inline declaration beats
+ * any stylesheet rule for the same property on the same element, so a
+ * colour-based selection would simply not exist on a branded viewer.
  */
 export const HotspotColor: Story = {
-	args: { hotspots: styleHotspots, hotspotColor: '#fc6c18' },
+	args: {
+		hotspots: styleHotspots,
+		hotspotColor: '#fc6c18',
+		// `selectedHotspotId` alone, deliberately: passing a select handler as well
+		// would make every marker here a button, and this story is the published
+		// product view.
+		selectedHotspotId: 'step-2'
+	},
 	render: hotspotRender
 }
 
-/** The publisher's view of the same scene: the internal-only hotspot appears. */
+/**
+ * The publisher's view of the same scene, with the props it actually passes.
+ *
+ * Two extra markers appear: the internal-only one, and the hidden one - greyed,
+ * with its ring dashed and still, because nobody browsing the published scene
+ * will ever touch it. Neither takes a step number. The hidden marker sits
+ * between steps 1 and 2 in the sequence and the numerals either side of it are
+ * unchanged, which is the whole rule: an author composes against the numbers a
+ * visitor gets.
+ */
 export const HotspotsOnAnEditingSurface: Story = {
-	args: { hotspots: styleHotspots, showInternalHotspots: true },
+	args: {
+		hotspots: styleHotspots,
+		showInternalHotspots: true,
+		showHiddenHotspots: true
+	},
+	render: hotspotRender
+}
+
+/**
+ * One marker picked out, as the publisher draws it while its hotspot tool is
+ * armed.
+ *
+ * A ring rather than a colour, and neutral rather than brand. Both are
+ * deliberate: `hotspotColor` writes the fill as an inline style, so a
+ * colour-based selection would vanish on a branded viewer, and a saturated
+ * marker sitting on somebody's product competes with the thing the scene exists
+ * to show. Compare with `HotspotColor` - the ring survives there too.
+ */
+export const HotspotSelection: Story = {
+	args: {
+		hotspots: styleHotspots,
+		showInternalHotspots: true,
+		showHiddenHotspots: true,
+		selectedHotspotId: 'step-2',
+		onHotspotSelect: () => {}
+	},
 	render: hotspotRender
 }
 

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -54,6 +54,7 @@ import {
 import { useAnimationRuntime } from './hooks/use-animation-runtime'
 import { useViewerLoading } from './hooks/use-viewer-loading'
 
+import type { HotspotPositionSetter } from './components/scene'
 import type {
 	BakedShadow,
 	SceneCameraSnapshotCapture,
@@ -216,6 +217,42 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	showInternalHotspots?: boolean
 
 	/**
+	 * When true, hotspots the author hid (`visible: false`) are drawn greyed, so
+	 * they can be found and switched back on. Editing surfaces only.
+	 *
+	 * Changes no step number: a marker a visitor would not see is never numbered
+	 * or counted, whichever of these flags drew it. Default: false.
+	 */
+	showHiddenHotspots?: boolean
+
+	/**
+	 * The hotspot to draw as the current one, with a selection ring. Neutral,
+	 * never a brand colour - see `styles.css`.
+	 */
+	selectedHotspotId?: string | null
+
+	/**
+	 * Runs when a marker is clicked on a surface that selects rather than
+	 * navigates. Passing it is what makes selection possible at all, and a marker
+	 * that could do either selects: selecting is local and reversible, while
+	 * activating a linked camera throws away the viewpoint the author was working
+	 * from. A surface that wants the camera instead simply does not pass this.
+	 */
+	onHotspotSelect?: (id: string) => void
+
+	/**
+	 * Hands back a setter that moves a marker without moving the hotspot, or
+	 * `null` on teardown - the same shape as `onCommandExecutorReady` and the
+	 * capture callbacks beside it.
+	 *
+	 * A setter rather than a viewer command because a drag emits a position every
+	 * frame and none of them may reach React: the command bus routes through
+	 * state, so a `set_hotspot_position` command would re-render every marker
+	 * sixty times a second, which is the whole cost this exists to avoid.
+	 */
+	onHotspotPositionSetterReady?: (setter: null | HotspotPositionSetter) => void
+
+	/**
 	 * When true, the accumulative shadow bakes in a single pass on mount instead of
 	 * fading in across frames, so it is present immediately when a scene opens.
 	 * Intended for read-only/preview surfaces; the editor leaves this off to keep
@@ -340,6 +377,10 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		// Editor affordances
 		shadowLightEditable,
 		showInternalHotspots = false,
+		showHiddenHotspots = false,
+		selectedHotspotId = null,
+		onHotspotSelect,
+		onHotspotPositionSetterReady,
 		staticShadowBake = false,
 		bakedShadow,
 		onShadowBakeReady,
@@ -404,37 +445,40 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 
 	const { forwardCommand: forwardAnimationCommand } = animation
 
-	const executeViewerCommand = useCallback((command: ViewerCommand) => {
-		switch (command.type) {
-			case 'activate_camera':
-				cameraCommandExecutorRef.current?.execute(command)
-				break
-			case 'set_controls_enabled':
-				setControlsEnabledOverride(command.enabled)
-				break
-			case 'set_auto_rotate':
-				setAutoRotateOverride({
-					enabled: command.enabled,
-					speed: command.speed
-				})
-				break
-			case 'set_controls_options':
-				setControlsOptionsOverride((prev) => ({ ...prev, ...command }))
-				break
-			case 'set_transition':
-				setTransitionOverride({
-					type: command.transitionType,
-					duration: command.duration,
-					easing: command.easing
-				})
-				break
-			case 'restart_animation':
-			case 'seek_animation_clip':
-			case 'set_animation_playing':
-				forwardAnimationCommand(command)
-				break
-		}
-	}, [forwardAnimationCommand])
+	const executeViewerCommand = useCallback(
+		(command: ViewerCommand) => {
+			switch (command.type) {
+				case 'activate_camera':
+					cameraCommandExecutorRef.current?.execute(command)
+					break
+				case 'set_controls_enabled':
+					setControlsEnabledOverride(command.enabled)
+					break
+				case 'set_auto_rotate':
+					setAutoRotateOverride({
+						enabled: command.enabled,
+						speed: command.speed
+					})
+					break
+				case 'set_controls_options':
+					setControlsOptionsOverride((prev) => ({ ...prev, ...command }))
+					break
+				case 'set_transition':
+					setTransitionOverride({
+						type: command.transitionType,
+						duration: command.duration,
+						easing: command.easing
+					})
+					break
+				case 'restart_animation':
+				case 'seek_animation_clip':
+				case 'set_animation_playing':
+					forwardAnimationCommand(command)
+					break
+			}
+		},
+		[forwardAnimationCommand]
+	)
 
 	// A hotspot's linked camera goes through the same command path an external
 	// `activate_camera` takes, so a hotspot click and a host calling the embed
@@ -588,8 +632,12 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									hotspots={hotspots}
 									model={model}
 									includeInternal={showInternalHotspots}
+									includeHidden={showHiddenHotspots}
 									color={hotspotColor}
+									selectedId={selectedHotspotId}
 									onActivateCamera={handleActivateHotspotCamera}
+									onSelect={onHotspotSelect}
+									onPositionSetterReady={onHotspotPositionSetterReady}
 								/>
 								{children}
 							</SceneBounds>


### PR DESCRIPTION
> **Split into a stack.** This PR is now one concern: the viewer becomes the single hotspot renderer. The follow-on work moved out to #770 (tool scoping), #771 (hotspot camera aim), #769 (camera snap, independent) and #768 (skills).

## Summary

`@vctrl/viewer` is now the single hotspot renderer, and every surface that owns a scene passes it `SceneSettings.hotspots`. Before this, **a published scene showed no hotspots at all** — an author placed markers, named them, linked cameras, ordered a sequence, saved and published, and a visitor saw nothing — while the publisher drew its own bespoke marker, so the thing an author composed against was not the thing anyone would ever see.

## Root cause

`SceneSettings.hotspots` was never handed to `VectrealViewer` by either surface that owns one, so the viewer's renderer sat unreached while the publisher kept the bespoke marker it had grown before that renderer existed.

## Changes

**Surfaces touched**

- `scene-embed-viewer.tsx` — passes `hotspots`, and deliberately nothing else. This lights up `/embed`, `/preview` and the dashboard scene panel.
- `publisher.$sceneId.tsx` — passes `hotspots` plus the editing props, and mirrors `camera_changed` into `selectedCameraIdAtom`.
- `publisher-editor-scene.tsx` — deletes `HotspotDot` and `useHotspotStyles` (~180 lines). Keeps `HotspotGizmo`, `ClickToPlace` and the view-cube withdrawal.
- `packages/viewer` — the editing affordances below.

**Surfaces deliberately not touched, having checked each**

- `client-vectreal-viewer.tsx` — it spreads `{...props}` and extends `VectrealViewerProps`, so it already forwarded every hotspot prop. No change needed.
- `hosted-preview-bridge.ts` — carries no scene settings (`sceneId`, `interactions`, `cameras`, `initialCommands`). Nothing to pass.
- `packages/embed` — the host-page postMessage SDK, not a renderer. Exposing hotspots over postMessage is a separate concern.

**New viewer props**, flat rather than a grouped object, because a grouped bag would re-register the imperative handle on every render — the exact trap `cameraOptions` is memoized to avoid:

- `showHiddenHotspots`, `selectedHotspotId`, `onHotspotSelect`, `onHotspotPositionSetterReady`

**The numbering rule.** Step rank and `stepCount` are now computed over the published set on every surface; each option decides only what is *drawn*. Without it the canvas and the sidebar disagreed from the first hidden or internal hotspot in a sequence onwards — a latent off-by-one that would have fired the moment the publisher passed `showInternalHotspots`.

**Three latent defects the wiring would otherwise have armed**, each verified in code before being fixed:

- The publisher injected `@keyframes vctrl-hotspot-pulse` into `document.head` under the same name the package defines, animating `box-shadow` spread. Last one wins, and the publisher's landed after the package stylesheet.
- drei's `Html` wrapper defaulted to `pointer-events: auto` (its non-transform branch spreads only `{position, transform, ...style}`), so an occluded marker still swallowed clicks despite `resolveHotspotInteraction` asking for `none` — a rule its own spec asserts. It also ate click-to-place presses.
- Releasing a drag never re-seated the anchor. R3F skips `applyProps` on an element-wise-equal `position` array, so an interrupted drag that committed nothing left the marker stranded.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

`HotspotMarker` gains a required `hidden` field and `HotspotInteraction` renames `activatable`. Neither is a break: consumers only *receive* the first, and the second is re-exported nowhere. **Minor, not a patch.**

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser — see below
- [x] Storybook story added/updated
- [ ] No tests required

**1503 unit tests, 111 files. 16 mutants killed by named tests**, including the exact original bug: deleting `hotspots={sceneData?.hotspots}` turns a test red, where before a complete renderer with no caller went unnoticed.

The `internalOnly` boundary is gated from both sides. The real tokenized manifest returns `Visor` only — the server strips `internalOnly` but **ships the hidden one**, so the viewer's own filter is what must drop it. Both gates are load-bearing, and this matters because two of the three surfaces rendering `SceneEmbedViewer` are served the *unredacted* manifest: the dashboard scene panel, and `/preview` of a scene with no published model row.

**Browser verification: I could not get it, and it is not this change.** No R3F canvas mounts anywhere in my local environment. Proven three ways: the same tokenized `/embed` URL hangs identically on clean `main`; the untouched `Default` Storybook story also renders no canvas; and WebGL itself is available. So there are no screenshots.

Instead the proof lives where it is durable — `packages/viewer-e2e`, which installs the **published tarball** into a throwaway Vite app and drives it with Playwright:

```ts
await expect(page.locator('.vctrl-viewer-hotspot')).toHaveCount(1)
await expect(page.getByRole('img', { name: 'Public marker' })).toBeVisible()
await expect(page.getByLabel('Internal marker')).toHaveCount(0)
```

Mutation-gated: adding `showInternalHotspots` fails it with **Expected 1, Received 2**. That confirms markers really render in a real browser and that the `internalOnly` gate is what stops the other two — and unlike a screenshot it runs in CI.

`render-embed-scene` is added to `CRITICAL_FLOWS`, so the funnel no longer stops at "serve the manifest" — which is precisely why a finished renderer could ship with no caller and nothing notice.

**Residual risk.** `publisher-editor-scene.tsx` still has no component-level coverage, so the gizmo drag, click-to-place and the view-cube withdrawal rest on reasoning and review rather than on a test. Four review rounds ran; the last found a defect in my own fix, described below.

## Filed rather than fixed

Eight rows in Vectreal Work Items, named here so the omissions are deliberate rather than lost:

- **A hotspot click can snap the camera mid-flight** when its linked camera has no stored position. Reachable — 4 of 14 cameras in the dev database have none. The remedy belongs in the viewer's camera module; removing the `camera_changed` mirror instead would reintroduce the sidebar desync, which is worse.
- **A camera-less hotspot is keyboard-unreachable** on a published scene. Pre-existing, but only reachable by customers now that scenes actually draw hotspots.
- **The published `.d.ts` files point outside the tarball.** I tried to fix the related "no importable name for `HotspotDefinition`" problem by re-exporting it, then **reverted that**: the built output rewrites it to `../../core/src/index.ts`, which escapes the package, and under the usual `skipLibCheck: true` it degrades silently to a name that accepts anything. A broken export is worse than none.
- The `internalOnly` marker being visually indistinguishable on the publisher canvas; the occlusion slack changing reference frame from model-diagonal to camera-distance; the marker's 24px hit box covering the gizmo's centre handles; the dropped "you-are-here" cue on a hotspot whose camera is active; and documenting the seven public hotspot props.

## Checklist

- [x] Gates green: `typecheck` + `lint` across `vctrl/core`, `vctrl/hooks`, `vctrl/viewer`, `vctrl/embed`, `vectreal-platform` (5 projects — all names resolved, since a typo matches nothing and still exits 0)
- [x] `npx vitest run --root .` — 1503 passed
- [x] `nx e2e vctrl/viewer-e2e` — passes, with the new hotspot assertions
- [x] Prettier clean on every changed file
- [x] Review loop run to a clean round, with each finding checked against the code before it became a fix