### PR TITLE
fix(embed): show the embed code section only when there is code to copy

### DIFF
--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@shared/components/ui/button'
 import { cn } from '@shared/utils'
+import { motion, useReducedMotion } from 'framer-motion'
 import { ExternalLink } from 'lucide-react'
 import { useEffect, useMemo, useState, type FC } from 'react'
 import { Link } from 'react-router'
@@ -25,7 +26,6 @@ import { DetailPanelSection, InlineNotice } from '../layout-components'
  * foreground keep it from competing with the `text-h4` title beside it.
  */
 const HEADING_LINK_CLASS = 'text-muted-foreground hover:text-foreground text-xs'
-
 
 interface EmbedOptionsPanelProps {
 	sceneId?: string
@@ -63,6 +63,7 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 	// collapsed and unmounted on first paint.
 	const [origin, setOrigin] = useState('')
 	useEffect(() => setOrigin(window.location.origin), [])
+	const reduceMotion = useReducedMotion()
 
 	const canEmbed = Boolean(sceneId && projectId)
 	const keysApi = useEmbedApiKeys({ projectId, enabled: canEmbed })
@@ -83,6 +84,12 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 	  `buildEmbedUrl` omits the parameter rather than failing, so the result
 	  looks finished and 404s on every site. Nothing is offered to copy until
 	  there is a key behind it.
+
+	  That rule used to be enforced only *inside* `EmbedSnippetCard`, by disabling
+	  its controls - so the section still rendered its heading, its tabs, a
+	  toolbar of three dead buttons and an empty box, and read as broken rather
+	  than as not yet applicable. The rule is unchanged; it decides the section
+	  now, and the card keeps its own guards for the state a section cannot see.
 	*/
 	const ready = Boolean(embedUrl)
 
@@ -106,6 +113,19 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 		if (!embedUrl) return
 		window.open(embedUrl, '_blank', 'noopener')
 	}
+
+	/*
+	  Fade in, and deliberately no exit. An exit animation has to keep the section
+	  mounted while `ready` is false, which is the empty frame again for the
+	  length of the transition.
+	*/
+	const appear = reduceMotion
+		? {}
+		: {
+				initial: { opacity: 0, y: -4 },
+				animate: { opacity: 1, y: 0 },
+				transition: { duration: 0.15, ease: 'easeOut' as const }
+			}
 
 	if (!canEmbed) {
 		return (
@@ -194,30 +214,56 @@ export const EmbedOptionsPanel: FC<EmbedOptionsPanelProps> = ({
 					))}
 			</DetailPanelSection>
 
-			<DetailPanelSection
-				title={EMBED_COPY.embedCodeLabel}
-				headingLevel="h4"
-				action={
-					/*
-					  `target="_blank"`, like the link above it. In the publisher this
-					  panel sits inside an unsaved composition; navigating away from it
-					  in the same tab loses that work.
-					*/
-					<Button
-						variant="ghost"
-						size="sm"
-						asChild
-						className={HEADING_LINK_CLASS}
+			{/*
+			  Absent until there is a snippet, rather than present and empty.
+
+			  Nothing stands in its place, and no sentence explains it: the Access
+			  section directly above is already saying whichever of the four things
+			  is true - no key yet and here is the button, a refused load and here is
+			  the retry, every key unusable and here is why. A heading over a void
+			  was the fourth statement, and the only one that said nothing.
+			*/}
+			{ready && (
+				<motion.div {...appear}>
+					<DetailPanelSection
+						title={EMBED_COPY.embedCodeLabel}
+						headingLevel="h4"
+						action={
+							/*
+							  `target="_blank"`, like the link above it. In the publisher this
+							  panel sits inside an unsaved composition; navigating away from
+							  it in the same tab loses that work.
+							*/
+							<Button
+								variant="ghost"
+								size="sm"
+								asChild
+								className={HEADING_LINK_CLASS}
+							>
+								<Link to={EMBED_DOCS_PATH} target="_blank" rel="noreferrer">
+									{EMBED_COPY.docsLink}
+									<ExternalLink />
+								</Link>
+							</Button>
+						}
 					>
-						<Link to={EMBED_DOCS_PATH} target="_blank" rel="noreferrer">
-							{EMBED_COPY.docsLink}
-							<ExternalLink />
-						</Link>
-					</Button>
-				}
-			>
-				<EmbedSnippetCard code={code} ready={ready} onTest={openEmbedUrl} />
-			</DetailPanelSection>
+						{/*
+						  `ready` is still passed, and the card still guards on the value it
+						  is about to copy - but not because this gate leaves a gap. It does
+						  not: a portalled Radix menu is a React child, so when a key
+						  revoked in another tab lands on a revalidation the whole section
+						  unmounts and takes the open menu with it. That was the failure the
+						  card's guards were written for, and this gate now prevents it on
+						  the panel's own path.
+
+						  They stay as the card's own contract, for a caller that mounts it
+						  unready. `embed-snippet-card.spec.tsx` is what holds them, because
+						  from here they can no longer be reached.
+						*/}
+						<EmbedSnippetCard code={code} ready={ready} onTest={openEmbedUrl} />
+					</DetailPanelSection>
+				</motion.div>
+			)}
 		</div>
 	)
 }

--- a/apps/vectreal-platform/app/components/embed/embed-snippet-card.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-snippet-card.tsx
@@ -251,12 +251,15 @@ export const EmbedSnippetCard: FC<EmbedSnippetCardProps> = ({
 					*/
 					<TabsContent key={candidate.id} value={candidate.id} tabIndex={-1}>
 						{/*
-						  Empty rather than explained when there is no key. Whatever the
-						  reason - no answer yet, a refused load, no keys at all, none
-						  usable - the Access section directly above is already saying it,
-						  and the sentence that stood here ("Select a key...") was an
-						  instruction the user could not act on in three of those four
-						  states.
+						  Nothing at all when there is no key, not an empty box.
+
+						  `EmbedOptionsPanel` no longer mounts this section unready, so on
+						  the panel's own path this branch does not render. It stays
+						  because `ready` does: this card is what guards the value being
+						  copied, and one that drew an empty `pre` for a caller who got
+						  the gate wrong would be back to handing over a broken snippet.
+						  The `min-h-20` spacer that used to sit here existed only to hold
+						  open the height of a frame that was permanently on screen.
 						*/}
 						{ready ? (
 							<pre
@@ -294,9 +297,7 @@ export const EmbedSnippetCard: FC<EmbedSnippetCardProps> = ({
 							>
 								<code>{code[candidate.id]}</code>
 							</pre>
-						) : (
-							<div className="min-h-20" />
-						)}
+						) : null}
 					</TabsContent>
 				))}
 			</div>

--- a/apps/vectreal-platform/tests/embed-options-panel.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-options-panel.spec.tsx
@@ -179,17 +179,18 @@ describe('the copy actions wait for a key', () => {
 	it('offers nothing to copy while no key is selected', () => {
 		renderPanel()
 
-		expect(button(EMBED_COPY.testEmbedUrl)).toHaveProperty('disabled', true)
-		expect(button(EMBED_COPY.copyHtml)).toHaveProperty('disabled', true)
-		expect(button(EMBED_COPY.copyOptions)).toHaveProperty('disabled', true)
-
 		/*
-		  And shows an empty surface rather than a placeholder that looks like
-		  output. The panel used to print `<!-- Save this scene ... -->` into the
-		  `pre`, which reads as a snippet and copies as one; the sentence that
-		  briefly replaced it ("Select a key...") was an instruction the user
-		  cannot act on here, since there is no key to select.
+		  The whole section, not three disabled controls inside it.
+
+		  Disabling was the previous enforcement, and it left a heading, a tab row,
+		  a toolbar and an empty box on screen - the rule was right and the surface
+		  read as broken. Asserting only on `pre` passes with all of that still
+		  rendered, which is exactly the state this replaced, so the chrome is
+		  named here too.
 		*/
+		expect(screen.queryByText(EMBED_COPY.embedCodeLabel)).toBeNull()
+		expect(screen.queryAllByRole('tab')).toHaveLength(0)
+		expect(screen.queryByRole('button', { name: /copy/i })).toBeNull()
 		expect(document.querySelector('pre')).toBeNull()
 	})
 
@@ -197,6 +198,7 @@ describe('the copy actions wait for a key', () => {
 		withLiveKey()
 		renderPanel()
 
+		expect(screen.getByText(EMBED_COPY.embedCodeLabel)).not.toBeNull()
 		expect(button(EMBED_COPY.testEmbedUrl)).toHaveProperty('disabled', false)
 		expect(button(EMBED_COPY.copyHtml)).toHaveProperty('disabled', false)
 		expect(button(EMBED_COPY.copyOptions)).toHaveProperty('disabled', false)
@@ -221,7 +223,14 @@ describe('the copy actions wait for a key', () => {
 		selectedKeyId = LIVE_KEY.id
 		renderPanel()
 
-		expect(button(EMBED_COPY.copyHtml)).toHaveProperty('disabled', true)
+		/*
+		  Anchored to what the panel still renders. Re-anchoring this test from
+		  disabled controls to an absent section left it holding two negatives, and
+		  two negatives are satisfied by a panel that returns null for this state -
+		  which is not the fix, it is a different bug.
+		*/
+		expect(screen.getByText(EMBED_COPY.accessTitle)).not.toBeNull()
+		expect(screen.queryByText(EMBED_COPY.embedCodeLabel)).toBeNull()
 		expect(document.querySelector('pre')).toBeNull()
 	})
 })
@@ -311,18 +320,24 @@ describe('the split copy button', () => {
 		expect(copied).not.toContain('<iframe')
 	})
 
-	it('goes dead if the key stops working while the menu is open', () => {
+	it('takes the whole menu away when the key stops working', () => {
 		/*
-		  Radix keeps an open menu mounted whatever its trigger does, so disabling
-		  only the trigger left three live items over an empty snippet: a key
-		  revoked in another tab lands on the next revalidation, `token` goes
-		  empty, and `writeText('')` resolves - so the toast said "copied" and the
-		  clipboard held nothing.
+		  This used to assert only that nothing was copied, and after the Embed Code
+		  section became conditional it could no longer fail: the section unmounts,
+		  the portalled menu goes with it, and a detached element takes no click -
+		  so deleting the value guard in `copyView` left it green. The clipboard
+		  half of the claim moved to `embed-snippet-card.spec.tsx`, where the card
+		  stays mounted and the guard can actually be reached.
+
+		  What is asserted here is the panel's own half, which nothing held: a key
+		  revoked in another tab arrives on a revalidation and the surface offering
+		  a snippet has to go, not merely stop responding.
 		*/
 		withLiveKey()
 		const view = renderPanel()
 
 		const items = openCopyMenu()
+		expect(items[0].isConnected).toBe(true)
 
 		keys = [{ ...LIVE_KEY, revoked: true, value: null }]
 		act(() => {
@@ -331,13 +346,8 @@ describe('the split copy button', () => {
 			)
 		})
 
-		/*
-		  Clicked directly, which is the point: `disabled` on a menu item is
-		  `aria-disabled` plus `pointer-events-none`, so it stops a real pointer
-		  and nothing else. The guard has to live where the value is read.
-		*/
-		fireEvent.click(items[0])
-
+		expect(items[0].isConnected).toBe(false)
+		expect(screen.queryByText(EMBED_COPY.embedCodeLabel)).toBeNull()
 		expect(writeText).not.toHaveBeenCalled()
 	})
 
@@ -366,6 +376,7 @@ describe('the panel groups what it offers', () => {
 		within(container).getAllByRole('heading')
 
 	it('titles the two sections it is made of', () => {
+		withLiveKey()
 		const { container } = renderPanel()
 
 		expect(headingsOf(container).map((h) => h.textContent)).toEqual([
@@ -374,7 +385,16 @@ describe('the panel groups what it offers', () => {
 		])
 	})
 
+	it('is one section until a key can build a snippet', () => {
+		const { container } = renderPanel()
+
+		expect(headingsOf(container).map((h) => h.textContent)).toEqual([
+			EMBED_COPY.accessTitle
+		])
+	})
+
 	it('puts every section on the rung both hosts leave open', () => {
+		withLiveKey()
 		/*
 		  h4 in both: the publisher nests the panel under an accordion trigger that
 		  Radix wraps in an h3, and the drawer nests it under `h3 Publishing` in a
@@ -390,6 +410,9 @@ describe('the panel groups what it offers', () => {
 	})
 
 	it('sends the detail it no longer inlines to the embedding guide', () => {
+		// With a key: the guide sits on the Embed Code heading row, and that row
+		// only exists once there is code beneath it.
+		withLiveKey()
 		renderPanel()
 
 		const guide = screen.getByRole('link', { name: EMBED_COPY.docsLink })

--- a/apps/vectreal-platform/tests/embed-snippet-card.spec.tsx
+++ b/apps/vectreal-platform/tests/embed-snippet-card.spec.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+/**
+ * The card's own refusal to copy a snippet that is no longer there.
+ *
+ * `EmbedOptionsPanel` stopped mounting this section before there is a key, so
+ * the panel-level test of this guard could no longer fail: the menu it clicks
+ * is unmounted with the section, and a detached element takes no click. The
+ * guard has to be asserted where it lives.
+ *
+ * What it is for, now that the panel gate covers the revoked-key case: a caller
+ * that mounts this card unready. `disabled` on a Radix menu item is
+ * `aria-disabled` plus `pointer-events-none`, which stops a real pointer and
+ * nothing else, so without the value guard `writeText('')` resolves and the
+ * toast reports a snippet copied. The card is the last thing standing between
+ * a wrong gate and an empty clipboard.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EmbedSnippetCard } from '../app/components/embed/embed-snippet-card'
+import { EMBED_COPY } from '../app/lib/domain/embed/embed-snippet'
+
+globalThis.ResizeObserver ??= class {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+Element.prototype.hasPointerCapture ??= () => false
+Element.prototype.setPointerCapture ??= () => {}
+Element.prototype.releasePointerCapture ??= () => {}
+Element.prototype.scrollIntoView ??= () => {}
+
+const writeText = vi.fn((_text: string) => Promise.resolve())
+Object.defineProperty(navigator, 'clipboard', {
+	value: { writeText },
+	configurable: true
+})
+
+vi.mock('sonner', () => ({
+	toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+const CODE = {
+	html: '<iframe src="https://vectreal.com/embed/p/s?token=abc"></iframe>',
+	sdk: 'new VectrealEmbed.VectrealEmbed(el)',
+	url: 'https://vectreal.com/embed/p/s?token=abc'
+}
+
+const EMPTY = { html: '', sdk: '', url: '' }
+
+beforeEach(() => {
+	writeText.mockClear()
+})
+
+const openCopyMenu = () => {
+	fireEvent.pointerDown(
+		screen.getByRole('button', {
+			name: new RegExp(EMBED_COPY.copyOptions, 'i')
+		}),
+		new MouseEvent('pointerdown', { bubbles: true, button: 0 })
+	)
+
+	return screen.getAllByRole('menuitem')
+}
+
+describe('the copy guard', () => {
+	it('copies what it is showing while the code is live', () => {
+		render(<EmbedSnippetCard code={CODE} ready onTest={vi.fn()} />)
+
+		fireEvent.click(screen.getByRole('button', { name: EMBED_COPY.copyHtml }))
+
+		expect(writeText).toHaveBeenCalledTimes(1)
+		expect(writeText.mock.calls[0][0]).toBe(CODE.html)
+	})
+
+	it('copies the view a menu item names, without leaving the tab', () => {
+		/*
+		  The only positive assertion in this file used to go through the split
+		  button, so `onClick={() => copyView(candidate)}` on the menu items could
+		  be replaced with a no-op and all three tests stayed green - a file about
+		  the menu-item guard that never proved a menu item was wired to anything.
+		*/
+		render(<EmbedSnippetCard code={CODE} ready onTest={vi.fn()} />)
+
+		const items = openCopyMenu()
+		const copyUrl = items.find((item) =>
+			item.textContent?.includes(EMBED_COPY.copyUrl)
+		)
+		fireEvent.click(copyUrl as HTMLElement)
+
+		expect(writeText).toHaveBeenCalledTimes(1)
+		expect(writeText.mock.calls[0][0]).toBe(CODE.url)
+	})
+
+	it('refuses a menu item whose snippet emptied under it', () => {
+		const view = render(<EmbedSnippetCard code={CODE} ready onTest={vi.fn()} />)
+
+		const items = openCopyMenu()
+
+		act(() => {
+			view.rerender(
+				<EmbedSnippetCard code={EMPTY} ready={false} onTest={vi.fn()} />
+			)
+		})
+
+		/*
+		  Still in the document, unlike the panel-level version of this test: a
+		  detached element takes no click, and a test that passes for that reason
+		  says nothing about the guard.
+		*/
+		expect(items[0].isConnected).toBe(true)
+
+		/*
+		  Clicked directly, past `pointer-events-none`, which is the only way to
+		  reach the state the guard is for.
+		*/
+		fireEvent.click(items[0])
+
+		expect(writeText).not.toHaveBeenCalled()
+	})
+
+	it('draws no empty frame when it is not ready', () => {
+		/*
+		  The `min-h-20` spacer that used to render here held open the height of a
+		  frame that was permanently on screen. Nothing is permanently on screen
+		  now, so a caller that mounts this unready gets no box rather than an
+		  empty one.
+		*/
+		render(<EmbedSnippetCard code={EMPTY} ready={false} onTest={vi.fn()} />)
+
+		expect(document.querySelector('pre')).toBeNull()
+		expect(
+			screen.getByRole('button', { name: EMBED_COPY.copyHtml })
+		).toHaveProperty('disabled', true)
+	})
+})


### PR DESCRIPTION
## Summary

With no API key, the embed panel rendered a heading, a tab row, a toolbar of three disabled controls and an empty box. Nothing was copyable — which was correct — but the surface read as broken rather than as not yet applicable. Stacked on #774.

## Root cause

The rule "never hand out a snippet without a key" was enforced *inside* `EmbedSnippetCard` by disabling its controls, rather than by not offering the section at all, so the chrome rendered around nothing. The rule is unchanged; it decides the section now.

This deliberately overrules the reasoning at `embed-options-panel.tsx:82` — a half-snippet must never be copyable, and it still isn't. Not rendering the section prevents that more completely than disabling it does.

## Changes

- The Embed Code section renders only when a key can build a real URL, and fades in when one arrives (`--duration-fast`, `useReducedMotion`-guarded, no exit animation — an exit would keep the section mounted through `ready` going false, which is the empty frame again).
- Nothing stands in its place and no sentence explains it. The Access section directly above already says whichever of the four things is true: no key yet and here is the button, a refused load and here is the retry, every key unusable and here is why. A heading over a void was the fourth statement and the only one that said nothing.
- `EmbedSnippetCard` keeps `ready` and its per-item value guard as its own contract for a caller that mounts it unready. Its `min-h-20` spacer goes — it existed to hold open the height of a frame that was permanently on screen.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit tests added and updated.

A portalled Radix menu is a React child, so the gate takes an open menu with it when a key is revoked in another tab. That moved the guard out of reach of the panel-level test, which could then no longer fail — deleting `if (!value) return` left it green. So `embed-snippet-card.spec.tsx` now holds that guard directly, and the panel-level test asserts the panel's own half: the surface offering a snippet is *removed*, not merely made unresponsive.

Mutations verified red: the section gate forced true; `copyView`'s value guard deleted; the menu items' copy handler no-op'd.

**Not verified in a browser** — the fade-in has not been seen. Reviewer should watch the no-key → create-key transition.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes (1666 on this commit)