### PR TITLE
fix(auth): make email sign-up work, and say why when it does not

### DIFF
--- a/apps/vectreal-platform/app/hooks/use-spend-turnstile-token.ts
+++ b/apps/vectreal-platform/app/hooks/use-spend-turnstile-token.ts
@@ -1,0 +1,111 @@
+import { useEffect, useRef } from 'react'
+
+/** The field every auth form carries its Turnstile token in. */
+const TURNSTILE_FIELD = 'cf-turnstile-response'
+
+/**
+ * The shape both `useNavigation()` and an entry of `useFetchers()` satisfy.
+ *
+ * `formData` is undefined while idle, and is the *same object* across
+ * `submitting` and `loading`, which is what makes identity the right key below.
+ */
+export interface TokenBearingSubmission {
+	formData: FormData | undefined
+}
+
+export interface SpendTurnstileTokenOptions {
+	/** Every submission the token's owner can observe: `[navigation, ...fetchers]`. */
+	submissions: readonly TokenBearingSubmission[]
+	/** The token currently held, or null while a fresh one is being minted. */
+	token: string | null
+	/** Called once, with the spent token, the first time it leaves for the server. */
+	onSpend: (spentToken: string) => void
+	fieldName?: string
+}
+
+/**
+ * Invalidates a Turnstile token the moment it is submitted, not when a response
+ * comes back.
+ *
+ * A Turnstile token is single-use: Cloudflare answers a replay with
+ * `timeout-or-duplicate`, and Supabase - which verifies the token server-side on
+ * the auth routes - turns that into a captcha error. So whoever owns the token
+ * has to know when it is gone.
+ *
+ * `signin-layout` used to leave that to its children, and each of them inferred
+ * it from their own `actionData`. That proxy fails on exactly the path that
+ * matters: a successful sign-up returns `redirect(...)`, which produces no
+ * `actionData`, so nothing reset and the layout - which does not remount when
+ * navigating between its own routes - carried the spent token into the next
+ * submit. Signing up, landing on `/auth/confirm-pending` and pressing "Resend
+ * confirmation email" replayed it every time, and the reason never reached the
+ * user.
+ *
+ * Watching the request instead of the response asks the question that was
+ * actually being asked.
+ *
+ * Three guards, doing different jobs. Each is load-bearing:
+ *
+ *   1. `examined`, keyed on `FormData` identity, makes a submission spend at
+ *      most once however many renders it spans. React Router rebuilds the
+ *      wrapper object on the `submitting` -> `loading` transition and again for
+ *      the redirect that follows, while carrying the same `submission.formData`
+ *      through all of them - so the `FormData` is the only stable key.
+ *   2. The token equality check leaves the OAuth path alone. It also rejects a
+ *      `File`, which is the other thing `formData.get` can return.
+ *   3. `!carried` is what stops a submission carrying no token from spending
+ *      one. `formData.get` returns null for an absent field, and the layout's
+ *      no-site-key branch submits with no token while the live token is also
+ *      null - so `null !== null` is false and equality alone would let it
+ *      through, resetting a widget that is not even mounted.
+ *
+ * The two OAuth branches are safe for different reasons, which is worth knowing
+ * before touching either: `handleSocialLogin` resets *before* submitting, so
+ * the live token is already null; `handleTurnstileSuccess` submits before
+ * resetting, but is only reachable while the live token is null anyway.
+ *
+ * Together the guards also make the obvious pathological loop unreachable:
+ * spending a token mints a new one, and the stale `FormData` fails both guards
+ * on the re-render.
+ */
+export function useSpendTurnstileToken({
+	submissions,
+	token,
+	onSpend,
+	fieldName = TURNSTILE_FIELD
+}: SpendTurnstileTokenOptions): void {
+	const examinedRef = useRef<WeakSet<FormData> | null>(null)
+	if (examinedRef.current === null) examinedRef.current = new WeakSet()
+	const examined = examinedRef.current
+
+	/*
+	  Held in a ref so the effect below always calls the latest handler. It cannot
+	  go stale behind a dependency list because there is none, but the ref keeps
+	  that true if one is ever added.
+	*/
+	const onSpendRef = useRef(onSpend)
+	onSpendRef.current = onSpend
+
+	/*
+	  Deliberately no dependency array. The caller builds `submissions` fresh on
+	  every render (`[navigation, ...fetchers]`), so a dependency list over it
+	  would compare new array identities and re-run anyway. `examined` - not a
+	  dependency list - is what makes this idempotent. It cannot loop: `onSpend`
+	  sets state, and the resulting render finds the same `FormData` already
+	  examined.
+	*/
+	useEffect(() => {
+		for (const submission of submissions) {
+			const { formData } = submission
+			if (!formData) continue
+			if (examined.has(formData)) continue
+			examined.add(formData)
+
+			const carried = formData.get(fieldName)
+			if (!carried) continue
+			if (carried !== token) continue
+
+			onSpendRef.current(carried)
+		}
+	})
+}

--- a/apps/vectreal-platform/app/lib/domain/auth/signup-failure.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/signup-failure.ts
@@ -1,0 +1,149 @@
+/**
+ * What a failed sign-up tells the visitor, and what it tells us.
+ *
+ * The route used to fold every Supabase failure into one of two fixed
+ * sentences, chosen by substring-matching the English message, and then
+ * deliberately skipped `reportServerError` for the whole branch it called a
+ * client error. A captcha rejection - the most common real failure, and for a
+ * while a guaranteed one, because a spent Turnstile token was being replayed -
+ * produced no reason for the visitor and no trace for anyone else. The account
+ * creation funnel's first step was the one place in the app that reported
+ * nothing.
+ *
+ * Two rules follow from that, and they are why this is a module rather than a
+ * branch in the route:
+ *
+ *   1. Every code reports except `already_registered`, which is withheld from
+ *      the visitor and so has nothing to investigate.
+ *   2. An unrecognized message reports. The visitor still gets the generic
+ *      sentence - there is nothing useful to tell them - but the call site
+ *      sends the original text along with the `unknown` code, so a failure
+ *      nobody has seen before is legible on its first occurrence instead of
+ *      looking exactly like one we already understand.
+ *
+ * Pure, and free of any database or Supabase import, so a spec can exercise it
+ * directly - a route module cannot be imported by a test, because `getDbClient`
+ * throws at module scope.
+ */
+
+export type SignupFailureCode =
+	| 'captcha'
+	| 'already_registered'
+	| 'weak_password'
+	| 'invalid_email'
+	| 'signups_disabled'
+	| 'email_send_failed'
+	| 'email_rate_limited'
+	| 'unknown'
+
+export interface SignupFailure {
+	code: SignupFailureCode
+	/** Shown to the visitor. Never names whether an address has an account. */
+	message: string
+	status: 400 | 429 | 500
+	/** Whether this warrants a report. False only where there is nothing to learn. */
+	report: boolean
+}
+
+/*
+  Ordered, because several of these overlap: "Unable to validate email address:
+  invalid format" contains "invalid", and "Error sending confirmation email"
+  contains "email". First match wins, so the specific patterns come first.
+*/
+const PATTERNS: { code: SignupFailureCode; match: RegExp }[] = [
+	{ code: 'captcha', match: /captcha|turnstile/ },
+	{
+		code: 'already_registered',
+		match: /already registered|already been registered/
+	},
+	/*
+	  `hook` carries this project, and "error sending" never fires here.
+
+	  `config.toml` enables `[auth.hook.send_email]` against `/auth/send-email`,
+	  so GoTrue never runs its own mailer and never emits "Error sending
+	  confirmation email". Our route answers a Resend failure with a 500, and
+	  GoTrue reads the hook's body only on 2xx - so the message it returns is its
+	  own: "Unexpected status code returned from hook: 500". Its siblings are
+	  "Invalid payload sent to hook", "Hook requires authorization token",
+	  "Service currently unavailable due to hook" and `hook_timeout`. The single
+	  word they share is the one that classifies them.
+
+	  The SMTP wording stays because `[auth.email.smtp]` is still configured and
+	  would take over if the hook were ever disabled.
+	*/
+	{
+		code: 'email_send_failed',
+		match: /error sending|failed to send|smtp|hook/
+	},
+	{
+		code: 'email_rate_limited',
+		match: /rate limit|too many requests|only request this after/
+	},
+	{
+		code: 'invalid_email',
+		match: /validate email|invalid format|invalid email/
+	},
+	{ code: 'weak_password', match: /password/ },
+	{ code: 'signups_disabled', match: /signups (not allowed|are disabled)/ }
+]
+
+const MESSAGES: Record<SignupFailureCode, string> = {
+	/*
+	  Deliberately does not name a cause. The pattern fires for an expired token,
+	  a replayed one and an outright invalid one, and the widget runs in
+	  `interaction-only` mode, so most people never saw a challenge to blame.
+	  Retrying mints a fresh token, which is the only thing they can act on.
+	*/
+	captcha: 'We could not verify your request. Please try again.',
+	/*
+	  Says nothing about whether this address has an account. The form would
+	  otherwise answer that question for anyone who asked it, which is what makes
+	  a sign-up form an enumeration oracle.
+	*/
+	already_registered:
+		'We could not create an account with those details. If you already have one, try signing in or resetting your password.',
+	weak_password:
+		'That password was rejected. Please choose a longer or less common one.',
+	invalid_email: 'That email address does not look valid. Please check it.',
+	signups_disabled:
+		'New sign-ups are paused right now. Please try again later.',
+	/*
+	  "Sign up again" rather than "sign in", and the difference is not cosmetic.
+
+	  GoTrue wraps `signupNewUser` and the confirmation send in one transaction
+	  and returns the send error from inside it, so a failed send rolls the user
+	  back and there is no account to sign in to. Even where one did exist,
+	  `signin-page` has no branch for an unconfirmed account: GoTrue answers
+	  "Email not confirmed" and the route falls through to its generic message
+	  and a 500. Signing up again is the path that works either way.
+	*/
+	email_send_failed:
+		'We could not send your confirmation email. Please try signing up again in a moment.',
+	email_rate_limited:
+		'Too many confirmation emails have been requested for this address. Please wait before trying again.',
+	unknown: 'We could not create your account right now. Please try again.'
+}
+
+const STATUS: Record<SignupFailureCode, 400 | 429 | 500> = {
+	captcha: 400,
+	already_registered: 400,
+	weak_password: 400,
+	invalid_email: 400,
+	signups_disabled: 400,
+	email_rate_limited: 429,
+	email_send_failed: 500,
+	unknown: 500
+}
+
+export function classifySignupFailure(supabaseMessage: string): SignupFailure {
+	const normalized = supabaseMessage.toLowerCase()
+	const code =
+		PATTERNS.find(({ match }) => match.test(normalized))?.code ?? 'unknown'
+
+	return {
+		code,
+		message: MESSAGES[code],
+		status: STATUS[code],
+		report: code !== 'already_registered'
+	}
+}

--- a/apps/vectreal-platform/app/lib/domain/auth/signup-validation.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/signup-validation.ts
@@ -1,0 +1,76 @@
+/**
+ * Field-level validation for the sign-up form.
+ *
+ * Pure and free of any server import, so a spec can reach it - the route module
+ * that used to hold this cannot be imported by a test, because `getDbClient()`
+ * throws at module scope.
+ */
+
+export interface SignupFieldErrors {
+	email?: string
+	password?: string
+	confirmPassword?: string
+	tos?: string
+}
+
+export interface SignupValues {
+	name: string
+	email: string
+	password: string
+}
+
+export interface SignupValidation {
+	errors: SignupFieldErrors
+	data: SignupValues
+}
+
+const asString = (value: FormDataEntryValue | null): string =>
+	typeof value === 'string' ? value : ''
+
+export function validateSignup(formData: FormData): SignupValidation {
+	const errors: SignupFieldErrors = {}
+
+	const name = formData.get('name')
+	const email = formData.get('email')
+	const password = formData.get('password')
+	const confirmPassword = formData.get('confirm_password')
+	const tosAccepted = formData.get('tos_accepted')
+
+	/*
+	  Name is deliberately absent from this list. Nothing downstream requires it:
+	  `ensureUserExistsDb` falls back to the email address and then to a literal,
+	  which is what satisfies the NOT NULL `users.name` column, and onboarding
+	  falls back to the email's local part. Asking for it was one more field
+	  between a visitor and an account.
+
+	  The caller omits an empty name from Supabase's user metadata rather than
+	  storing `''`, because those two fallbacks disagree about what "missing"
+	  means - one tests truthiness, the other nullishness.
+	*/
+	if (!email || typeof email !== 'string' || !email.includes('@')) {
+		errors.email = 'Please enter a valid email address.'
+	}
+	if (!password || typeof password !== 'string' || password.length < 8) {
+		errors.password = 'Password must be at least 8 characters long.'
+	}
+	if (
+		!confirmPassword ||
+		typeof confirmPassword !== 'string' ||
+		confirmPassword !== password
+	) {
+		errors.confirmPassword = 'Passwords do not match.'
+	}
+	if (!tosAccepted || tosAccepted !== 'on') {
+		errors.tos =
+			'You must accept the Terms of Service and Privacy Policy to create an account.'
+	}
+
+	return {
+		errors,
+		data: {
+			name: asString(name).trim(),
+			email: asString(email),
+			password: asString(password)
+		}
+	}
+}

--- a/apps/vectreal-platform/app/lib/motion/motion-tokens.ts
+++ b/apps/vectreal-platform/app/lib/motion/motion-tokens.ts
@@ -1,0 +1,64 @@
+/**
+ * The motion scale from `globals.css`, in the units Framer Motion wants.
+ *
+ * The CSS custom properties are milliseconds and are only usable inside a CSS
+ * rule; Framer takes seconds as a plain number, so it cannot read them. Every
+ * animated component therefore re-typed the numbers, and they drifted: the auth
+ * screens alone carried 0.2, 0.22, 0.25, 0.35 and 0.4 second transitions, only
+ * two of which corresponded to a rung on the scale.
+ *
+ * Keep these in sync with the `--duration-*` and `--ease-*` blocks in
+ * `shared/components/src/styles/globals.css`. They are the same scale expressed
+ * twice because two runtimes need it, not a second source of truth.
+ */
+
+export const duration = {
+	instant: 0.08,
+	fast: 0.15,
+	base: 0.25,
+	slow: 0.4,
+	cinematic: 0.7
+} as const
+
+/**
+ * Gap between consecutive items in a staggered entrance.
+ *
+ * Not a `--duration-*` rung: this is the offset between two animations, not the
+ * length of one, so the scale has no name for it. Kept here anyway so a form
+ * does not pick its own.
+ */
+export const STAGGER_STEP = 0.05
+
+/** Cubic-bezier control points, matching the `--ease-*` tokens. */
+export const ease = {
+	out: [0.16, 1, 0.3, 1],
+	inOut: [0.4, 0, 0.2, 1],
+	spring: [0.34, 1.56, 0.64, 1]
+} as const satisfies Record<string, [number, number, number, number]>
+
+/**
+ * The entrance for an auth panel that animates in as a whole.
+ *
+ * Used by the confirmation gate and the forgot-password screen. Sign-in and
+ * sign-up stagger their fields with `authFieldEntrance` instead, and
+ * reset-password does not animate at all - so this is the shared shape for the
+ * screens that need it, not a claim that all five behave alike.
+ */
+export const authPanelEntrance = {
+	initial: { opacity: 0, y: 12 },
+	animate: { opacity: 1, y: 0 },
+	transition: { duration: duration.slow, ease: ease.out }
+} as const
+
+/** Staggered field entrance, `index` being the field's position in the form. */
+export function authFieldEntrance(index: number) {
+	return {
+		initial: { opacity: 0, y: 8 },
+		animate: { opacity: 1, y: 0 },
+		transition: {
+			duration: duration.base,
+			delay: index * STAGGER_STEP,
+			ease: ease.out
+		}
+	}
+}

--- a/apps/vectreal-platform/app/lib/observability/critical-flows.ts
+++ b/apps/vectreal-platform/app/lib/observability/critical-flows.ts
@@ -59,6 +59,22 @@ const API_PROJECT_KEYS = {
 }
 
 export const CRITICAL_FLOWS: CriticalFlow[] = [
+	/*
+	  Step zero. Everything below it assumes an account, and for a while creating
+	  one was reliably broken while this list said the funnel started at "save a
+	  scene" - the route reported nothing at all on the branch that was firing.
+	*/
+	{
+		id: 'create-account',
+		step: 'create an account',
+		module: 'app/lib/domain/auth/signup-failure.ts',
+		routes: [
+			{
+				file: './routes/signup-page/signup-page.tsx',
+				pattern: /^\/sign-up$/
+			}
+		]
+	},
 	{
 		id: 'save-scene',
 		step: 'save a scene',

--- a/apps/vectreal-platform/app/routes/confirm-pending.tsx
+++ b/apps/vectreal-platform/app/routes/confirm-pending.tsx
@@ -5,7 +5,7 @@
  * and provides a rate-limited "Resend confirmation" button.
  */
 import { Button } from '@shared/components/ui/button'
-import { AnimatePresence, motion, MotionConfig } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import { Loader2, Mail, RotateCcw } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import {
@@ -24,6 +24,12 @@ import { AuthErrorBoundary } from '../components/errors'
 import { clearReferralAttribution } from '../lib/domain/analytics/referral-attribution'
 import { ensureValidCsrfFormData } from '../lib/http/csrf.server'
 import { recordRateLimitAttempt } from '../lib/http/rate-limit.server'
+import {
+	authPanelEntrance,
+	duration,
+	ease,
+	STAGGER_STEP
+} from '../lib/motion/motion-tokens'
 import { reportServerError } from '../lib/observability/report-server-error.server'
 import { buildMeta } from '../lib/seo'
 import { createSupabaseClient } from '../lib/supabase.server'
@@ -155,8 +161,7 @@ const RESEND_COOLDOWN_SECONDS = 60
 export default function ConfirmPending() {
 	const { email, referrer, utm_source } = useLoaderData<typeof loader>()
 	const fetcher = useFetcher<ActionData>()
-	const { turnstileToken, resetTurnstile, hasTurnstile } =
-		useOutletContext<AuthLayoutContext>()
+	const { turnstileToken, hasTurnstile } = useOutletContext<AuthLayoutContext>()
 
 	const [cooldown, setCooldown] = useState(0)
 
@@ -169,12 +174,12 @@ export default function ConfirmPending() {
 	const sendError = fetcher.data?.error
 	const isRateLimited = fetcher.data?.rateLimited
 
-	// Start cooldown after a successful send; also reset Turnstile for next use
+	// Start cooldown after a successful send. The token the send spent was
+	// already invalidated at submit time by the layout, which owns it.
 	useEffect(() => {
 		if (!wasSent) return
 		setCooldown(RESEND_COOLDOWN_SECONDS)
-		resetTurnstile()
-	}, [wasSent, resetTurnstile])
+	}, [wasSent])
 
 	// Countdown tick
 	useEffect(() => {
@@ -187,171 +192,190 @@ export default function ConfirmPending() {
 	const turnstileReady = !hasTurnstile || !!turnstileToken
 	const canResend = !isSending && cooldown === 0 && turnstileReady
 
+	/*
+	  No background of its own. The layout's panel is already a raised surface on
+	  the elevation ladder, and painting the page background on top of it drew an
+	  opaque hard-edged box inside the panel - the thing that made this screen
+	  read as unfinished.
+	*/
 	return (
-		<MotionConfig reducedMotion="user">
-			<div className="bg-background flex flex-col items-center justify-center px-4">
+		<div className="flex flex-col items-center justify-center px-4">
+			<motion.div {...authPanelEntrance} className="w-full max-w-md">
+				{/* Icon */}
+				{/*
+						The brand tint goes through the channel form of the token. Applying
+						a slash-alpha to the hex-backed color instead compiles to a
+						`color-mix()` whose no-alpha fallback paints solid brand orange.
+					*/}
 				<motion.div
-					initial={{ opacity: 0, y: 16 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
-					className="w-full max-w-md"
+					className="mb-6 flex justify-center"
+					initial={{ scale: 0.92, opacity: 0 }}
+					animate={{ scale: 1, opacity: 1 }}
+					transition={{
+						delay: duration.instant,
+						duration: duration.slow,
+						ease: ease.out
+					}}
 				>
-					{/* Icon */}
-					<motion.div
-						className="mb-6 flex justify-center"
-						initial={{ scale: 0.8, opacity: 0 }}
-						animate={{ scale: 1, opacity: 1 }}
-						transition={{ delay: 0.1, duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
-					>
-						<div
-							className="flex h-16 w-16 items-center justify-center rounded-2xl"
-							style={{
-								background: 'rgb(var(--orange-rgb) / 0.1)',
-								border: '1px solid rgb(var(--orange-rgb) / 0.2)'
-							}}
-						>
-							<Mail className="h-7 w-7" style={{ color: 'var(--orange)' }} />
-						</div>
-					</motion.div>
-
-					{/* Heading */}
-					<motion.h1
-						className="mb-2 text-center text-2xl font-semibold"
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						transition={{ delay: 0.15 }}
-					>
-						Check your inbox
-					</motion.h1>
-
-					{/* Body */}
-					<motion.p
-						className="text-muted-foreground mb-8 text-center text-sm leading-relaxed"
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						transition={{ delay: 0.2 }}
-					>
-						We sent a confirmation link to{' '}
-						{email ? (
-							<span className="text-foreground font-medium">
-								{maskEmail(email)}
-							</span>
-						) : (
-							'your email address'
-						)}
-						. Click the link in the email to activate your account.
-					</motion.p>
-
-					{/* Resend form */}
-					<motion.div
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						transition={{ delay: 0.25 }}
-					>
-						<fetcher.Form method="post">
-							<AuthenticityTokenInput />
-							<input type="hidden" name="email" value={email} />
-							{referrer && (
-								<input type="hidden" name="referrer" value={referrer} />
-							)}
-							{utm_source && (
-								<input type="hidden" name="utm_source" value={utm_source} />
-							)}
-							{turnstileToken && (
-								<input
-									type="hidden"
-									name="cf-turnstile-response"
-									value={turnstileToken}
-								/>
-							)}
-							<Button
-								type="submit"
-								variant="outline"
-								className="w-full"
-								disabled={!canResend}
-							>
-								{isSending ? (
-									<>
-										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-										Sending…
-									</>
-								) : cooldown > 0 ? (
-									<>
-										<RotateCcw className="mr-2 h-4 w-4" />
-										Resend in {cooldown}s
-									</>
-								) : !turnstileReady ? (
-									<>
-										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-										Verifying…
-									</>
-								) : (
-									<>
-										<RotateCcw className="mr-2 h-4 w-4" />
-										Resend confirmation email
-									</>
-								)}
-							</Button>
-						</fetcher.Form>
-					</motion.div>
-
-					{/* Feedback messages */}
-					<AnimatePresence>
-						{wasSent && (
-							<motion.p
-								key="sent"
-								initial={{ opacity: 0, height: 0, marginTop: 0 }}
-								animate={{ opacity: 1, height: 'auto', marginTop: 12 }}
-								exit={{ opacity: 0, height: 0, marginTop: 0 }}
-								className="overflow-hidden text-center text-sm text-green-500"
-							>
-								Confirmation email sent - check your inbox.
-							</motion.p>
-						)}
-						{(sendError || isRateLimited) && (
-							<motion.p
-								key="error"
-								initial={{ opacity: 0, height: 0, marginTop: 0 }}
-								animate={{ opacity: 1, height: 'auto', marginTop: 12 }}
-								exit={{ opacity: 0, height: 0, marginTop: 0 }}
-								className="text-destructive overflow-hidden text-center text-sm"
-								role="alert"
-							>
-								{isRateLimited
-									? 'Too many requests. Please wait before trying again.'
-									: sendError}
-							</motion.p>
-						)}
-					</AnimatePresence>
-
-					{/* Footer links */}
-					<motion.div
-						className="text-muted-foreground mt-8 flex flex-col items-center gap-2 text-sm"
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						transition={{ delay: 0.3 }}
-					>
-						<span>
-							Wrong email?{' '}
-							<Link
-								to="/sign-up"
-								className="text-foreground underline-offset-2 hover:underline"
-							>
-								Start over
-							</Link>
-						</span>
-						<span>
-							Already confirmed?{' '}
-							<Link
-								to="/sign-in"
-								className="text-foreground underline-offset-2 hover:underline"
-							>
-								Sign in
-							</Link>
-						</span>
-					</motion.div>
+					<div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-[rgb(var(--orange-rgb)/0.2)] bg-[rgb(var(--orange-rgb)/0.1)]">
+						<Mail className="text-orange h-7 w-7" />
+					</div>
 				</motion.div>
-			</div>
-		</MotionConfig>
+
+				{/* Heading */}
+				<motion.h1
+					className="text-h3 mb-2 text-center"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					transition={{
+						delay: 2 * STAGGER_STEP,
+						duration: duration.base,
+						ease: ease.out
+					}}
+				>
+					Check your inbox
+				</motion.h1>
+
+				{/* Body */}
+				<motion.p
+					className="text-muted-foreground mb-8 text-center text-sm leading-relaxed"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					transition={{
+						delay: 3 * STAGGER_STEP,
+						duration: duration.base,
+						ease: ease.out
+					}}
+				>
+					We sent a confirmation link to{' '}
+					{email ? (
+						<span className="text-foreground font-medium">
+							{maskEmail(email)}
+						</span>
+					) : (
+						'your email address'
+					)}
+					. Click the link in the email to activate your account.
+				</motion.p>
+
+				{/* Resend form */}
+				<motion.div
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					transition={{
+						delay: 4 * STAGGER_STEP,
+						duration: duration.base,
+						ease: ease.out
+					}}
+				>
+					<fetcher.Form method="post">
+						<AuthenticityTokenInput />
+						<input type="hidden" name="email" value={email} />
+						{referrer && (
+							<input type="hidden" name="referrer" value={referrer} />
+						)}
+						{utm_source && (
+							<input type="hidden" name="utm_source" value={utm_source} />
+						)}
+						{turnstileToken && (
+							<input
+								type="hidden"
+								name="cf-turnstile-response"
+								value={turnstileToken}
+							/>
+						)}
+						<Button
+							type="submit"
+							variant="outline"
+							className="w-full"
+							disabled={!canResend}
+						>
+							{isSending ? (
+								<>
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									Sending…
+								</>
+							) : cooldown > 0 ? (
+								<>
+									<RotateCcw className="mr-2 h-4 w-4" />
+									Resend in {cooldown}s
+								</>
+							) : !turnstileReady ? (
+								<>
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									Verifying…
+								</>
+							) : (
+								<>
+									<RotateCcw className="mr-2 h-4 w-4" />
+									Resend confirmation email
+								</>
+							)}
+						</Button>
+					</fetcher.Form>
+				</motion.div>
+
+				{/* Feedback messages */}
+				<AnimatePresence>
+					{wasSent && (
+						<motion.p
+							key="sent"
+							initial={{ opacity: 0, height: 0, marginTop: 0 }}
+							animate={{ opacity: 1, height: 'auto', marginTop: 12 }}
+							exit={{ opacity: 0, height: 0, marginTop: 0 }}
+							className="text-success-foreground overflow-hidden text-center text-sm"
+							role="status"
+						>
+							Confirmation email sent - check your inbox.
+						</motion.p>
+					)}
+					{(sendError || isRateLimited) && (
+						<motion.p
+							key="error"
+							initial={{ opacity: 0, height: 0, marginTop: 0 }}
+							animate={{ opacity: 1, height: 'auto', marginTop: 12 }}
+							exit={{ opacity: 0, height: 0, marginTop: 0 }}
+							className="text-destructive overflow-hidden text-center text-sm"
+							role="alert"
+						>
+							{isRateLimited
+								? 'Too many requests. Please wait before trying again.'
+								: sendError}
+						</motion.p>
+					)}
+				</AnimatePresence>
+
+				{/* Footer links */}
+				<motion.div
+					className="text-muted-foreground mt-8 flex flex-col items-center gap-2 text-sm"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					transition={{
+						delay: 5 * STAGGER_STEP,
+						duration: duration.base,
+						ease: ease.out
+					}}
+				>
+					<span>
+						Wrong email?{' '}
+						<Link
+							to="/sign-up"
+							className="text-foreground underline-offset-2 hover:underline"
+						>
+							Start over
+						</Link>
+					</span>
+					<span>
+						Already confirmed?{' '}
+						<Link
+							to="/sign-in"
+							className="text-foreground underline-offset-2 hover:underline"
+						>
+							Sign in
+						</Link>
+					</span>
+				</motion.div>
+			</motion.div>
+		</div>
 	)
 }

--- a/apps/vectreal-platform/app/routes/forgot-password-page/forgot-password.tsx
+++ b/apps/vectreal-platform/app/routes/forgot-password-page/forgot-password.tsx
@@ -4,9 +4,10 @@
  * Sends a Supabase password-reset email via Resend (through the send-auth-email hook).
  * Always returns 200 regardless of whether the email is registered - prevents enumeration.
  */
+import { Alert, AlertDescription } from '@shared/components/ui/alert'
 import { Button } from '@shared/components/ui/button'
 import { Input } from '@shared/components/ui/input'
-import { AnimatePresence, motion, MotionConfig } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import { CheckCircle2, Loader2, Mail } from 'lucide-react'
 import { useId } from 'react'
 import {
@@ -22,6 +23,11 @@ import { Route } from './+types/forgot-password'
 import { AuthErrorBoundary } from '../../components/errors'
 import { ensureValidCsrfFormData } from '../../lib/http/csrf.server'
 import { recordRateLimitAttempt } from '../../lib/http/rate-limit.server'
+import {
+	authPanelEntrance,
+	duration,
+	ease
+} from '../../lib/motion/motion-tokens'
 import { buildMeta } from '../../lib/seo'
 import { createSupabaseClient } from '../../lib/supabase.server'
 
@@ -98,10 +104,6 @@ export async function action({ request }: Route.ActionArgs) {
 	return data<ActionData>({ ok: true }, { headers })
 }
 
-// ─── Motion config ────────────────────────────────────────────────────────────
-
-const ease = [0.16, 1, 0.3, 1] as [number, number, number, number]
-
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export default function ForgotPassword() {
@@ -114,126 +116,116 @@ export default function ForgotPassword() {
 	const isRateLimited = fetcher.data?.rateLimited
 
 	return (
-		<MotionConfig reducedMotion="user">
-			<div className="w-full max-w-md">
-				<motion.div
-					initial={{ opacity: 0, y: 8 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.3, ease }}
-				>
-					<h1 className="mb-2 text-2xl font-semibold">Forgot your password?</h1>
-					<p className="text-muted-foreground mb-8 text-sm leading-relaxed">
-						Enter your account email and we'll send you a reset link.
-					</p>
-				</motion.div>
+		<div className="w-full max-w-md">
+			<motion.div {...authPanelEntrance}>
+				<h1 className="text-h3 mb-2">Forgot your password?</h1>
+				<p className="text-muted-foreground mb-8 text-sm leading-relaxed">
+					Enter your account email and we'll send you a reset link.
+				</p>
+			</motion.div>
 
-				<AnimatePresence mode="wait">
-					{wasSubmitted ? (
-						/* Success state */
-						<motion.div
-							key="success"
-							initial={{ opacity: 0, scale: 0.97 }}
-							animate={{ opacity: 1, scale: 1 }}
-							transition={{ duration: 0.3, ease }}
-							className="flex flex-col items-center gap-4 py-8 text-center"
+			<AnimatePresence mode="wait">
+				{wasSubmitted ? (
+					/* Success state */
+					<motion.div
+						key="success"
+						initial={{ opacity: 0, scale: 0.97 }}
+						animate={{ opacity: 1, scale: 1 }}
+						transition={{ duration: duration.base, ease: ease.out }}
+						className="flex flex-col items-center gap-4 py-8 text-center"
+					>
+						<div className="border-success/25 bg-success/10 flex h-14 w-14 items-center justify-center rounded-2xl border">
+							<CheckCircle2 className="text-success h-6 w-6" />
+						</div>
+						<div>
+							<p className="mb-1 font-medium">Check your inbox</p>
+							<p className="text-muted-foreground text-sm">
+								If that address is registered, a reset link is on its way.
+							</p>
+						</div>
+						<Link
+							to="/sign-in"
+							className="text-muted-foreground mt-2 text-sm underline-offset-2 hover:underline"
 						>
-							<div
-								className="flex h-14 w-14 items-center justify-center rounded-2xl"
-								style={{
-									background: 'rgba(34,197,94,0.1)',
-									border: '1px solid rgba(34,197,94,0.25)'
-								}}
+							Back to sign in
+						</Link>
+					</motion.div>
+				) : (
+					/* Form state */
+					<motion.div key="form" exit={{ opacity: 0 }}>
+						<fetcher.Form method="post">
+							<AuthenticityTokenInput />
+
+							{/* Form-level error */}
+							<AnimatePresence>
+								{(formError || isRateLimited) && (
+									<motion.div
+										key="error"
+										initial={{ opacity: 0, height: 0, marginBottom: 0 }}
+										animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
+										exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+										className="overflow-hidden"
+									>
+										<Alert variant="destructive" aria-live="assertive">
+											<AlertDescription>
+												{isRateLimited
+													? 'Too many requests. Please wait before trying again.'
+													: formError}
+											</AlertDescription>
+										</Alert>
+									</motion.div>
+								)}
+							</AnimatePresence>
+
+							<div className="mb-6">
+								<label
+									className="mb-2 block text-sm font-medium"
+									htmlFor={emailId}
+								>
+									Email
+								</label>
+								<div className="relative">
+									<Input
+										id={emailId}
+										name="email"
+										type="email"
+										autoComplete="email"
+										placeholder="jane@example.com"
+										required
+										className="pr-10"
+									/>
+									<Mail className="text-muted-foreground absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2" />
+								</div>
+							</div>
+
+							<Button
+								type="submit"
+								className="w-full font-semibold"
+								disabled={isSending}
 							>
-								<CheckCircle2 className="h-6 w-6 text-green-500" />
-							</div>
-							<div>
-								<p className="mb-1 font-medium">Check your inbox</p>
-								<p className="text-muted-foreground text-sm">
-									If that address is registered, a reset link is on its way.
-								</p>
-							</div>
+								{isSending ? (
+									<>
+										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+										Sending…
+									</>
+								) : (
+									'Send reset link'
+								)}
+							</Button>
+						</fetcher.Form>
+
+						<p className="text-muted-foreground mt-6 text-center text-sm">
+							Remember your password?{' '}
 							<Link
 								to="/sign-in"
-								className="text-muted-foreground mt-2 text-sm underline-offset-2 hover:underline"
+								className="text-foreground underline-offset-2 hover:underline"
 							>
-								Back to sign in
+								Sign in
 							</Link>
-						</motion.div>
-					) : (
-						/* Form state */
-						<motion.div key="form" exit={{ opacity: 0 }}>
-							<fetcher.Form method="post">
-								<AuthenticityTokenInput />
-
-								{/* Form-level error */}
-								<AnimatePresence>
-									{(formError || isRateLimited) && (
-										<motion.div
-											key="error"
-											initial={{ opacity: 0, height: 0, marginBottom: 0 }}
-											animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
-											exit={{ opacity: 0, height: 0, marginBottom: 0 }}
-											className="border-destructive/50 bg-destructive/10 text-destructive overflow-hidden rounded-lg border p-4 text-sm"
-											role="alert"
-											aria-live="assertive"
-										>
-											{isRateLimited
-												? 'Too many requests. Please wait before trying again.'
-												: formError}
-										</motion.div>
-									)}
-								</AnimatePresence>
-
-								<div className="mb-6">
-									<label
-										className="mb-2 block text-sm font-medium"
-										htmlFor={emailId}
-									>
-										Email
-									</label>
-									<div className="relative">
-										<Input
-											id={emailId}
-											name="email"
-											type="email"
-											autoComplete="email"
-											placeholder="jane@example.com"
-											required
-											className="pr-10"
-										/>
-										<Mail className="text-muted-foreground absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2" />
-									</div>
-								</div>
-
-								<Button
-									type="submit"
-									className="w-full font-semibold"
-									disabled={isSending}
-								>
-									{isSending ? (
-										<>
-											<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-											Sending…
-										</>
-									) : (
-										'Send reset link'
-									)}
-								</Button>
-							</fetcher.Form>
-
-							<p className="text-muted-foreground mt-6 text-center text-sm">
-								Remember your password?{' '}
-								<Link
-									to="/sign-in"
-									className="text-foreground underline-offset-2 hover:underline"
-								>
-									Sign in
-								</Link>
-							</p>
-						</motion.div>
-					)}
-				</AnimatePresence>
-			</div>
-		</MotionConfig>
+						</p>
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</div>
 	)
 }

--- a/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/signin-layout.tsx
@@ -2,10 +2,18 @@ import { GithubLogo } from '@shared/components/assets/icons/github-logo'
 import GoogleLogo from '@shared/components/assets/icons/google-logo'
 import { Button } from '@shared/components/ui/button'
 import { Separator } from '@shared/components/ui/separator'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion, MotionConfig } from 'framer-motion'
 import { Loader2 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Link, Outlet, useLocation, useNavigate, useSubmit } from 'react-router'
+import {
+	Link,
+	Outlet,
+	useFetchers,
+	useLocation,
+	useNavigate,
+	useNavigation,
+	useSubmit
+} from 'react-router'
 import { useAuthenticityToken } from 'remix-utils/csrf/react'
 
 import { Route } from './+types/signin-layout'
@@ -13,15 +21,22 @@ import { useConsent } from '../../components/consent/consent-context'
 import { AuthErrorBoundary } from '../../components/errors'
 import HeroScene from '../../components/home/hero-scene'
 import { TurnstileWidget } from '../../components/turnstile-widget'
+import { useSpendTurnstileToken } from '../../hooks/use-spend-turnstile-token'
 import {
 	clearReferralAttribution,
 	getReferralAttribution,
 	saveReferralAttribution
 } from '../../lib/domain/analytics/referral-attribution'
+import { duration, ease } from '../../lib/motion/motion-tokens'
 
+/**
+ * No `resetTurnstile`. Invalidating a token is the layout's job, because the
+ * layout is what owns it - see `useSpendTurnstileToken`. Handing children a
+ * reset is what let each of them invalidate on their own response shape, and a
+ * redirecting action has no response to observe.
+ */
 export interface AuthLayoutContext {
 	turnstileToken: string | null
-	resetTurnstile: () => void
 	hasTurnstile: boolean
 }
 
@@ -35,7 +50,12 @@ const SignupModel = () => {
 	return (
 		<div className="relative flex h-full w-full items-center justify-center md:block">
 			<HeroScene vertical />
-			<div className="absolute right-0 bottom-0 z-10 max-w-1/2 px-8 pb-8">
+			{/*
+				A half-width cap wrapped the tagline to three lines at narrower desktop
+				widths, and the third sat below the visible area of the column. Two
+				thirds keeps it to two.
+			*/}
+			<div className="absolute right-0 bottom-0 z-10 max-w-2/3 px-8 pb-10">
 				<p className="text-primary/75! text-right text-xl! font-extralight!">
 					Join our community and start creating amazing{' '}
 					<strong className="text-primary">
@@ -56,7 +76,33 @@ const SigninLayout = ({ loaderData }: Route.ComponentProps) => {
 	const nextPath =
 		new URLSearchParams(location.search).get('next') || '/dashboard'
 
-	const isSignUp = location.pathname.endsWith('/sign-up')
+	/*
+	  Five routes sit under this layout and only two of them ask the visitor to
+	  choose a credential. The other three - the post-signup confirmation gate
+	  and the two password screens - used to inherit the whole apparatus anyway:
+	  a heading reading "Sign In", the Google and GitHub buttons, the "or"
+	  separator, a switch offering to sign up to someone who just did, and a
+	  second copy of the legal footer beneath their own. So the confirmation
+	  screen, which is on the account-creation funnel, read as broken.
+
+	  Naming the three cases rather than adding a second boolean beside
+	  `isSignUp`, because the question the chrome asks is not "is this sign-up"
+	  but "is this a credential choice at all".
+
+	  The pathname is normalized first, because React Router matches a route more
+	  loosely than `endsWith` does: it compiles the path with a trailing `\/*$`
+	  and matches case-insensitively, so `/sign-up/` and `/SIGN-UP` both render
+	  the sign-up page. Comparing the raw pathname would classify those as
+	  `other` and serve the sign-up form with no Google or GitHub button on it.
+	*/
+	const normalizedPath = location.pathname.toLowerCase().replace(/\/+$/, '')
+	const authScreen = normalizedPath.endsWith('/sign-up')
+		? 'sign-up'
+		: normalizedPath.endsWith('/sign-in')
+			? 'sign-in'
+			: 'other'
+	const isSignUp = authScreen === 'sign-up'
+	const isCredentialChoice = authScreen !== 'other'
 
 	const { consent } = useConsent()
 
@@ -86,6 +132,24 @@ const SigninLayout = ({ loaderData }: Route.ComponentProps) => {
 		setTurnstileToken(null)
 		setTurnstileResetNonce((n) => n + 1)
 	}, [])
+
+	/*
+	  A Turnstile token is single-use, so it dies when it is submitted rather than
+	  when the server answers.
+
+	  Both watchers are needed. `useNavigation()` covers the sign-in and sign-up
+	  forms; `useFetchers()` covers the "Resend confirmation email" fetcher on
+	  `/auth/confirm-pending`, which is the submission the reported bug was
+	  actually replaying a spent token on. Dropping either one fails no test and
+	  no type check - it just silently stops invalidating that half.
+	*/
+	const navigation = useNavigation()
+	const fetchers = useFetchers()
+	useSpendTurnstileToken({
+		submissions: [navigation, ...fetchers],
+		token: turnstileToken,
+		onSpend: resetTurnstile
+	})
 
 	function submitSocialLogin(
 		provider: 'google' | 'github',
@@ -163,156 +227,190 @@ const SigninLayout = ({ loaderData }: Route.ComponentProps) => {
 	}
 
 	return (
-		<main className="h-full min-h-dvh w-full overflow-hidden">
-			<section className="flex min-h-dvh w-full flex-col overflow-hidden">
-				<div className="grid grow overflow-hidden md:grid-cols-[1fr_1fr]">
-					<div className="ds-raised relative flex flex-col justify-center p-8 shadow-2xl">
-						<div className="mx-auto flex max-w-md flex-col gap-8 py-16">
-							<div className="flex grow flex-col justify-end">
-								<h1 className="mb-6 text-2xl leading-tight font-medium sm:text-3xl md:text-4xl lg:text-5xl">
-									{isSignUp ? 'Sign Up' : 'Sign In'}
-								</h1>
-							</div>
-
-							<div className="flex w-full flex-col gap-4 md:flex-row">
-								<Button
-									className="grow"
-									onClick={() => handleSocialLogin('google')}
-									disabled={loadingProvider !== null}
-									style={{
-										opacity: loadingProvider === 'github' ? 0.45 : 1,
-										transition: 'opacity 0.2s ease'
-									}}
-								>
-									<span className="relative flex items-center justify-center gap-2">
-										{/* Idle label - defines the button width */}
-										<span
-											className="flex items-center gap-2 transition-opacity duration-150"
-											style={{ opacity: loadingProvider === 'google' ? 0 : 1 }}
-										>
-											<GoogleLogo className="h-4 w-4" /> Continue with Google
-										</span>
-										{/* Loading overlay - absolutely positioned, same space */}
-										<span
-											className="absolute inset-0 flex items-center justify-center gap-2 transition-opacity duration-150"
-											style={{ opacity: loadingProvider === 'google' ? 1 : 0 }}
-											aria-hidden={loadingProvider !== 'google'}
-										>
-											<Loader2 className="h-4 w-4 animate-spin" />
-											Connecting…
-										</span>
-									</span>
-								</Button>
-								<Button
-									className="grow"
-									onClick={() => handleSocialLogin('github')}
-									disabled={loadingProvider !== null}
-									style={{
-										opacity: loadingProvider === 'google' ? 0.45 : 1,
-										transition: 'opacity 0.2s ease'
-									}}
-								>
-									<span className="relative flex items-center justify-center gap-2">
-										<span
-											className="flex items-center gap-2 transition-opacity duration-150"
-											style={{ opacity: loadingProvider === 'github' ? 0 : 1 }}
-										>
-											<GithubLogo className="h-4 w-4" /> Continue with GitHub
-										</span>
-										<span
-											className="absolute inset-0 flex items-center justify-center gap-2 transition-opacity duration-150"
-											style={{ opacity: loadingProvider === 'github' ? 1 : 0 }}
-											aria-hidden={loadingProvider !== 'github'}
-										>
-											<Loader2 className="h-4 w-4 animate-spin" />
-											Connecting…
-										</span>
-									</span>
-								</Button>
-							</div>
-							<AnimatePresence>
-								{loadingProvider && (
-									<motion.p
-										initial={{ opacity: 0, y: -6 }}
-										animate={{ opacity: 1, y: 0 }}
-										exit={{ opacity: 0, y: -6 }}
-										transition={{ duration: 0.2, ease: 'easeOut' }}
-										className="text-muted-foreground -mt-4 text-center text-sm"
-									>
-										Redirecting to{' '}
-										{loadingProvider === 'google' ? 'Google' : 'GitHub'}…
-									</motion.p>
+		/*
+		  The reduced-motion guard lives here rather than in each child, because
+		  `MotionConfig` is React context: a child route's provider cannot reach the
+		  layout's own animated chrome above it, which is what left the
+		  "Redirecting to…" line moving for people who asked it not to.
+		*/
+		<MotionConfig reducedMotion="user">
+			<main className="h-full min-h-dvh w-full overflow-hidden">
+				<section className="flex min-h-dvh w-full flex-col overflow-hidden">
+					<div className="grid grow overflow-hidden md:grid-cols-[1fr_1fr]">
+						<div className="ds-raised relative flex flex-col justify-center p-8 shadow-2xl">
+							<div className="mx-auto flex max-w-md flex-col gap-8 py-16">
+								{isCredentialChoice && (
+									<div className="flex grow flex-col justify-end">
+										<h1 className="text-h2 mb-6">
+											{isSignUp ? 'Sign Up' : 'Sign In'}
+										</h1>
+									</div>
 								)}
-							</AnimatePresence>
-							<span className="relative">
-								<Separator />
-								{/*
+
+								{isCredentialChoice && (
+									<>
+										<div className="flex w-full flex-col gap-4 md:flex-row">
+											<Button
+												className="grow"
+												onClick={() => handleSocialLogin('google')}
+												disabled={loadingProvider !== null}
+												style={{
+													opacity: loadingProvider === 'github' ? 0.45 : 1,
+													transition: `opacity var(--duration-base) var(--ease-out)`
+												}}
+											>
+												<span className="relative flex items-center justify-center gap-2">
+													{/* Idle label - defines the button width */}
+													<span
+														className="flex items-center gap-2 transition-opacity duration-150"
+														style={{
+															opacity: loadingProvider === 'google' ? 0 : 1
+														}}
+													>
+														<GoogleLogo className="h-4 w-4" /> Continue with
+														Google
+													</span>
+													{/* Loading overlay - absolutely positioned, same space */}
+													<span
+														className="absolute inset-0 flex items-center justify-center gap-2 transition-opacity duration-150"
+														style={{
+															opacity: loadingProvider === 'google' ? 1 : 0
+														}}
+														aria-hidden={loadingProvider !== 'google'}
+													>
+														<Loader2 className="h-4 w-4 animate-spin" />
+														Connecting…
+													</span>
+												</span>
+											</Button>
+											<Button
+												className="grow"
+												onClick={() => handleSocialLogin('github')}
+												disabled={loadingProvider !== null}
+												style={{
+													opacity: loadingProvider === 'google' ? 0.45 : 1,
+													transition: `opacity var(--duration-base) var(--ease-out)`
+												}}
+											>
+												<span className="relative flex items-center justify-center gap-2">
+													<span
+														className="flex items-center gap-2 transition-opacity duration-150"
+														style={{
+															opacity: loadingProvider === 'github' ? 0 : 1
+														}}
+													>
+														<GithubLogo className="h-4 w-4" /> Continue with
+														GitHub
+													</span>
+													<span
+														className="absolute inset-0 flex items-center justify-center gap-2 transition-opacity duration-150"
+														style={{
+															opacity: loadingProvider === 'github' ? 1 : 0
+														}}
+														aria-hidden={loadingProvider !== 'github'}
+													>
+														<Loader2 className="h-4 w-4 animate-spin" />
+														Connecting…
+													</span>
+												</span>
+											</Button>
+										</div>
+										<AnimatePresence>
+											{loadingProvider && (
+												<motion.p
+													initial={{ opacity: 0, y: -6 }}
+													animate={{ opacity: 1, y: 0 }}
+													exit={{ opacity: 0, y: -6 }}
+													transition={{
+														duration: duration.fast,
+														ease: ease.out
+													}}
+													className="text-muted-foreground -mt-4 text-center text-sm"
+												>
+													Redirecting to{' '}
+													{loadingProvider === 'google' ? 'Google' : 'GitHub'}…
+												</motion.p>
+											)}
+										</AnimatePresence>
+										<span className="relative">
+											<Separator />
+											{/*
 									Paint the chip with the panel's base raised surface (4% mix)
 									so it masks the separator seamlessly. Not `ds-raised`: nested
 									inside the ds-raised panel it steps up to 8% (see
 									`.ds-raised .ds-raised` in globals.css) and reads as a darker
 									box, most visibly in light mode.
 								*/}
-								<p className="text-muted-foreground absolute left-1/2 -translate-x-1/2 -translate-y-3 bg-[color-mix(in_oklch,var(--foreground)_4%,var(--background))] px-2">
-									or
-								</p>
-							</span>
+											<p className="text-muted-foreground absolute left-1/2 -translate-x-1/2 -translate-y-3 bg-[color-mix(in_oklch,var(--foreground)_4%,var(--background))] px-2">
+												or
+											</p>
+										</span>
+									</>
+								)}
 
-							<Outlet
-								context={
-									{
-										turnstileToken,
-										resetTurnstile,
-										hasTurnstile: !!loaderData.turnstileSiteKey
-									} satisfies AuthLayoutContext
-								}
-							/>
-							{loaderData.turnstileSiteKey && (
-								<TurnstileWidget
-									siteKey={loaderData.turnstileSiteKey}
-									onSuccess={handleTurnstileSuccess}
-									onError={handleTurnstileError}
-									resetNonce={turnstileResetNonce}
+								<Outlet
+									context={
+										{
+											turnstileToken,
+											hasTurnstile: !!loaderData.turnstileSiteKey
+										} satisfies AuthLayoutContext
+									}
 								/>
-							)}
-							<div className="mt-4 flex grow flex-col items-center justify-between">
-								<button
-									type="button"
-									className="text-muted-foreground text-sm transition-colors hover:underline"
-									onClick={handleSwitch}
-								>
-									{isSignUp
-										? 'Already have an account? Sign in'
-										: "Don't have an account? Sign up"}
-								</button>
-								<p className="text-muted-foreground mt-2 max-w-xs text-center text-xs">
-									By continuing, you agree to our{' '}
-									<Link
-										viewTransition
-										to="/privacy-policy"
-										className="hover:text-primary underline"
-									>
-										Privacy Policy
-									</Link>{' '}
-									and{' '}
-									<Link
-										viewTransition
-										to="/terms-of-service"
-										className="hover:text-primary underline"
-									>
-										Terms of Service
-									</Link>
-									.
-								</p>
+								{loaderData.turnstileSiteKey && (
+									<TurnstileWidget
+										siteKey={loaderData.turnstileSiteKey}
+										onSuccess={handleTurnstileSuccess}
+										onError={handleTurnstileError}
+										resetNonce={turnstileResetNonce}
+									/>
+								)}
+								{/*
+								Both belong to the credential choice. The switch offers to sign
+								up to someone who has just signed up, and the sign-up form
+								carries its own Terms checkbox, so on the confirmation screen
+								this was a second consent notice for a decision already made.
+							*/}
+								{isCredentialChoice && (
+									<div className="mt-4 flex grow flex-col items-center justify-between">
+										<button
+											type="button"
+											className="text-muted-foreground text-sm transition-colors hover:underline"
+											onClick={handleSwitch}
+										>
+											{isSignUp
+												? 'Already have an account? Sign in'
+												: "Don't have an account? Sign up"}
+										</button>
+										<p className="text-muted-foreground mt-2 max-w-xs text-center text-xs">
+											By continuing, you agree to our{' '}
+											<Link
+												viewTransition
+												to="/privacy-policy"
+												className="hover:text-primary underline"
+											>
+												Privacy Policy
+											</Link>{' '}
+											and{' '}
+											<Link
+												viewTransition
+												to="/terms-of-service"
+												className="hover:text-primary underline"
+											>
+												Terms of Service
+											</Link>
+											.
+										</p>
+									</div>
+								)}
 							</div>
 						</div>
+						<div className="bg-muted/50 hidden items-center justify-center md:flex">
+							<SignupModel />
+						</div>
 					</div>
-					<div className="bg-muted/50 hidden items-center justify-center md:flex">
-						<SignupModel />
-					</div>
-				</div>
-			</section>
-		</main>
+				</section>
+			</main>
+		</MotionConfig>
 	)
 }
 

--- a/apps/vectreal-platform/app/routes/reset-password-page/reset-password.tsx
+++ b/apps/vectreal-platform/app/routes/reset-password-page/reset-password.tsx
@@ -1,3 +1,4 @@
+import { Alert, AlertDescription } from '@shared/components/ui/alert'
 import { Button } from '@shared/components/ui/button'
 import { Input } from '@shared/components/ui/input'
 import { data, redirect, useNavigation, type MetaFunction } from 'react-router'
@@ -93,7 +94,7 @@ export default function ResetPasswordPage({
 
 	return (
 		<div className="w-full max-w-md">
-			<h1 className="mb-2 text-2xl font-semibold">Set a new password</h1>
+			<h1 className="text-h3 mb-2">Set a new password</h1>
 			<p className="text-muted-foreground mb-8 text-sm leading-relaxed">
 				Choose a new password for your account.
 			</p>
@@ -102,13 +103,9 @@ export default function ResetPasswordPage({
 				<AuthenticityTokenInput />
 
 				{formError && (
-					<div
-						className="border-destructive/50 bg-destructive/10 text-destructive rounded-lg border p-4 text-sm"
-						role="alert"
-						aria-live="assertive"
-					>
-						{formError}
-					</div>
+					<Alert variant="destructive" aria-live="assertive">
+						<AlertDescription>{formError}</AlertDescription>
+					</Alert>
 				)}
 
 				<div>

--- a/apps/vectreal-platform/app/routes/signin-page/signin-page.tsx
+++ b/apps/vectreal-platform/app/routes/signin-page/signin-page.tsx
@@ -1,3 +1,8 @@
+import {
+	Alert,
+	AlertDescription,
+	AlertTitle
+} from '@shared/components/ui/alert'
 import { Button } from '@shared/components/ui/button'
 import { Input } from '@shared/components/ui/input'
 import {
@@ -8,7 +13,7 @@ import {
 } from '@shared/components/ui/tooltip'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import { Eye, EyeClosed, ExternalLink, Save } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
 	data,
 	Form,
@@ -24,6 +29,7 @@ import { Route } from './+types/signin-page'
 import { captureServerEvent } from '../../lib/domain/analytics/server-events.server'
 import { ensureValidCsrfFormData } from '../../lib/http/csrf.server'
 import { recordRateLimitAttempt } from '../../lib/http/rate-limit.server'
+import { duration, ease, STAGGER_STEP } from '../../lib/motion/motion-tokens'
 import { reportServerError } from '../../lib/observability/report-server-error.server'
 import { buildMeta } from '../../lib/seo'
 import { createSupabaseClient } from '../../lib/supabase.server'
@@ -277,13 +283,7 @@ const SigninPage = ({ actionData, loaderData }: Route.ComponentProps) => {
 	const formError =
 		typedActionData?.formError ?? loaderData?.authErrorMessage ?? null
 
-	const { turnstileToken, resetTurnstile, hasTurnstile } =
-		useOutletContext<AuthLayoutContext>()
-
-	useEffect(() => {
-		if (!typedActionData) return
-		resetTurnstile()
-	}, [typedActionData, resetTurnstile])
+	const { turnstileToken, hasTurnstile } = useOutletContext<AuthLayoutContext>()
 
 	const isSubmitting = navigation.state === 'submitting'
 
@@ -292,7 +292,11 @@ const SigninPage = ({ actionData, loaderData }: Route.ComponentProps) => {
 		visible: (i: number) => ({
 			opacity: 1,
 			y: 0,
-			transition: { delay: i * 0.06, duration: 0.22, ease: 'easeOut' }
+			transition: {
+				delay: i * STAGGER_STEP,
+				duration: duration.base,
+				ease: ease.out
+			}
 		})
 	}
 
@@ -306,40 +310,40 @@ const SigninPage = ({ actionData, loaderData }: Route.ComponentProps) => {
 						initial={{ opacity: 0, y: -6 }}
 						animate={{ opacity: 1, y: 0 }}
 						exit={{ opacity: 0, y: -6 }}
-						transition={{ duration: 0.2 }}
-						className="border-error-border bg-error-bg text-error-foreground mb-6 rounded-lg border p-4 text-sm"
+						transition={{ duration: duration.fast, ease: ease.out }}
+						className="mb-6"
 					>
-						{formError}
+						<Alert variant="destructive" aria-live="assertive">
+							<AlertDescription>{formError}</AlertDescription>
+						</Alert>
 					</motion.div>
 				)}
 			</AnimatePresence>
 
 			{loaderData?.sceneSaved && (
-				<div className="border-success/50 bg-success/25 text-success-foreground/80 mb-6 space-y-2 rounded-lg border p-4 text-sm">
-					<span className="flex gap-2">
-						<Save className="h-4 w-4 text-inherit" aria-hidden="true" />
-						<p className="font-medium! text-inherit!">
-							Scene Saved Temporarily!
+				<Alert variant="success" role="status" className="mb-6">
+					<Save aria-hidden="true" />
+					<AlertTitle>Scene saved temporarily</AlertTitle>
+					<AlertDescription>
+						<p>
+							Your scene configuration has been saved. Sign up with Google or
+							GitHub to convert to a permanent account and access your scene.
 						</p>
-					</span>
-					<p className="text-success-foreground/60!">
-						Your scene configuration has been saved. Sign up with Google or
-						GitHub to convert to a permanent account and access your scene.
-					</p>
-					{loaderData.nextPath && (
-						<Button
-							asChild
-							size="sm"
-							variant="outline"
-							className="border-success/50 text-success-foreground/80 hover:bg-success/20 hover:text-success-foreground mt-1 w-full"
-						>
-							<Link to={loaderData.nextPath}>
-								<ExternalLink className="mr-1 h-3 w-3" />
-								Open Publisher to restore draft
-							</Link>
-						</Button>
-					)}
-				</div>
+						{loaderData.nextPath && (
+							<Button
+								asChild
+								size="sm"
+								variant="outline"
+								className="mt-2 w-full"
+							>
+								<Link to={loaderData.nextPath}>
+									<ExternalLink className="mr-1 h-3 w-3" />
+									Open Publisher to restore draft
+								</Link>
+							</Button>
+						)}
+					</AlertDescription>
+				</Alert>
 			)}
 
 			<Form className="w-full" method="post" action="/sign-in">

--- a/apps/vectreal-platform/app/routes/signup-page/signup-page.tsx
+++ b/apps/vectreal-platform/app/routes/signup-page/signup-page.tsx
@@ -1,7 +1,13 @@
+import {
+	Alert,
+	AlertDescription,
+	AlertTitle
+} from '@shared/components/ui/alert'
 import { Button } from '@shared/components/ui/button'
 import { Checkbox } from '@shared/components/ui/checkbox'
 import { Input } from '@shared/components/ui/input'
-import { AnimatePresence, motion, MotionConfig } from 'framer-motion'
+import { cn } from '@shared/utils'
+import { AnimatePresence, motion } from 'framer-motion'
 import {
 	Eye,
 	EyeClosed,
@@ -26,8 +32,18 @@ import { Route } from './+types/signup-page'
 import { AuthErrorBoundary } from '../../components/errors'
 import { getReferralAttribution } from '../../lib/domain/analytics/referral-attribution'
 import { captureServerEvent } from '../../lib/domain/analytics/server-events.server'
+import { classifySignupFailure } from '../../lib/domain/auth/signup-failure'
+import {
+	validateSignup,
+	type SignupFieldErrors
+} from '../../lib/domain/auth/signup-validation'
 import { ensureValidCsrfFormData } from '../../lib/http/csrf.server'
 import { recordRateLimitAttempt } from '../../lib/http/rate-limit.server'
+import {
+	authFieldEntrance,
+	duration,
+	ease
+} from '../../lib/motion/motion-tokens'
 import { reportServerError } from '../../lib/observability/report-server-error.server'
 import { buildMeta } from '../../lib/seo'
 import { createSupabaseClient } from '../../lib/supabase.server'
@@ -55,9 +71,8 @@ export const meta: MetaFunction = () =>
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface SignupActionData {
-	errors?: Record<string, string>
+	errors?: SignupFieldErrors
 	formError?: string
-	errorCode?: 'rate_limited' | 'signup_failed' | 'unknown'
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -67,48 +82,6 @@ const getSafeNext = (request: Request) => {
 	const next = url.searchParams.get('next')
 	if (!next || !next.startsWith('/')) return '/dashboard'
 	return next
-}
-
-// ─── Validation ───────────────────────────────────────────────────────────────
-
-function validateSignup(formData: FormData) {
-	const errors: Record<string, string> = {}
-
-	const name = formData.get('name')
-	const email = formData.get('email')
-	const password = formData.get('password')
-	const confirmPassword = formData.get('confirm_password')
-	const tosAccepted = formData.get('tos_accepted')
-
-	if (!name || typeof name !== 'string' || name.trim().length < 2) {
-		errors.name = 'Please enter your name (at least 2 characters).'
-	}
-	if (!email || typeof email !== 'string' || !email.includes('@')) {
-		errors.email = 'Please enter a valid email address.'
-	}
-	if (!password || typeof password !== 'string' || password.length < 8) {
-		errors.password = 'Password must be at least 8 characters long.'
-	}
-	if (
-		!confirmPassword ||
-		typeof confirmPassword !== 'string' ||
-		confirmPassword !== password
-	) {
-		errors.confirmPassword = 'Passwords do not match.'
-	}
-	if (!tosAccepted || tosAccepted !== 'on') {
-		errors.tos =
-			'You must accept the Terms of Service and Privacy Policy to create an account.'
-	}
-
-	return {
-		errors,
-		data: {
-			name: typeof name === 'string' ? name.trim() : '',
-			email: typeof email === 'string' ? email : '',
-			password: typeof password === 'string' ? password : ''
-		}
-	}
 }
 
 // ─── Action ───────────────────────────────────────────────────────────────────
@@ -136,10 +109,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
 	if (rateLimitResult.limited) {
 		return data<SignupActionData>(
-			{
-				formError: 'Too many sign-up attempts. Please try again shortly.',
-				errorCode: 'rate_limited'
-			},
+			{ formError: 'Too many sign-up attempts. Please try again shortly.' },
 			{
 				status: 429,
 				headers: { 'Retry-After': String(rateLimitResult.retryAfterSeconds) }
@@ -179,7 +149,14 @@ export async function action({ request, context }: Route.ActionArgs) {
 			email: normalizedEmail,
 			password,
 			options: {
-				data: { name, tos_accepted_at: tosAcceptedAt },
+				/*
+				  Omitted rather than sent as an empty string, now that the field is
+				  optional. Readers of this metadata are split between `||` and `??`
+				  - `onboarding-page` uses `??` to fall back to the email's local
+				  part - and `''` is not nullish, so storing it would silently kill
+				  every `??` fallback written for exactly this case.
+				*/
+				data: { ...(name && { name }), tos_accepted_at: tosAcceptedAt },
 				captchaToken,
 				emailRedirectTo: confirmUrl.toString()
 			}
@@ -187,13 +164,16 @@ export async function action({ request, context }: Route.ActionArgs) {
 		signupData = response.data
 		signupError = response.error
 	} catch (err) {
-		reportServerError(err, { request })
+		// A thrown signUp is a transport or client failure, not a GoTrue verdict,
+		// so there is no message to classify - only the generic fallback.
+		const failure = classifySignupFailure('')
+		reportServerError(err, {
+			request,
+			properties: { signup_failure_code: failure.code }
+		})
 		return data<SignupActionData>(
-			{
-				formError: 'Unable to create your account right now. Please try again.',
-				errorCode: 'unknown'
-			},
-			{ status: 500, headers }
+			{ formError: failure.message },
+			{ status: failure.status, headers }
 		)
 	}
 
@@ -226,36 +206,41 @@ export async function action({ request, context }: Route.ActionArgs) {
 	}
 
 	if (signupError) {
-		const message = signupError.message.toLowerCase()
-		const captchaFailed =
-			message.includes('captcha') || message.includes('turnstile')
-		const isClientError =
-			captchaFailed ||
-			message.includes('already registered') ||
-			message.includes('invalid') ||
-			message.includes('password')
+		const failure = classifySignupFailure(signupError.message)
 
-		if (!isClientError) {
-			reportServerError(signupError, { request })
+		if (failure.report) {
+			/*
+			  `signup_failure_code` is what turns "sign-ups are failing" into a
+			  cause without reading stack traces, and the original message rides
+			  along so a code of `unknown` names the message it did not recognize.
+			*/
+			reportServerError(signupError, {
+				request,
+				properties: {
+					signup_failure_code: failure.code,
+					supabase_message: signupError.message
+				}
+			})
 		}
 
 		return data<SignupActionData>(
-			{
-				formError: isClientError
-					? 'Unable to create account with the provided details.'
-					: 'Unable to create your account right now. Please try again.',
-				errorCode: 'signup_failed'
-			},
-			{ status: isClientError ? 400 : 500, headers }
+			{ formError: failure.message },
+			{ status: failure.status, headers }
 		)
 	}
 
+	/*
+	  Supabase returned neither a user nor an error. Nothing has ever been seen
+	  taking this path, which is exactly why it reports rather than staying quiet.
+	*/
+	const unexpected = classifySignupFailure('')
+	reportServerError(
+		new Error('Supabase signUp returned neither a user nor an error'),
+		{ request, properties: { signup_failure_code: unexpected.code } }
+	)
 	return data<SignupActionData>(
-		{
-			formError: 'Unable to create your account right now. Please try again.',
-			errorCode: 'unknown'
-		},
-		{ status: 500, headers }
+		{ formError: unexpected.message },
+		{ status: unexpected.status, headers }
 	)
 }
 
@@ -282,9 +267,12 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 function getPasswordStrength(password: string): {
 	score: number
 	label: string
-	color: string
+	/** Saturated hue for the bar, which is a non-text mark. */
+	barColor: string
+	/** Muted token class for the label, which is text and must clear AA. */
+	labelClass: string
 } {
-	if (!password) return { score: 0, label: '', color: '' }
+	if (!password) return { score: 0, label: '', barColor: '', labelClass: '' }
 	let score = 0
 	// Length is the primary factor (NIST guidelines weight it most heavily)
 	if (password.length >= 8) score++
@@ -295,24 +283,33 @@ function getPasswordStrength(password: string): {
 	if (/[0-9]/.test(password)) score++
 	if (/[^a-zA-Z0-9]/.test(password)) score++
 	if (score <= 2)
-		return { score: 1, label: 'Weak', color: 'var(--destructive)' }
-	if (score <= 4) return { score: 2, label: 'Fair', color: 'var(--warning)' }
-	return { score: 3, label: 'Strong', color: 'var(--success)' }
+		return {
+			score: 1,
+			label: 'Weak',
+			barColor: 'var(--destructive)',
+			labelClass: 'text-destructive'
+		}
+	if (score <= 4)
+		return {
+			score: 2,
+			label: 'Fair',
+			barColor: 'var(--warning)',
+			labelClass: 'text-warning-muted-foreground'
+		}
+	return {
+		score: 3,
+		label: 'Strong',
+		barColor: 'var(--success)',
+		labelClass: 'text-success-foreground'
+	}
 }
 
 // ─── Motion config ────────────────────────────────────────────────────────────
 
-const ease = [0.16, 1, 0.3, 1] as [number, number, number, number]
-
-function fieldVariants(delay: number) {
-	return {
-		initial: { opacity: 0, y: 8 },
-		animate: {
-			opacity: 1,
-			y: 0,
-			transition: { duration: 0.25, delay, ease }
-		}
-	}
+/* Field order drives the stagger, so inserting a field cannot skip a beat. */
+const fieldVariants = (index: number) => {
+	const { initial, animate, transition } = authFieldEntrance(index)
+	return { initial, animate: { ...animate, transition } }
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -332,8 +329,7 @@ const SignupPage = ({ loaderData, actionData }: Route.ComponentProps) => {
 		utm_source?: string
 	}>({})
 
-	const { turnstileToken, resetTurnstile, hasTurnstile } =
-		useOutletContext<AuthLayoutContext>()
+	const { turnstileToken, hasTurnstile } = useOutletContext<AuthLayoutContext>()
 
 	useEffect(() => {
 		setReferralData(getReferralAttribution())
@@ -344,7 +340,7 @@ const SignupPage = ({ loaderData, actionData }: Route.ComponentProps) => {
 	const passwordId = useId()
 	const confirmId = useId()
 
-	const errors: Record<string, string> =
+	const errors: SignupFieldErrors =
 		actionData && 'errors' in actionData ? (actionData.errors ?? {}) : {}
 	const formError =
 		actionData && 'formError' in actionData
@@ -363,413 +359,395 @@ const SignupPage = ({ loaderData, actionData }: Route.ComponentProps) => {
 
 	useEffect(() => {
 		if (!actionData) return
-		resetTurnstile()
 		if ('errors' in actionData && actionData.errors?.tos) {
 			setTosShake(true)
 			setTimeout(() => setTosShake(false), 500)
 		}
-	}, [actionData, resetTurnstile])
+	}, [actionData])
 
 	return (
-		<MotionConfig reducedMotion="user">
-			<div className="w-full max-w-md">
-				{loaderTyped?.accountDeleted && (
-					<motion.div
-						initial={{ opacity: 0, y: -8 }}
-						animate={{ opacity: 1, y: 0 }}
-						className="border-success/50 bg-success/25 text-success-foreground/80 mb-6 space-y-2 rounded-lg border p-4 text-sm"
-					>
-						<span className="flex gap-2">
-							<ShieldCheck
-								className="h-4 w-4 text-inherit"
-								aria-hidden="true"
-							/>
-							<p className="font-medium text-inherit">Account deleted</p>
-						</span>
-						<p className="text-success-foreground/60">
+		<div className="w-full max-w-md">
+			{loaderTyped?.accountDeleted && (
+				<motion.div
+					initial={{ opacity: 0, y: -8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ duration: duration.base, ease: ease.out }}
+				>
+					<Alert variant="success" role="status" className="mb-6">
+						<ShieldCheck aria-hidden="true" />
+						<AlertTitle>Account deleted</AlertTitle>
+						<AlertDescription>
 							Your Vectreal account was deleted successfully. You can create a
 							new account at any time.
-						</p>
-					</motion.div>
-				)}
+						</AlertDescription>
+					</Alert>
+				</motion.div>
+			)}
 
-				{/* Scene preservation notice */}
-				{loaderTyped?.sceneSaved && (
-					<motion.div
-						initial={{ opacity: 0, y: -8 }}
-						animate={{ opacity: 1, y: 0 }}
-						className="border-success/50 bg-success/25 text-success-foreground/80 mb-6 space-y-2 rounded-lg border p-4 text-sm"
-					>
-						<span className="flex gap-2">
-							<Save className="h-4 w-4 text-inherit" aria-hidden="true" />
-							<p className="font-medium text-inherit">
-								Scene Saved Temporarily!
-							</p>
-						</span>
-						<p className="text-success-foreground/60">
-							Your scene has been saved. Create an account to make it permanent.
-						</p>
-						{loaderTyped.nextPath && (
-							<Button
-								asChild
-								size="sm"
-								variant="secondary"
-								className="border-success/50 text-success-foreground/80 hover:bg-success/20 mt-1 w-full"
-							>
-								<Link to={loaderTyped.nextPath}>
-									<ExternalLink className="mr-1 h-3 w-3" />
-									Open Publisher to restore draft
-								</Link>
-							</Button>
-						)}
-					</motion.div>
-				)}
-
-				{/* Form-level error */}
-				<AnimatePresence>
-					{formError && (
-						<motion.div
-							key="form-error"
-							initial={{ opacity: 0, height: 0, marginBottom: 0 }}
-							animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
-							exit={{ opacity: 0, height: 0, marginBottom: 0 }}
-							className="border-destructive/50 bg-destructive/10 text-destructive overflow-hidden rounded-lg border p-4 text-sm"
-							role="alert"
-							aria-live="assertive"
-						>
-							{formError}
-						</motion.div>
-					)}
-				</AnimatePresence>
-
-				<Form
-					method="post"
-					action="/sign-up"
-					aria-label="Sign up form"
-					noValidate
+			{/* Scene preservation notice */}
+			{loaderTyped?.sceneSaved && (
+				<motion.div
+					initial={{ opacity: 0, y: -8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ duration: duration.base, ease: ease.out }}
 				>
-					<AuthenticityTokenInput />
+					<Alert variant="success" role="status" className="mb-6">
+						<Save aria-hidden="true" />
+						<AlertTitle>Scene saved temporarily</AlertTitle>
+						<AlertDescription>
+							<p>
+								Your scene has been saved. Create an account to make it
+								permanent.
+							</p>
+							{loaderTyped.nextPath && (
+								<Button
+									asChild
+									size="sm"
+									variant="secondary"
+									className="mt-2 w-full"
+								>
+									<Link to={loaderTyped.nextPath}>
+										<ExternalLink className="mr-1 h-3 w-3" />
+										Open Publisher to restore draft
+									</Link>
+								</Button>
+							)}
+						</AlertDescription>
+					</Alert>
+				</motion.div>
+			)}
+
+			{/* Form-level error */}
+			<AnimatePresence>
+				{formError && (
+					<motion.div
+						key="form-error"
+						initial={{ opacity: 0, height: 0, marginBottom: 0 }}
+						animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
+						exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+						className="overflow-hidden"
+					>
+						<Alert variant="destructive" aria-live="assertive">
+							<AlertDescription>{formError}</AlertDescription>
+						</Alert>
+					</motion.div>
+				)}
+			</AnimatePresence>
+
+			<Form
+				method="post"
+				action="/sign-up"
+				aria-label="Sign up form"
+				noValidate
+			>
+				<AuthenticityTokenInput />
+				<input
+					type="hidden"
+					name="cf-turnstile-response"
+					value={turnstileToken ?? ''}
+				/>
+				{referralData.referrer && (
+					<input type="hidden" name="referrer" value={referralData.referrer} />
+				)}
+				{referralData.utm_source && (
 					<input
 						type="hidden"
-						name="cf-turnstile-response"
-						value={turnstileToken ?? ''}
+						name="utm_source"
+						value={referralData.utm_source}
 					/>
-					{referralData.referrer && (
-						<input
-							type="hidden"
-							name="referrer"
-							value={referralData.referrer}
-						/>
-					)}
-					{referralData.utm_source && (
-						<input
-							type="hidden"
-							name="utm_source"
-							value={referralData.utm_source}
-						/>
-					)}
+				)}
 
-					{/* Name */}
-					<motion.div className="mb-4" {...fieldVariants(0)}>
-						<label className="mb-2 block text-sm font-medium" htmlFor={nameId}>
-							Full Name
-						</label>
-						<Input
-							id={nameId}
-							name="name"
-							type="text"
-							autoComplete="name"
-							placeholder="Jane Smith"
-							required
-							aria-invalid={!!errors.name}
-							aria-describedby={errors.name ? `${nameId}-error` : undefined}
-						/>
-						<AnimatePresence>
-							{errors.name && (
-								<motion.p
-									id={`${nameId}-error`}
-									role="alert"
-									initial={{ opacity: 0, height: 0 }}
-									animate={{ opacity: 1, height: 'auto' }}
-									exit={{ opacity: 0, height: 0 }}
-									className="text-destructive mt-1 overflow-hidden text-sm"
-								>
-									{errors.name}
-								</motion.p>
-							)}
-						</AnimatePresence>
-					</motion.div>
+				{/* Name */}
+				<motion.div className="mb-4" {...fieldVariants(0)}>
+					<label className="mb-2 block text-sm font-medium" htmlFor={nameId}>
+						Full Name{' '}
+						<span className="text-muted-foreground font-normal">
+							(optional)
+						</span>
+					</label>
+					{/* No error slot: an optional field has nothing to reject. */}
+					<Input
+						id={nameId}
+						name="name"
+						type="text"
+						autoComplete="name"
+						placeholder="Jane Smith"
+					/>
+				</motion.div>
 
-					{/* Email */}
-					<motion.div className="mb-4" {...fieldVariants(0.05)}>
-						<label className="mb-2 block text-sm font-medium" htmlFor={emailId}>
-							Email
-						</label>
-						<Input
-							id={emailId}
-							name="email"
-							type="email"
-							autoComplete="email"
-							placeholder="jane@example.com"
-							required
-							aria-invalid={!!errors.email}
-							aria-describedby={errors.email ? `${emailId}-error` : undefined}
-						/>
-						<AnimatePresence>
-							{errors.email && (
-								<motion.p
-									id={`${emailId}-error`}
-									role="alert"
-									initial={{ opacity: 0, height: 0 }}
-									animate={{ opacity: 1, height: 'auto' }}
-									exit={{ opacity: 0, height: 0 }}
-									className="text-destructive mt-1 overflow-hidden text-sm"
-								>
-									{errors.email}
-								</motion.p>
-							)}
-						</AnimatePresence>
-					</motion.div>
-
-					{/* Password */}
-					<motion.div className="mb-4" {...fieldVariants(0.1)}>
-						<label
-							className="mb-2 block text-sm font-medium"
-							htmlFor={passwordId}
-						>
-							Password
-						</label>
-						<div className="relative">
-							<Input
-								id={passwordId}
-								name="password"
-								type={showPassword ? 'text' : 'password'}
-								autoComplete="new-password"
-								placeholder="At least 8 characters"
-								required
-								value={password}
-								onChange={(e) => setPassword(e.target.value)}
-								aria-invalid={!!errors.password}
-								aria-describedby={
-									errors.password ? `${passwordId}-error` : 'password-strength'
-								}
-								className="pr-10"
-							/>
-							<button
-								type="button"
-								aria-label={showPassword ? 'Hide password' : 'Show password'}
-								onClick={() => setShowPassword((v) => !v)}
-								className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
+				{/* Email */}
+				<motion.div className="mb-4" {...fieldVariants(1)}>
+					<label className="mb-2 block text-sm font-medium" htmlFor={emailId}>
+						Email
+					</label>
+					<Input
+						id={emailId}
+						name="email"
+						type="email"
+						autoComplete="email"
+						placeholder="jane@example.com"
+						required
+						aria-invalid={!!errors.email}
+						aria-describedby={errors.email ? `${emailId}-error` : undefined}
+					/>
+					<AnimatePresence>
+						{errors.email && (
+							<motion.p
+								id={`${emailId}-error`}
+								role="alert"
+								initial={{ opacity: 0, height: 0 }}
+								animate={{ opacity: 1, height: 'auto' }}
+								exit={{ opacity: 0, height: 0 }}
+								className="text-destructive mt-1 overflow-hidden text-sm"
 							>
-								{showPassword ? (
-									<EyeClosed className="h-4 w-4" />
-								) : (
-									<Eye className="h-4 w-4" />
-								)}
-							</button>
-						</div>
+								{errors.email}
+							</motion.p>
+						)}
+					</AnimatePresence>
+				</motion.div>
 
-						{/* Strength bar */}
-						<AnimatePresence>
-							{password.length > 0 && (
-								<motion.div
-									id="password-strength"
-									aria-live="polite"
-									initial={{ opacity: 0, height: 0 }}
-									animate={{ opacity: 1, height: 'auto' }}
-									exit={{ opacity: 0, height: 0 }}
-									className="mt-2 overflow-hidden"
-								>
-									<div className="bg-muted h-1 overflow-hidden rounded-full">
-										<motion.div
-											className="h-full rounded-full"
-											animate={{
-												width: `${(strength.score / 3) * 100}%`,
-												backgroundColor: strength.color
-											}}
-											transition={{
-												type: 'spring',
-												stiffness: 300,
-												damping: 30
-											}}
-										/>
-									</div>
-									{strength.label && (
-										<p
-											className="mt-1 text-xs"
-											style={{ color: strength.color }}
-										>
-											{strength.label}
-										</p>
-									)}
-								</motion.div>
+				{/* Password */}
+				<motion.div className="mb-4" {...fieldVariants(2)}>
+					<label
+						className="mb-2 block text-sm font-medium"
+						htmlFor={passwordId}
+					>
+						Password
+					</label>
+					<div className="relative">
+						<Input
+							id={passwordId}
+							name="password"
+							type={showPassword ? 'text' : 'password'}
+							autoComplete="new-password"
+							placeholder="At least 8 characters"
+							required
+							value={password}
+							onChange={(e) => setPassword(e.target.value)}
+							aria-invalid={!!errors.password}
+							aria-describedby={
+								errors.password ? `${passwordId}-error` : 'password-strength'
+							}
+							className="pr-10"
+						/>
+						<button
+							type="button"
+							aria-label={showPassword ? 'Hide password' : 'Show password'}
+							onClick={() => setShowPassword((v) => !v)}
+							className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
+						>
+							{showPassword ? (
+								<EyeClosed className="h-4 w-4" />
+							) : (
+								<Eye className="h-4 w-4" />
 							)}
-						</AnimatePresence>
+						</button>
+					</div>
 
-						<AnimatePresence>
-							{errors.password && (
-								<motion.p
-									id={`${passwordId}-error`}
-									role="alert"
-									initial={{ opacity: 0, height: 0 }}
-									animate={{ opacity: 1, height: 'auto' }}
-									exit={{ opacity: 0, height: 0 }}
-									className="text-destructive mt-1 overflow-hidden text-sm"
-								>
-									{errors.password}
-								</motion.p>
-							)}
-						</AnimatePresence>
-					</motion.div>
-
-					{/* Confirm password - revealed once password has content */}
+					{/* Strength bar */}
 					<AnimatePresence>
 						{password.length > 0 && (
 							<motion.div
-								key="confirm-password-field"
-								initial={{ opacity: 0, height: 0, marginBottom: 0 }}
-								animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
-								exit={{ opacity: 0, height: 0, marginBottom: 0 }}
-								className="overflow-hidden"
+								id="password-strength"
+								aria-live="polite"
+								initial={{ opacity: 0, height: 0 }}
+								animate={{ opacity: 1, height: 'auto' }}
+								exit={{ opacity: 0, height: 0 }}
+								className="mt-2 overflow-hidden"
 							>
-								<label
-									className="mb-2 block text-sm font-medium"
-									htmlFor={confirmId}
-								>
-									Confirm Password
-								</label>
-								<div className="relative">
-									<Input
-										id={confirmId}
-										name="confirm_password"
-										type={showConfirm ? 'text' : 'password'}
-										autoComplete="new-password"
-										placeholder="Repeat your password"
-										required
-										value={confirmPassword}
-										onChange={(e) => setConfirmPassword(e.target.value)}
-										aria-invalid={passwordMismatch || !!errors.confirmPassword}
-										aria-describedby={
-											passwordMismatch || errors.confirmPassword
-												? `${confirmId}-error`
-												: undefined
-										}
-										className="pr-10"
+								<div className="bg-muted h-1 overflow-hidden rounded-full">
+									<motion.div
+										className="h-full rounded-full"
+										animate={{
+											width: `${(strength.score / 3) * 100}%`,
+											backgroundColor: strength.barColor
+										}}
+										transition={{
+											type: 'spring',
+											stiffness: 300,
+											damping: 30
+										}}
 									/>
-									<button
-										type="button"
-										aria-label={
-											showConfirm
-												? 'Hide confirm password'
-												: 'Show confirm password'
-										}
-										onClick={() => setShowConfirm((v) => !v)}
-										className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
-									>
-										{showConfirm ? (
-											<EyeClosed className="h-4 w-4" />
-										) : (
-											<Eye className="h-4 w-4" />
-										)}
-									</button>
 								</div>
-								<AnimatePresence>
-									{(passwordMismatch || errors.confirmPassword) && (
-										<motion.p
-											id={`${confirmId}-error`}
-											role="alert"
-											initial={{ opacity: 0, height: 0 }}
-											animate={{ opacity: 1, height: 'auto' }}
-											exit={{ opacity: 0, height: 0 }}
-											className="text-destructive mt-1 overflow-hidden text-sm"
-										>
-											{errors.confirmPassword ?? 'Passwords do not match.'}
-										</motion.p>
-									)}
-								</AnimatePresence>
+								{/*
+										The bar keeps the saturated hue - it is a non-text mark, so
+										the 3:1 floor applies. The label does not: as text on the
+										raised panel the saturated tokens land between 1.9:1 and
+										3.5:1, all of them short of AA, so it takes the muted
+										`-foreground` role instead.
+									*/}
+								{strength.label && (
+									<p className={cn('mt-1 text-xs', strength.labelClass)}>
+										{strength.label}
+									</p>
+								)}
 							</motion.div>
 						)}
 					</AnimatePresence>
 
-					{/* ToS checkbox */}
-					<motion.div className="mb-6" {...fieldVariants(0.15)}>
-						<motion.div
-							animate={tosShake ? { x: [0, -5, 5, -5, 5, 0] } : {}}
-							transition={{ duration: 0.35 }}
-							className="flex items-start gap-3"
-						>
-							<Checkbox
-								id="tos_accepted"
-								name="tos_accepted"
-								checked={tosChecked}
-								onCheckedChange={(checked) => setTosChecked(!!checked)}
-								aria-invalid={!!errors.tos}
-								aria-describedby={errors.tos ? 'tos-error' : undefined}
-								className="mt-0.5"
-							/>
-							<label
-								htmlFor="tos_accepted"
-								className="text-muted-foreground cursor-pointer text-sm leading-snug"
+					<AnimatePresence>
+						{errors.password && (
+							<motion.p
+								id={`${passwordId}-error`}
+								role="alert"
+								initial={{ opacity: 0, height: 0 }}
+								animate={{ opacity: 1, height: 'auto' }}
+								exit={{ opacity: 0, height: 0 }}
+								className="text-destructive mt-1 overflow-hidden text-sm"
 							>
-								I agree to the{' '}
-								<Link
-									to="/terms-of-service"
-									target="_blank"
-									rel="noopener noreferrer"
-									className="text-foreground underline-offset-2 hover:underline"
-								>
-									Terms of Service
-								</Link>{' '}
-								and{' '}
-								<Link
-									to="/privacy-policy"
-									target="_blank"
-									rel="noopener noreferrer"
-									className="text-foreground underline-offset-2 hover:underline"
-								>
-									Privacy Policy
-								</Link>
-							</label>
-						</motion.div>
-						<AnimatePresence>
-							{errors.tos && (
-								<motion.p
-									id="tos-error"
-									role="alert"
-									initial={{ opacity: 0, height: 0 }}
-									animate={{ opacity: 1, height: 'auto' }}
-									exit={{ opacity: 0, height: 0 }}
-									className="text-destructive mt-2 overflow-hidden text-sm"
-								>
-									{errors.tos}
-								</motion.p>
-							)}
-						</AnimatePresence>
-					</motion.div>
+								{errors.password}
+							</motion.p>
+						)}
+					</AnimatePresence>
+				</motion.div>
 
-					{/* Submit */}
-					<motion.div {...fieldVariants(0.2)}>
-						<Button
-							type="submit"
-							className="w-full font-semibold"
-							disabled={isSubmitting || (hasTurnstile && !turnstileToken)}
+				{/* Confirm password - revealed once password has content */}
+				<AnimatePresence>
+					{password.length > 0 && (
+						<motion.div
+							key="confirm-password-field"
+							initial={{ opacity: 0, height: 0, marginBottom: 0 }}
+							animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
+							exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+							className="overflow-hidden"
 						>
-							{isSubmitting ? (
-								<>
-									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-									Creating account…
-								</>
-							) : (
-								<>
-									<ShieldCheck className="mr-2 h-4 w-4" />
-									Create Account
-								</>
-							)}
-						</Button>
+							<label
+								className="mb-2 block text-sm font-medium"
+								htmlFor={confirmId}
+							>
+								Confirm Password
+							</label>
+							<div className="relative">
+								<Input
+									id={confirmId}
+									name="confirm_password"
+									type={showConfirm ? 'text' : 'password'}
+									autoComplete="new-password"
+									placeholder="Repeat your password"
+									required
+									value={confirmPassword}
+									onChange={(e) => setConfirmPassword(e.target.value)}
+									aria-invalid={passwordMismatch || !!errors.confirmPassword}
+									aria-describedby={
+										passwordMismatch || errors.confirmPassword
+											? `${confirmId}-error`
+											: undefined
+									}
+									className="pr-10"
+								/>
+								<button
+									type="button"
+									aria-label={
+										showConfirm
+											? 'Hide confirm password'
+											: 'Show confirm password'
+									}
+									onClick={() => setShowConfirm((v) => !v)}
+									className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
+								>
+									{showConfirm ? (
+										<EyeClosed className="h-4 w-4" />
+									) : (
+										<Eye className="h-4 w-4" />
+									)}
+								</button>
+							</div>
+							<AnimatePresence>
+								{(passwordMismatch || errors.confirmPassword) && (
+									<motion.p
+										id={`${confirmId}-error`}
+										role="alert"
+										initial={{ opacity: 0, height: 0 }}
+										animate={{ opacity: 1, height: 'auto' }}
+										exit={{ opacity: 0, height: 0 }}
+										className="text-destructive mt-1 overflow-hidden text-sm"
+									>
+										{errors.confirmPassword ?? 'Passwords do not match.'}
+									</motion.p>
+								)}
+							</AnimatePresence>
+						</motion.div>
+					)}
+				</AnimatePresence>
+
+				{/* ToS checkbox */}
+				<motion.div className="mb-6" {...fieldVariants(3)}>
+					<motion.div
+						animate={tosShake ? { x: [0, -5, 5, -5, 5, 0] } : {}}
+						transition={{ duration: duration.slow, ease: ease.out }}
+						className="flex items-start gap-3"
+					>
+						<Checkbox
+							id="tos_accepted"
+							name="tos_accepted"
+							checked={tosChecked}
+							onCheckedChange={(checked) => setTosChecked(!!checked)}
+							aria-invalid={!!errors.tos}
+							aria-describedby={errors.tos ? 'tos-error' : undefined}
+							className="mt-0.5"
+						/>
+						<label
+							htmlFor="tos_accepted"
+							className="text-muted-foreground cursor-pointer text-sm leading-snug"
+						>
+							I agree to the{' '}
+							<Link
+								to="/terms-of-service"
+								target="_blank"
+								rel="noopener noreferrer"
+								className="text-foreground underline-offset-2 hover:underline"
+							>
+								Terms of Service
+							</Link>{' '}
+							and{' '}
+							<Link
+								to="/privacy-policy"
+								target="_blank"
+								rel="noopener noreferrer"
+								className="text-foreground underline-offset-2 hover:underline"
+							>
+								Privacy Policy
+							</Link>
+						</label>
 					</motion.div>
-				</Form>
-			</div>
-		</MotionConfig>
+					<AnimatePresence>
+						{errors.tos && (
+							<motion.p
+								id="tos-error"
+								role="alert"
+								initial={{ opacity: 0, height: 0 }}
+								animate={{ opacity: 1, height: 'auto' }}
+								exit={{ opacity: 0, height: 0 }}
+								className="text-destructive mt-2 overflow-hidden text-sm"
+							>
+								{errors.tos}
+							</motion.p>
+						)}
+					</AnimatePresence>
+				</motion.div>
+
+				{/* Submit */}
+				<motion.div {...fieldVariants(4)}>
+					<Button
+						type="submit"
+						className="w-full font-semibold"
+						disabled={isSubmitting || (hasTurnstile && !turnstileToken)}
+					>
+						{isSubmitting ? (
+							<>
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+								Creating account…
+							</>
+						) : (
+							<>
+								<ShieldCheck className="mr-2 h-4 w-4" />
+								Create Account
+							</>
+						)}
+					</Button>
+				</motion.div>
+			</Form>
+		</div>
 	)
 }
 

--- a/apps/vectreal-platform/tests/signup-failure.spec.ts
+++ b/apps/vectreal-platform/tests/signup-failure.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * The messages this list did not used to recognize are the point.
+ *
+ * Three real GoTrue failures - a confirmation email that could not be sent, the
+ * hourly email cap, and a database error saving the user - matched none of the
+ * route's old substring heuristic, so all three arrived as the same generic
+ * sentence with no report behind it.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	classifySignupFailure,
+	type SignupFailureCode
+} from '../app/lib/domain/auth/signup-failure'
+
+const CASES: [string, SignupFailureCode][] = [
+	// Cloudflare's own wording, via GoTrue, for a replayed or expired token.
+	['captcha protection: request disallowed (timeout-or-duplicate)', 'captcha'],
+	['captcha verification process failed', 'captcha'],
+	['User already registered', 'already_registered'],
+	['Password should be at least 6 characters', 'weak_password'],
+	['Password is known to be weak and easy to guess', 'weak_password'],
+	['Unable to validate email address: invalid format', 'invalid_email'],
+	['Signups not allowed for this instance', 'signups_disabled'],
+	['Email signups are disabled', 'signups_disabled'],
+	// Matched nothing before this module existed:
+	['Error sending confirmation email', 'email_send_failed'],
+	['email rate limit exceeded', 'email_rate_limited'],
+	[
+		'For security purposes, you can only request this after 51 seconds',
+		'email_rate_limited'
+	],
+	['Database error saving new user', 'unknown'],
+	/*
+	  The strings this deployment actually produces, read from supabase/auth
+	  rather than guessed. `[auth.hook.send_email]` is enabled, so GoTrue never
+	  runs its own mailer: it invokes our route, reads the response body only on
+	  2xx, and on our 500 reports its own wording. "Error sending confirmation
+	  email" above is therefore unreachable while the hook is on - it is kept
+	  because `[auth.email.smtp]` would take over if the hook were disabled.
+	*/
+	['Unexpected status code returned from hook: 500', 'email_send_failed'],
+	['Invalid payload sent to hook', 'email_send_failed'],
+	['Hook requires authorization token', 'email_send_failed'],
+	['Service currently unavailable due to hook', 'email_send_failed'],
+	['hook_timeout_after_retry', 'email_send_failed']
+]
+
+describe('classifySignupFailure', () => {
+	it.each(CASES)('classifies %j as %s', (message, code) => {
+		expect(classifySignupFailure(message).code).toBe(code)
+	})
+
+	it('reports every failure except the one it withholds from the visitor', () => {
+		expect(classifySignupFailure('User already registered').report).toBe(false)
+
+		for (const [message, code] of CASES) {
+			if (code === 'already_registered') continue
+			expect(
+				classifySignupFailure(message).report,
+				`${message} must be reported`
+			).toBe(true)
+		}
+	})
+
+	/*
+	  The form must not answer "does this address have an account". Asserting the
+	  exact string rather than a vocabulary blocklist, because every phrasing
+	  that leaks - "an account with this email exists", "that address is
+	  registered" - gets past a list of banned words.
+	*/
+	it('never confirms that an address is already registered', () => {
+		expect(classifySignupFailure('User already registered').message).toBe(
+			'We could not create an account with those details. If you already have one, try signing in or resetting your password.'
+		)
+	})
+
+	it('keeps an unrecognized message reportable rather than silent', () => {
+		const failure = classifySignupFailure('Some GoTrue error nobody has seen')
+
+		expect(failure.code).toBe('unknown')
+		expect(failure.report).toBe(true)
+		expect(failure.status).toBe(500)
+	})
+
+	/*
+	  The route calls this with an empty string on both paths where there is no
+	  GoTrue verdict to classify: a thrown `signUp`, and a response carrying
+	  neither a user nor an error.
+	*/
+	it('falls back to a reportable unknown when there is no message at all', () => {
+		const failure = classifySignupFailure('')
+
+		expect(failure.code).toBe('unknown')
+		expect(failure.report).toBe(true)
+		expect(failure.status).toBe(500)
+		expect(failure.message).toBeTruthy()
+	})
+
+	it('answers a client error with 4xx and a server error with 5xx', () => {
+		expect(classifySignupFailure('captcha verification failed').status).toBe(
+			400
+		)
+		expect(classifySignupFailure('User already registered').status).toBe(400)
+		expect(classifySignupFailure('Password should be longer').status).toBe(400)
+		expect(classifySignupFailure('Signups not allowed').status).toBe(400)
+		expect(classifySignupFailure('email rate limit exceeded').status).toBe(429)
+		expect(
+			classifySignupFailure('Error sending confirmation email').status
+		).toBe(500)
+	})
+
+	/*
+	  Must not claim the account exists: GoTrue rolls the user back with the
+	  failed send, both being inside one transaction. And it must not send anyone
+	  to sign in, which has no branch for an unconfirmed account.
+	*/
+	it('advises the one recovery path that exists when the email fails', () => {
+		const { message } = classifySignupFailure(
+			'Error sending confirmation email'
+		)
+
+		expect(message).toBe(
+			'We could not send your confirmation email. Please try signing up again in a moment.'
+		)
+		expect(message).not.toMatch(/sign(ing)? in/i)
+	})
+
+	it('is case-insensitive, since GoTrue capitalization is not stable', () => {
+		expect(classifySignupFailure('USER ALREADY REGISTERED').code).toBe(
+			'already_registered'
+		)
+	})
+
+	/*
+	  First match wins, and these two genuinely overlap: "Error sending password
+	  reset email" matches both the send-failure pattern and the bare /password/
+	  one. Reorder the list and this is the assertion that fails.
+	*/
+	it('prefers the specific pattern where two genuinely overlap', () => {
+		expect(
+			classifySignupFailure('Error sending password reset email').code
+		).toBe('email_send_failed')
+	})
+})

--- a/apps/vectreal-platform/tests/signup-validation.spec.ts
+++ b/apps/vectreal-platform/tests/signup-validation.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * The name field is optional, and this is the file that says so.
+ *
+ * It used to be required at two characters, which rejected a submission before
+ * the form ever reached Supabase. Nothing downstream needs it, so the only
+ * thing that made it mandatory was this function.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { validateSignup } from '../app/lib/domain/auth/signup-validation'
+
+function form(fields: Record<string, string>): FormData {
+	const data = new FormData()
+	for (const [key, value] of Object.entries(fields)) data.set(key, value)
+	return data
+}
+
+const valid = {
+	name: 'Jane Smith',
+	email: 'jane@example.com',
+	password: 'a-long-enough-password',
+	confirm_password: 'a-long-enough-password',
+	tos_accepted: 'on'
+}
+
+describe('validateSignup', () => {
+	it('accepts a complete submission', () => {
+		expect(validateSignup(form(valid)).errors).toEqual({})
+	})
+
+	it('accepts a submission with no name at all', () => {
+		const { name, ...withoutName } = valid
+		void name
+		const { errors, data } = validateSignup(form(withoutName))
+
+		expect(errors).toEqual({})
+		expect(data.name).toBe('')
+	})
+
+	it.each(['', ' ', 'J'])(
+		'accepts %j as a name, since the field is optional',
+		(value) => {
+			expect(validateSignup(form({ ...valid, name: value })).errors).toEqual({})
+		}
+	)
+
+	it('still trims the name it was given', () => {
+		expect(validateSignup(form({ ...valid, name: '  Jane  ' })).data.name).toBe(
+			'Jane'
+		)
+	})
+
+	/*
+	  Everything below stayed required. Asserting each one individually so that
+	  making the name optional cannot quietly take a neighbour with it.
+	*/
+	/*
+	  Exact message, not just the key. The claim this extraction rests on is that
+	  the four surviving rules came across byte-identical, and a presence-only
+	  assertion would pass against any copy at all.
+	*/
+	it('rejects an address with no @', () => {
+		expect(
+			validateSignup(form({ ...valid, email: 'jane.example.com' })).errors
+		).toEqual({ email: 'Please enter a valid email address.' })
+	})
+
+	it('rejects a password under eight characters', () => {
+		const short = 'abc1234'
+		expect(
+			validateSignup(
+				form({ ...valid, password: short, confirm_password: short })
+			).errors
+		).toHaveProperty('password')
+	})
+
+	it('rejects a confirmation that does not match', () => {
+		expect(
+			validateSignup(form({ ...valid, confirm_password: 'something-else' }))
+				.errors
+		).toHaveProperty('confirmPassword')
+	})
+
+	it('rejects an unchecked Terms box', () => {
+		const { tos_accepted, ...withoutTos } = valid
+		void tos_accepted
+		expect(validateSignup(form(withoutTos)).errors).toHaveProperty('tos')
+	})
+
+	it('returns every failure at once rather than the first', () => {
+		const { errors } = validateSignup(form({ email: 'nope', password: 'x' }))
+
+		expect(Object.keys(errors).sort()).toEqual([
+			'confirmPassword',
+			'email',
+			'password',
+			'tos'
+		])
+	})
+})

--- a/apps/vectreal-platform/tests/use-spend-turnstile-token.spec.tsx
+++ b/apps/vectreal-platform/tests/use-spend-turnstile-token.spec.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+/**
+ * The defect this hook exists for, written as case 3.
+ *
+ * A Turnstile token is single-use. `signin-layout` used to let each child
+ * invalidate it when that child's own action returned data, and a successful
+ * sign-up returns `redirect(...)` - no data, no reset, so the spent token was
+ * replayed on the next submit under the same layout and Supabase rejected it
+ * with a captcha error the UI reported as nothing at all.
+ *
+ * The three guards are pinned separately, because each one alone looks
+ * redundant and none is.
+ */
+
+import { render } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+	useSpendTurnstileToken,
+	type TokenBearingSubmission
+} from '../app/hooks/use-spend-turnstile-token'
+
+function submissionWith(token: string): TokenBearingSubmission {
+	const formData = new FormData()
+	formData.set('cf-turnstile-response', token)
+	return { formData }
+}
+
+const IDLE: TokenBearingSubmission = { formData: undefined }
+
+function renderWith(
+	submissions: readonly TokenBearingSubmission[],
+	token: string | null,
+	onSpend: (spent: string) => void
+) {
+	function Probe(props: {
+		submissions: readonly TokenBearingSubmission[]
+		token: string | null
+	}) {
+		useSpendTurnstileToken({ ...props, onSpend })
+		return null
+	}
+
+	const view = render(<Probe submissions={submissions} token={token} />)
+	return {
+		rerender: (
+			next: readonly TokenBearingSubmission[],
+			nextToken: string | null
+		) => view.rerender(<Probe submissions={next} token={nextToken} />)
+	}
+}
+
+describe('useSpendTurnstileToken', () => {
+	it('ignores a navigation that is not submitting anything', () => {
+		const onSpend = vi.fn()
+		renderWith([IDLE], 'tok-1', onSpend)
+
+		expect(onSpend).not.toHaveBeenCalled()
+	})
+
+	it('spends the live token once, and reports which token was spent', () => {
+		const onSpend = vi.fn()
+		renderWith([submissionWith('tok-1')], 'tok-1', onSpend)
+
+		expect(onSpend).toHaveBeenCalledOnce()
+		expect(onSpend).toHaveBeenCalledWith('tok-1')
+	})
+
+	/*
+	  The defect. React Router hands back the same `FormData` object across
+	  `submitting` and `loading`, and an action redirect keeps the navigation in
+	  `loading` for another render.
+	*/
+	it('spends once across the submitting and loading renders of one submission', () => {
+		const onSpend = vi.fn()
+		const inFlight = submissionWith('tok-1')
+		const { rerender } = renderWith([inFlight], 'tok-1', onSpend)
+
+		/*
+		  The real sequence, wrapper identity included: `getLoadingNavigation`
+		  returns a new navigation object and the redirect that follows returns
+		  another, each carrying the same `submission.formData`. The token is null
+		  from the first spend onward, exactly as production leaves it.
+		*/
+		rerender([{ formData: inFlight.formData }], null)
+		rerender([{ formData: inFlight.formData }], null)
+
+		expect(onSpend).toHaveBeenCalledOnce()
+	})
+
+	/*
+	  Guard 2, in isolation. The OAuth path resets the token before submitting, so
+	  the live token is null - or already replaced - when its navigation appears.
+	  Spending again would throw away a freshly minted token.
+	*/
+	it('does not spend a token the owner is no longer holding', () => {
+		const onSpend = vi.fn()
+		renderWith([submissionWith('tok-1')], null, onSpend)
+		expect(onSpend).not.toHaveBeenCalled()
+
+		const onSpendReplaced = vi.fn()
+		renderWith([submissionWith('tok-1')], 'tok-2', onSpendReplaced)
+		expect(onSpendReplaced).not.toHaveBeenCalled()
+	})
+
+	/*
+	  Guard 1, in isolation: the token is held constant so equality cannot be what
+	  rejects the repeats, and each rerender passes a fresh wrapper around the
+	  same FormData so keying the set on the wrapper cannot pass either. Delete
+	  the WeakSet, or key it on the submission, and this is the case that fails.
+	*/
+	it('examines a submission once even when spending does not change the token', () => {
+		const onSpend = vi.fn()
+		const inFlight = submissionWith('tok-1')
+		const { rerender } = renderWith([inFlight], 'tok-1', onSpend)
+
+		rerender([{ formData: inFlight.formData }], 'tok-1')
+		rerender([{ formData: inFlight.formData }], 'tok-1')
+
+		expect(onSpend).toHaveBeenCalledOnce()
+	})
+
+	/*
+	  With no site key the sign-up and sign-in forms still render the hidden
+	  input, so they post an empty string while the live token is null.
+	*/
+	it('ignores the empty token an unconfigured Turnstile posts', () => {
+		const onSpend = vi.fn()
+		renderWith([submissionWith('')], null, onSpend)
+
+		expect(onSpend).not.toHaveBeenCalled()
+	})
+
+	/*
+	  Guard 3, in isolation. The layout's no-site-key OAuth branch submits with no
+	  token field at all while the live token is also null, and `formData.get`
+	  returns null for an absent field - so `null !== null` is false and equality
+	  alone would spend, resetting a widget that is not even mounted.
+	*/
+	it('ignores a submission carrying no token field while holding no token', () => {
+		const onSpend = vi.fn()
+		renderWith([{ formData: new FormData() }], null, onSpend)
+
+		expect(onSpend).not.toHaveBeenCalled()
+	})
+
+	// The resend button on /auth/confirm-pending submits through a fetcher.
+	it('spends a token carried by a fetcher rather than the navigation', () => {
+		const onSpend = vi.fn()
+		renderWith([IDLE, submissionWith('tok-1')], 'tok-1', onSpend)
+
+		expect(onSpend).toHaveBeenCalledOnce()
+	})
+
+	/*
+	  The OAuth buttons render on every child route, `/auth/confirm-pending`
+	  included, so its resend fetcher can be submitted while an OAuth navigation
+	  is still in flight ahead of it in the list. Skipping an examined entry has
+	  to keep scanning: stop at it and the resend's token is never spent, and the
+	  next resend replays it - the exact bug this hook exists to prevent.
+	*/
+	it('spends a later submission when an earlier one is already examined', () => {
+		const onSpend = vi.fn()
+		const oauth = submissionWith('tok-1')
+
+		// The OAuth handler reset the token before submitting, so this is skipped.
+		const { rerender } = renderWith([oauth], null, onSpend)
+		expect(onSpend).not.toHaveBeenCalled()
+
+		// The widget minted tok-2, and the resend fetcher carries it.
+		rerender(
+			[{ formData: oauth.formData }, submissionWith('tok-2')],
+			'tok-2'
+		)
+
+		expect(onSpend).toHaveBeenCalledOnce()
+		expect(onSpend).toHaveBeenCalledWith('tok-2')
+	})
+
+	it('spends each of two successive submissions', () => {
+		const onSpend = vi.fn()
+		const { rerender } = renderWith([submissionWith('tok-1')], 'tok-1', onSpend)
+
+		rerender([submissionWith('tok-2')], 'tok-2')
+
+		expect(onSpend).toHaveBeenCalledTimes(2)
+		expect(onSpend).toHaveBeenNthCalledWith(1, 'tok-1')
+		expect(onSpend).toHaveBeenNthCalledWith(2, 'tok-2')
+	})
+
+	it('spends once under StrictMode double-invocation', () => {
+		const onSpend = vi.fn()
+		// Hoisted, because `navigation.formData` is one object across renders.
+		const inFlight = submissionWith('tok-1')
+
+		function Probe() {
+			useSpendTurnstileToken({
+				submissions: [inFlight],
+				token: 'tok-1',
+				onSpend
+			})
+			return null
+		}
+
+		render(
+			<StrictMode>
+				<Probe />
+			</StrictMode>
+		)
+
+		expect(onSpend).toHaveBeenCalledOnce()
+	})
+})

--- a/shared/components/src/ui/alert.tsx
+++ b/shared/components/src/ui/alert.tsx
@@ -9,7 +9,17 @@ const alertVariants = cva(
 			variant: {
 				default: 'ds-raised text-card-foreground',
 				destructive:
-					'text-destructive ds-raised [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90'
+					'text-destructive ds-raised [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+				/*
+				  Elevation comes from the ladder, as in `destructive`, so a success
+				  alert nested on a raised panel keeps the same edge as every other
+				  alert. The icon differs from `destructive` on purpose: it takes the
+				  saturated hue while the text takes the `-foreground` role, because
+				  the saturated green only just clears the 3:1 non-text floor on a
+				  light raised surface and would fail outright behind body copy.
+				*/
+				success:
+					'text-success-foreground ds-raised [&>svg]:text-success *:data-[slot=alert-description]:text-success-foreground/80'
 			}
 		},
 		defaultVariants: {


### PR DESCRIPTION
## Summary

Email sign-up failed with a server error that stated no reason, and the
confirmation screen it redirects to read as broken. This is the original fix.
The follow-ups found while reviewing it are stacked in a second PR.

## Root cause

`signin-layout` mints one single-use Turnstile token and each child route
invalidated it only when its own action returned `data(...)` — but a successful
sign-up returns `redirect(...)`, which produces no `actionData`, so the spent
token survived into the next submit under a layout that does not remount,
Cloudflare rejected the replay, and `signup-page`'s error branch flattened the
resulting captcha rejection into a fixed sentence while deliberately skipping
`reportServerError`. Invalidation belongs in the layout that owns the token
rather than in each child guessing from its own response shape.

## Changes

- `useSpendTurnstileToken` invalidates at submit time, and `resetTurnstile` is
  gone from `AuthLayoutContext` so no child can get this wrong again.
- `classifySignupFailure` gives each Supabase failure its own message and
  reports all but `already_registered`, which stays generic so the form is not
  an account-enumeration oracle. Sign-up joins `CRITICAL_FLOWS`.
- The credential-choice chrome is gated to the two routes that are one.
  `/auth/confirm-pending` was rendering a "Sign In" heading, the OAuth buttons
  and an offer to sign up to someone who just had; the two password screens
  were rendering two `<h1>`s.
- The name field is optional. An empty name is omitted from Supabase metadata
  rather than stored as `''`, because readers are split between `||` and `??`.
- The five screens move onto the type scale, the `ds-*` ladder via the shared
  `Alert`, the brand token's channel form, and the motion scale.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser

1355 tests pass; typecheck and lint green. Every new guard was mutation-tested —
the line deleted and the named test confirmed red. Screens checked in the
browser in light, dark and mobile.

**Known, fixed in the stacked PR:** the `create-account` flow added here cannot
fire on the path it was added for. React Router's single fetch posts to
`/sign-up.data` and the pattern matches the raw path.

**Not exercised end to end:** the confirmation-email leg needs Supabase and a
real inbox.

**One honest caveat on the diff.** Five concerns are interleaved at the line
level in one commit — a 156-line hunk in the layout carries three of them — so
they could not be separated afterwards. They should have been cut apart before
the work started.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [x] I updated documentation where needed