### PR TITLE
fix(publisher): scope a scene tool's affordances to its own open sidebar

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
@@ -13,8 +13,8 @@ import {
 	resolveHotspotAnchor
 } from '../../lib/domain/scene/scene-hotspot-placement'
 import {
-	isClickToPlaceActiveAtom,
-	processAtom
+	activeComposeToolAtom,
+	isClickToPlaceActiveAtom
 } from '../../lib/stores/publisher-config-store'
 import {
 	activeHotspotIdAtom,
@@ -350,8 +350,10 @@ export const PublisherEditorScene = memo(() => {
 	const [isClickToPlaceActive, setIsClickToPlaceActive] = useAtom(
 		isClickToPlaceActiveAtom
 	)
-	const process = useAtomValue(processAtom)
-	const isHotspotToolActive = process.activeComposeTool === 'hotspots'
+	const activeComposeTool = useAtomValue(activeComposeToolAtom)
+	// The tool whose panel is open, never the one merely selected: closing the
+	// drawer has to take the gizmo and click-to-place with it.
+	const isHotspotToolActive = activeComposeTool === 'hotspots'
 	const isPlacementArmed = isClickToPlaceActive && isHotspotToolActive
 	// The object the viewer renders, and the only thing a hotspot anchors to.
 	const { file } = useModelContext()

--- a/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
@@ -13,7 +13,7 @@ import {
 	resolveHotspotAnchor
 } from '../../lib/domain/scene/scene-hotspot-placement'
 import {
-	activeComposeToolAtom,
+	openComposeToolAtom,
 	isClickToPlaceActiveAtom
 } from '../../lib/stores/publisher-config-store'
 import {
@@ -350,10 +350,10 @@ export const PublisherEditorScene = memo(() => {
 	const [isClickToPlaceActive, setIsClickToPlaceActive] = useAtom(
 		isClickToPlaceActiveAtom
 	)
-	const activeComposeTool = useAtomValue(activeComposeToolAtom)
+	const openComposeTool = useAtomValue(openComposeToolAtom)
 	// The tool whose panel is open, never the one merely selected: closing the
 	// drawer has to take the gizmo and click-to-place with it.
-	const isHotspotToolActive = activeComposeTool === 'hotspots'
+	const isHotspotToolActive = openComposeTool === 'hotspots'
 	const isPlacementArmed = isClickToPlaceActive && isHotspotToolActive
 	// The object the viewer renders, and the only thing a hotspot anchors to.
 	const { file } = useModelContext()

--- a/apps/vectreal-platform/app/components/publisher/sidebars/tool-sidebar.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/tool-sidebar.tsx
@@ -20,12 +20,10 @@ import {
 	arePublisherActionsDisabledAtom,
 	isPreviewModeAtom,
 	processAtom,
+	openComposeToolAtom,
 	toolSidebarStateAtom
 } from '../../../lib/stores/publisher-config-store'
-import {
-	PUBLISHER_EDGE_INSET,
-	PUBLISHER_LAYER
-} from '../shell/shell-layout'
+import { PUBLISHER_EDGE_INSET, PUBLISHER_LAYER } from '../shell/shell-layout'
 
 import type { ComposeTool } from '../../../types/publisher-config'
 
@@ -38,6 +36,9 @@ export const ToolSidebar = memo(
 	({ user: _user, isMobile = false }: ToolSidebarProps) => {
 		const { activeComposeTool, showSidebar } =
 			useAtomValue(toolSidebarStateAtom)
+		// The same derivation every in-scene affordance uses, so the rail's
+		// highlight and a tool's canvas UI can never disagree about what is open.
+		const openComposeTool = useAtomValue(openComposeToolAtom)
 		const arePublisherActionsDisabled = useAtomValue(
 			arePublisherActionsDisabledAtom
 		)
@@ -82,9 +83,7 @@ export const ToolSidebar = memo(
 				<motion.div
 					// Editing tools have no meaning in preview mode, so the rail leaves
 					// instead of sitting there disabled.
-					animate={
-						isPreviewMode ? { opacity: 0, x: -8 } : { opacity: 1, x: 0 }
-					}
+					animate={isPreviewMode ? { opacity: 0, x: -8 } : { opacity: 1, x: 0 }}
 					transition={{ duration: 0.24, ease: [0.4, 0, 0.2, 1] }}
 					aria-hidden={isPreviewMode}
 					className={cn(
@@ -95,7 +94,7 @@ export const ToolSidebar = memo(
 					)}
 				>
 					{COMPOSE_TOOL_DEFINITIONS.map(({ value, icon: Icon, shortLabel }) => {
-						const isActive = value === activeComposeTool && showSidebar
+						const isActive = value === openComposeTool
 						return (
 							<Tooltip key={value}>
 								<TooltipTrigger asChild>

--- a/apps/vectreal-platform/app/lib/stores/publisher-config-store.spec.ts
+++ b/apps/vectreal-platform/app/lib/stores/publisher-config-store.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * The publisher's "which tool is active" predicate.
+ *
+ * This exists because the answer was written by hand three times and one copy
+ * got it wrong: the hotspot editor asked `activeComposeTool === 'hotspots'` and
+ * kept its gizmo, its click-to-select and its click-to-place alive after the
+ * author had closed the drawer - the tool rail stopped highlighting the button
+ * while the canvas went on offering the tool. A scene tool has to be scoped to
+ * its tool, so the predicate lives in one place and is pinned here.
+ */
+import { createStore } from 'jotai'
+import { describe, expect, it } from 'vitest'
+
+import {
+	activeComposeToolAtom,
+	processAtom,
+	processInitialState
+} from './publisher-config-store'
+
+import type { ProcessState } from '../../types/publisher-config'
+
+const storeWith = (overrides: Partial<ProcessState>) => {
+	const store = createStore()
+	store.set(processAtom, { ...processInitialState, ...overrides })
+	return store
+}
+
+describe('activeComposeToolAtom', () => {
+	it('names the tool whose panel is open', () => {
+		const store = storeWith({
+			mode: 'compose',
+			activeComposeTool: 'hotspots',
+			showSidebar: true
+		})
+
+		expect(store.get(activeComposeToolAtom)).toBe('hotspots')
+	})
+
+	it('goes null when the drawer closes, though the tool stays selected', () => {
+		// Closing a tool flips `showSidebar` and leaves `activeComposeTool` exactly
+		// where it was, which is the whole reason reading that field alone is wrong.
+		const store = storeWith({
+			mode: 'compose',
+			activeComposeTool: 'hotspots',
+			showSidebar: false
+		})
+
+		expect(store.get(processAtom).activeComposeTool).toBe('hotspots')
+		expect(store.get(activeComposeToolAtom)).toBeNull()
+	})
+
+	it('goes null outside compose mode', () => {
+		const store = storeWith({
+			mode: 'optimize',
+			activeComposeTool: 'hotspots',
+			showSidebar: true
+		})
+
+		expect(store.get(activeComposeToolAtom)).toBeNull()
+	})
+
+	it('names no tool before the author has opened one', () => {
+		// The default is a real tool, not null, which is the other half of the trap.
+		const store = createStore()
+
+		expect(processInitialState.activeComposeTool).toBe('environment')
+		expect(store.get(activeComposeToolAtom)).toBeNull()
+	})
+
+	it('follows the author from one tool to the next', () => {
+		const store = storeWith({
+			mode: 'compose',
+			activeComposeTool: 'hotspots',
+			showSidebar: true
+		})
+		store.set(processAtom, (previous) => ({
+			...previous,
+			activeComposeTool: 'shadow'
+		}))
+
+		expect(store.get(activeComposeToolAtom)).toBe('shadow')
+	})
+})

--- a/apps/vectreal-platform/app/lib/stores/publisher-config-store.spec.ts
+++ b/apps/vectreal-platform/app/lib/stores/publisher-config-store.spec.ts
@@ -12,7 +12,7 @@ import { createStore } from 'jotai'
 import { describe, expect, it } from 'vitest'
 
 import {
-	activeComposeToolAtom,
+	openComposeToolAtom,
 	processAtom,
 	processInitialState
 } from './publisher-config-store'
@@ -25,7 +25,7 @@ const storeWith = (overrides: Partial<ProcessState>) => {
 	return store
 }
 
-describe('activeComposeToolAtom', () => {
+describe('openComposeToolAtom', () => {
 	it('names the tool whose panel is open', () => {
 		const store = storeWith({
 			mode: 'compose',
@@ -33,7 +33,7 @@ describe('activeComposeToolAtom', () => {
 			showSidebar: true
 		})
 
-		expect(store.get(activeComposeToolAtom)).toBe('hotspots')
+		expect(store.get(openComposeToolAtom)).toBe('hotspots')
 	})
 
 	it('goes null when the drawer closes, though the tool stays selected', () => {
@@ -46,7 +46,7 @@ describe('activeComposeToolAtom', () => {
 		})
 
 		expect(store.get(processAtom).activeComposeTool).toBe('hotspots')
-		expect(store.get(activeComposeToolAtom)).toBeNull()
+		expect(store.get(openComposeToolAtom)).toBeNull()
 	})
 
 	it('goes null outside compose mode', () => {
@@ -56,7 +56,7 @@ describe('activeComposeToolAtom', () => {
 			showSidebar: true
 		})
 
-		expect(store.get(activeComposeToolAtom)).toBeNull()
+		expect(store.get(openComposeToolAtom)).toBeNull()
 	})
 
 	it('names no tool before the author has opened one', () => {
@@ -64,7 +64,7 @@ describe('activeComposeToolAtom', () => {
 		const store = createStore()
 
 		expect(processInitialState.activeComposeTool).toBe('environment')
-		expect(store.get(activeComposeToolAtom)).toBeNull()
+		expect(store.get(openComposeToolAtom)).toBeNull()
 	})
 
 	it('follows the author from one tool to the next', () => {
@@ -78,6 +78,6 @@ describe('activeComposeToolAtom', () => {
 			activeComposeTool: 'shadow'
 		}))
 
-		expect(store.get(activeComposeToolAtom)).toBe('shadow')
+		expect(store.get(openComposeToolAtom)).toBe('shadow')
 	})
 })

--- a/apps/vectreal-platform/app/lib/stores/publisher-config-store.ts
+++ b/apps/vectreal-platform/app/lib/stores/publisher-config-store.ts
@@ -79,6 +79,29 @@ const toolSidebarStateAtom = selectAtom(
 		a.showSidebar === b.showSidebar
 )
 
+/**
+ * The compose tool whose panel is actually open, or null when none is.
+ *
+ * `activeComposeTool` on its own answers a different question: which tool is
+ * *selected*. It is never null, it defaults to `environment` before the author
+ * has opened anything, and closing a drawer flips `showSidebar` while leaving it
+ * exactly where it was. So a scene affordance that reads it directly stays live
+ * after the tool that owns it has closed - the tool rail stops highlighting the
+ * button while the canvas goes on offering the tool's gizmo.
+ *
+ * That predicate already existed twice, written by hand: the rail's own
+ * `value === activeComposeTool && showSidebar`, and the shadow light handle's
+ * copy of it. The hotspot editor wrote a third version that omitted
+ * `showSidebar`, which is exactly the drift a shared derivation prevents. Scene
+ * affordances read this; nothing reads `activeComposeTool` to mean "active".
+ *
+ * `mode` is in the test because these are *compose* tools: leaving optimize mode
+ * showing a compose tool's in-scene handles is the same category of leak.
+ */
+const activeComposeToolAtom = selectAtom(processAtom, (state) =>
+	state.mode === 'compose' && state.showSidebar ? state.activeComposeTool : null
+)
+
 const showPublishPanelAtom = selectAtom(
 	processAtom,
 	(state) => state.showPublishPanel
@@ -108,6 +131,7 @@ export {
 	maxSceneBytesAtom,
 	showSidebarAtom,
 	toolSidebarStateAtom,
+	activeComposeToolAtom,
 	showPublishPanelAtom,
 	isSavingAtom,
 	hasUnsavedChangesAtom,

--- a/apps/vectreal-platform/app/lib/stores/publisher-config-store.ts
+++ b/apps/vectreal-platform/app/lib/stores/publisher-config-store.ts
@@ -98,7 +98,7 @@ const toolSidebarStateAtom = selectAtom(
  * `mode` is in the test because these are *compose* tools: leaving optimize mode
  * showing a compose tool's in-scene handles is the same category of leak.
  */
-const activeComposeToolAtom = selectAtom(processAtom, (state) =>
+const openComposeToolAtom = selectAtom(processAtom, (state) =>
 	state.mode === 'compose' && state.showSidebar ? state.activeComposeTool : null
 )
 
@@ -131,7 +131,7 @@ export {
 	maxSceneBytesAtom,
 	showSidebarAtom,
 	toolSidebarStateAtom,
-	activeComposeToolAtom,
+	openComposeToolAtom,
 	showPublishPanelAtom,
 	isSavingAtom,
 	hasUnsavedChangesAtom,

--- a/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
+++ b/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
@@ -12,7 +12,7 @@ import { useAutomaticOpeningView } from '../../components/publisher/shell/use-op
 import { ClientVectrealViewer } from '../../components/viewer/client-vectreal-viewer'
 import {
 	sceneMetaAtom,
-	toolSidebarStateAtom
+	activeComposeToolAtom
 } from '../../lib/stores/publisher-config-store'
 import {
 	activeHotspotIdAtom,
@@ -149,11 +149,13 @@ const PublisherPage = () => {
 	const [selectedCameraId, setSelectedCameraId] = useAtom(selectedCameraIdAtom)
 	const [activeHotspotId, setActiveHotspotId] = useAtom(activeHotspotIdAtom)
 	const sceneMeta = useAtomValue(sceneMetaAtom)
-	const { activeComposeTool, showSidebar } = useAtomValue(toolSidebarStateAtom)
+	// The tool whose panel is open, not the one merely selected. Every in-scene
+	// affordance below scopes to it, so no tool's handles outlive its drawer.
+	const activeComposeTool = useAtomValue(activeComposeToolAtom)
 	// The in-scene light handle only belongs to the shadow tool, so show it only
 	// while that tool's panel is open (and shadows are on).
 	const isShadowToolActive =
-		showSidebar && activeComposeTool === 'shadow' && (shadows?.enabled ?? false)
+		activeComposeTool === 'shadow' && (shadows?.enabled ?? false)
 	const loadingThumbnail = toViewerLoadingThumbnail(
 		sceneMeta.thumbnailUrl,
 		'Scene thumbnail preview'
@@ -199,9 +201,10 @@ const PublisherPage = () => {
 	)
 
 	/**
-	 * Selection is offered only while the hotspot tool is armed, and passing it is
-	 * exactly what makes a marker select rather than fly its camera. Outside the
-	 * tool the publisher wants the embed's behaviour, so it passes nothing.
+	 * Selection is offered only while the hotspot tool's panel is open, and
+	 * passing it is exactly what makes a marker select rather than fly its camera.
+	 * Outside the tool the publisher wants the visitor's behaviour - a click
+	 * activates the linked camera - so it passes nothing at all.
 	 */
 	const handleHotspotSelect = useMemo(
 		() =>

--- a/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
+++ b/apps/vectreal-platform/app/routes/publisher-page/publisher.$sceneId.tsx
@@ -12,7 +12,7 @@ import { useAutomaticOpeningView } from '../../components/publisher/shell/use-op
 import { ClientVectrealViewer } from '../../components/viewer/client-vectreal-viewer'
 import {
 	sceneMetaAtom,
-	activeComposeToolAtom
+	openComposeToolAtom
 } from '../../lib/stores/publisher-config-store'
 import {
 	activeHotspotIdAtom,
@@ -151,11 +151,11 @@ const PublisherPage = () => {
 	const sceneMeta = useAtomValue(sceneMetaAtom)
 	// The tool whose panel is open, not the one merely selected. Every in-scene
 	// affordance below scopes to it, so no tool's handles outlive its drawer.
-	const activeComposeTool = useAtomValue(activeComposeToolAtom)
+	const openComposeTool = useAtomValue(openComposeToolAtom)
 	// The in-scene light handle only belongs to the shadow tool, so show it only
 	// while that tool's panel is open (and shadows are on).
 	const isShadowToolActive =
-		activeComposeTool === 'shadow' && (shadows?.enabled ?? false)
+		openComposeTool === 'shadow' && (shadows?.enabled ?? false)
 	const loadingThumbnail = toViewerLoadingThumbnail(
 		sceneMeta.thumbnailUrl,
 		'Scene thumbnail preview'
@@ -208,11 +208,11 @@ const PublisherPage = () => {
 	 */
 	const handleHotspotSelect = useMemo(
 		() =>
-			activeComposeTool === 'hotspots'
+			openComposeTool === 'hotspots'
 				? (id: string) =>
 						setActiveHotspotId((previous) => (previous === id ? null : id))
 				: undefined,
-		[activeComposeTool, setActiveHotspotId]
+		[openComposeTool, setActiveHotspotId]
 	)
 
 	// Memoized: a fresh object here re-creates the viewer's screenshot capture on
@@ -258,7 +258,7 @@ const PublisherPage = () => {
 					  where there is no gizmo and no way to clear it from the canvas.
 					*/
 					selectedHotspotId={
-						activeComposeTool === 'hotspots' ? activeHotspotId : null
+						openComposeTool === 'hotspots' ? activeHotspotId : null
 					}
 					onHotspotSelect={handleHotspotSelect}
 					onHotspotPositionSetterReady={registerHotspotPositionSetter}

--- a/apps/vectreal-platform/tests/publisher-tool-scope.spec.ts
+++ b/apps/vectreal-platform/tests/publisher-tool-scope.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * A compose tool's active state and its extra UI are scoped to that tool's open
+ * sidebar, always.
+ *
+ * The rule exists because the predicate is easy to write and easy to write
+ * wrong. `activeComposeTool` answers "which tool is selected": it is never null,
+ * it defaults to a real tool before the author has opened anything, and closing
+ * a drawer flips `showSidebar` while leaving it untouched. Read on its own it
+ * says a tool is active when its panel is shut - which is how the hotspot gizmo
+ * came to outlive its drawer, letting a click select a marker for editing where
+ * it should have flown the marker's linked camera.
+ *
+ * So this is a ratchet rather than a convention: `openComposeToolAtom` is the
+ * single answer, and the raw field is readable only where the question is
+ * genuinely "which tool's panel is this", not "is a tool active".
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const APP = join(import.meta.dirname, '..', 'app')
+
+/**
+ * The two places the raw field is legitimate.
+ *
+ * The store derives `openComposeToolAtom` from it, and the tool rail needs to
+ * know which panel to title and render once one is open - a different question
+ * from whether anything is open, which the rail also asks, through the derived
+ * atom like everyone else.
+ */
+const MAY_READ_RAW = [
+	'lib/stores/publisher-config-store.ts',
+	'components/publisher/sidebars/tool-sidebar.tsx'
+]
+
+function sourceFiles(dir: string, found: string[] = []): string[] {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name)
+		if (entry.isDirectory()) sourceFiles(full, found)
+		else if (/\.tsx?$/.test(entry.name) && !/\.spec\.tsx?$/.test(entry.name)) {
+			found.push(full)
+		}
+	}
+	return found
+}
+
+describe('a compose tool is scoped to its own open sidebar', () => {
+	const offenders = sourceFiles(APP)
+		.filter((file) => {
+			const relative = file.slice(APP.length + 1)
+			return !MAY_READ_RAW.includes(relative.split('\\').join('/'))
+		})
+		.filter((file) => {
+			const source = readFileSync(file, 'utf8')
+			// Reading the field to compare it against a tool is the mistake. Writing
+			// it - which is how a tool is opened - is not.
+			return /activeComposeTool\s*===|===\s*activeComposeTool/.test(source)
+		})
+		.map((file) => file.slice(APP.length + 1))
+
+	it('never decides a tool is active from activeComposeTool alone', () => {
+		expect(offenders).toEqual([])
+	})
+
+	it('keeps the derived predicate as the single answer', () => {
+		const store = readFileSync(
+			join(APP, 'lib/stores/publisher-config-store.ts'),
+			'utf8'
+		)
+
+		// Both halves, or the predicate is not the one the rest of the app trusts.
+		expect(store).toContain('openComposeToolAtom')
+		expect(store).toContain("state.mode === 'compose' && state.showSidebar")
+	})
+})


### PR DESCRIPTION
> **Stacked on #764.** Review that first; this diff is only the two commits above it.

## Summary

Clicking a hotspot with the hotspot tool **closed** selected it for editing and raised its gizmo, instead of activating the hotspot's linked camera the way a visitor's click does. A tool's affordances now end where its sidebar does.

## Root cause

`activeComposeTool` records which compose tool is *selected*, not whether its panel is *open*: it is never null, it defaults to `environment` before the author opens anything, and closing a drawer flips `showSidebar` while leaving it untouched. The hotspot editor read that field alone, so the tool rail stopped highlighting the button while the canvas went on offering the tool's gizmo, click-to-select and click-to-place.

## Changes

The predicate already existed **twice, hand-written** — the rail's own `value === activeComposeTool && showSidebar` and the shadow light handle's copy — and the hotspot editor wrote a third that dropped the `showSidebar` half. So the fix is one derived `openComposeToolAtom`, not a fourth check at the call site.

- The rail reads it too. Its highlight was the third copy, and it is the surface guaranteed to disagree visibly when the two drift.
- Locals are renamed to match, so a call site now reads `openComposeTool === 'hotspots'` and states its own rule.
- `mode` is in the predicate for the same reason: these are *compose* tools, and sitting in optimize mode with a compose tool's in-scene handles is the same leak.
- `tests/publisher-tool-scope.spec.ts` fails on any file outside the store and the rail that compares `activeComposeTool` against a tool.

With the tool closed a marker has no select handler, so `resolveHotspotInteraction` resolves the click to `activate` — the visitor's path, and where an info popover will hang later.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated
- [ ] No tests required

Mutation-gated both ways: removing the `showSidebar` half of the predicate **reproduces the reported bug** and fails a named test; removing the `mode` half fails another; pointing a call site back at the raw field fails the ratchet.

The ratchet earned its keep on first run — it failed and caught two files I had called done, because I had renamed the atom but left the locals named after the raw field.

**Limit worth knowing:** the ratchet is a text scan, so it catches the comparison shape that caused this bug, not every possible misuse. It was chosen over an ESLint rule because `no-restricted-syntax` here is one shared array, and exempting the store and the rail would have disabled the z-index, `cn()` and inline-SVG rules in those files too.

**Not verified in a browser** — no R3F canvas mounts locally on any branch, including clean `main`. The store predicate is directly tested; "close the drawer, click a marker, camera flies" wants a human.

## Checklist

- [x] Gates green across the five projects
- [x] Full unit suite green
- [x] Every remaining raw read of `activeComposeTool` audited: the rail renders itself, the other two only write it