### PR TITLE
ci(infra): apply platform secrets and the auth hook from a workflow

### DIFF
--- a/.github/workflows/cd-platform-secrets.yaml
+++ b/.github/workflows/cd-platform-secrets.yaml
@@ -1,0 +1,116 @@
+# .github/workflows/cd-platform-secrets.yaml
+#
+# Applies runtime configuration to one environment: Fly app secrets, and the
+# Supabase `send_email` hook URI and signing secret.
+#
+# This ran from a laptop against a local `.env.development` holding every value
+# for both environments. Nothing recorded when it last ran, or whether the live
+# configuration still matched. The hook URI in particular is editable in the
+# Supabase dashboard and invisible to the repo, and it is what decides whether
+# any confirmation email is delivered at all.
+#
+# What lives where, after this: the repo owns the mapping - which value goes to
+# which app under which name - and GitHub Environments own the values. That is
+# less than Terraform gives you. There is no plan and no state, and `verify` can
+# only prove a secret exists, never that it holds the right value. The hook URI
+# is the exception: it is read back and compared.
+name: CD - Sync Platform Secrets
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Which environment to act on'
+        required: true
+        type: choice
+        options: [staging, production]
+      mode:
+        description: 'stage = apply on next deploy, immediate = restart now, verify = read-only'
+        required: true
+        default: stage
+        type: choice
+        options: [stage, immediate, verify]
+
+concurrency:
+  # Serialized per environment. Two overlapping runs would race on the same Fly
+  # app and the same Supabase project config.
+  group: cd-platform-secrets-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: ${{ inputs.mode }} → ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    # Binds the job to the GitHub Environment, so its secrets are readable here
+    # and whatever protection rules it carries - required reviewers, branch
+    # restrictions - apply before anything is written.
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Sync
+        env:
+          # Bare names. Each Environment holds its own copy, which is what keeps
+          # staging credentials out of a production run; the script looks a name
+          # up suffixed first and then bare, so the local `.env.development`
+          # path keeps working unchanged.
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+          APPLICATION_URL: ${{ secrets.APPLICATION_URL }}
+          CSRF_SECRET: ${{ secrets.CSRF_SECRET }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          SEND_EMAIL_HOOK_SECRET: ${{ secrets.SEND_EMAIL_HOOK_SECRET }}
+          CLOUDFLARE_TURNSTILE_SITE_KEY: ${{ secrets.CLOUDFLARE_TURNSTILE_SITE_KEY }}
+          CLOUDFLARE_TURNSTILE_SECRET_KEY: ${{ secrets.CLOUDFLARE_TURNSTILE_SECRET_KEY }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          EMBED_TOKEN_ENCRYPTION_KEY: ${{ secrets.EMBED_TOKEN_ENCRYPTION_KEY }}
+          CONTACT_DATA_ENCRYPTION_KEY: ${{ secrets.CONTACT_DATA_ENCRYPTION_KEY }}
+          RESEND_WEBHOOK_SECRET: ${{ secrets.RESEND_WEBHOOK_SECRET }}
+          CONTACT_INBOX_EMAIL: ${{ secrets.CONTACT_INBOX_EMAIL }}
+          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
+          # Read as shell variables rather than interpolated into the script
+          # body. Both are `type: choice` and so already constrained, but a
+          # workflow_dispatch input is caller-supplied and inlining one into
+          # `run:` is the shape that becomes an injection the day it is not.
+          TARGET_ENV: ${{ inputs.environment }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+
+          # The script's own vocabulary is staging|prod; the GitHub Environment
+          # is named production. Translated here rather than renaming the
+          # Environment, which `shared-fly-deploy.yaml` already depends on.
+          case "$TARGET_ENV" in
+            staging)    script_env=staging ;;
+            production) script_env=prod ;;
+            *) echo "unknown environment: $TARGET_ENV"; exit 1 ;;
+          esac
+
+          case "$MODE" in
+            verify)    flags=(--verify) ;;
+            stage)     flags=(--stage) ;;
+            immediate) flags=() ;;
+            *) echo "unknown mode: $MODE"; exit 1 ;;
+          esac
+
+          # `${flags[@]+...}` because an empty array under `set -u` is an error
+          # on bash before 4.4, and `immediate` passes no flags.
+          ./terraform/scripts/setup-fly-secrets.sh \
+            --env "$script_env" ${flags[@]+"${flags[@]}"}
+
+      - name: What happens next
+        if: success() && inputs.mode == 'stage'
+        run: |
+          echo "Secrets are staged on the Fly app but the running machines still" >> $GITHUB_STEP_SUMMARY
+          echo "hold the previous values. Deploy ${{ inputs.environment }} to apply them." >> $GITHUB_STEP_SUMMARY

--- a/apps/vectreal-platform/tests/embed-token-storage.spec.ts
+++ b/apps/vectreal-platform/tests/embed-token-storage.spec.ts
@@ -79,22 +79,32 @@ describe('the deployment that has to configure it', () => {
 		const script = read('terraform/scripts/setup-fly-secrets.sh')
 
 		expect(script).toContain(`${ENV_VAR}="$emb_key"`)
-		expect(script).toContain(`${ENV_VAR}_${'${ENV}'}`)
+		// Resolved per environment, so staging and production get their own.
+		expect(script).toContain(`resolve ${ENV_VAR} "$ENV"`)
 	})
 
 	it('fails the run when it is missing, rather than deploying without it', () => {
 		/*
-		  `REQUIRED_STAGING` / `REQUIRED_PROD` are the only lists that `exit 1`.
-		  The verify-mode check list only warns and then exits 0, and the earlier
-		  `${emb_key:+...}` form skipped a missing value without comment - so a
-		  forgotten key produced a *successful* deploy that minted keys nobody
-		  could ever be shown, which is the failure this whole change exists to
-		  end.
+		  `REQUIRED_PER_ENV` is the list that `exit 1`s, and it is checked once
+		  per environment - so the bare name appearing there covers both. The
+		  earlier `${emb_key:+...}` form skipped a missing value without comment,
+		  so a forgotten key produced a *successful* deploy that minted keys
+		  nobody could ever be shown, which is the failure this whole change
+		  exists to end.
 		*/
 		const script = read('terraform/scripts/setup-fly-secrets.sh')
 
+		const required = script.slice(
+			script.indexOf('REQUIRED_PER_ENV=('),
+			script.indexOf('MISSING=()')
+		)
+		expect(required).toContain(`"${ENV_VAR}"`)
+
+		// Checked for staging and for prod, not just once overall.
 		for (const env of ['STAGING', 'PROD']) {
-			expect(script, env).toContain(`"${ENV_VAR}_${env}"`)
+			expect(script, env).toContain(
+				`check_env_vars ${env} "\${REQUIRED_PER_ENV[@]}"`
+			)
 		}
 
 		expect(script).toContain(`${ENV_VAR}="$emb_key"`)
@@ -109,6 +119,23 @@ describe('the deployment that has to configure it', () => {
 		)
 
 		expect(checkList).toContain(ENV_VAR)
+	})
+
+	/*
+	  Verify used to `warn` and exit 0, so it could report this key missing and
+	  still pass. It is a gate now, which is the only reason the check above is
+	  worth anything in CI.
+	*/
+	it('makes verify mode a gate rather than a report', () => {
+		const script = read('terraform/scripts/setup-fly-secrets.sh')
+		const verifyMode = script.slice(
+			script.indexOf('if [[ "$MODE" == "verify" ]]; then'),
+			script.indexOf('# SYNC MODE')
+		)
+
+		expect(verifyMode).toContain('VERIFY_FAILED+=')
+		expect(verifyMode).toMatch(/VERIFY_FAILED\[@\]}\s*-gt 0/)
+		expect(verifyMode).toContain('exit 1')
 	})
 
 	it('is documented for both deployed environments', () => {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,15 +48,47 @@ pnpm nx run terraform:plan-infrastructure    # init + validate + plan
 pnpm nx run terraform:apply-infrastructure   # runs scripts/apply-infrastructure.sh
 ```
 
-### 3. Sync Fly.io app secrets
+### 3. Sync Fly.io app secrets and the Supabase hook
 
-`scripts/setup-fly-secrets.sh` reads `.env.development` and (a) sets Fly.io app secrets via `fly secrets set` and (b) syncs the Supabase `send_email` hook via the Management API:
+`scripts/setup-fly-secrets.sh` (a) sets Fly.io app secrets via `fly secrets set`
+and (b) syncs the Supabase `send_email` hook URI and signing secret through the
+Management API.
+
+**Prefer the workflow.** `CD - Sync Platform Secrets`
+(`.github/workflows/cd-platform-secrets.yaml`) runs it against one environment
+at a time, reading values from that GitHub Environment rather than from anyone's
+laptop, and inheriting whatever protection rules the Environment carries.
+
+| Mode | What it does |
+| --- | --- |
+| `stage` | Writes the secrets with `--stage`. The app keeps running the old values until the next deploy applies them. The default, because a routine rotation should not bounce production. |
+| `immediate` | Writes and restarts now. For an urgent rotation, such as a leaked key. |
+| `verify` | Read-only, and a gate: exits non-zero when a secret is missing, when the `send_email` hook is disabled, or when its live URI does not match `APPLICATION_URL`. |
+
+Rotating a value is: change it in the GitHub Environment, run the workflow.
+Adding one is a PR - the name goes in the script's `REQUIRED_PER_ENV` list and
+the workflow's `env:` block - then the value goes in the Environment.
+
+The local path still works and is unchanged:
 
 ```bash
 pnpm nx run terraform:setup-fly-secrets-staging
 pnpm nx run terraform:setup-fly-secrets-prod
-pnpm nx run terraform:verify-fly-secrets      # read-only check
+pnpm nx run terraform:verify-fly-secrets      # now exits non-zero on drift
 ```
+
+Names are looked up suffixed first (`DATABASE_URL_PROD`, which is how
+`.env.development` namespaces both environments in one file) and then bare
+(`DATABASE_URL`, which is what a per-environment GitHub secret holds), so both
+callers read the same script.
+
+**What this is not.** The repo owns the mapping - which value reaches which app
+under which name - and GitHub Environments own the values. There is no state
+file and no plan, and `verify` can only prove a Fly secret *exists*: `fly
+secrets list` reports digests, never values. The hook URI is the one thing
+checked against its expected value, because it is editable in the Supabase
+dashboard, invisible to this repo, and decides whether any auth email is
+delivered at all.
 
 ## Variables
 

--- a/terraform/scripts/setup-fly-secrets.sh
+++ b/terraform/scripts/setup-fly-secrets.sh
@@ -7,12 +7,21 @@
 #   ./setup-fly-secrets.sh --env staging # sync staging only
 #   ./setup-fly-secrets.sh --env prod    # sync production only
 #   ./setup-fly-secrets.sh --verify      # read-only: check current state
+#   ./setup-fly-secrets.sh --stage       # stage secrets, apply on next deploy
 #   ./setup-fly-secrets.sh --help        # show this help
 #
-# Reads from .env.development at the repo root.
+# Values come from .env.development at the repo root when it exists, and from
+# the process environment when it does not - which is how CI supplies them.
+# Each name is looked up suffixed first (DATABASE_URL_PROD, the local file's
+# convention) and then bare (DATABASE_URL, what a GitHub Environment holds), so
+# both callers read the same script.
+#
 # Syncs:
 #   1. Fly.io app secrets (fly secrets set)
 #   2. Supabase send_email hook URI + secret (via Management API)
+#
+# --verify is a gate, not a report: it exits non-zero when a secret is missing
+# or the live hook URI does not match APPLICATION_URL.
 # =============================================================================
 
 RED='\033[0;31m'
@@ -34,6 +43,9 @@ HOOKS_FAILED=()
 
 MODE="sync"
 ENV_FILTER=""
+# Staged secrets land on the app without restarting it; the next deploy applies
+# them. Keeps a routine rotation from bouncing production.
+STAGE_ONLY=false
 
 show_help() {
   grep '^#' "$0" | grep -v '^#!/' | sed 's/^# \{0,2\}//'
@@ -43,6 +55,7 @@ show_help() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --verify) MODE="verify"; shift ;;
+    --stage)  STAGE_ONLY=true; shift ;;
     --env)
       shift
       case "$1" in
@@ -81,68 +94,86 @@ fi
 
 section "Fly.io authentication"
 if ! fly auth whoami &>/dev/null; then
+  # `fly auth login` opens a browser and blocks. There is nobody to answer it in
+  # CI, so fail with the thing that would have fixed it instead of hanging.
+  if [[ -n "${CI:-}" ]] || [[ ! -t 0 ]]; then
+    err "Not authenticated and no terminal to log in from."
+    printf "\n  Set FLY_API_TOKEN in the environment.\n"
+    exit 1
+  fi
   warn "Not authenticated - launching fly auth login..."
   fly auth login || { err "Authentication failed"; exit 1; }
 fi
 ok "Authenticated: $(fly auth whoami)"
 
 ENV_FILE="$REPO_ROOT/.env.development"
-section "Environment file"
-if [[ ! -f "$ENV_FILE" ]]; then
-  err "$ENV_FILE not found"
-  printf "\n  Create it: cp .env.development.example .env.development\n"
-  exit 1
+section "Values"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+  ok "$ENV_FILE loaded"
+else
+  # Not an error. CI has no such file and supplies the values directly, which is
+  # the whole point of moving this into a workflow.
+  ok "no .env.development - reading the process environment"
 fi
-set -a
-# shellcheck disable=SC1090
-source "$ENV_FILE"
-set +a
-ok "$ENV_FILE loaded"
+
+# Suffixed first, then bare. The local file namespaces every value by
+# environment in one flat file; a GitHub Environment does the namespacing
+# itself and holds the bare name. Shared values have no suffix either way.
+resolve() {
+  local name="$1" env_upper="${2:-}"
+  local suffixed="${name}_${env_upper}"
+  if [[ -n "$env_upper" && -n "${!suffixed:-}" ]]; then
+    printf '%s' "${!suffixed}"
+  else
+    printf '%s' "${!name:-}"
+  fi
+}
 
 section "Validating required variables"
 
+# Logical names, not spellings. `resolve` decides whether a value arrives as
+# DATABASE_URL_PROD or as DATABASE_URL in a production Environment.
 REQUIRED_SHARED=(
   "FROM_EMAIL"
   "CONTACT_INBOX_EMAIL"
   "SUPABASE_ACCESS_TOKEN"
 )
-REQUIRED_STAGING=(
-  "SUPABASE_PROJECT_REF_STAGING"
-  "DATABASE_URL_STAGING"
-  "SUPABASE_URL_STAGING"
-  "SUPABASE_KEY_STAGING"
-  "SUPABASE_SECRET_KEY_STAGING"
-  "APPLICATION_URL_STAGING"
-  "CSRF_SECRET_STAGING"
-  "STRIPE_SECRET_KEY_STAGING"
-  "SEND_EMAIL_HOOK_SECRET_STAGING"
-  "CLOUDFLARE_TURNSTILE_SITE_KEY_STAGING"
-  "CLOUDFLARE_TURNSTILE_SECRET_KEY_STAGING"
-  "RESEND_API_KEY_STAGING"
-  "EMBED_TOKEN_ENCRYPTION_KEY_STAGING"
-)
-REQUIRED_PROD=(
-  "SUPABASE_PROJECT_REF_PROD"
-  "DATABASE_URL_PROD"
-  "SUPABASE_URL_PROD"
-  "SUPABASE_KEY_PROD"
-  "SUPABASE_SECRET_KEY_PROD"
-  "APPLICATION_URL_PROD"
-  "CSRF_SECRET_PROD"
-  "STRIPE_SECRET_KEY_PROD"
-  "SEND_EMAIL_HOOK_SECRET_PROD"
-  "CLOUDFLARE_TURNSTILE_SITE_KEY_PROD"
-  "CLOUDFLARE_TURNSTILE_SECRET_KEY_PROD"
-  "RESEND_API_KEY_PROD"
-  "EMBED_TOKEN_ENCRYPTION_KEY_PROD"
+REQUIRED_PER_ENV=(
+  "SUPABASE_PROJECT_REF"
+  "DATABASE_URL"
+  "SUPABASE_URL"
+  "SUPABASE_KEY"
+  "SUPABASE_SECRET_KEY"
+  "APPLICATION_URL"
+  "CSRF_SECRET"
+  "STRIPE_SECRET_KEY"
+  "SEND_EMAIL_HOOK_SECRET"
+  "CLOUDFLARE_TURNSTILE_SITE_KEY"
+  "CLOUDFLARE_TURNSTILE_SECRET_KEY"
+  "RESEND_API_KEY"
+  "EMBED_TOKEN_ENCRYPTION_KEY"
 )
 
 MISSING=()
-check_vars() { for var in "$@"; do [[ -z "${!var}" ]] && MISSING+=("$var"); done; }
+check_shared() {
+  for var in "$@"; do [[ -z "$(resolve "$var")" ]] && MISSING+=("$var"); done
+}
+check_env_vars() {
+  local env_upper="$1"; shift
+  for var in "$@"; do
+    [[ -z "$(resolve "$var" "$env_upper")" ]] && MISSING+=("${var} (${env_upper})")
+  done
+}
 
-check_vars "${REQUIRED_SHARED[@]}"
-[[ -z "$ENV_FILTER" || "$ENV_FILTER" == "staging" ]] && check_vars "${REQUIRED_STAGING[@]}"
-[[ -z "$ENV_FILTER" || "$ENV_FILTER" == "prod"    ]] && check_vars "${REQUIRED_PROD[@]}"
+check_shared "${REQUIRED_SHARED[@]}"
+[[ -z "$ENV_FILTER" || "$ENV_FILTER" == "staging" ]] && \
+  check_env_vars STAGING "${REQUIRED_PER_ENV[@]}"
+[[ -z "$ENV_FILTER" || "$ENV_FILTER" == "prod"    ]] && \
+  check_env_vars PROD "${REQUIRED_PER_ENV[@]}"
 
 if [[ ${#MISSING[@]} -gt 0 ]]; then
   err "Missing required variables:"
@@ -161,21 +192,24 @@ strip_hook_prefix() {
 # VERIFY MODE
 # ===========================================================================
 if [[ "$MODE" == "verify" ]]; then
+  VERIFY_FAILED=()
+
   section "Fly.io secrets (existence check)"
 
+  # Presence only. `fly secrets list` reports digests, never values, so nothing
+  # here can tell a correct secret from a wrong one - only a missing one.
   check_fly_secret() {
     local app="$1" name="$2"
     if fly secrets list --app "$app" 2>/dev/null | grep -qw "$name"; then
       ok "$app / $name"
     else
-      warn "$app / $name NOT FOUND"
+      err "$app / $name NOT FOUND"
+      VERIFY_FAILED+=("$app/$name")
     fi
   }
 
   check_env_secrets() {
     local env="$1" app="$2"
-    local ENV
-    ENV=$(printf '%s' "$env" | tr '[:lower:]' '[:upper:]')
     for field in DATABASE_URL SUPABASE_URL SUPABASE_KEY SUPABASE_SECRET_KEY \
                  CSRF_SECRET STRIPE_SECRET_KEY APPLICATION_URL SEND_EMAIL_HOOK_SECRET \
                  CLOUDFLARE_TURNSTILE_SITE_KEY CLOUDFLARE_TURNSTILE_SECRET_KEY \
@@ -191,7 +225,66 @@ if [[ "$MODE" == "verify" ]]; then
   [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "prod" ]] && \
     check_env_secrets prod "vectreal-platform"
 
-  printf "\n${GREEN}Verify complete. No changes made.${NC}\n\n"
+  section "Supabase auth hook (live value)"
+
+  # The one thing here that is a real drift check rather than a presence check.
+  # The hook URI is what decides whether confirmation emails are delivered at
+  # all, and it lives in Supabase's project config - editable in a dashboard,
+  # invisible to this repo. Reading it back is the only way the repo learns that
+  # someone changed it.
+  check_hook_uri() {
+    local project_ref="$1" expected_url="$2" label="$3"
+    local expected="${expected_url}/auth/send-email"
+
+    if [[ -z "$project_ref" || -z "$expected_url" ]]; then
+      err "$label - cannot check: project ref or APPLICATION_URL is unset"
+      VERIFY_FAILED+=("$label/hook-inputs")
+      return
+    fi
+
+    local response http_code body
+    response=$(curl -s -w "\n%{http_code}" \
+      "https://api.supabase.com/v1/projects/${project_ref}/config/auth" \
+      -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" 2>&1)
+    http_code=$(printf '%s' "$response" | tail -n1)
+    body=$(printf '%s' "$response" | sed '$d')
+
+    if [[ ! "$http_code" =~ ^2 ]]; then
+      err "$label - HTTP ${http_code} reading auth config"
+      VERIFY_FAILED+=("$label/hook-read")
+      return
+    fi
+
+    local enabled actual
+    enabled=$(printf '%s' "$body" | jq -r '.hook_send_email_enabled // false')
+    actual=$(printf '%s' "$body" | jq -r '.hook_send_email_uri // ""')
+
+    if [[ "$enabled" != "true" ]]; then
+      err "$label - send_email hook is DISABLED; no auth email is delivered"
+      VERIFY_FAILED+=("$label/hook-disabled")
+    elif [[ "$actual" != "$expected" ]]; then
+      err "$label - hook URI drifted"
+      printf "      expected: %s\n      actual:   %s\n" "$expected" "$actual"
+      VERIFY_FAILED+=("$label/hook-uri")
+    else
+      ok "$label - $actual"
+    fi
+  }
+
+  [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "staging" ]] && \
+    check_hook_uri "$(resolve SUPABASE_PROJECT_REF STAGING)" \
+      "$(resolve APPLICATION_URL STAGING)" "staging"
+  [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "prod" ]] && \
+    check_hook_uri "$(resolve SUPABASE_PROJECT_REF PROD)" \
+      "$(resolve APPLICATION_URL PROD)" "prod"
+
+  printf "\n"
+  if [[ ${#VERIFY_FAILED[@]} -gt 0 ]]; then
+    err "Verify failed: ${VERIFY_FAILED[*]}"
+    printf "\n"
+    exit 1
+  fi
+  printf "${GREEN}Verify passed. No changes made.${NC}\n\n"
   exit 0
 fi
 
@@ -208,21 +301,27 @@ sync_fly_secrets() {
   env_title="$(printf '%s' "$env" | sed 's/\(.\)/\u\1/')"
   section "${env_title} → $app"
 
-  local db_url; db_url="$(eval echo "\${DATABASE_URL_${ENV}}")"
-  local sb_url; sb_url="$(eval echo "\${SUPABASE_URL_${ENV}}")"
-  local sb_key; sb_key="$(eval echo "\${SUPABASE_KEY_${ENV}}")"
-  local sb_secret_key; sb_secret_key="$(eval echo "\${SUPABASE_SECRET_KEY_${ENV}}")"
-  local app_url; app_url="$(eval echo "\${APPLICATION_URL_${ENV}}")"
-  local csrf;    csrf="$(eval echo "\${CSRF_SECRET_${ENV}}")"
-  local stripe;  stripe="$(eval echo "\${STRIPE_SECRET_KEY_${ENV}}")"
-  local ts_site; ts_site="$(eval echo "\${CLOUDFLARE_TURNSTILE_SITE_KEY_${ENV}}")"
-  local ts_sec;  ts_sec="$(eval echo "\${CLOUDFLARE_TURNSTILE_SECRET_KEY_${ENV}}")"
-  local resend;  resend="$(eval echo "\${RESEND_API_KEY_${ENV}}")"
-  local hook_raw; hook_raw="$(eval echo "\${SEND_EMAIL_HOOK_SECRET_${ENV}}")"
+  local db_url;   db_url="$(resolve DATABASE_URL "$ENV")"
+  local sb_url;   sb_url="$(resolve SUPABASE_URL "$ENV")"
+  local sb_key;   sb_key="$(resolve SUPABASE_KEY "$ENV")"
+  local sb_secret_key; sb_secret_key="$(resolve SUPABASE_SECRET_KEY "$ENV")"
+  local app_url;  app_url="$(resolve APPLICATION_URL "$ENV")"
+  local csrf;     csrf="$(resolve CSRF_SECRET "$ENV")"
+  local stripe;   stripe="$(resolve STRIPE_SECRET_KEY "$ENV")"
+  local ts_site;  ts_site="$(resolve CLOUDFLARE_TURNSTILE_SITE_KEY "$ENV")"
+  local ts_sec;   ts_sec="$(resolve CLOUDFLARE_TURNSTILE_SECRET_KEY "$ENV")"
+  local resend;   resend="$(resolve RESEND_API_KEY "$ENV")"
+  local hook_raw; hook_raw="$(resolve SEND_EMAIL_HOOK_SECRET "$ENV")"
   local hook; hook="$(strip_hook_prefix "$hook_raw")"
-  local enc_key;  enc_key="$(eval echo "\${CONTACT_DATA_ENCRYPTION_KEY_${ENV}:-}")"
-  local emb_key;  emb_key="$(eval echo "\${EMBED_TOKEN_ENCRYPTION_KEY_${ENV}}")"
-  local resend_wh; resend_wh="$(eval echo "\${RESEND_WEBHOOK_SECRET_${ENV}:-}")"
+  local enc_key;  enc_key="$(resolve CONTACT_DATA_ENCRYPTION_KEY "$ENV")"
+  local emb_key;  emb_key="$(resolve EMBED_TOKEN_ENCRYPTION_KEY "$ENV")"
+  local resend_wh; resend_wh="$(resolve RESEND_WEBHOOK_SECRET "$ENV")"
+
+  local stage_flag=()
+  if [[ "$STAGE_ONLY" == "true" ]]; then
+    stage_flag=(--stage)
+    warn "staged only - the next deploy applies these"
+  fi
 
   if fly secrets set \
       DATABASE_URL="$db_url" \
@@ -243,6 +342,7 @@ sync_fly_secrets() {
       ${enc_key:+CONTACT_DATA_ENCRYPTION_KEY="$enc_key"} \
       EMBED_TOKEN_ENCRYPTION_KEY="$emb_key" \
       ${resend_wh:+RESEND_WEBHOOK_SECRET="$resend_wh"} \
+      "${stage_flag[@]}" \
       --app "$app" 2>/dev/null; then
     SECRETS_SET+=("$app")
     ok "Secrets set for $app"
@@ -279,11 +379,13 @@ sync_supabase_hook() {
 
 section "Supabase auth hook sync"
 [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "staging" ]] && \
-  sync_supabase_hook "$SUPABASE_PROJECT_REF_STAGING" \
-    "$SEND_EMAIL_HOOK_SECRET_STAGING" "$APPLICATION_URL_STAGING" "staging"
+  sync_supabase_hook "$(resolve SUPABASE_PROJECT_REF STAGING)" \
+    "$(resolve SEND_EMAIL_HOOK_SECRET STAGING)" \
+    "$(resolve APPLICATION_URL STAGING)" "staging"
 [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "prod" ]] && \
-  sync_supabase_hook "$SUPABASE_PROJECT_REF_PROD" \
-    "$SEND_EMAIL_HOOK_SECRET_PROD" "$APPLICATION_URL_PROD" "prod"
+  sync_supabase_hook "$(resolve SUPABASE_PROJECT_REF PROD)" \
+    "$(resolve SEND_EMAIL_HOOK_SECRET PROD)" \
+    "$(resolve APPLICATION_URL PROD)" "prod"
 
 printf "\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n"
 printf "  Fly.io apps updated: ${GREEN}%d${NC}\n" "${#SECRETS_SET[@]}"


### PR DESCRIPTION
## Summary

Moves the Fly secrets and Supabase `send_email` hook sync off a laptop and into
a workflow, and turns `--verify` from a report into a gate.

Independent of #765 and #766 — no shared files, mergeable in any order.

## Root cause

n/a as a product defect; this is tooling. The prompt was concrete though: asked
where the production `send_email` hook points, the only way to answer was to
read `.env.development.example` and infer, because the value is applied by a
script run by hand from a local file and nothing reads it back. `--verify`
looked like it would have answered — it does not: it `warn`s and exits 0, so it
could list every secret as missing and still pass, and it never checked the hook
at all.

## Changes

- `CD - Sync Platform Secrets`: `workflow_dispatch`, one environment at a time,
  bound to the GitHub Environment so its protection rules apply. Three modes —
  `stage` (writes with `fly secrets set --stage`, so a routine rotation does not
  bounce production), `immediate`, and `verify`.
- The script keeps working locally, unchanged. Names resolve suffixed first
  (`DATABASE_URL_PROD`, how the local file namespaces both environments in one
  file) then bare (`DATABASE_URL`, what a per-environment secret holds), so one
  script serves both callers instead of forking.
- `--verify` exits non-zero, and reads the live `send_email` config back from
  the Management API to check the URI matches `APPLICATION_URL` and that the
  hook is enabled at all.
- Fails fast instead of hanging when unauthenticated with no terminal;
  `fly auth login` opens a browser and CI has nobody to answer it.

## Type of Change

- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated

1307 tests pass on this branch alone; typecheck and lint green on five projects.
The name resolver was tested in isolation across nine cases including the
fallthroughs. `embed-token-storage.spec.ts` already guarded this script and
caught the refactor — it is updated to the new shape and gained a case pinning
verify-as-a-gate, both mutation-tested.

**Before this can run, you need to populate the two GitHub Environments** — 13
values each plus four shared. Use the bare names; the Environment does the
namespacing. Run `verify` first: it touches nothing and reports whether the
wiring is right.

**What this is not.** The repo owns the mapping; GitHub owns the values. No
state, no plan. `verify` can prove a Fly secret exists but never that it holds
the right value — `fly secrets list` returns digests. The hook URI is the one
real drift check, and it is the one that prompted this.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [x] I updated documentation where needed