### PR TITLE
fix(dashboard): put the API key edit panel back on the radius scale

### DIFF
--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys-edit.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys-edit.tsx
@@ -318,7 +318,7 @@ export default function ApiKeysEditPage({
 					<DrawerDescription>
 						Update the name, description, or project access for this API key
 					</DrawerDescription>
-					<div className="bg-muted text-muted-foreground mt-2 rounded-md px-3 py-2 text-sm">
+					<div className="bg-muted text-muted-foreground mt-2 rounded-xl px-3 py-2 text-sm">
 						<span className="font-medium">{apiKeyData.apiKey.name}</span>
 						<code className="ml-2 font-mono text-xs">
 							...{apiKeyData.apiKey.keyPreview}


### PR DESCRIPTION
## Root cause

The key preview block in the API key edit drawer was authored at `rounded-md`, a step the project's scale does not use for blocks, so it disagreed with every `Input` in the same form.

## Change

One value: `rounded-md` → `rounded-xl` in `api-keys-edit.tsx`.

`globals.css` derives the whole scale from one `--radius` and records the pairing — panels `rounded-2xl`, nested blocks `rounded-xl` — while controls sit on `rounded-lg` per the unification `input.tsx` documents. 12px belongs to neither.

## What was deliberately not changed

The embed panel was audited in the same pass and is already on-scale: controls `rounded-lg`, blocks `rounded-xl`, domain chips `rounded-full`. Whether a 16px control stacked on a 20px block reads as one column or two is a design judgement rather than a rule violation, so it is deferred rather than guessed at.

`TabsTrigger`'s `rounded-md` inside a `rounded-lg` `TabsList` is also left alone: with the list's 3px padding that is correct concentric geometry, not a straggler.

## Verification

- `pnpm nx run-many --target=typecheck,lint -p vectreal-platform` — green
- `npx vitest run --root .` — 137 files, 1720 tests, green