### PR TITLE
fix(dashboard): stop nesting a second main landmark in the scene detail page

### DIFF
--- a/apps/vectreal-platform/app/components/skeletons/scene-details-skeleton.tsx
+++ b/apps/vectreal-platform/app/components/skeletons/scene-details-skeleton.tsx
@@ -20,7 +20,9 @@ export const SceneDetailsSkeleton = () => {
 			aria-label="Loading scene"
 		>
 			<div className="grid grid-cols-1 gap-4 xl:h-full xl:min-h-0 xl:grid-cols-[minmax(0,1fr)_auto]">
-				<main className="flex flex-col gap-4 xl:min-h-0">
+				{/* A `div` for the reason `scene.tsx` records: `SidebarInset` owns
+				    this page's only `main` landmark. */}
+				<div className="flex flex-col gap-4 xl:min-h-0">
 					<Skeleton className="h-[55svh] min-h-64 shrink-0 rounded-2xl xl:h-auto xl:min-h-0 xl:flex-1" />
 
 					<div className="ds-raised space-y-4 rounded-2xl px-4 py-4 sm:px-5">
@@ -44,7 +46,7 @@ export const SceneDetailsSkeleton = () => {
 							<Skeleton className="h-4 w-56" />
 						</div>
 					</div>
-				</main>
+				</div>
 
 				{/*
 				  The `xl` column only, mirroring `SceneFactsPanel`. Below `xl` the

--- a/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/projects/scene.tsx
@@ -233,7 +233,14 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 				<link rel="preload" as="image" href={sceneState.thumbnailUrl} />
 			) : null}
 			<div className="grid grid-cols-1 gap-4 xl:h-full xl:min-h-0 xl:grid-cols-[minmax(0,1fr)_auto]">
-				<main className="flex flex-col gap-4 xl:min-h-0">
+				{/*
+				  A `div`, not a `main`. `SidebarInset` renders the dashboard's `main`
+				  landmark and every route renders inside it, so a `main` here is a
+				  second one nested in the first - which HTML forbids and axe reports
+				  as `landmark-no-duplicate-main`. This element is a layout column,
+				  and the column beside it is the `aside` that `SceneFactsPanel` draws.
+				*/}
+				<div className="flex flex-col gap-4 xl:min-h-0">
 					{model.status === 'error' ? (
 						<DetailPanelSection
 							surface="raised"
@@ -340,7 +347,7 @@ const ScenePage = ({ loaderData }: Route.ComponentProps) => {
 							)}
 						</div>
 					</DetailPanelSection>
-				</main>
+				</div>
 
 				{/*
 				  Two hosts, one for each side of `xl`, and exactly one of them is


### PR DESCRIPTION
## Summary

`SidebarInset` renders the dashboard's `<main>` and every route renders inside it, so the scene detail page's own `<main>` was a second one nested in the first. Stacked on #777, and the last of the six.

## Root cause

The element reads like the page's main column, and it is — but the landmark for that column is already owned one level up by the shell. HTML forbids a `main` descendant of another `main`, and axe reports `landmark-no-duplicate-main`; a screen reader user navigating by landmark gets two mains on one page.

## Changes

- The route's `<main>` and the skeleton's become `<div>`. They are layout columns; the `aside` beside them is left as the landmark it genuinely is.
- Both carry a comment naming `SidebarInset`, since the next person writing this markup will reach for `main` for the same reason.

These two were the only places under the dashboard shell doing it.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] No tests required — the route half is unreachable from a test (route modules throw `Missing DATABASE_URL` at import), and a skeleton-only landmark assertion would guard the half that matters less. Recurrence is guarded by the comments; if it recurs, a `documented-claims.spec.ts` claim is the mechanism this repo already has for it.

`typecheck` + `lint` pass, 1674 tests pass.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes