### PR TITLE
feat(publisher): point a hotspot's camera at its hotspot, and keep it pointed there

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
+++ b/apps/vectreal-platform/app/components/publisher/publisher-editor-scene.tsx
@@ -1,12 +1,13 @@
 import { TransformControls } from '@react-three/drei'
 import { useThree } from '@react-three/fiber'
 import { useModelContext } from '@vctrl/hooks/use-load-model'
-import { useAtom, useAtomValue } from 'jotai/react'
+import { useAtom, useAtomValue, useStore } from 'jotai/react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 
 import { PublisherViewCube } from './publisher-view-cube'
 import { usePublisherViewerCapture } from './publisher-viewer-capture-context'
+import { applyHotspotPlacement } from '../../lib/domain/scene/client/apply-hotspot-placement'
 import {
 	isHotspotPlacementGesture,
 	prepareHotspotRaycaster,
@@ -345,7 +346,9 @@ function ClickToPlace({
  * cube out of the way while placement is armed.
  */
 export const PublisherEditorScene = memo(() => {
-	const [hotspots, setHotspots] = useAtom(hotspotsAtom)
+	// Read for rendering; every write goes through the store below, so the pair
+	// of atoms a placement touches stays one edit.
+	const hotspots = useAtomValue(hotspotsAtom)
 	const activeHotspotId = useAtomValue(activeHotspotIdAtom)
 	const [isClickToPlaceActive, setIsClickToPlaceActive] = useAtom(
 		isClickToPlaceActiveAtom
@@ -359,14 +362,28 @@ export const PublisherEditorScene = memo(() => {
 	const { file } = useModelContext()
 	const modelRoot = file?.model ?? null
 	const gizmoGrabbedRef = useRef(false)
+	/*
+	  The edit needs both atoms at once - which camera a hotspot owns is a fact
+	  about the two together - and this callback has to keep a stable identity:
+	  it reaches `HotspotGizmo` as `onMove`, whose unmount cleanup commits an
+	  interrupted drag, so a new identity mid-drag would re-run that effect and
+	  commit the drag out from under the author. Reading through the store keeps
+	  both properties; putting `hotspots` in the dependency list would lose the
+	  second.
+	*/
+	const store = useStore()
 
+	/**
+	 * Both ways of placing a marker go through here, because both are the author
+	 * saying where the point of interest is, and the camera the hotspot owns has
+	 * to end up looking at it either way. `placeHotspot` owns that pairing so
+	 * neither this file nor the sidebar has to know the ownership rule.
+	 */
 	const handleMoveHotspot = useCallback(
 		(id: string, position: [number, number, number]) => {
-			setHotspots((prev) =>
-				prev.map((h) => (h.id === id ? { ...h, worldPosition: position } : h))
-			)
+			applyHotspotPlacement(store, id, position)
 		},
-		[setHotspots]
+		[store]
 	)
 
 	/**
@@ -376,12 +393,10 @@ export const PublisherEditorScene = memo(() => {
 	 */
 	const handlePlaceHotspot = useCallback(
 		(id: string, position: [number, number, number]) => {
-			setHotspots((prev) =>
-				prev.map((h) => (h.id === id ? { ...h, worldPosition: position } : h))
-			)
+			handleMoveHotspot(id, position)
 			setIsClickToPlaceActive(false)
 		},
-		[setHotspots, setIsClickToPlaceActive]
+		[handleMoveHotspot, setIsClickToPlaceActive]
 	)
 
 	const activeHotspot = hotspots.find((h) => h.id === activeHotspotId) ?? null

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
@@ -97,6 +97,27 @@ beforeEach(() => {
 })
 
 describe('HotspotsSettingsPanel arming', () => {
+	/**
+	 * Typing a coordinate is placing the marker, exactly as dragging it is, so it
+	 * goes through the same paired edit: the hotspot moves and the camera it owns
+	 * turns to keep looking at it. This was the last placement path that wrote
+	 * only the hotspot, which would have left the sidebar quietly disagreeing
+	 * with the canvas about where a viewpoint points.
+	 */
+	it('turns the hotspot’s own camera when an axis is typed', () => {
+		arrange()
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.change(screen.getByLabelText('X position'), {
+				target: { value: '9' }
+			})
+		})
+
+		expect(store.get(hotspotsAtom)[0].worldPosition).toEqual([9, 2, 3])
+		expect(store.get(cameraAtom).cameras?.[0].target).toEqual([9, 2, 3])
+	})
+
 	it('disarms click-to-place when the panel unmounts', () => {
 		arrange()
 		const { unmount } = render(<HotspotsSettingsPanel />)

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -30,7 +30,7 @@ import {
 	useDragControls,
 	useReducedMotion
 } from 'framer-motion'
-import { useAtom, useSetAtom } from 'jotai/react'
+import { useAtom, useSetAtom, useStore } from 'jotai/react'
 import {
 	ChevronDown,
 	Crosshair,
@@ -43,6 +43,7 @@ import {
 } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { applyHotspotPlacement } from '../../../../lib/domain/scene/client/apply-hotspot-placement'
 import {
 	PAIRED_HOTSPOT_CAMERA_ID_PREFIX,
 	resolveDefaultSceneCameraId
@@ -423,6 +424,7 @@ const SequencedRow = ({
 }
 
 const HotspotsSettingsPanel = memo(() => {
+	const store = useStore()
 	const [hotspots, setHotspots] = useAtom(hotspotsAtom)
 	const [camera, setCamera] = useAtom(cameraAtom)
 	const [selectedId, setSelectedId] = useAtom(activeHotspotIdAtom)
@@ -745,9 +747,13 @@ const HotspotsSettingsPanel = memo(() => {
 				number
 			]
 			next[axis] = value
-			updateHotspot(hotspot.id, { worldPosition: next })
+			// The same paired edit the canvas makes: a marker moves and the camera
+			// it owns turns to keep looking at it. Typing a coordinate is placing
+			// the marker just as much as dragging it is, so it cannot be the one
+			// path that leaves the viewpoint behind.
+			applyHotspotPlacement(store, hotspot.id, next)
 		},
-		[updateHotspot]
+		[store]
 	)
 
 	const handleMembershipChange = useCallback(

--- a/apps/vectreal-platform/app/lib/domain/scene/client/apply-hotspot-placement.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/apply-hotspot-placement.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Placing a marker is one edit across two atoms, and the second one is the one
+ * that goes missing: dropping the camera write leaves the hotspot moving on its
+ * own, type-checks cleanly, and breaks nothing else. So the wiring is tested
+ * against a real store rather than asserted about in a comment.
+ */
+import { createStore } from 'jotai'
+import { describe, expect, it } from 'vitest'
+
+import { applyHotspotPlacement } from './apply-hotspot-placement'
+import { cameraAtom, hotspotsAtom } from '../../../stores/scene-settings-store'
+
+import type { CameraConfig, HotspotDefinition } from '@vctrl/core'
+
+const AT: [number, number, number] = [1, 2, 3]
+
+const hotspot = (
+	id: string,
+	overrides: Partial<HotspotDefinition> = {}
+): HotspotDefinition => ({
+	id,
+	name: id,
+	worldPosition: [0, 0, 0],
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot',
+	...overrides
+})
+
+const seed = (hotspots: HotspotDefinition[], cameras: CameraConfig[]) => {
+	const store = createStore()
+	store.set(hotspotsAtom, hotspots)
+	store.set(cameraAtom, { cameras })
+	return store
+}
+
+describe('applyHotspotPlacement', () => {
+	it('moves the hotspot and turns the camera it owns, in one edit', () => {
+		const store = seed(
+			[hotspot('a', { linkedCameraId: 'cam-a' })],
+			[{ cameraId: 'cam-a', name: 'A Camera', kind: 'hotspot' }]
+		)
+
+		applyHotspotPlacement(store, 'a', AT)
+
+		expect(store.get(hotspotsAtom)[0].worldPosition).toEqual(AT)
+		expect(store.get(cameraAtom).cameras?.[0].target).toEqual(AT)
+	})
+
+	it('moves a hotspot that owns no camera without touching the cameras', () => {
+		const cameras: CameraConfig[] = [
+			{ cameraId: 'default', name: 'Default', kind: 'scene' }
+		]
+		const store = seed([hotspot('a', { linkedCameraId: 'default' })], cameras)
+
+		applyHotspotPlacement(store, 'a', AT)
+
+		expect(store.get(hotspotsAtom)[0].worldPosition).toEqual(AT)
+		expect(store.get(cameraAtom).cameras?.[0].target).toBeUndefined()
+	})
+
+	it('leaves the other hotspots alone', () => {
+		const store = seed(
+			[
+				hotspot('a', { linkedCameraId: 'cam-a' }),
+				hotspot('b', { worldPosition: [7, 7, 7] })
+			],
+			[{ cameraId: 'cam-a', name: 'A Camera', kind: 'hotspot' }]
+		)
+
+		applyHotspotPlacement(store, 'a', AT)
+
+		expect(store.get(hotspotsAtom)[1].worldPosition).toEqual([7, 7, 7])
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/scene/client/apply-hotspot-placement.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/apply-hotspot-placement.ts
@@ -1,0 +1,39 @@
+import { cameraAtom, hotspotsAtom } from '../../../stores/scene-settings-store'
+import { placeHotspot } from '../scene-hotspot-camera-links'
+
+import type { createStore } from 'jotai'
+
+type PublisherStore = ReturnType<typeof createStore>
+
+/**
+ * Commits a hotspot placement to the two atoms it spans.
+ *
+ * Placing a marker is one edit across two pieces of state: the hotspot moves,
+ * and the camera it owns turns to keep looking at it. `placeHotspot` decides
+ * both; this puts the answer back.
+ *
+ * It lives here rather than inside `PublisherEditorScene` for two reasons. The
+ * component mounts inside an R3F canvas and has no test that can reach it, so
+ * logic left in there is logic nothing can check - and this is the wiring, which
+ * is precisely the part that fails silently: dropping the camera write leaves
+ * the marker moving on its own, type-checks cleanly and breaks no other test.
+ *
+ * Reading through the store rather than through hooks also keeps the caller's
+ * callback referentially stable, which matters because it reaches the transform
+ * gizmo as `onMove`, and the gizmo's unmount cleanup commits an interrupted
+ * drag - a new identity mid-drag would fire that cleanup under the author.
+ */
+export function applyHotspotPlacement(
+	store: PublisherStore,
+	hotspotId: string,
+	worldPosition: [number, number, number]
+): void {
+	const next = placeHotspot(
+		{ camera: store.get(cameraAtom), hotspots: store.get(hotspotsAtom) },
+		hotspotId,
+		worldPosition
+	)
+
+	store.set(hotspotsAtom, next.hotspots)
+	store.set(cameraAtom, next.camera)
+}

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-camera-links.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-camera-links.spec.ts
@@ -3,6 +3,7 @@ import {
 	relinkHotspot,
 	removeCamera,
 	removeHotspot,
+	placeHotspot,
 	renameHotspot,
 	repointHotspotLinks
 } from './scene-hotspot-camera-links'
@@ -340,6 +341,123 @@ describe('relinkHotspot', () => {
 		relinkHotspot(state, 'a', 'default')
 		expect(cameraIds(state)).toEqual(['default', 'empty', 'framed', 'aimed'])
 		expect(state.hotspots[0].linkedCameraId).toBe('empty')
+	})
+})
+
+describe('placeHotspot', () => {
+	const cameras = [sceneCamera, legacyCamera, cameraA]
+	const AT: [number, number, number] = [1, 2, 3]
+
+	it('moves the hotspot', () => {
+		const result = placeHotspot(
+			{ camera: { cameras }, hotspots: [hotspot('a')] },
+			'a',
+			AT
+		)
+
+		expect(result.hotspots[0].worldPosition).toEqual(AT)
+	})
+
+	it('takes the camera the hotspot owns along with it', () => {
+		const result = placeHotspot(
+			{
+				camera: { cameras },
+				hotspots: [hotspot('a', { linkedCameraId: 'cam-a' })]
+			},
+			'a',
+			AT
+		)
+
+		expect(
+			result.camera.cameras?.find((c) => c.cameraId === 'cam-a')?.target
+		).toEqual(AT)
+	})
+
+	it('leaves where the camera stands, and only where it looks', () => {
+		// Moving a marker says where the point of interest is, not where the author
+		// wants to stand to see it.
+		const framed = camera('cam-a', {
+			kind: 'hotspot',
+			position: [5, 5, 5],
+			target: [0, 0, 0]
+		})
+		const result = placeHotspot(
+			{
+				camera: { cameras: [framed] },
+				hotspots: [hotspot('a', { linkedCameraId: 'cam-a' })]
+			},
+			'a',
+			AT
+		)
+
+		expect(result.camera.cameras?.[0].position).toEqual([5, 5, 5])
+		expect(result.camera.cameras?.[0].target).toEqual(AT)
+	})
+
+	it('never re-aims a camera the author composed', () => {
+		// The Linked Camera picker offers every camera in the scene, so a hotspot
+		// can point at the opening frame. Moving the marker must not turn it.
+		const result = placeHotspot(
+			{
+				camera: { cameras },
+				hotspots: [hotspot('a', { linkedCameraId: 'default' })]
+			},
+			'a',
+			AT
+		)
+
+		expect(
+			result.camera.cameras?.find((c) => c.cameraId === 'default')?.target
+		).toBeUndefined()
+	})
+
+	it('never re-aims a camera another hotspot also points at', () => {
+		const result = placeHotspot(
+			{
+				camera: { cameras },
+				hotspots: [
+					hotspot('a', { linkedCameraId: 'cam-a' }),
+					hotspot('b', { linkedCameraId: 'cam-a' })
+				]
+			},
+			'a',
+			AT
+		)
+
+		expect(
+			result.camera.cameras?.find((c) => c.cameraId === 'cam-a')?.target
+		).toBeUndefined()
+	})
+
+	it('leaves every other hotspot and camera untouched', () => {
+		const result = placeHotspot(
+			{
+				camera: { cameras },
+				hotspots: [
+					hotspot('a', { linkedCameraId: 'cam-a' }),
+					hotspot('b', { worldPosition: [7, 7, 7] })
+				]
+			},
+			'a',
+			AT
+		)
+
+		expect(result.hotspots[1].worldPosition).toEqual([7, 7, 7])
+		expect(cameraIds(result)).toEqual(['default', 'legacy', 'cam-a'])
+	})
+
+	it('moves a hotspot that owns no camera at all', () => {
+		const result = placeHotspot(
+			{ camera: { cameras }, hotspots: [hotspot('a')] },
+			'a',
+			AT
+		)
+
+		expect(result.hotspots[0].worldPosition).toEqual(AT)
+		expect(result.camera).toBe(result.camera)
+		expect(result.camera.cameras?.every((c) => c.target === undefined)).toBe(
+			true
+		)
 	})
 })
 

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-camera-links.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-camera-links.ts
@@ -235,6 +235,57 @@ export function relinkHotspot(
  * stopped at the hotspot would leave every hotspot camera in the scene sharing
  * one label with no way to tell them apart.
  */
+/**
+ * Moves a hotspot, and takes the camera it owns along with it.
+ *
+ * A hotspot camera exists to look at its hotspot, so a marker that moves and a
+ * viewpoint that stays behind is a scene that quietly stops making sense: the
+ * author drags a marker onto the handle and the camera keeps framing where it
+ * used to be. Placement is the moment the author says where the point of
+ * interest is, so it is the moment the aim follows.
+ *
+ * Only the camera the hotspot owns. The Linked Camera picker offers every
+ * camera in the scene, so a hotspot can point at the opening frame or at
+ * another hotspot's camera, and re-aiming one of those would rewrite a
+ * viewpoint the author composed by moving something else entirely.
+ *
+ * Position is left alone here too - this decides where the camera looks, not
+ * where it stands, so a viewpoint the author framed keeps its framing and
+ * merely turns to follow the marker.
+ *
+ * Distinct from the viewer's `resolveHotspotCameraTargets`, and both are wanted.
+ * That one is a runtime default for a camera nobody ever framed, and it stops
+ * applying the moment a target exists. This one is the authoring edit: it moves
+ * a target that is already there, which is the case the default cannot reach.
+ */
+export function placeHotspot(
+	state: CameraHotspotState,
+	hotspotId: string,
+	worldPosition: [number, number, number]
+): CameraHotspotState {
+	const hotspots = state.hotspots.map((h) =>
+		h.id === hotspotId ? { ...h, worldPosition } : h
+	)
+	const ownedCameraId = resolveOwnedHotspotCameraId(
+		state.hotspots,
+		state.camera.cameras,
+		hotspotId
+	)
+	if (!ownedCameraId) return { camera: state.camera, hotspots }
+
+	return {
+		camera: {
+			...state.camera,
+			cameras: (state.camera.cameras ?? []).map((entry) =>
+				entry.cameraId === ownedCameraId
+					? { ...entry, target: worldPosition }
+					: entry
+			)
+		},
+		hotspots
+	}
+}
+
 export function renameHotspot(
 	state: CameraHotspotState,
 	hotspotId: string,

--- a/packages/viewer/src/components/scene/hotspot-camera-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-camera-wiring.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * The aim derivation reaches the camera that uses it.
+ *
+ * A source guard rather than a behavioural test, and it exists because deleting
+ * the one line that applies `resolveHotspotCameraTargets` type-checks cleanly
+ * and breaks nothing else: the module keeps its own eight passing tests while
+ * every hotspot camera silently goes back to looking at the middle of the model.
+ *
+ * That is the exact shape of the defect this whole change was written to fix - a
+ * complete implementation with nothing calling it - so it gets a guard rather
+ * than a comment. This package's runner loads `.ts` only (components need a
+ * WebGL context), so reading the source is the coverage available here.
+ *
+ * Its limits, stated plainly: it pins that the derivation is computed from the
+ * camera list and handed to `SceneCamera`, not that the camera then flies
+ * anywhere. Renaming the local is meant to fail it - re-point the guard rather
+ * than deleting it.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+	join(import.meta.dirname, '..', '..', 'vectreal-viewer.tsx'),
+	'utf8'
+)
+
+describe('hotspot camera aiming is wired into the viewer', () => {
+	it('derives the aimed camera list from the cameras and the hotspots', () => {
+		expect(source).toContain('resolveHotspotCameraTargets(')
+		// Both inputs, or the aim cannot follow a marker the author moves.
+		expect(source).toMatch(
+			/resolveHotspotCameraTargets\(\s*cameraOptions\?\.cameras,\s*hotspots\s*\)/
+		)
+	})
+
+	it('hands that list to SceneCamera, after the spread that would shadow it', () => {
+		const mount = source.slice(
+			source.indexOf('<SceneCamera'),
+			source.indexOf('/>', source.indexOf('<SceneCamera'))
+		)
+
+		expect(mount).toContain('cameras={aimedCameras}')
+		// `{...cameraOptions}` carries the unaimed list, so order decides which wins.
+		expect(mount.indexOf('{...cameraOptions}')).toBeLessThan(
+			mount.indexOf('cameras={aimedCameras}')
+		)
+	})
+})

--- a/packages/viewer/src/components/scene/index.ts
+++ b/packages/viewer/src/components/scene/index.ts
@@ -13,6 +13,7 @@ export {
 	default as SceneEnvironment,
 	defaultEnvOptions
 } from './scene-environment'
+export { resolveHotspotCameraTargets } from './resolve-hotspot-camera-targets'
 export { default as SceneHotspots } from './scene-hotspots'
 export type { HotspotPositionSetter } from './scene-hotspots'
 export {

--- a/packages/viewer/src/components/scene/resolve-hotspot-camera-targets.spec.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-camera-targets.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveHotspotCameraTargets } from './resolve-hotspot-camera-targets'
+
+import type { CameraConfig, HotspotDefinition } from '@vctrl/core'
+
+const hotspot = (
+	overrides: Partial<HotspotDefinition> & Pick<HotspotDefinition, 'id'>
+): HotspotDefinition => ({
+	name: overrides.id,
+	worldPosition: [1, 2, 3],
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot',
+	...overrides
+})
+
+const camera = (overrides: Partial<CameraConfig> = {}): CameraConfig =>
+	({
+		cameraId: 'cam-1',
+		name: 'Cam',
+		kind: 'hotspot',
+		...overrides
+	}) as CameraConfig
+
+describe('resolveHotspotCameraTargets', () => {
+	it('aims a hotspot camera at its hotspot', () => {
+		const result = resolveHotspotCameraTargets(
+			[camera()],
+			[hotspot({ id: 'h1', linkedCameraId: 'cam-1', worldPosition: [1, 2, 3] })]
+		)
+
+		expect(result?.[0].target).toEqual([1, 2, 3])
+	})
+
+	it('leaves a target the author set by hand', () => {
+		const result = resolveHotspotCameraTargets(
+			[camera({ target: [9, 9, 9] })],
+			[hotspot({ id: 'h1', linkedCameraId: 'cam-1', worldPosition: [1, 2, 3] })]
+		)
+
+		expect(result?.[0].target).toEqual([9, 9, 9])
+	})
+
+	it('leaves a legacy lookAt alone too', () => {
+		const result = resolveHotspotCameraTargets(
+			[camera({ lookAt: [9, 9, 9] } as Partial<CameraConfig>)],
+			[hotspot({ id: 'h1', linkedCameraId: 'cam-1', worldPosition: [1, 2, 3] })]
+		)
+
+		expect(result?.[0].target).toBeUndefined()
+	})
+
+	it('never re-aims a camera the author composed', () => {
+		// A hotspot may link the opening frame or another hotspot's camera, and
+		// turning that viewpoint to face a marker is an edit nobody asked for.
+		const result = resolveHotspotCameraTargets(
+			[camera({ kind: 'scene' })],
+			[hotspot({ id: 'h1', linkedCameraId: 'cam-1' })]
+		)
+
+		expect(result?.[0].target).toBeUndefined()
+	})
+
+	it('leaves the position alone, so only the aim changes', () => {
+		const result = resolveHotspotCameraTargets(
+			[camera()],
+			[hotspot({ id: 'h1', linkedCameraId: 'cam-1' })]
+		)
+
+		expect(result?.[0].position).toBeUndefined()
+	})
+
+	it('resolves a camera two hotspots share the same way every time', () => {
+		const cameras = [camera()]
+		const first = resolveHotspotCameraTargets(cameras, [
+			hotspot({ id: 'a', linkedCameraId: 'cam-1', worldPosition: [1, 1, 1] }),
+			hotspot({ id: 'b', linkedCameraId: 'cam-1', worldPosition: [2, 2, 2] })
+		])
+
+		expect(first?.[0].target).toEqual([1, 1, 1])
+	})
+
+	it('ignores a hotspot whose position is malformed', () => {
+		const result = resolveHotspotCameraTargets(
+			[camera()],
+			[
+				{
+					...hotspot({ id: 'h1', linkedCameraId: 'cam-1' }),
+					worldPosition: [Number.NaN, 0, 0]
+				}
+			]
+		)
+
+		expect(result?.[0].target).toBeUndefined()
+	})
+
+	it('hands back the very same array when nothing needed aiming', () => {
+		// The publisher memoizes its camera options on identity, so a fresh array
+		// every render would re-register the viewer's capture callbacks.
+		const cameras = [camera({ target: [9, 9, 9] })]
+
+		expect(resolveHotspotCameraTargets(cameras, [hotspot({ id: 'h1' })])).toBe(
+			cameras
+		)
+		expect(resolveHotspotCameraTargets(cameras, undefined)).toBe(cameras)
+		expect(resolveHotspotCameraTargets(undefined, [])).toBeUndefined()
+	})
+})

--- a/packages/viewer/src/components/scene/resolve-hotspot-camera-targets.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-camera-targets.ts
@@ -1,0 +1,59 @@
+import type { CameraConfig, HotspotDefinition } from '@vctrl/core'
+
+/**
+ * Aims a hotspot's camera at its hotspot, where the author never said otherwise.
+ *
+ * A hotspot camera is minted with a name and a field of view and nothing else,
+ * so it carries neither a position nor a target. `resolveCameraSelection` fills
+ * a missing target from the live orbit target, which is the frame the visitor is
+ * already looking at - so activating a hotspot left the camera where it stood,
+ * still looking at the middle of the model. The one thing a hotspot camera is
+ * for is looking at its hotspot, and that was the one thing it did not do.
+ *
+ * A default, not an override: an explicit `target` (or the legacy `lookAt`) is
+ * the author framing the shot by hand and always wins. Position is deliberately
+ * left alone - inventing one would be inventing a viewpoint, whereas a target
+ * only decides where an existing viewpoint looks.
+ *
+ * Narrow on purpose: only a camera tagged `kind: 'hotspot'` is filled in. The
+ * Linked Camera picker offers every camera in the scene, so a hotspot can point
+ * at the opening frame or at another hotspot's camera, and re-aiming a viewpoint
+ * the author composed is exactly the edit nobody asked for.
+ *
+ * Returns the array it was given when nothing changed, so a caller can keep
+ * memoizing on its identity.
+ */
+export function resolveHotspotCameraTargets(
+	cameras: CameraConfig[] | undefined,
+	hotspots: readonly HotspotDefinition[] | undefined
+): CameraConfig[] | undefined {
+	if (!Array.isArray(cameras) || cameras.length === 0) return cameras
+	if (!Array.isArray(hotspots) || hotspots.length === 0) return cameras
+
+	const targets = new Map<string, [number, number, number]>()
+	for (const hotspot of hotspots) {
+		const cameraId = hotspot?.linkedCameraId
+		if (typeof cameraId !== 'string' || cameraId.length === 0) continue
+		// The first hotspot naming a camera wins, so two hotspots sharing one
+		// cannot make the aim depend on array order.
+		if (targets.has(cameraId)) continue
+		const position = hotspot.worldPosition
+		if (!Array.isArray(position) || position.length !== 3) continue
+		if (!position.every((axis) => Number.isFinite(axis))) continue
+		targets.set(cameraId, [position[0], position[1], position[2]])
+	}
+
+	if (targets.size === 0) return cameras
+
+	let changed = false
+	const aimed = cameras.map((camera) => {
+		if (camera?.kind !== 'hotspot') return camera
+		if (camera.target || camera.lookAt) return camera
+		const target = targets.get(camera.cameraId)
+		if (!target) return camera
+		changed = true
+		return { ...camera, target }
+	})
+
+	return changed ? aimed : cameras
+}

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -34,6 +34,7 @@ import {
 	Suspense,
 	useCallback,
 	useEffect,
+	useMemo,
 	useRef,
 	useState
 } from 'react'
@@ -46,6 +47,7 @@ import {
 	SceneCamera,
 	SceneControls,
 	SceneEnvironment,
+	resolveHotspotCameraTargets,
 	SceneHotspots,
 	SceneModel,
 	ScenePostProcessing,
@@ -483,6 +485,18 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 	// A hotspot's linked camera goes through the same command path an external
 	// `activate_camera` takes, so a hotspot click and a host calling the embed
 	// API land on one implementation of "fly to this viewpoint".
+	/*
+	  A hotspot camera aims at its hotspot unless the author framed it by hand.
+
+	  Applied here rather than baked into the saved settings, so it follows a
+	  marker that moves, needs no migration for scenes already saved, and holds on
+	  every surface rather than only where the publisher wrote it.
+	*/
+	const aimedCameras = useMemo(
+		() => resolveHotspotCameraTargets(cameraOptions?.cameras, hotspots),
+		[cameraOptions?.cameras, hotspots]
+	)
+
 	const handleActivateHotspotCamera = useCallback(
 		(cameraId: string) => {
 			executeViewerCommand({ type: 'activate_camera', cameraId })
@@ -584,6 +598,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 							<SceneBounds {...boundsOptions} enable={boundsEnabled}>
 								<SceneCamera
 									{...cameraOptions}
+									cameras={aimedCameras}
 									sceneTransition={
 										transitionOverride ?? cameraOptions?.sceneTransition
 									}


### PR DESCRIPTION
## Summary

A hotspot camera exists to look at its hotspot, and did not. Minted with a name and a field of view and nothing else, it carried neither position nor target, so activating a hotspot left the camera where it stood, still framing the middle of the model. And a marker that moved left its camera framing where the marker used to be.

## Root cause

Two different gaps, needing two different answers:

1. **A camera nobody framed had nothing to aim at**, so `resolveCameraSelection` filled the missing target from the live orbit target — the frame the visitor was already looking at.
2. **Placement wrote only the hotspot.** Moving a marker is the author saying where the point of interest is, but the camera it owns was never told.

## Changes

**`resolveHotspotCameraTargets` (viewer)** — a runtime *default*: a hotspot camera with no explicit target aims at its hotspot. Applied at render rather than baked into saved settings, so it follows a marker that moves, needs no migration, and holds on every surface.

**`placeHotspot` (publisher)** — the authoring *edit*: placing a marker moves the target that is already there, which is the case the default cannot reach. It joins the other paired edits in `scene-hotspot-camera-links`, so no call site restates the ownership rule.

Both draw the same two boundaries:

- **Only the camera the hotspot owns.** The Linked Camera picker offers every camera in the scene, so a hotspot can point at the opening frame or another hotspot's camera; re-aiming one of those rewrites a viewpoint the author composed by moving something else.
- **Only the aim.** Position is untouched, so a framed viewpoint keeps its framing and merely turns. Inventing a position would be inventing a viewpoint.

**All three placement paths** — gizmo drag, click-to-place, and the sidebar's X/Y/Z fields — now go through one `applyHotspotPlacement`.

## Type of Change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated
- [ ] No tests required

Mutation-gated on every boundary: not aiming, overriding a hand-framed target, re-aiming a camera the author composed, re-aiming one two hotspots share, moving the position as well as the aim, and reverting the sidebar field to the plain hotspot write — each fails a named test.

**The wiring is where this kept going wrong.** Deleting the paired write from `PublisherEditorScene` type-checked cleanly and broke no test, twice. It mounts inside an R3F canvas and nothing can reach it, so the write was extracted to `applyHotspotPlacement` and tested against a real jotai store; removing either half now fails a named test.

**Not verified in a browser** — no R3F canvas mounts locally on any branch, including clean `main`. Every rule here is tested at the store and domain level, but "drag the marker, watch the camera follow" wants a human.

## Note on ordering

This is what makes #769 (the mid-flight camera snap) reachable rather than latent: hotspot cameras now routinely carry a target and no position, which is exactly the branch that derives from live state. #769 is independent of this stack and can merge in any order, but it should not merge *after* this reaches production.

## Checklist

- [x] Gates green across the five projects
- [x] Full unit suite green
- [x] The viewer default and the authoring edit are documented as distinct, with the case each one covers