### PR TITLE
fix(dashboard): tell two identical mutation responses apart

### DIFF
--- a/apps/vectreal-platform/app/hooks/use-dashboard-mutations.ts
+++ b/apps/vectreal-platform/app/hooks/use-dashboard-mutations.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useFetcher, useFetchers, useRevalidator } from 'react-router'
 import { useAuthenticityToken } from 'remix-utils/csrf/react'
 import { toast } from 'sonner'
 
+import { useOncePerFetcherResponse } from './use-once-per-fetcher-response'
 import {
 	serializeDashboardMutationRequest,
 	type DashboardMutationRequest,
@@ -69,6 +70,11 @@ function describeOutcome(response: DashboardMutationResponse): {
  *
  * The fetcher is unkeyed for the same reason: a shared key made every mount
  * observe every other mount's response.
+ *
+ * Which response has been handled is `useOncePerFetcherResponse`'s question,
+ * and it is the fourth call site to ask it. The three before it each keyed on
+ * the response body and each shipped the same pair of defects; see that hook
+ * for why identity is the only thing that answers it.
  */
 export function useDashboardMutations(options?: {
 	onSuccess?: (response: DashboardMutationResponse) => void
@@ -84,7 +90,6 @@ export function useDashboardMutations(options?: {
 		useState<DashboardMutationResponse | null>(null)
 	const [lastError, setLastError] = useState<string | null>(null)
 
-	const handledSignatureRef = useRef<string | null>(null)
 	const onSuccessRef = useRef(options?.onSuccess)
 	const silentRef = useRef(options?.silent)
 	onSuccessRef.current = options?.onSuccess
@@ -92,7 +97,6 @@ export function useDashboardMutations(options?: {
 
 	const submit = useCallback(
 		(request: DashboardMutationRequest) => {
-			handledSignatureRef.current = null
 			setLastError(null)
 
 			const targetIds =
@@ -111,21 +115,11 @@ export function useDashboardMutations(options?: {
 		[csrfToken, fetcher]
 	)
 
-	useEffect(() => {
-		if (fetcher.state !== 'idle' || !fetcher.data) {
-			return
-		}
-
-		const signature = JSON.stringify(fetcher.data)
-		if (handledSignatureRef.current === signature) {
-			return
-		}
-		handledSignatureRef.current = signature
-
+	useOncePerFetcherResponse(fetcher, (envelope) => {
 		setPendingIds(new Set())
 
-		if (!fetcher.data.success) {
-			const message = fetcher.data.error ?? 'Action failed'
+		if (!envelope.success) {
+			const message = envelope.error ?? 'Action failed'
 			setLastError(message)
 			if (!silentRef.current) {
 				toast.error(message)
@@ -133,7 +127,7 @@ export function useDashboardMutations(options?: {
 			return
 		}
 
-		const response = fetcher.data.data
+		const response = envelope.data
 		setLastResponse(response)
 
 		if (!silentRef.current) {
@@ -145,7 +139,7 @@ export function useDashboardMutations(options?: {
 			onSuccessRef.current?.(response)
 			revalidator.revalidate()
 		}
-	}, [fetcher.data, fetcher.state, revalidator])
+	})
 
 	return {
 		submit,

--- a/apps/vectreal-platform/tests/use-dashboard-mutations.spec.tsx
+++ b/apps/vectreal-platform/tests/use-dashboard-mutations.spec.tsx
@@ -1,0 +1,293 @@
+// @vitest-environment jsdom
+/**
+ * One handle per response, for the dashboard's create/rename/move/delete client.
+ *
+ * The sequence every defect case below drives is the one React Router actually
+ * produces. `fetcher.state` is read from router state, which lands through
+ * `startTransition`, while `fetcher.data` is read from a ref the router mutates
+ * as it pushes that state - so after a submit the fetcher keeps reading `idle`
+ * with the *previous* response for at least one commit, and a revalidation
+ * settling in that window re-runs any effect watching the fetcher.
+ *
+ * That is why `state` is driven explicitly here instead of flipping inside
+ * `submit`. Swap in a fixture where submitting is instantaneous and the window
+ * disappears, taking the defect with it: every test below then passes against
+ * the hook this replaced.
+ */
+
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDashboardMutations } from '../app/hooks/use-dashboard-mutations'
+
+import type { DashboardMutationsApi } from '../app/hooks/use-dashboard-mutations'
+import type {
+	DashboardMutationRequest,
+	DashboardMutationResponse
+} from '../app/lib/domain/dashboard/dashboard-mutations'
+
+const router = vi.hoisted(() => ({
+	fetcher: { state: 'idle', data: undefined as unknown },
+	revalidation: 'idle' as 'idle' | 'loading',
+	revalidate: vi.fn()
+}))
+
+vi.mock('react-router', () => {
+	let lastRevalidation: string | null = null
+	let revalidator: unknown = null
+
+	return {
+		useFetcher: () => ({
+			state: router.fetcher.state,
+			data: router.fetcher.data,
+			submit: () => {}
+		}),
+		useFetchers: () => [],
+		/*
+		  Memoized on the revalidation state, exactly as the real one is
+		  (`useMemo([revalidate, state.revalidation])`). A fixture returning a
+		  fresh object every render would re-run the effect on every commit and
+		  a fixture returning a frozen one would never re-run it; only this
+		  matches when React Router hands out a new identity.
+		*/
+		useRevalidator: () => {
+			if (lastRevalidation !== router.revalidation) {
+				lastRevalidation = router.revalidation
+				revalidator = {
+					state: router.revalidation,
+					revalidate: router.revalidate
+				}
+			}
+			return revalidator
+		}
+	}
+})
+
+vi.mock('remix-utils/csrf/react', () => ({
+	useAuthenticityToken: () => 'csrf-token'
+}))
+
+const toasts = vi.hoisted(() => [] as string[])
+vi.mock('sonner', () => ({
+	toast: {
+		success: (message: string) => toasts.push(`success:${message}`),
+		warning: (message: string) => toasts.push(`warning:${message}`),
+		error: (message: string) => toasts.push(`error:${message}`)
+	}
+}))
+
+const handled: DashboardMutationResponse[] = []
+
+function mount() {
+	let api!: DashboardMutationsApi
+
+	function Probe() {
+		api = useDashboardMutations({
+			onSuccess: (response) => handled.push(response)
+		})
+		return null
+	}
+
+	const view = render(<Probe />)
+	const commit = () => act(() => void view.rerender(<Probe />))
+
+	return {
+		get api() {
+			return api
+		},
+		submit: (request: DashboardMutationRequest) => {
+			act(() => api.submit(request))
+			commit()
+		},
+		/** The router's `submitting` state, one commit behind the click. */
+		submitting: () => {
+			act(() => {
+				router.fetcher = { state: 'submitting', data: router.fetcher.data }
+			})
+			commit()
+		},
+		settle: (data: unknown) => {
+			act(() => {
+				router.fetcher = { state: 'idle', data }
+			})
+			commit()
+		},
+		revalidation: (state: 'idle' | 'loading') => {
+			act(() => {
+				router.revalidation = state
+			})
+			commit()
+		}
+	}
+}
+
+const deleteScene: DashboardMutationRequest = {
+	verb: 'delete',
+	targets: [{ type: 'scene', id: 'scene-1' }],
+	confirmationText: null
+}
+
+/** Two deletes of the same scene return byte-identical bodies. */
+const deleted = () => ({
+	success: true as const,
+	data: {
+		verb: 'delete' as const,
+		results: [{ type: 'scene' as const, id: 'scene-1', success: true }],
+		summary: { total: 1, succeeded: 1, failed: 0 }
+	}
+})
+
+const rejected = () => ({ success: false as const, error: 'Invalid CSRF token' })
+
+beforeEach(() => {
+	router.fetcher = { state: 'idle', data: undefined }
+	router.revalidation = 'idle'
+	router.revalidate.mockClear()
+	toasts.length = 0
+	handled.length = 0
+})
+
+describe('useDashboardMutations', () => {
+	it('handles a settled response once', () => {
+		const probe = mount()
+
+		probe.submit(deleteScene)
+		expect(probe.api.pendingIds).toEqual(new Set(['scene-1']))
+
+		probe.submitting()
+		const response = deleted()
+		probe.settle(response)
+
+		expect(handled).toEqual([response.data])
+		expect(handled[0]).toBe(response.data)
+		expect(toasts).toEqual(['success:Item deleted'])
+		expect(probe.api.lastResponse).toBe(response.data)
+		expect(probe.api.pendingIds.size).toBe(0)
+		expect(router.revalidate).toHaveBeenCalledOnce()
+	})
+
+	/*
+	  The defect. Deleting the same scene twice - or renaming a folder to the
+	  name it already has - returns two responses with identical bodies, and a
+	  content signature cannot tell them apart. The revalidation here is the one
+	  the hook itself started on the first response; it settles while the fetcher
+	  still reads idle with that first response, which is what re-runs the
+	  effect inside the window.
+	*/
+	it('handles the second of two responses whose bodies are identical', () => {
+		const probe = mount()
+
+		probe.submit(deleteScene)
+		probe.submitting()
+		const first = deleted()
+		probe.settle(first)
+		probe.revalidation('loading')
+
+		probe.submit(deleteScene)
+		probe.revalidation('idle')
+		probe.submitting()
+		const second = deleted()
+		probe.settle(second)
+
+		/*
+		  By identity, not value: the two bodies are deep-equal, so a hook that
+		  handled the first response twice and dropped the second satisfies any
+		  structural assertion written here.
+		*/
+		expect(handled).toHaveLength(2)
+		expect(handled[0]).toBe(first.data)
+		expect(handled[1]).toBe(second.data)
+		expect(router.revalidate).toHaveBeenCalledTimes(2)
+	})
+
+	/*
+	  The other half of the same defect: with the signature blanked on submit,
+	  the response the fetcher is still carrying is handled a second time - the
+	  row's spinner clears and the dialog closes before the server has answered.
+	*/
+	it('does not re-handle the response the fetcher still carries in flight', () => {
+		const probe = mount()
+
+		probe.submit(deleteScene)
+		probe.submitting()
+		probe.settle(deleted())
+		probe.revalidation('loading')
+
+		probe.submit(deleteScene)
+		probe.revalidation('idle')
+
+		expect(handled).toHaveLength(1)
+		expect(probe.api.pendingIds).toEqual(new Set(['scene-1']))
+	})
+
+	/*
+	  The identity comparison, which nothing else here reaches. The response a
+	  component sees is stickier than the one the router holds: `RouterProvider`
+	  copies a fetcher's data into a ref map only when it is not `undefined`
+	  and never writes `undefined` back (`components.js:137`), and `useFetcher`
+	  reads `data` from that map rather than from router state
+	  (`dom/lib.js:997`). So once a response has landed it stays visible even
+	  after the router clears the fetcher's own data - which is what answering
+	  a submission with a redirect does (`router.js:841,847,850`) - and the
+	  state cycling back to idle re-presents the object already handled. The
+	  transition alone re-runs the effect; only comparing the object stops it.
+	*/
+	it('does not re-handle a response the fetcher settles back onto', () => {
+		const probe = mount()
+
+		probe.submit(deleteScene)
+		probe.submitting()
+		const response = deleted()
+		probe.settle(response)
+		expect(handled).toHaveLength(1)
+
+		probe.submit(deleteScene)
+		probe.submitting()
+		// Superseded: the router marks the fetcher done carrying the response
+		// it already had, rather than a new one.
+		probe.settle(response)
+
+		expect(handled).toHaveLength(1)
+		expect(router.revalidate).toHaveBeenCalledOnce()
+	})
+
+	it('surfaces a rejection and clears the pending ids', () => {
+		const probe = mount()
+
+		probe.submit(deleteScene)
+		probe.submitting()
+		probe.settle(rejected())
+
+		expect(handled).toHaveLength(0)
+		expect(toasts).toEqual(['error:Invalid CSRF token'])
+		expect(probe.api.lastError).toBe('Invalid CSRF token')
+		expect(probe.api.pendingIds.size).toBe(0)
+		expect(router.revalidate).not.toHaveBeenCalled()
+	})
+
+	it('does not revalidate when every target failed', () => {
+		const probe = mount()
+
+		probe.submit(deleteScene)
+		probe.submitting()
+		probe.settle({
+			success: true as const,
+			data: {
+				verb: 'delete' as const,
+				results: [
+					{
+						type: 'scene' as const,
+						id: 'scene-1',
+						success: false,
+						code: 'forbidden' as const
+					}
+				],
+				summary: { total: 1, succeeded: 0, failed: 1 }
+			}
+		})
+
+		expect(handled).toHaveLength(0)
+		expect(toasts).toEqual(['warning:0/1 deleted, 1 failed'])
+		expect(router.revalidate).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
## Summary

Deleting the same scene twice, or renaming a folder to the name it already has, could leave the dialog open and the row on screen: the second response was discarded as a duplicate of the first.

## Root cause

`useDashboardMutations` decided whether a settled response was new by hashing its body (`JSON.stringify(fetcher.data)`) instead of comparing the response object's identity, so any two responses with identical bodies were one response as far as the effect could tell — and the rule for "once per response" already lives in `useOncePerFetcherResponse`, which keys on identity, so the fix belongs there rather than at a fourth call site.

## Changes

- Replace the content-signature effect, and the `handledSignatureRef.current = null` reset in `submit`, with `useOncePerFetcherResponse`.
- Add `tests/use-dashboard-mutations.spec.tsx`.

### Why this is the fourth call site, and why nothing is patched here

The three call sites before this one each keyed on the response body and each shipped the same pair of defects; `useOncePerFetcherResponse` was extracted in #746 once the mechanism itself was recognised as the cause. Patching a fourth would have been the fourth patch of one symptom.

### Why the plain reproduction does not fail

Submitting twice and settling twice passes against the old hook. The signature was paired with a reset in `submit` that masked it on the simple path — and opened the opposite hole.

React Router reads `fetcher.state` from router state, which lands through `startTransition`, and `fetcher.data` from a ref map it mutates as it pushes that state (`components.js:136-138`, `dom/lib.js:996-997`). A caller's own `setState` from a click handler is urgent and commits first, so **after a submit the fetcher keeps reading `idle` carrying the previous response for at least one commit**. A revalidation settling in that window re-runs the effect against the blanked ref: the previous response is handled a second time — closing the dialog and clearing the row's spinner before the server has answered — and the real response, byte-identical, is then swallowed as a signature match.

Brute-forcing the well-formed transition space against an oracle (each settled response handled exactly once, by identity, in order) fails 6 of 64 six-step sequences, all this shape:

```
submit -> submitting -> settle -> submit -> reval:loading -> submitting -> settle
```

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [x] No tests required (explain why) — see below

Not tested in a browser. There is no `.env` in the repo, so the dashboard does not boot locally without provisioned secrets, and the window above is a race that could not be hit by hand regardless. The proof is the spec, which runs in CI.

Every guard is mutation-gated — each mutation reddens a named test:

| Mutation | Test that fails |
| --- | --- |
| identity → `JSON.stringify` comparison | `handles the second of two responses whose bodies are identical` |
| identity guard deleted | `does not re-handle a response the fetcher settles back onto` |
| old blanking + `revalidator` dep restored | `does not re-handle the response the fetcher still carries in flight` |
| `useOncePerFetcherResponse` call removed | 5 of 6 |

The fixture drives `state` and `data` as separate steps on purpose: one where `submit()` flips to `submitting` in the same tick cannot express the window, and every test below passes against the hook this replaces.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
