### PR TITLE
docs(skills): fold the delivery lessons into fewer, larger patterns

### DIFF
--- a/.agents/skills/vectreal-extension-architecture/SKILL.md
+++ b/.agents/skills/vectreal-extension-architecture/SKILL.md
@@ -80,6 +80,12 @@ const hasLoaded = fetcher.data !== undefined
 This shipped three separate symptom fixes before the cause was found. When you
 patch the same defect at a third call site, stop and find the cause.
 
+**State that records a *choice* rarely answers whether that choice is in
+effect.** `activeComposeTool` is never null and does not change when its panel
+closes, so three call sites combined it with `showSidebar` by hand and a fourth
+forgot - leaving an editing gizmo live after its tool had closed. Derive the
+question once, and name the derivation for the question rather than the field.
+
 **StrictMode double-invokes mount effects**, not update effects. A ref guard
 around a load-once or submit-once effect exists for that reason alone. Say so in
 a comment, or the next reader deletes it.
@@ -140,13 +146,8 @@ bundles a dependency declares that as an `ignoredDependencies` entry in
 
 ## Gates
 
-```bash
-pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform
-```
-
-Unit tests: `npx vitest run --root .` (or `pnpm nx test vectreal-platform`).
-Integration tests need `pnpm nx run vectreal-platform:supabase-start` first, then
-`pnpm nx run vectreal-platform:test-integration`.
+`vectreal-iterative-delivery` owns them, including the trap: a project name
+matching nothing still exits 0, so a typo turns a gate into a silent pass.
 
 ## Source of truth
 

--- a/.agents/skills/vectreal-iterative-delivery/SKILL.md
+++ b/.agents/skills/vectreal-iterative-delivery/SKILL.md
@@ -43,18 +43,10 @@ need seven review rounds, and days spent perfecting something nobody depends on.
 
 **Cut by concern. Always.** One concern per task, per PR, per subagent. Review
 rounds track the number of concerns in a diff, not its size. Measured on this
-workstream:
-
-| PR | Concerns | Files | Review rounds |
-| --- | --- | --- | --- |
-| #736 eslint rules | 1 | 7 | 1 |
-| #732 hotspot fixes + module split + comparison | 3 | 20 | 3 |
-| #734 server manifest + client loader | 2 | 20 | 5 |
-| #735 route + hook + panel + dialog + key options + snippet | 6 | 14 | 7 |
-| embed domain policy | 1 | 2 | 0 |
-
-Twenty files with two concerns cost more rounds than seven files with one.
-Splitting is close to free; mixing is not.
+workstream: #736 carried one concern across seven files and needed one round;
+#735 carried six concerns across fourteen files and needed seven. Twenty files
+with two concerns cost more rounds than seven files with one. Splitting is close
+to free; mixing is not.
 
 **Spend by tier.** Distance from the funnel sets depth, and only depth.
 
@@ -67,12 +59,11 @@ Splitting is close to free; mixing is not.
 `apps/vectreal-platform/tests/critical-path.spec.ts` holds the funnel as data and
 fails when a step loses its guard. It is the tier-1 list.
 
-So the grid is:
-
-|  | Narrow scope | Wide scope |
-| --- | --- | --- |
-| **Deep** | Tier 1, correct | #735: seven rounds for one feature |
-| **Shallow** | Tier 3, correct | how the wildcard bug shipped |
+Below every tier: a change whose only purpose is to satisfy a mechanical gate -
+lint, typecheck, formatting, a renamed import - is reviewed by that gate. One
+pass that it is green and minimal, then ship. Running the loop there only grows
+the diff, because each round has to find something and the only thing left is the
+prose the last round wrote.
 
 Hyperfixation is not caused by narrow scope. It is deep effort spent on a tier-3
 concern. On 2026-08-22 three agent skill files were rewritten and verified with
@@ -85,17 +76,6 @@ sat filed and untouched from the day before. Narrow was right; deep was wrong.
    is two PRs. #735's needed five.
 2. **If the diff touches a file the scope line did not name**, stop. Either
    rename the scope out loud, or file the finding and leave the file alone.
-
-## When the loop does not run
-
-**A change whose whole purpose is to satisfy a mechanical gate - lint,
-typecheck, formatting, a renamed import - is reviewed by that gate.** One pass to
-confirm the gate is green and the change is minimal, then ship. No loop.
-
-The loop exists for changes where behavior is in question. Running it on a
-one-line lint fix does not make the fix safer; it makes the diff bigger, because
-each round has to find something and the only thing left to find is the prose the
-previous round produced.
 
 ## The loop, which is never skipped
 
@@ -141,22 +121,26 @@ enough that a finding gets checked against the code before it becomes a fix.
 **For every guard you add, mutate the production line and confirm a test goes
 red.** Run this while implementing, not after review asks for it.
 
-This is the single highest-value habit here. On PR #735 the review loop ran seven
-rounds; three separate rounds found a test of mine that could not fail, and one
-was directly beneath a comment I had written warning about that exact failure
-mode. The mutation check catches all of them in seconds and takes rounds off the
-loop.
+The mutation names what you actually verified, and whatever survives it was never
+covered however green the suite. On PR #735 three separate review rounds each
+found a test of mine that could not fail; every one would have died to a
+five-second mutation instead of a round.
 
-Named failure modes it catches:
+So mutate the line that would really break:
 
-- **The tautological assertion.** A regex capture group that can never match what
-  it claims (`[^"]*` will not contain a quote), or asserting attribute names
-  while the payload injects sibling elements. Parse with `DOMParser` and assert
-  an exact element list rather than pattern-matching a string.
-- **The untested guard.** Delete the guard; if the suite is still green, the test
-  was never testing it.
-- **The test that pins the bug.** Write the failing test first when fixing a
-  defect, and watch it fail for the stated reason before fixing.
+- **The call, not only the rule.** Tests cluster around the interesting logic,
+  which is exactly where the wiring is not, so a well-tested module that nothing
+  reaches type-checks cleanly and breaks no suite. #755 shipped a complete
+  renderer no surface called.
+- **The guard itself.** Delete it; a still-green suite was never testing it.
+- **The assertion's shape.** `[^"]*` cannot contain a quote, so a regex built on
+  it passes for reasons unrelated to the behaviour. Assert a parsed result.
+- **The defect, before the fix.** Watch the test fail for the stated reason.
+
+Environments ask the same question and cannot automate it: a check that only ever
+ran on your machine has not been run. When the surface will not run locally, show
+the obstacle is not yours (try `main`), move the proof into a gate that runs
+without you, and name what stayed unverified.
 
 ## Stop symptom-patching
 
@@ -168,6 +152,8 @@ that never runs during SSR, so both empty-state claims were baked into the serve
 HTML.
 
 Two patches of one symptom is a coincidence. Three is a missing root cause.
+Count shapes rather than files: a guard you keep re-applying somewhere new is
+itself the symptom.
 
 ## Scope discipline
 
@@ -242,8 +228,9 @@ Any claim that a phase is done carries:
 
 1. Commands run, with their result.
 2. Surfaces validated, including the failure path exercised.
-3. What was filed rather than fixed.
-4. Residual risk.
+3. What could not be verified, and what stands in for it.
+4. What was filed rather than fixed.
+5. Residual risk.
 
 If the evidence is incomplete, report in progress. Report outcomes faithfully: if
 tests fail, say so with the output; if a step was skipped, say that.
@@ -260,7 +247,7 @@ tests fail, say so with the output; if a step was skipped, say that.
 | Third patch of one symptom | Find the cause |
 | Reviewers and fixers running concurrently | Phase barrier |
 | Subagent finding applied without checking the code | Verify, then fix |
-| Success reported from a passing type-check | Runtime failure-path check in the changed surface |
+| Done declared from a green suite | Evidence it is reached, and runs where it ships |
 | Out-of-scope fix folded into the diff | Catalogue row, named in the PR |
 
 ## Verified claims


### PR DESCRIPTION
## Summary

Consolidation rather than accretion. Three patterns added, four redundant blocks removed, **combined payload flat to within 58 bytes** (23,719 → 23,777).

## Root cause

n/a — skills and docs. The lessons come from a session where the review loop ran four rounds and still shipped the same defect shape five times, which is a signal about the guidance rather than about any one change.

## Changes

**The mutation gate states a principle instead of listing failure modes.** The three named modes were instances of one idea: *the mutation names what you actually verified, and whatever survives it was never covered.* The four places to apply it now include the one this workstream kept missing — **the call, not only the rule.** A well-tested module nothing reaches type-checks cleanly and breaks no suite; that is how a complete renderer shipped with no surface calling it, and how the change fixing that repeated the shape at four more sites in one session.

**Environments get the same question**, since they cannot be automated: a check that only ever ran on your machine has not been run. When the surface will not run locally — show the obstacle is not yours, move the proof into a gate that runs without you, and name what stayed unverified. The evidence block gains a slot for that last part, so an unverifiable step is reported rather than quietly downgraded.

**Removed as redundant:**

- `When the loop does not run` — a fourth statement of depth calibration, sitting directly above a heading promising the loop is never skipped. Now one line under the tier table it restated.
- The scope/depth grid — restated the paragraph beneath it.
- The review-rounds table — its conclusion was already drawn twice in the surrounding prose.
- `vectreal-extension-architecture`'s copy of the gates — a strict subset of the real one that omitted the `-p` trap, which is the part worth documenting.

**Added to `vectreal-extension-architecture`:** state recording a *choice* rarely answers whether that choice is *in effect*. `activeComposeTool` is never null and does not change when its panel closes, so three call sites combined it with `showSidebar` by hand and a fourth forgot.

## Type of Change

- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [x] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [ ] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated
- [x] No tests required — but `tests/documented-claims.spec.ts` passes (68), which is what keeps these files honest

**No new entries in either claims block.** Every added line is prose about an incident rather than a claim about a path, so nothing here can go stale against a file that lands in a different PR — which matters, because the code those incidents came from is in separate PRs.

**Formatting is left exactly as found.** These files are not prettier-clean on `main` and CI does not gate them, so reformatting would bury the change in table padding. An earlier attempt at this did exactly that, and reached into a third skill file that had no business being in the diff.

## Checklist

- [x] Reviewed for redundancy against the other skills, not just internally
- [x] Payload measured in bytes rather than lines, since table padding makes lines a poor proxy
- [x] No claims added that depend on files in other PRs