### PR TITLE
test(dashboard): cover the scene delete capability the loader ships

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/dashboard/scene-detail-capabilities.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/scene-detail-capabilities.spec.ts
@@ -1,0 +1,41 @@
+import { DASHBOARD_OPERATION_ROLES } from './dashboard-operations'
+import { canDeleteScene } from './scene-detail-capabilities'
+
+import type { MembershipRole } from './dashboard-operations'
+
+const ROLES: MembershipRole[] = ['owner', 'admin', 'member']
+
+describe('canDeleteScene', () => {
+	it('answers with the permission table rather than a rule of its own', () => {
+		/*
+		  Read from the table, not restated. A hand-written list here would pass
+		  while disagreeing with the map the mutation endpoint enforces against -
+		  which is the drift this whole module exists to prevent, reproduced in its
+		  own test.
+		*/
+		for (const role of ROLES) {
+			expect(canDeleteScene({ role })).toBe(
+				DASHBOARD_OPERATION_ROLES['scene:delete'].includes(role)
+			)
+		}
+	})
+
+	it('names the operation the endpoint enforces, not a neighbouring one', () => {
+		/*
+		  The assertion above is satisfied by any operation whose roles happen to
+		  match, so it is anchored to a role that separates them: a member may
+		  update and move a scene and may not delete it. Pointing this at
+		  `scene:update` reads identically and hands every member a Delete button.
+		*/
+		expect(canDeleteScene({ role: 'member' })).toBe(false)
+		expect(DASHBOARD_OPERATION_ROLES['scene:update']).toContain('member')
+	})
+
+	it('refuses an actor with no membership at all', () => {
+		/*
+		  Absent membership is no membership. Defaulting this to `true` is invisible
+		  on every surface an owner ever sees.
+		*/
+		expect(canDeleteScene(null)).toBe(false)
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/dashboard/scene-detail-capabilities.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/scene-detail-capabilities.ts
@@ -1,0 +1,38 @@
+import { canPerformDashboardOperation } from './dashboard-operations'
+
+import type { MembershipRole } from './dashboard-operations'
+
+/**
+ * The minimum this needs to answer the question.
+ *
+ * Deliberately structural rather than the `ResolvedMembership` returned by
+ * `dashboard-permissions.server.ts`, for the reason `dashboard-capabilities.ts`
+ * gives for the same shape beside it: naming that type here would pull a
+ * server-only module into something the client renders from.
+ */
+export interface SceneActorLike {
+	role: MembershipRole
+}
+
+/**
+ * Whether this actor may delete the scene they are looking at.
+ *
+ * A pure module for one boolean, which is not the usual justification. It is
+ * here because a route module cannot be imported by a test - `getDbClient()`
+ * runs at module scope and throws `Missing DATABASE_URL` - so the loader's
+ * `canDeleteScene` was the one part of the delete gate nothing could reach.
+ * Both ends were covered and the wiring between them was not: naming a
+ * different operation, or defaulting an absent membership to `true`, broke no
+ * test. That is the "the call, not only the rule" case exactly.
+ *
+ * Absent membership means the actor is in no organization that owns this
+ * scene, which is no. It is not a fallback: `getScene` has already 404'd for
+ * anything the actor cannot see by the time a loader asks this.
+ */
+export function canDeleteScene(membership: SceneActorLike | null): boolean {
+	if (!membership) {
+		return false
+	}
+
+	return canPerformDashboardOperation('scene:delete', membership)
+}

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
@@ -16,8 +16,8 @@ import SceneEmbedViewer from '../../../components/scene-embed/scene-embed-viewer
 import { useSceneMetadata } from '../../../hooks/use-scene-metadata'
 import { loadAuthenticatedSession } from '../../../lib/domain/auth/auth-loader.server'
 import { toSceneRef } from '../../../lib/domain/dashboard/dashboard-confirmation'
-import { canPerformDashboardOperation } from '../../../lib/domain/dashboard/dashboard-operations'
 import { resolveSceneMembership } from '../../../lib/domain/dashboard/dashboard-permissions.server'
+import { canDeleteScene } from '../../../lib/domain/dashboard/scene-detail-capabilities'
 import { buildInternalPreviewPath } from '../../../lib/domain/embed/embed-snippet'
 import { getProject } from '../../../lib/domain/project/project-repository.server'
 import { useSceneModel } from '../../../lib/domain/scene/client/use-scene-model'
@@ -114,10 +114,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 			},
 			folderPath,
 			sceneDetails,
-			// Absent membership is no membership, which is no.
-			canDeleteScene: membership
-				? canPerformDashboardOperation('scene:delete', membership)
-				: false
+			canDeleteScene: canDeleteScene(membership)
 		},
 		{ headers }
 	)


### PR DESCRIPTION
## Summary

The delete gate had both ends tested and the wiring between them untested. Stacked on #776.

## Root cause

It was unreachable, not overlooked: a route module cannot be imported by a test, because `getDbClient()` runs at module scope and throws `Missing DATABASE_URL`. So the loader line deriving `canDeleteScene` from the permission table was the one part of the gate nothing could hold — naming a neighbouring operation, or defaulting an absent membership to allowed, broke no test while handing every member a Delete button.

## Changes

- The derivation moves into a pure module (`scene-detail-capabilities.ts`), the pattern `scene-route-params.ts` sets and `vectreal-extension-architecture` names for exactly this. The loader calls it.
- The actor type is structural rather than the `ResolvedMembership` from `dashboard-permissions.server.ts`, for the reason `dashboard-capabilities.ts` gives beside it: naming that type here would pull a server-only module into something the client renders from.
- The spec reads roles out of `DASHBOARD_OPERATION_ROLES` rather than restating them, so it cannot pass while disagreeing with the table the mutation endpoint enforces against — the drift the module exists to prevent, reproduced in its own test. It is anchored on the role that separates delete from its neighbours: a member may update and move a scene but may not delete it.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit tests added.

Mutations verified red: `scene:delete` → `scene:update` (which members *can* do, so the anchor is what catches it); absent membership defaulting to `true`.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes (1674 on this commit)