### PR TITLE
fix(core): count meshes instead of weighing them

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/scene/scene-metrics-draco.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-metrics-draco.spec.ts
@@ -23,7 +23,10 @@ const buildReport = (
 		textures: { before: 2_000_000, after: 2_000_000 },
 		texturesCount: { before: 4, after: 4 },
 		textureResolutions: { before: [], after: [] },
-		meshes: { before: 6_000_000, after: 3_000_000 }
+		// Bytes, per `OptimizationStats`. The count is its own field, which is the
+		// distinction this fixture predates.
+		meshes: { before: 6_000_000, after: 3_000_000 },
+		meshesCount: { before: 12, after: 12 }
 	},
 	...overrides
 })

--- a/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.spec.ts
+++ b/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * What gets persisted as a mesh count.
+ *
+ * `OptimizationStats` carries both a mesh payload size and a mesh count, and
+ * their names do not both say which is which: `meshes` is bytes, `meshesCount`
+ * is the quantity. This snapshot was built from the first and stored under the
+ * second, so the scene detail page reported a shoe as having 2,902,308 meshes -
+ * the byte size of its geometry buffer.
+ *
+ * Nothing held that. The two fields are both numbers, both plausible, and the
+ * only place the difference is visible is a tile four layers downstream.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { createSceneStatsFromReport } from './scene-stats-helpers'
+
+import type { OptimizationReport } from '@vctrl/core'
+
+/*
+  Deliberately far apart in magnitude. A fixture where the count and the byte
+  size are close would let the two be swapped without the assertions moving,
+  which is the whole failure being pinned.
+*/
+const REPORT = {
+	originalSize: 8_000_000,
+	optimizedSize: 5_000_000,
+	compressionRatio: 1.6,
+	appliedOptimizations: ['draco compression'],
+	stats: {
+		vertices: { before: 100_000, after: 60_000 },
+		triangles: { before: 50_000, after: 30_000 },
+		materials: { before: 3, after: 3 },
+		textures: { before: 2_000_000, after: 1_000_000 },
+		texturesCount: { before: 4, after: 4 },
+		textureResolutions: { before: [], after: [] },
+		/** Bytes. */
+		meshes: { before: 6_000_000, after: 3_000_000 },
+		/** Meshes. */
+		meshesCount: { before: 12, after: 9 }
+	}
+} as unknown as OptimizationReport
+
+describe('the persisted mesh count', () => {
+	it('stores the count, not the payload size', () => {
+		const stats = createSceneStatsFromReport(REPORT, 'scene-1', 'user-1')
+
+		expect(stats.baseline?.meshesCount).toBe(12)
+		expect(stats.optimized?.meshesCount).toBe(9)
+	})
+
+	it('never stores the byte size under that name', () => {
+		/*
+		  Stated as its own assertion because it is the bug, not a restatement of
+		  the one above: a snapshot fed from `stats.meshes` produces 6,000,000 and
+		  3,000,000, and both are perfectly valid numbers to a type checker and to
+		  every screen that renders them.
+		*/
+		const stats = createSceneStatsFromReport(REPORT, 'scene-1', 'user-1')
+
+		expect(stats.baseline?.meshesCount).not.toBe(6_000_000)
+		expect(stats.optimized?.meshesCount).not.toBe(3_000_000)
+	})
+
+	it('keeps the counts that were already right', () => {
+		/*
+		  Anchored, so a snapshot that stopped writing this half of the shape
+		  altogether cannot pass the two assertions above by rendering undefined.
+		*/
+		const stats = createSceneStatsFromReport(REPORT, 'scene-1', 'user-1')
+
+		expect(stats.baseline?.verticesCount).toBe(100_000)
+		expect(stats.baseline?.primitivesCount).toBe(50_000)
+		expect(stats.optimized?.verticesCount).toBe(60_000)
+		expect(stats.optimized?.texturesCount).toBe(4)
+	})
+})

--- a/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.ts
+++ b/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.ts
@@ -120,9 +120,12 @@ function buildSceneStatsSnapshot(
 		primitivesCount: isBaseline
 			? report.stats.triangles.before
 			: report.stats.triangles.after,
+		// `stats.meshes` is the mesh payload in bytes; the count is its own field.
+		// Persisting the former under this name is what put 2,902,308 in the
+		// scene detail page's mesh count.
 		meshesCount: isBaseline
-			? report.stats.meshes.before
-			: report.stats.meshes.after,
+			? report.stats.meshesCount.before
+			: report.stats.meshesCount.after,
 		// Texture asset count, not byte size.
 		texturesCount: isBaseline
 			? report.stats.texturesCount.before

--- a/packages/core/src/model-optimizer/report-helpers.spec.ts
+++ b/packages/core/src/model-optimizer/report-helpers.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Two mesh numbers that are not the same number.
+ *
+ * `calculateMeshSize` sums the payload; `calculateMeshCount` counts the meshes.
+ * Only the first existed, so everything downstream wanting a quantity took it -
+ * and a shoe with twelve meshes was persisted, and rendered, as having
+ * 2,902,308 of them.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { calculateMeshCount, calculateMeshSize } from './report-helpers'
+
+import type { InspectReport } from '@gltf-transform/functions'
+
+/*
+  A size and a count that cannot be confused for one another. Real reports look
+  exactly like this - a handful of meshes over megabytes of geometry - which is
+  why swapping them produced a number nobody could read as a mistake.
+*/
+const REPORT = {
+	meshes: {
+		properties: [
+			{ size: 2_000_000, vertices: 20_000, glPrimitives: 40_000 },
+			{ size: 800_000, vertices: 15_000, glPrimitives: 30_000 },
+			{ size: 102_308, vertices: 5_968, glPrimitives: 7_987 }
+		]
+	}
+} as unknown as InspectReport
+
+describe('mesh metrics', () => {
+	it('counts meshes, and it is not their size', () => {
+		expect(calculateMeshCount(REPORT)).toBe(3)
+		expect(calculateMeshSize(REPORT)).toBe(2_902_308)
+	})
+
+	it('reports nothing rather than guessing when the document has no meshes', () => {
+		const empty = {} as InspectReport
+
+		expect(calculateMeshCount(empty)).toBe(0)
+		expect(calculateMeshSize(empty)).toBe(0)
+	})
+
+	it('counts a mesh whose size is missing', () => {
+		/*
+		  A count must not be derived from the size field in any form. A mesh with
+		  no recorded size still exists, and an implementation that filtered or
+		  summed its way to a count would drop it.
+		*/
+		const partial = {
+			meshes: { properties: [{ vertices: 10 }, { size: 500 }] }
+		} as unknown as InspectReport
+
+		expect(calculateMeshCount(partial)).toBe(2)
+		expect(calculateMeshSize(partial)).toBe(500)
+	})
+})

--- a/packages/core/src/model-optimizer/report-helpers.ts
+++ b/packages/core/src/model-optimizer/report-helpers.ts
@@ -90,6 +90,18 @@ export function calculateTextureResolutions(
 	return Array.from(resolutions)
 }
 
+/**
+ * How many meshes the document has.
+ *
+ * The count that did not exist, which is why `meshesCount` everywhere
+ * downstream was fed from `calculateMeshSize` instead and reported a byte size
+ * as a quantity.
+ */
+export function calculateMeshCount(inspectReport: InspectReport): number {
+	return inspectReport.meshes?.properties?.length ?? 0
+}
+
+/** Summed mesh payload size in bytes. Not a count - see `calculateMeshCount`. */
 export function calculateMeshSize(inspectReport: InspectReport): number {
 	let totalSize = 0
 	if (inspectReport.meshes?.properties) {
@@ -237,6 +249,10 @@ export function buildOptimizationReport(
 			meshes: {
 				before: originalReport ? calculateMeshSize(originalReport) : 0,
 				after: calculateMeshSize(currentInspectReport)
+			},
+			meshesCount: {
+				before: originalReport ? calculateMeshCount(originalReport) : 0,
+				after: calculateMeshCount(currentInspectReport)
 			}
 		}
 	}

--- a/packages/core/src/model-optimizer/types.ts
+++ b/packages/core/src/model-optimizer/types.ts
@@ -106,10 +106,19 @@ export interface TextureBinaryPayload {
 /**
  * Canonical optimization metrics payload used by OptimizationReport.
  *
- * Conventions:
- * - `textures` holds texture payload bytes.
- * - `texturesCount` holds the number of texture assets.
- * - `vertices`, `triangles`, `meshes`, `materials` are all counts.
+ * Conventions, and read them: this shape mixes byte sizes and counts under
+ * names that do not all say which they are.
+ * - `vertices`, `triangles`, `materials`, `texturesCount` and `meshesCount` are
+ *   counts.
+ * - `textures` and `meshes` are byte sizes.
+ *
+ * `meshes` is the trap. It is the summed byte size of the mesh payload, and the
+ * comment here used to list it among the counts while the comment ten lines
+ * below correctly called it a size - two contradictory statements about one
+ * field, in one file. Consumers believed the wrong one: `meshesCount` in the
+ * stored scene stats and in `use-calc-optimization-info` were both fed from it,
+ * so a shoe with twelve meshes reported 2,902,308 of them, which was the byte
+ * size of its geometry buffer.
  */
 export interface OptimizationStats {
 	vertices: BeforeAfterMetric
@@ -123,7 +132,16 @@ export interface OptimizationStats {
 		before: string[]
 		after: string[]
 	}
+	/**
+	 * Mesh payload size in bytes (before/after) - NOT a number of meshes.
+	 *
+	 * Kept under this name because `scene-metrics-resolution` reads it as one
+	 * half of a "did anything shrink" test, where a byte size is a valid signal.
+	 * Anything wanting a quantity wants `meshesCount`.
+	 */
 	meshes: BeforeAfterMetric
+	/** Number of meshes (before/after). */
+	meshesCount: BeforeAfterMetric
 }
 
 /**

--- a/packages/hooks/src/use-optimize-model/use-calc-optimization-info.ts
+++ b/packages/hooks/src/use-optimize-model/use-calc-optimization-info.ts
@@ -33,7 +33,9 @@ function getSnapshotFromReport(
 	return {
 		verticesCount: report.stats.vertices.after ?? 0,
 		primitivesCount: report.stats.triangles.after ?? 0,
-		meshesCount: report.stats.meshes.after ?? 0,
+		// `stats.meshes` is a byte size; `stats.meshesCount` is the quantity. This
+		// read the former and called it a count.
+		meshesCount: report.stats.meshesCount.after ?? 0,
 		textureAssetCount: report.stats.texturesCount.after ?? 0,
 		materialsCount: report.stats.materials.after ?? 0,
 		sceneBytes: report.optimizedSize ?? 0


### PR DESCRIPTION
## Summary

The scene detail page reported a shoe as having **2,902,308 meshes**. That number is the byte size of its geometry buffer. Independent of the scene-detail stack (#773–#778) — it touches `@vctrl/core`, `@vctrl/hooks` and one app util, and fixes the data those surfaces render.

```
scene_stats row, before:            the same scene's assets:
  meshesCount:     2902308            buffer.bin   2.8 MB   ← this
  verticesCount:     40968
  primitivesCount:   77987
```

## Root cause

`OptimizationStats` has no mesh count, and its byte-size field is called `meshes` — so every consumer that wanted a quantity took the only mesh number on offer.

`types.ts` said both things about that field, ten lines apart:

- line 112 — "`vertices`, `triangles`, `meshes`, `materials` are all **counts**"
- line 131 — "`OptimizationStats.meshes`, which always reflects uncompressed geometry **byte size**"

The implementation follows the second (`calculateMeshSize` sums `mesh.size`). Two consumers believed the first.

## Changes

- **`calculateMeshCount`** — the count that did not exist, from `meshes.properties.length`. `OptimizationStats.meshesCount` carries it.
- **`buildSceneStatsSnapshot`** reads it, so the value the dashboard renders is a count.
- **`use-calc-optimization-info`** reads it. That one also did `initial.meshesCount - current.meshesCount`, subtracting two byte sizes to produce a "count" delta.
- **`meshes` keeps its name**, with a comment that can no longer be read two ways. `scene-metrics-resolution` uses it as one half of a "did anything shrink" test, where a byte size is a valid signal — renaming it would change a file owned by another workstream for no behavioural gain. That is the one deliberate half-measure here and it is called out in the type.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit tests added — `report-helpers.spec.ts` and `scene-stats-helpers.spec.ts`. Neither number had any coverage: both are plain numbers, both plausible, and the only place the difference surfaces is a tile four layers downstream.

The fixtures use a count and a size that cannot be mistaken for one another, and the specs assert the byte values are specifically *not* what gets stored — because "stores 12" passes just as well against a fixture where 12 is also the byte size.

Mutations verified red: the original bug reintroduced (persisting `stats.meshes` as the count); the count derived from the size; the count filtered by `size` so a mesh with none is dropped.

## Known gaps

- **Rows written before this keep the old value.** They correct themselves when a scene is next optimized. No backfill here — that is a DML change and wants its own decision.
- One line changed in `app/lib/domain/scene/scene-metrics-draco.spec.ts`: a test fixture needed the new required field. It is in another workstream's territory, so flagging it rather than burying it.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes (1640 on this branch)