### PR TITLE
refactor(shared): one file-size formatter, not four

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/scene-asset-list-item.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/scene-asset-list-item.tsx
@@ -1,17 +1,9 @@
 import { Badge } from '@shared/components/ui/badge'
-import { cn } from '@shared/utils'
+import { cn, formatFileSize } from '@shared/utils'
 import { toSerializedAssetBytes } from '@vctrl/core'
 
 import type { SerializedSceneAssetDataMap } from '../../types/api'
 import type { SceneAssetSummary } from '../../types/dashboard'
-
-function formatBytes(bytes: number | null | undefined): string {
-	if (bytes == null || Number.isNaN(bytes)) return '-'
-	if (bytes === 0) return '0 B'
-	const units = ['B', 'KB', 'MB', 'GB']
-	const i = Math.floor(Math.log(bytes) / Math.log(1024))
-	return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`
-}
 
 type TextureAssetProps = {
 	asset: SceneAssetSummary & { type: 'texture' }
@@ -102,7 +94,7 @@ export function SceneAssetListItem({
 					</Badge>
 				</div>
 				<p className="text-muted-foreground mt-1 text-xs">
-					{formatBytes(asset.fileSize)}
+					{formatFileSize(asset.fileSize)}
 					{asset.mimeType ? ` • ${asset.mimeType}` : ''}
 				</p>
 			</div>

--- a/apps/vectreal-platform/app/components/dashboard/scene-detail/scene-metrics-section.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/scene-detail/scene-metrics-section.tsx
@@ -1,32 +1,8 @@
+import { formatFileSize } from '@shared/utils'
+
 import { DetailPanelSection, StatGrid, StatTile } from '../../layout-components'
 
 import type { SceneDetailsSummary } from '../../../types/dashboard'
-
-/**
- * Bytes as a scene page says them.
- *
- * Not `formatFileSize` from `@shared/utils`, and not the copy inside
- * `scene-asset-list-item.tsx`: all three round differently, and swapping one for
- * another here would change every figure on this surface for no reason anybody
- * asked for. The three are a real duplication and are filed as their own row.
- */
-function formatBytes(bytes: number | null | undefined): string {
-	if (bytes == null || Number.isNaN(bytes)) {
-		return '-'
-	}
-
-	if (bytes === 0) {
-		return '0 B'
-	}
-
-	const units = ['B', 'KB', 'MB', 'GB']
-	const index = Math.min(
-		Math.floor(Math.log(bytes) / Math.log(1024)),
-		units.length - 1
-	)
-	const size = bytes / 1024 ** index
-	return `${size >= 100 ? Math.round(size) : size.toFixed(size < 10 ? 1 : 0)} ${units[index]}`
-}
 
 /**
  * Texture weight, or the count when the weight was never recorded.
@@ -38,7 +14,7 @@ function formatBytes(bytes: number | null | undefined): string {
  */
 function describeTextures(details: SceneDetailsSummary): string {
 	if (details.textureBytes != null) {
-		return formatBytes(details.textureBytes)
+		return formatFileSize(details.textureBytes)
 	}
 
 	if (details.textureCount != null) {
@@ -84,7 +60,7 @@ export function SceneMetricsSection({
 	return (
 		<DetailPanelSection title="Scene Metrics" headingLevel={headingLevel}>
 			<StatGrid>
-				<StatTile label="Size" value={formatBytes(details.fileSizeBytes)} />
+				<StatTile label="Size" value={formatFileSize(details.fileSizeBytes)} />
 				<StatTile label="Assets" value={details.assetCount} />
 				<StatTile label="Texture Size" value={describeTextures(details)} />
 				<StatTile

--- a/apps/vectreal-platform/app/components/dashboard/scene-detail/scene-publish-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/scene-detail/scene-publish-panel.spec.tsx
@@ -128,7 +128,7 @@ describe('a published scene', () => {
 		  Date and size in one line. The size is what a visitor pays to load it,
 		  which is the number this product exists to keep small.
 		*/
-		expect(container.textContent).toContain('2.10 MB')
+		expect(container.textContent).toContain('2.1 MB')
 		expect(container.textContent).toMatch(/Published\s/)
 	})
 

--- a/apps/vectreal-platform/app/components/dashboard/scene-detail/scene-summary-bar.spec.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/scene-detail/scene-summary-bar.spec.tsx
@@ -121,13 +121,7 @@ describe('what stays on screen', () => {
 	it('keeps the two figures that drive the page', () => {
 		renderBar()
 
-		/*
-		  Two decimals is what `formatFileSize` renders today. The unification that
-		  makes it adaptive stacks on top of this branch and declares the shift to
-		  `618 KB` as its own visible change; this asserts the current truth rather
-		  than a future one.
-		*/
-		expect(tileValue('Size')).toBe('618.00 KB')
+		expect(tileValue('Size')).toBe('618 KB')
 		expect(tileValue('Assets')).toBe('7')
 	})
 
@@ -169,7 +163,7 @@ describe('the scene details door', () => {
 
 		expect(
 			screen.getByRole('button', { name: /scene details/i }).textContent
-		).toContain('7 assets · 618.00 KB')
+		).toContain('7 assets · 618 KB')
 	})
 
 	it('speaks of one asset in the singular', () => {

--- a/apps/vectreal-platform/app/components/publisher/optimization/results/metric-row.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/results/metric-row.tsx
@@ -1,13 +1,9 @@
-import { formatFileSize } from '@shared/utils'
 import { ArrowRight } from 'lucide-react'
 
 import type { FC, ReactNode } from 'react'
 
 export const formatCount = (value: number | null | undefined) =>
 	typeof value === 'number' ? value.toLocaleString() : '-'
-
-export const formatBytes = (value: number | null | undefined) =>
-	typeof value === 'number' ? formatFileSize(value) : '-'
 
 interface MetricRowProps {
 	label: string

--- a/apps/vectreal-platform/app/components/publisher/optimization/results/optimization-results.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/results/optimization-results.tsx
@@ -2,7 +2,7 @@ import { formatFileSize } from '@shared/utils'
 import { motion } from 'framer-motion'
 import { useMemo } from 'react'
 
-import { BeforeAfter, MetricRow, formatBytes, formatCount } from './metric-row'
+import { BeforeAfter, MetricRow, formatCount } from './metric-row'
 import { FileSizeComparison } from '../../sidebars/file-size-comparison'
 
 import type { resolveSceneMetrics } from '../../../../lib/domain/scene'
@@ -72,8 +72,8 @@ export const OptimizationResults: FC<OptimizationResultsProps> = ({
 					<MetricRow label="Geometry (Draco)">
 						{dracoReport.isWorthApplying ? (
 							<BeforeAfter
-								before={formatBytes(dracoReport.geometryBytesBefore)}
-								after={formatBytes(dracoReport.geometryBytesAfterCompression)}
+								before={formatFileSize(dracoReport.geometryBytesBefore)}
+								after={formatFileSize(dracoReport.geometryBytesAfterCompression)}
 								suffix={`(-${Math.round(dracoReport.reductionPercent)}%)`}
 							/>
 						) : (
@@ -87,7 +87,7 @@ export const OptimizationResults: FC<OptimizationResultsProps> = ({
 				{sizeInfo.workingSceneBytes != null ? (
 					<MetricRow label="Before Draco">
 						<span className="text-muted-foreground">
-							{formatBytes(sizeInfo.workingSceneBytes)}
+							{formatFileSize(sizeInfo.workingSceneBytes)}
 						</span>
 					</MetricRow>
 				) : null}
@@ -129,8 +129,8 @@ export const OptimizationResults: FC<OptimizationResultsProps> = ({
 
 				<MetricRow label="Texture size">
 					<BeforeAfter
-						before={formatBytes(resolvedMetrics.textureBytes.initial)}
-						after={formatBytes(resolvedMetrics.textureBytes.current)}
+						before={formatFileSize(resolvedMetrics.textureBytes.initial)}
+						after={formatFileSize(resolvedMetrics.textureBytes.current)}
 					/>
 				</MetricRow>
 			</div>

--- a/apps/vectreal-platform/app/components/publisher/optimization/results/pre-optimization-summary.tsx
+++ b/apps/vectreal-platform/app/components/publisher/optimization/results/pre-optimization-summary.tsx
@@ -1,6 +1,7 @@
+import { formatFileSize } from '@shared/utils'
 import { motion } from 'framer-motion'
 
-import { formatBytes, formatCount } from './metric-row'
+import { formatCount } from './metric-row'
 
 import type { SizeInfo } from '../use-optimization-process'
 import type { FC } from 'react'
@@ -19,7 +20,7 @@ export const PreOptimizationSummary: FC<PreOptimizationSummaryProps> = ({
 }) => {
 	const metrics = [
 		{ label: 'Triangles', value: formatCount(primitivesCount) },
-		{ label: 'File size', value: formatBytes(sizeInfo.initialSceneBytes) },
+		{ label: 'File size', value: formatFileSize(sizeInfo.initialSceneBytes) },
 		{ label: 'Textures', value: formatCount(texturesCount) }
 	]
 

--- a/shared/utils/src/lib/formatting.utils.spec.ts
+++ b/shared/utils/src/lib/formatting.utils.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * The one byte formatter, pinned at the edges the three it replaced disagreed on.
+ *
+ * They diverged exactly where nothing was asserted: above a gigabyte, below a
+ * kilobyte, at the rounding boundaries, and on "not measured". A scene could
+ * report three different sizes on one page and every suite stayed green.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { formatFileSize } from './formatting.utils'
+
+const KB = 1024
+const MB = 1024 * KB
+const GB = 1024 * MB
+const TB = 1024 * GB
+
+describe('formatFileSize', () => {
+	it('names every unit it can reach', () => {
+		/*
+		  GB is the case that mattered: this function used to stop at MB, so a 3 GiB
+		  scene - which the plan limits allow - rendered as "3072.00 MB".
+		*/
+		expect(formatFileSize(512)).toBe('512 B')
+		expect(formatFileSize(4 * KB)).toBe('4.0 KB')
+		expect(formatFileSize(4 * MB)).toBe('4.0 MB')
+		expect(formatFileSize(3 * GB)).toBe('3.0 GB')
+		expect(formatFileSize(2 * TB)).toBe('2.0 TB')
+	})
+
+	it('clamps rather than running off the end of its units', () => {
+		/*
+		  A petabyte. The copy in `scene-asset-list-item.tsx` indexed an array of
+		  four by an unbounded logarithm and rendered "1.0 undefined".
+		*/
+		expect(formatFileSize(1024 * TB)).toBe('1024 TB')
+	})
+
+	it('spends decimals where they carry information', () => {
+		// Under 10: one decimal is the difference between 4.4 and 4 MB.
+		expect(formatFileSize(4.4 * MB)).toBe('4.4 MB')
+		// 10 to 100: the decimal is noise.
+		expect(formatFileSize(48.6 * MB)).toBe('49 MB')
+		// At or above 100: so is the fraction.
+		expect(formatFileSize(150.7 * MB)).toBe('151 MB')
+	})
+
+	it('crosses into the next unit rather than counting past it', () => {
+		/* 1023.9 KB is still KB; one byte more is not. */
+		expect(formatFileSize(MB - 1)).toBe('1024 KB')
+		expect(formatFileSize(MB)).toBe('1.0 MB')
+	})
+
+	it('distinguishes an empty file from an unmeasured one', () => {
+		/*
+		  Both used to be spelled by hand at each call site, and two of the three
+		  formatters got one of them wrong. Zero is a fact; null is the absence of
+		  one, and they must not render the same.
+		*/
+		expect(formatFileSize(0)).toBe('0 B')
+		expect(formatFileSize(null)).toBe('-')
+		expect(formatFileSize(undefined)).toBe('-')
+		expect(formatFileSize(Number.NaN)).toBe('-')
+	})
+})

--- a/shared/utils/src/lib/formatting.utils.ts
+++ b/shared/utils/src/lib/formatting.utils.ts
@@ -1,15 +1,50 @@
+/** Largest unit first would read backwards; index into this by power of 1024. */
+const FILE_SIZE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB'] as const
+
 /**
- * Format the file size for display.
+ * A byte count as the product says it.
  *
- * @param bytes - The size in bytes.
- * @returns A human-readable file size string.
+ * The one implementation. There were three, and they disagreed on every axis
+ * that shows: this one stopped at MB and rendered a 3 GiB scene as
+ * "3072.00 MB", always at two decimals, with sizes under a kilobyte spelled
+ * "512 bytes"; a copy in the scene detail route used adaptive precision and
+ * B/KB/MB/GB; a third in `scene-asset-list-item.tsx` was fixed at one decimal
+ * and indexed past its own unit array above a terabyte, yielding "1.0
+ * undefined". The same scene could therefore report three different sizes on
+ * one page.
+ *
+ * Precision is adaptive because a fixed one is wrong at both ends: two decimals
+ * makes "3.00 KB" out of a number nobody needs that precisely, and zero makes
+ * "4 MB" out of 4.4. Under 10, one decimal carries real information; from 10 to
+ * 100 it is noise; at or above 100 even the integer part is more than the
+ * reader wants.
+ *
+ * @param bytes Byte count. `null`, `undefined` and `NaN` render as a dash -
+ * every call site had to handle "not measured" and two of the three did it by
+ * hand.
  */
-export const formatFileSize = (bytes: number): string => {
-	if (bytes >= 1024 * 1024) {
-		return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
-	} else if (bytes >= 1024) {
-		return `${(bytes / 1024).toFixed(2)} KB`
-	} else {
-		return `${bytes} bytes`
+export const formatFileSize = (bytes: number | null | undefined): string => {
+	if (bytes == null || Number.isNaN(bytes)) {
+		return '-'
 	}
+
+	if (bytes === 0) {
+		return '0 B'
+	}
+
+	/*
+	  Clamped, which the copy in the asset list was not: `Math.log` keeps
+	  climbing past the last unit, so a petabyte indexed off the end of the array
+	  and formatted as `undefined`.
+	*/
+	const index = Math.min(
+		Math.floor(Math.log(bytes) / Math.log(1024)),
+		FILE_SIZE_UNITS.length - 1
+	)
+	const size = bytes / 1024 ** index
+
+	const rendered =
+		size >= 100 ? Math.round(size) : size.toFixed(size < 10 ? 1 : 0)
+
+	return `${rendered} ${FILE_SIZE_UNITS[index]}`
 }


### PR DESCRIPTION
## Summary

Four functions formatted bytes and disagreed on every axis that shows, so the same scene could report different sizes in two places on one page. Stacked on #775.

## Root cause

The shared `formatFileSize` could not express what the app needed — no GB, no "not measured" — so each surface wrote its own instead of fixing it.

## Changes

What the four did differently, all of it visible:

| | Behaviour |
| --- | --- |
| `formatFileSize` (`@shared/utils`, 10 call sites) | Stopped at MB, so a 3 GiB scene read `3072.00 MB`. Always two decimals. Under a kilobyte: `512 bytes`. |
| `formatBytes` (scene detail route) | Adaptive precision, reached GB, null-safe. |
| `formatBytes` (`scene-asset-list-item.tsx`) | Fixed one decimal; indexed an array of four units by an unbounded logarithm, so a petabyte rendered `1.0 undefined`. |
| `formatBytes` (`metric-row.tsx`) | A null-guard wrapper around the first. |

`formatFileSize` absorbs what the copies were right about: units through TB with the index **clamped**, `null`/`undefined`/`NaN` as a dash, and adaptive precision — a fixed one is wrong at both ends, since two decimals makes `3.00 KB` of a number nobody needs that precisely and zero makes `4 MB` of 4.4. The wrapper goes now that the function is null-safe itself.

**Visible change:** publisher figures move from two decimals to adaptive, and sizes under a kilobyte from `512 bytes` to `512 B`. That is the point — one rule.

`formatLimitValue` is deliberately untouched: it renders plan limits, which are round marketing numbers with their own `Custom` and `Unlimited` cases, and it has its own spec.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit tests added — `formatting.utils.spec.ts`, the first test any of the four ever had. It pins exactly the edges they disagreed on: every unit boundary, the clamp, the rounding thresholds, and zero against not-measured, which must not render the same.

Mutations verified red: clamp removed; adaptive precision replaced by the old fixed two decimals; null and zero collapsed to one branch.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes (1671 on this commit)