### PR TITLE
refactor(core)!: name every metric field by its unit

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/optimization/model/simplification-outcome.spec.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/model/simplification-outcome.spec.ts
@@ -4,7 +4,7 @@ import type { OptimizationReport } from '@vctrl/core'
 
 const reportWith = (before: number, after: number) =>
 	({
-		stats: { vertices: { before, after } }
+		stats: { verticesCount: { before, after } }
 	}) as unknown as OptimizationReport
 
 describe('resolveSimplificationOutcome', () => {

--- a/apps/vectreal-platform/app/components/publisher/optimization/model/simplification-outcome.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/model/simplification-outcome.ts
@@ -43,8 +43,8 @@ export function resolveSimplificationOutcome(
 	report: OptimizationReport | null | undefined,
 	requestedKeepRatio: number | undefined
 ): SimplificationOutcome | null {
-	const verticesBefore = report?.stats.vertices.before
-	const verticesAfter = report?.stats.vertices.after
+	const verticesBefore = report?.stats.verticesCount.before
+	const verticesAfter = report?.stats.verticesCount.after
 
 	if (
 		typeof verticesBefore !== 'number' ||

--- a/apps/vectreal-platform/app/components/publisher/optimization/use-optimization-process.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/use-optimization-process.ts
@@ -68,7 +68,7 @@ export const useOptimizationProcess = () => {
 			optimizer,
 			file ?? null,
 			isReady,
-			report?.stats.textures.after,
+			report?.stats.textureBytes.after,
 			setOptimizationRuntime
 		)
 
@@ -106,7 +106,7 @@ export const useOptimizationProcess = () => {
 					sourcePackageBytes: file?.sourcePackageBytes,
 					sourceTextureBytes: file?.sourceTextureBytes,
 					statsSceneBytes: latestSceneStats?.currentSceneBytes,
-					reportTextureBytesBefore: report?.stats.textures.before,
+					reportTextureBytesBefore: report?.stats.textureBytes.before,
 					calculateSceneBytes
 				},
 				setRuntime: setOptimizationRuntime
@@ -136,7 +136,7 @@ export const useOptimizationProcess = () => {
 			file?.sourcePackageBytes,
 			file?.sourceTextureBytes,
 			latestSceneStats?.currentSceneBytes,
-			report?.stats.textures.before,
+			report?.stats.textureBytes.before,
 			calculateSceneBytes,
 			setOptimizationRuntime,
 			refreshOptimizedSizeInfo

--- a/apps/vectreal-platform/app/lib/domain/scene/client/scene-metrics-resolution.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/scene-metrics-resolution.ts
@@ -165,8 +165,8 @@ export const resolveSceneMetrics = ({
 	const vertices = resolvePair({
 		persistedInitial: stats?.baseline?.verticesCount,
 		persistedCurrent: stalePersistCurrent ?? stats?.optimized?.verticesCount,
-		reportInitial: allowReportBaseline ? report?.stats.vertices.before : null,
-		reportCurrent: allowReportCurrent ? report?.stats.vertices.after : null,
+		reportInitial: allowReportBaseline ? report?.stats.verticesCount.before : null,
+		reportCurrent: allowReportCurrent ? report?.stats.verticesCount.after : null,
 		infoInitial: info?.initial.verticesCount,
 		infoCurrent: info?.optimized.verticesCount,
 		allowInfo
@@ -175,8 +175,8 @@ export const resolveSceneMetrics = ({
 	const primitives = resolvePair({
 		persistedInitial: stats?.baseline?.primitivesCount,
 		persistedCurrent: stalePersistCurrent ?? stats?.optimized?.primitivesCount,
-		reportInitial: allowReportBaseline ? report?.stats.triangles.before : null,
-		reportCurrent: allowReportCurrent ? report?.stats.triangles.after : null,
+		reportInitial: allowReportBaseline ? report?.stats.primitivesCount.before : null,
+		reportCurrent: allowReportCurrent ? report?.stats.primitivesCount.after : null,
 		infoInitial: info?.initial.primitivesCount,
 		infoCurrent: info?.optimized.primitivesCount,
 		allowInfo
@@ -185,8 +185,8 @@ export const resolveSceneMetrics = ({
 	const meshes = resolvePair({
 		persistedInitial: stats?.baseline?.meshesCount,
 		persistedCurrent: stalePersistCurrent ?? stats?.optimized?.meshesCount,
-		reportInitial: allowReportBaseline ? report?.stats.meshes.before : null,
-		reportCurrent: allowReportCurrent ? report?.stats.meshes.after : null,
+		reportInitial: allowReportBaseline ? report?.stats.meshBytes.before : null,
+		reportCurrent: allowReportCurrent ? report?.stats.meshBytes.after : null,
 		infoInitial: info?.initial.meshesCount,
 		infoCurrent: info?.optimized.meshesCount,
 		allowInfo
@@ -211,8 +211,8 @@ export const resolveSceneMetrics = ({
 		persistedCurrent: stats?.additionalMetrics?.currentTextureBytes,
 		runtimeInitial: normalizedRuntime.initialTextureBytes,
 		runtimeCurrent: normalizedRuntime.currentTextureBytes,
-		reportInitial: allowReportBaseline ? report?.stats.textures.before : null,
-		reportCurrent: allowReportCurrent ? report?.stats.textures.after : null,
+		reportInitial: allowReportBaseline ? report?.stats.textureBytes.before : null,
+		reportCurrent: allowReportCurrent ? report?.stats.textureBytes.after : null,
 		allowInfo: false
 	})
 

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-metrics-draco.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-metrics-draco.spec.ts
@@ -17,15 +17,13 @@ const buildReport = (
 	compressionRatio: 1.6,
 	appliedOptimizations: ['simplification', 'draco compression'],
 	stats: {
-		vertices: { before: 100_000, after: 60_000 },
-		triangles: { before: 50_000, after: 30_000 },
-		materials: { before: 3, after: 3 },
-		textures: { before: 2_000_000, after: 2_000_000 },
+		verticesCount: { before: 100_000, after: 60_000 },
+		primitivesCount: { before: 50_000, after: 30_000 },
+		materialsCount: { before: 3, after: 3 },
+		textureBytes: { before: 2_000_000, after: 2_000_000 },
 		texturesCount: { before: 4, after: 4 },
 		textureResolutions: { before: [], after: [] },
-		// Bytes, per `OptimizationStats`. The count is its own field, which is the
-		// distinction this fixture predates.
-		meshes: { before: 6_000_000, after: 3_000_000 },
+		meshBytes: { before: 6_000_000, after: 3_000_000 },
 		meshesCount: { before: 12, after: 12 }
 	},
 	...overrides

--- a/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.spec.ts
+++ b/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.spec.ts
@@ -1,11 +1,12 @@
 /**
  * What gets persisted as a mesh count.
  *
- * `OptimizationStats` carries both a mesh payload size and a mesh count, and
- * their names do not both say which is which: `meshes` is bytes, `meshesCount`
- * is the quantity. This snapshot was built from the first and stored under the
- * second, so the scene detail page reported a shoe as having 2,902,308 meshes -
- * the byte size of its geometry buffer.
+ * `OptimizationStats` carries both a mesh payload size and a mesh count. This
+ * snapshot was built from the size and stored under the count, so the scene
+ * detail page reported a shoe as having 2,902,308 meshes - the byte size of its
+ * geometry buffer. Both fields say their unit in their name now
+ * (`meshBytes` / `meshesCount`), which is what makes the swap below a mistake
+ * someone would see rather than one they would make.
  *
  * Nothing held that. The two fields are both numbers, both plausible, and the
  * only place the difference is visible is a tile four layers downstream.
@@ -28,15 +29,13 @@ const REPORT = {
 	compressionRatio: 1.6,
 	appliedOptimizations: ['draco compression'],
 	stats: {
-		vertices: { before: 100_000, after: 60_000 },
-		triangles: { before: 50_000, after: 30_000 },
-		materials: { before: 3, after: 3 },
-		textures: { before: 2_000_000, after: 1_000_000 },
+		verticesCount: { before: 100_000, after: 60_000 },
+		primitivesCount: { before: 50_000, after: 30_000 },
+		materialsCount: { before: 3, after: 3 },
+		textureBytes: { before: 2_000_000, after: 1_000_000 },
 		texturesCount: { before: 4, after: 4 },
 		textureResolutions: { before: [], after: [] },
-		/** Bytes. */
-		meshes: { before: 6_000_000, after: 3_000_000 },
-		/** Meshes. */
+		meshBytes: { before: 6_000_000, after: 3_000_000 },
 		meshesCount: { before: 12, after: 9 }
 	}
 } as unknown as OptimizationReport
@@ -52,7 +51,7 @@ describe('the persisted mesh count', () => {
 	it('never stores the byte size under that name', () => {
 		/*
 		  Stated as its own assertion because it is the bug, not a restatement of
-		  the one above: a snapshot fed from `stats.meshes` produces 6,000,000 and
+		  the one above: a snapshot fed from `stats.meshBytes` produces 6,000,000 and
 		  3,000,000, and both are perfectly valid numbers to a type checker and to
 		  every screen that renders them.
 		*/

--- a/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.ts
+++ b/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.ts
@@ -52,10 +52,10 @@ export function resolveTextureByteMetricsScope(
 	existingAdditionalMetrics?: TextureByteMetrics | null
 ): TextureByteMetrics | null {
 	const initialTextureBytes =
-		asNonNegativeNumber(report?.stats.textures.before) ??
+		asNonNegativeNumber(report?.stats.textureBytes.before) ??
 		asNonNegativeNumber(existingAdditionalMetrics?.initialTextureBytes)
 	const currentTextureBytes =
-		asNonNegativeNumber(report?.stats.textures.after) ??
+		asNonNegativeNumber(report?.stats.textureBytes.after) ??
 		asNonNegativeNumber(existingAdditionalMetrics?.currentTextureBytes)
 
 	if (initialTextureBytes == null && currentTextureBytes == null) {
@@ -115,14 +115,14 @@ function buildSceneStatsSnapshot(
 
 	return {
 		verticesCount: isBaseline
-			? report.stats.vertices.before
-			: report.stats.vertices.after,
+			? report.stats.verticesCount.before
+			: report.stats.verticesCount.after,
 		primitivesCount: isBaseline
-			? report.stats.triangles.before
-			: report.stats.triangles.after,
-		// `stats.meshes` is the mesh payload in bytes; the count is its own field.
-		// Persisting the former under this name is what put 2,902,308 in the
-		// scene detail page's mesh count.
+			? report.stats.primitivesCount.before
+			: report.stats.primitivesCount.after,
+		// The count, not `stats.meshBytes` beside it. Persisting the payload size
+		// under this name is what put 2,902,308 in the scene detail page's mesh
+		// count, back when the size was called `meshes`.
 		meshesCount: isBaseline
 			? report.stats.meshesCount.before
 			: report.stats.meshesCount.after,
@@ -131,8 +131,8 @@ function buildSceneStatsSnapshot(
 			? report.stats.texturesCount.before
 			: report.stats.texturesCount.after,
 		materialsCount: isBaseline
-			? report.stats.materials.before
-			: report.stats.materials.after
+			? report.stats.materialsCount.before
+			: report.stats.materialsCount.after
 	}
 }
 

--- a/packages/core/src/model-optimizer/report-helpers.ts
+++ b/packages/core/src/model-optimizer/report-helpers.ts
@@ -220,19 +220,19 @@ export function buildOptimizationReport(
 		appliedOptimizations: [...appliedOptimizations],
 		...(dracoReport ? { draco: dracoReport } : {}),
 		stats: {
-			vertices: {
+			verticesCount: {
 				before: originalCounts.vertices,
 				after: currentCounts.vertices
 			},
-			triangles: {
+			primitivesCount: {
 				before: originalCounts.primitives,
 				after: currentCounts.primitives
 			},
-			materials: {
+			materialsCount: {
 				before: originalReport?.materials?.properties?.length ?? 0,
 				after: currentInspectReport.materials?.properties?.length ?? 0
 			},
-			textures: {
+			textureBytes: {
 				before: originalReport ? calculateTextureSize(originalReport) : 0,
 				after: calculateTextureSize(currentInspectReport)
 			},
@@ -246,7 +246,7 @@ export function buildOptimizationReport(
 					: [],
 				after: calculateTextureResolutions(currentInspectReport)
 			},
-			meshes: {
+			meshBytes: {
 				before: originalReport ? calculateMeshSize(originalReport) : 0,
 				after: calculateMeshSize(currentInspectReport)
 			},

--- a/packages/core/src/model-optimizer/types.ts
+++ b/packages/core/src/model-optimizer/types.ts
@@ -106,48 +106,53 @@ export interface TextureBinaryPayload {
 /**
  * Canonical optimization metrics payload used by OptimizationReport.
  *
- * Conventions, and read them: this shape mixes byte sizes and counts under
- * names that do not all say which they are.
- * - `vertices`, `triangles`, `materials`, `texturesCount` and `meshesCount` are
- *   counts.
- * - `textures` and `meshes` are byte sizes.
+ * Every field states its unit in its name: `*Count` is a quantity, `*Bytes` is
+ * a size. This is the vocabulary `ModelTotals` in `@vctrl/hooks` already used,
+ * so the two published shapes now agree rather than describing the same
+ * measurements three ways.
  *
- * `meshes` is the trap. It is the summed byte size of the mesh payload, and the
- * comment here used to list it among the counts while the comment ten lines
- * below correctly called it a size - two contradictory statements about one
- * field, in one file. Consumers believed the wrong one: `meshesCount` in the
- * stored scene stats and in `use-calc-optimization-info` were both fed from it,
- * so a shoe with twelve meshes reported 2,902,308 of them, which was the byte
- * size of its geometry buffer.
+ * It did not, and that is what made a bug rather than an inconvenience. Five
+ * fields were bare plurals: `vertices`, `triangles` and `materials` held counts
+ * while `textures` and `meshes` held byte sizes, with nothing in any name to
+ * separate them. `types.ts` then said both things about `meshes` ten lines
+ * apart. Two consumers believed the wrong one and stored a geometry buffer's
+ * byte size as a mesh count, so a shoe with twelve meshes reported 2,902,308.
+ *
+ * Reading the wrong meaning out of the old shape was not carelessness; the
+ * shape offered no way to read it right.
  */
 export interface OptimizationStats {
-	vertices: BeforeAfterMetric
-	triangles: BeforeAfterMetric
-	materials: BeforeAfterMetric
+	/** Number of vertices (before/after). */
+	verticesCount: BeforeAfterMetric
+	/**
+	 * Number of GL primitives - triangles, for triangle-mode meshes.
+	 *
+	 * Named for `mesh.glPrimitives`, which is what it is summed from, and for the
+	 * `primitivesCount` every consumer downstream already called it. It was
+	 * `triangles` here and `primitivesCount` everywhere else: one quantity under
+	 * two names, renamed silently at each boundary it crossed.
+	 */
+	primitivesCount: BeforeAfterMetric
+	/** Number of materials (before/after). */
+	materialsCount: BeforeAfterMetric
 	/** Texture payload size in bytes (before/after). */
-	textures: BeforeAfterMetric
+	textureBytes: BeforeAfterMetric
 	/** Number of texture assets (before/after). */
 	texturesCount: BeforeAfterMetric
 	textureResolutions: {
 		before: string[]
 		after: string[]
 	}
-	/**
-	 * Mesh payload size in bytes (before/after) - NOT a number of meshes.
-	 *
-	 * Kept under this name because `scene-metrics-resolution` reads it as one
-	 * half of a "did anything shrink" test, where a byte size is a valid signal.
-	 * Anything wanting a quantity wants `meshesCount`.
-	 */
-	meshes: BeforeAfterMetric
+	/** Mesh payload size in bytes (before/after). */
+	meshBytes: BeforeAfterMetric
 	/** Number of meshes (before/after). */
 	meshesCount: BeforeAfterMetric
 }
 
 /**
  * Draco geometry-compression metrics, from `measureDracoCompression`. Distinct
- * from `OptimizationStats.meshes`, which always reflects uncompressed geometry
- * byte size. Draco compression is deferred until write time, so `inspect()`
+ * from `OptimizationStats.meshBytes`, which always reflects uncompressed
+ * geometry byte size. Draco compression is deferred until write time, so `inspect()`
  * can't see it.
  */
 export interface DracoCompressionReport {

--- a/packages/hooks/src/use-optimize-model/use-calc-optimization-info.ts
+++ b/packages/hooks/src/use-optimize-model/use-calc-optimization-info.ts
@@ -31,13 +31,13 @@ function getSnapshotFromReport(
 	}
 
 	return {
-		verticesCount: report.stats.vertices.after ?? 0,
-		primitivesCount: report.stats.triangles.after ?? 0,
-		// `stats.meshes` is a byte size; `stats.meshesCount` is the quantity. This
-		// read the former and called it a count.
+		verticesCount: report.stats.verticesCount.after ?? 0,
+		primitivesCount: report.stats.primitivesCount.after ?? 0,
+		// The quantity, not `stats.meshBytes`. This read the size and called it a
+		// count, and the improvement below then subtracted two byte sizes.
 		meshesCount: report.stats.meshesCount.after ?? 0,
 		textureAssetCount: report.stats.texturesCount.after ?? 0,
-		materialsCount: report.stats.materials.after ?? 0,
+		materialsCount: report.stats.materialsCount.after ?? 0,
 		sceneBytes: report.optimizedSize ?? 0
 	}
 }
@@ -52,7 +52,9 @@ export const useCalcOptimizationInfo = (
 ): OptimizationInfoData => {
 	// State (not ref) so that capturing the initial report triggers a re-render,
 	// allowing the memo below to recompute info.initial with the real values.
-	const [initialReport, setInitialReport] = useState<OptimizationReport | null>(null)
+	const [initialReport, setInitialReport] = useState<OptimizationReport | null>(
+		null
+	)
 	const report = state.report
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary

`OptimizationStats` used **one naming pattern for two meanings**. Stacked on #783, which supplied the missing mesh count; this removes the reason that count went missing in the first place.

| field | held | name said |
| --- | --- | --- |
| `vertices` | count | bare plural |
| `triangles` | count | bare plural |
| `materials` | count | bare plural |
| `textures` | **bytes** | bare plural |
| `meshes` | **bytes** | bare plural |

## Root cause

Reading the wrong meaning out of that shape was not carelessness — it was the shape working as designed. Nothing in a name separated a count from a size, and `types.ts` stated both readings of `meshes` ten lines apart. Two consumers stored a geometry buffer's byte size as a mesh count, and a shoe with twelve meshes reported 2,902,308 of them.

#783 fixed the value. This fixes the thing that produced it.

## Changes

Every field states its unit: `*Count` is a quantity, `*Bytes` is a size.

```
vertices  → verticesCount        textures → textureBytes
triangles → primitivesCount      meshes   → meshBytes
materials → materialsCount
```

`texturesCount`, `meshesCount` and `textureResolutions` were already right and are unchanged.

This is the vocabulary **`ModelTotals` in `@vctrl/hooks` already used**, so the two published shapes now agree rather than describing one set of measurements three ways.

**`triangles` → `primitivesCount`**, not `trianglesCount`: it is summed from `mesh.glPrimitives`, and all 19 downstream call sites already called it `primitivesCount`. One quantity was being renamed silently at every boundary it crossed; it keeps one name end to end now.

## Type of Change

- [x] Breaking change (existing functionality changes)

`OptimizationStats` is public API — `export * from './model-optimizer'` plus its own package export. The commit carries a `BREAKING CHANGE` footer so Release Please versions it.

## Testing

- [x] `pnpm nx affected --target=test` passes (1640), typecheck + lint green across all seven projects.

Mutations verified red: the snapshot reading `meshBytes` under the new name; `primitivesCount` fed from `verticesCount`; core assembling `meshBytes` from the texture size.

**Worth knowing:** two fixtures are cast through `as unknown as OptimizationReport`, so typecheck could not see them and only the suite caught the rename — `simplification-outcome.spec.ts` and `scene-stats-helpers.spec.ts`. A cast fixture is a place the compiler cannot help, on a type whose whole problem was that its fields are interchangeable numbers.

## Note on territory

This touches `app/lib/domain/scene/` (`scene-metrics-resolution.ts`, ~8 lines, and one spec fixture), which was previously another workstream's. Confirmed clear before starting.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes