### PR TITLE
fix(hooks): treat a reset fetcher as no response, not a null one

### DIFF
--- a/apps/vectreal-platform/app/hooks/use-once-per-fetcher-response.ts
+++ b/apps/vectreal-platform/app/hooks/use-once-per-fetcher-response.ts
@@ -23,7 +23,13 @@ import { useEffect, useRef } from 'react'
  * comparing the reference asks the question that was actually being asked.
  */
 export function useOncePerFetcherResponse<TData>(
-	fetcher: { state: string; data: TData | undefined },
+	/*
+	  `data` admits null because React Router puts one there, whatever its own
+	  types say: `fetcher.reset()` settles the fetcher with `getDoneFetcher(null)`.
+	  Declaring only `undefined` would let a reset through to `handle` as a
+	  response.
+	*/
+	fetcher: { state: string; data: TData | undefined | null },
 	handle: (data: TData) => void
 ): void {
 	const lastHandled = useRef<TData | undefined>(undefined)
@@ -36,7 +42,7 @@ export function useOncePerFetcherResponse<TData>(
 	handleRef.current = handle
 
 	useEffect(() => {
-		if (fetcher.state !== 'idle' || fetcher.data === undefined) {
+		if (fetcher.state !== 'idle' || fetcher.data == null) {
 			return
 		}
 

--- a/apps/vectreal-platform/tests/use-once-per-fetcher-response.spec.tsx
+++ b/apps/vectreal-platform/tests/use-once-per-fetcher-response.spec.tsx
@@ -13,7 +13,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { useOncePerFetcherResponse } from '../app/hooks/use-once-per-fetcher-response'
 
-type Fetcher<T> = { state: string; data: T | undefined }
+type Fetcher<T> = { state: string; data: T | undefined | null }
 
 function renderWith<T>(fetcher: Fetcher<T>, handle: (data: T) => void) {
 	function Probe({ value }: { value: Fetcher<T> }) {
@@ -108,6 +108,22 @@ describe('useOncePerFetcherResponse', () => {
 		settle(csrf())
 
 		expect(handle).toHaveBeenCalledTimes(3)
+	})
+
+	/*
+	  Defect 4: `fetcher.reset()` settles with `getDoneFetcher(null)`, not
+	  `undefined`, so a guard written against `undefined` alone hands the reset
+	  to the handler as though it were a response. No caller resets today; the
+	  guard is what keeps that true for the one that does.
+	*/
+	it('ignores a fetcher reset after it has answered', () => {
+		const handle = vi.fn()
+		const { settle } = renderWith(idle({ ok: true }), handle)
+		expect(handle).toHaveBeenCalledOnce()
+
+		settle({ state: 'idle', data: null })
+
+		expect(handle).toHaveBeenCalledOnce()
 	})
 
 	it('does not re-run when only the handler identity changes', () => {


### PR DESCRIPTION
## Summary

`useOncePerFetcherResponse` guarded against `undefined` data but not `null`, so a reset fetcher would reach the handler as though it carried a response. Independent of the dashboard stack; can merge on its own.

## Root cause

The guard tested `fetcher.data === undefined`, but a reset fetcher carries `null` — `resetFetcher` settles it with `getDoneFetcher(null)` (react-router 8.3.0, `router.js:1116-1118`) — so the reset reached `handle` and the first property read on it would throw; the guard is where the rule already lives, so it is widened rather than each caller checking.

## Changes

- Guard with `fetcher.data == null` instead of `=== undefined`.
- Admit `null` in the parameter type, with the reason.
- Add a test for a reset after the fetcher has answered.

## Notes for the reviewer

**Nothing is broken in the app today.** No caller resets, and `useDashboardMutations` never exposes its fetcher. This is a latent narrowing, not a live defect: the predecessor's `!fetcher.data` covered `null` by accident, and tightening to `=== undefined` dropped it. The guard is what keeps the app correct for the first caller that does reset.

The parameter type admits `null` for the same reason. React Router's own types declare `data` as `TData | undefined`, which is exactly what made the narrowing look correct — the type describes what the router promises, not what it does.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser

Not browser-tested: unreachable from the UI today, which is the point of the change. Mutation-gated — reverting the guard to `=== undefined` reddens `ignores a fetcher reset after it has answered`, and nothing else.

Worth noting how this was found: mutating the guard proved it was covered by *no* test in either spec. The identity comparison absorbs `undefined` on first render, so the `undefined` check never had to do anything and neither spec noticed it was gone.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
