### PR TITLE
refactor(dashboard): drop the mutation API nothing reads

### DIFF
--- a/apps/vectreal-platform/app/hooks/use-dashboard-mutations.ts
+++ b/apps/vectreal-platform/app/hooks/use-dashboard-mutations.ts
@@ -22,12 +22,9 @@ type MutationEnvelope =
 
 export interface DashboardMutationsApi {
 	submit: (request: DashboardMutationRequest) => void
-	/** Idle until a response arrives, then the last response or its error. */
 	state: 'idle' | 'submitting' | 'loading'
-	isBusy: boolean
-	lastResponse: DashboardMutationResponse | null
+	/** The last rejection, for a dialog to render in place. Cleared on submit. */
 	lastError: string | null
-	pendingIds: ReadonlySet<string>
 }
 
 function describeOutcome(response: DashboardMutationResponse): {
@@ -85,9 +82,6 @@ export function useDashboardMutations(options?: {
 	const revalidator = useRevalidator()
 	const csrfToken = useAuthenticityToken()
 
-	const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(new Set())
-	const [lastResponse, setLastResponse] =
-		useState<DashboardMutationResponse | null>(null)
 	const [lastError, setLastError] = useState<string | null>(null)
 
 	const onSuccessRef = useRef(options?.onSuccess)
@@ -99,14 +93,6 @@ export function useDashboardMutations(options?: {
 		(request: DashboardMutationRequest) => {
 			setLastError(null)
 
-			const targetIds =
-				request.verb === 'rename'
-					? [request.target.id]
-					: request.verb === 'create-folder'
-						? []
-						: request.targets.map((target) => target.id)
-			setPendingIds(new Set(targetIds))
-
 			fetcher.submit(
 				{ ...serializeDashboardMutationRequest(request), csrf: csrfToken },
 				{ method: 'post', action: ENDPOINT }
@@ -116,8 +102,6 @@ export function useDashboardMutations(options?: {
 	)
 
 	useOncePerFetcherResponse(fetcher, (envelope) => {
-		setPendingIds(new Set())
-
 		if (!envelope.success) {
 			const message = envelope.error ?? 'Action failed'
 			setLastError(message)
@@ -128,7 +112,6 @@ export function useDashboardMutations(options?: {
 		}
 
 		const response = envelope.data
-		setLastResponse(response)
 
 		if (!silentRef.current) {
 			const outcome = describeOutcome(response)
@@ -141,14 +124,7 @@ export function useDashboardMutations(options?: {
 		}
 	})
 
-	return {
-		submit,
-		state: fetcher.state,
-		isBusy: fetcher.state !== 'idle' || revalidator.state !== 'idle',
-		lastResponse,
-		lastError,
-		pendingIds
-	}
+	return { submit, state: fetcher.state, lastError }
 }
 
 export interface DashboardMutationStatus {

--- a/apps/vectreal-platform/tests/use-dashboard-mutations.spec.tsx
+++ b/apps/vectreal-platform/tests/use-dashboard-mutations.spec.tsx
@@ -152,8 +152,6 @@ describe('useDashboardMutations', () => {
 		const probe = mount()
 
 		probe.submit(deleteScene)
-		expect(probe.api.pendingIds).toEqual(new Set(['scene-1']))
-
 		probe.submitting()
 		const response = deleted()
 		probe.settle(response)
@@ -161,8 +159,6 @@ describe('useDashboardMutations', () => {
 		expect(handled).toEqual([response.data])
 		expect(handled[0]).toBe(response.data)
 		expect(toasts).toEqual(['success:Item deleted'])
-		expect(probe.api.lastResponse).toBe(response.data)
-		expect(probe.api.pendingIds.size).toBe(0)
 		expect(router.revalidate).toHaveBeenCalledOnce()
 	})
 
@@ -217,7 +213,6 @@ describe('useDashboardMutations', () => {
 		probe.revalidation('idle')
 
 		expect(handled).toHaveLength(1)
-		expect(probe.api.pendingIds).toEqual(new Set(['scene-1']))
 	})
 
 	/*
@@ -251,7 +246,7 @@ describe('useDashboardMutations', () => {
 		expect(router.revalidate).toHaveBeenCalledOnce()
 	})
 
-	it('surfaces a rejection and clears the pending ids', () => {
+	it('surfaces a rejection', () => {
 		const probe = mount()
 
 		probe.submit(deleteScene)
@@ -261,7 +256,6 @@ describe('useDashboardMutations', () => {
 		expect(handled).toHaveLength(0)
 		expect(toasts).toEqual(['error:Invalid CSRF token'])
 		expect(probe.api.lastError).toBe('Invalid CSRF token')
-		expect(probe.api.pendingIds.size).toBe(0)
 		expect(router.revalidate).not.toHaveBeenCalled()
 	})
 


### PR DESCRIPTION
## Summary

`useDashboardMutations` returned three fields no consumer has ever read. Removing them also removes the only reason `submit` carried a per-verb ternary.

> **Stacked on #779.** Base is `fix/dashboard-mutation-response-dedup`; review that one first. Merge in order.

## Root cause

n/a — no behavior changes. This is dead API surface, kept alive only by the hook returning it.

## Changes

- Remove `pendingIds`, `isBusy` and `lastResponse` from `DashboardMutationsApi` and the state backing them.
- Remove the per-verb `targetIds` ternary in `submit`, whose only consumer was `setPendingIds`.
- Drop the spec assertions that read the removed fields.

## Notes for the reviewer

Row spinners and table-busy state come from `useDashboardMutationStatus`, which derives both from the in-flight fetcher list (`project.tsx:155`, `folder.tsx:164` feed `pendingItemIds`). The four `useDashboardMutations` call sites take only `submit`, `state`, `lastError` and the `onSuccess` callback.

`pendingIds` was the expensive one. Maintaining it was the sole reason `submit` picked target ids out of a request by verb — a branch that would throw on every rename if it were ever got wrong, guarding state nothing rendered. Two sources of pending ids also invited the reader to wonder which one a row was using, when only one was ever wired up.

I found `pendingIds` while reviewing #779 and filed it; checking before cutting showed `isBusy` and `lastResponse` were dead on the same interface, so all three go together rather than leaving two to be rediscovered.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [x] No tests required (explain why)

No test can cover a removal. The evidence that the fields were dead is `typecheck` passing across both `tsconfig.app.json` and `tsconfig.spec.json` with them gone — nothing in app or test code referenced them.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
