### PR TITLE
fix(viewer): stop a camera snapping mid-flight to the viewpoint it was flying to

### DIFF
--- a/packages/viewer/src/components/scene/camera-selection-signature.spec.ts
+++ b/packages/viewer/src/components/scene/camera-selection-signature.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { cameraSelectionSignature } from './camera-selection-signature'
+
+import type { CameraConfig } from '@vctrl/core'
+
+const camera = (overrides: Partial<CameraConfig> = {}): CameraConfig =>
+	({ cameraId: 'cam-a', name: 'A', ...overrides }) as CameraConfig
+
+const sign = (cameras: CameraConfig[], id = 'cam-a') =>
+	cameraSelectionSignature(cameras, id, undefined)
+
+describe('cameraSelectionSignature', () => {
+	it('is the same for a camera nobody edited', () => {
+		const cameras = [
+			camera({ position: [0, 1, 2], target: [0, 0, 0], fov: 50 })
+		]
+
+		expect(sign(cameras)).toBe(sign(cameras))
+	})
+
+	/**
+	 * The case the snap came from. A hotspot camera carries a target and no
+	 * position, so the resolved pose was completed from the live scene camera -
+	 * and the live camera moves on every frame of a flight. Signing stored fields
+	 * makes the signature blind to that, which is the whole point: it answers
+	 * "did the author change anything", not "where is the camera right now".
+	 */
+	it('ignores everything about where the camera currently is', () => {
+		const hotspotCamera = [camera({ kind: 'hotspot', target: [1, 2, 3] })]
+		const before = sign(hotspotCamera)
+
+		// Nothing here is an edit; only the live camera would have moved.
+		expect(sign(hotspotCamera)).toBe(before)
+		expect(sign([...hotspotCamera])).toBe(before)
+	})
+
+	it('changes when the author moves the camera', () => {
+		expect(sign([camera({ position: [0, 1, 2] })])).not.toBe(
+			sign([camera({ position: [0, 1, 9] })])
+		)
+	})
+
+	it('changes when the author re-aims it', () => {
+		expect(sign([camera({ target: [0, 0, 0] })])).not.toBe(
+			sign([camera({ target: [1, 2, 3] })])
+		)
+	})
+
+	it('changes when the author gives a camera a pose it did not have', () => {
+		// Absent fields are signed as null rather than skipped, so this reads as an
+		// edit instead of collapsing onto the same string.
+		expect(sign([camera()])).not.toBe(sign([camera({ position: [0, 1, 2] })]))
+	})
+
+	it('changes when the field of view changes', () => {
+		expect(sign([camera({ fov: 50 })])).not.toBe(sign([camera({ fov: 60 })]))
+	})
+
+	it('follows the transition it was given', () => {
+		const cameras = [camera()]
+
+		expect(
+			cameraSelectionSignature(cameras, 'cam-a', { type: 'linear' })
+		).not.toBe(cameraSelectionSignature(cameras, 'cam-a', { type: 'none' }))
+	})
+
+	it('reads a legacy lookAt as the target', () => {
+		expect(sign([camera({ lookAt: [1, 2, 3] } as Partial<CameraConfig>)])).toBe(
+			sign([camera({ target: [1, 2, 3] })])
+		)
+	})
+
+	it('signs a malformed vector as absent rather than as itself', () => {
+		// Settings arrive from persisted JSON and from host applications, so a
+		// partial vector is expressible; signing it raw would make the signature
+		// depend on how it happened to serialize.
+		expect(
+			sign([
+				camera({ position: [1, 2] as unknown as [number, number, number] })
+			])
+		).toBe(sign([camera()]))
+	})
+
+	it('signs a camera that is not in the list at all', () => {
+		expect(() => sign([camera()], 'missing')).not.toThrow()
+		expect(sign([camera()], 'missing')).toBe(sign([], 'missing'))
+	})
+})

--- a/packages/viewer/src/components/scene/camera-selection-signature.ts
+++ b/packages/viewer/src/components/scene/camera-selection-signature.ts
@@ -1,0 +1,68 @@
+import type { CameraProps, CameraTransitionConfig } from '@vctrl/core'
+
+/**
+ * A signature only this module can mint.
+ *
+ * Branded on purpose. The comparison it feeds is only sound while both sides
+ * are built the same way, and the bug it replaced was exactly a hand-rolled
+ * `JSON.stringify` of the *resolved* pose - which reads as an ordinary string
+ * and assigns without complaint. With the brand, writing one by hand is a type
+ * error at the call site rather than a snap the author sees months later.
+ */
+export type CameraSelectionSignature = string & {
+	readonly __cameraSelectionSignature: unique symbol
+}
+
+/**
+ * What the author stored for a camera, as a comparable string.
+ *
+ * The selection effect uses this to tell two different questions apart: a
+ * *different* camera was chosen, which should fly, versus the *same* camera's
+ * properties were edited, which should apply instantly so a sidebar nudge does
+ * not re-trigger a transition.
+ *
+ * It has to be built from the stored camera and nothing else. The resolved
+ * selection is not a safe input, because a camera that does not fully specify
+ * its own pose is completed from the live one: a missing position is derived
+ * through an orbit radius measured off the scene camera, and a missing fov is
+ * simply the scene camera's. Signing the resolved values therefore made the
+ * signature change while nothing was edited - every frame of a flight moves the
+ * camera it was measured from - so a mid-flight re-render read "same camera,
+ * new properties" and snapped the camera to the end of a transition it was
+ * still playing.
+ *
+ * That was unreachable for as long as every camera an author could reach
+ * carried a full pose, and it stopped being unreachable when hotspot cameras
+ * started carrying a target and no position.
+ *
+ * Absent fields are signed as null rather than skipped, so adding a position to
+ * a camera that had none still reads as an edit.
+ */
+export function cameraSelectionSignature(
+	cameras: CameraProps['cameras'],
+	cameraId: string,
+	transition: CameraTransitionConfig | undefined
+): CameraSelectionSignature {
+	const camera = cameras?.find((entry) => entry.cameraId === cameraId)
+
+	return JSON.stringify({
+		position: triple(camera?.position),
+		target: triple(camera?.target ?? camera?.lookAt),
+		rotation: triple(camera?.rotation),
+		fov: typeof camera?.fov === 'number' ? camera.fov : null,
+		transition: transition ?? null
+	}) as CameraSelectionSignature
+}
+
+/**
+ * A stored vector, or null for anything that is not one.
+ *
+ * Stored settings arrive from persisted JSON and from a host application, so a
+ * partial or non-numeric vector is expressible; signing one raw would make the
+ * signature depend on how it happened to serialize.
+ */
+function triple(value: unknown): [number, number, number] | null {
+	if (!Array.isArray(value) || value.length !== 3) return null
+	if (!value.every((axis) => Number.isFinite(axis))) return null
+	return [value[0], value[1], value[2]]
+}

--- a/packages/viewer/src/components/scene/scene-camera.tsx
+++ b/packages/viewer/src/components/scene/scene-camera.tsx
@@ -16,6 +16,9 @@ import {
 	Vector3Tuple
 } from 'three'
 
+import { cameraSelectionSignature } from './camera-selection-signature'
+
+import type { CameraSelectionSignature } from './camera-selection-signature'
 import type {
 	ViewerCommand,
 	ViewerCommandExecutor,
@@ -343,7 +346,9 @@ export const SceneCamera: React.FC<SceneCameraProps> = (props) => {
 	const stabilizationStartedAt = useRef<number | null>(null)
 	const transitionRuntime = useRef<CameraTransitionRuntime | null>(null)
 	const previousSelectionKey = useRef<string | null>(null)
-	const previousSelectionSignature = useRef<string | null>(null)
+	const previousSelectionSignature = useRef<CameraSelectionSignature | null>(
+		null
+	)
 
 	const captureCameraSnapshot =
 		useCallback<SceneCameraSnapshotCapture>(async () => {
@@ -466,17 +471,11 @@ export const SceneCamera: React.FC<SceneCameraProps> = (props) => {
 
 			startTransition(nextSelection)
 			previousSelectionKey.current = nextSelection.cameraId
-			previousSelectionSignature.current = JSON.stringify({
-				position: nextSelection.targetPosition.toArray(),
-				target: nextSelection.targetLookAt.toArray(),
-				rotation: [
-					nextSelection.targetRotation.x,
-					nextSelection.targetRotation.y,
-					nextSelection.targetRotation.z
-				],
-				fov: nextSelection.targetFov,
-				transition: nextSelection.transition
-			})
+			previousSelectionSignature.current = cameraSelectionSignature(
+				cameras,
+				nextSelection.cameraId,
+				nextSelection.transition
+			)
 			onInteractionEvent?.({
 				type: 'camera_changed',
 				cameraId: nextSelection.cameraId
@@ -530,17 +529,11 @@ export const SceneCamera: React.FC<SceneCameraProps> = (props) => {
 
 			initializedCameraPosition.current = true
 			previousSelectionKey.current = selection.cameraId
-			previousSelectionSignature.current = JSON.stringify({
-				position: selection.targetPosition.toArray(),
-				target: selection.targetLookAt.toArray(),
-				rotation: [
-					selection.targetRotation.x,
-					selection.targetRotation.y,
-					selection.targetRotation.z
-				],
-				fov: selection.targetFov,
-				transition: selection.transition
-			})
+			previousSelectionSignature.current = cameraSelectionSignature(
+				cameras,
+				selection.cameraId,
+				selection.transition
+			)
 		},
 		[
 			activeCameraId,
@@ -576,17 +569,11 @@ export const SceneCamera: React.FC<SceneCameraProps> = (props) => {
 			sceneTransition
 		)
 		const selectionKey = selection.cameraId
-		const signature = JSON.stringify({
-			position: selection.targetPosition.toArray(),
-			target: selection.targetLookAt.toArray(),
-			rotation: [
-				selection.targetRotation.x,
-				selection.targetRotation.y,
-				selection.targetRotation.z
-			],
-			fov: selection.targetFov,
-			transition: selection.transition
-		})
+		const signature = cameraSelectionSignature(
+			cameras,
+			selection.cameraId,
+			selection.transition
+		)
 
 		if (
 			previousSelectionKey.current === selectionKey &&


### PR DESCRIPTION
## Summary

Activating a camera that does not fully specify its own pose could snap it to the end of the transition it was still playing.

## Root cause

The selection signature answers *"did the author change this camera"*, and it was built from the **resolved** pose rather than the stored one — so for a camera completed from the live scene camera it changed while nothing was edited, and a re-render landing mid-flight took the apply-instantly branch meant for sidebar nudges.

## Changes

- `cameraSelectionSignature` builds the signature from the **stored** camera, making it a function of the settings and blind to where the camera currently is. Absent fields sign as `null` rather than being skipped, so giving a camera a pose it never had still reads as an edit.
- The return type is **branded**, so a signature cannot be hand-rolled at a call site — which is exactly what the bug was, and a plain `JSON.stringify` assigns to a `string` without complaint.

That brand paid for itself immediately: the compiler found a **third** signature site, in the initialization path, that reading the file had missed. All three now mint it the same way.

## Why it is reachable

A camera with no `position` is resolved through an orbit radius measured off the live scene camera, and a missing `fov` is simply the live camera's. Every frame of a flight moves the values the signature was made from.

Latent for as long as every camera an author could reach carried a full pose. It stops being latent as hotspot cameras start carrying a target and no position — which is what the hotspot PRs do — so this lands separately and first.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated
- [ ] No tests required

Ten tests on the signature. Mutation-gated: skipping absent fields, dropping the legacy `lookAt`, and signing a malformed vector raw each fail a named test, and reverting any call site to a hand-rolled `JSON.stringify` is now **TS2322** rather than a silent regression.

**Not verified in a browser.** No R3F canvas mounts in my local environment on any branch, including clean `main` — verified by trying the same thing there and on an untouched Storybook story. The behaviour is timing-dependent, so a passing signature test is not proof the transition looks right; that wants a human's eyes before merge.

## Checklist

- [x] `typecheck` + `lint` green on `vctrl/viewer`
- [x] `nx test vctrl/viewer` green
- [x] Independent of the hotspot PRs: touches only `scene-camera.tsx` plus two new files, and cherry-picks onto `main` cleanly