### PR TITLE
docs(embed): state one model for the preview key

### DIFF
--- a/apps/vectreal-platform/app/routes/docs/getting-started/first-model.mdx
+++ b/apps/vectreal-platform/app/routes/docs/getting-started/first-model.mdx
@@ -90,7 +90,7 @@ The snippet looks like:
 
 Paste this into any HTML page. The embedded viewer loads your published model.
 
-> A **preview API key** is required for external iframe access, and the embedding domain must be on that key's allowlist - a key with an empty allowlist rejects every external host. Create and configure one in [Dashboard → API Keys](/dashboard/api-keys).
+> A **preview API key** is required for external iframe access, and the embedding site must be on the **owning project's** allowed domain list - the list belongs to the project, not to the key, so every key scoped to that project shares it. A project with an empty list rejects every external host. Create a key in [Dashboard → API Keys](/dashboard/api-keys) and set the domains in [Dashboard → Projects](/dashboard/projects).
 
 ---
 

--- a/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
@@ -265,8 +265,19 @@ If you prefer zero dependencies, you can implement the protocol directly. Both s
 ## Security
 
 - **Origin validation** - the bridge accepts messages only from the first origin that successfully contacts it. The SDK uses `new URL(iframe.src).origin` as `targetOrigin` automatically; never `'*'`.
-- **Token privacy** - keep the key server-side or in environment variables. Tokens are validated against the project's allowed domain list on every request.
+- **What the key is** - in an embed, a preview key is public by design. It travels in the iframe `src`, so it is in the page source of every site that embeds your scene, and no placement changes that for an iframe: the frame cannot set request headers. Treat the embedded key as an identifier, not a credential. Server-to-server calls are the exception - those can send it as `Authorization: Bearer` and keep it off the page entirely.
+- **What restricts it** - the owning project's allowed domain list, checked against `Referer`/`Origin` on every request. Two things to know about it. It is browser-enforced rather than an authorization boundary: a non-browser client sets those headers freely, so anyone holding the key can read the published scenes it points at. And your own host is exempt - a request whose referer is the Vectreal app itself is allowed whatever the list says, which is why testing an embed from the dashboard proves nothing about your domains.
+- **What it cannot do** - a preview key is read-only and reaches published scenes only. It cannot modify your scenes or project data, and requests carrying one are refused on every mutating endpoint - including the editor payload, which is refused even on a read.
 - **Domain allowlist** - configure which external origins can load your preview at [Dashboard → Projects](/dashboard/projects). Requests from unlisted domains receive `403 Forbidden`.
+
+{/* claims
+present apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts url.searchParams.set('token', token)
+present apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.ts scheme.toLowerCase() !== 'bearer'
+present apps/vectreal-platform/app/db/schema/project/projects.ts allowed_embed_domains
+absent apps/vectreal-platform/app/db/schema/auth/api-keys.ts allowed_embed_domains
+present apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.ts requesterHost === applicationHost
+present apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts authContext.mode === 'apiKey'
+*/}
 
 ---
 

--- a/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
@@ -41,9 +41,11 @@ To create a key with your own name, description or expiry instead:
 >
 > Do not rotate a key just to recover it. Rotation issues a fresh secret and refuses the old one from that moment, so it breaks every embed still carrying the previous value. Rotate a live key you cannot read back; create a replacement for one that is revoked or expired, because rotation refuses both.
 
-### Replacing a key that leaked
+### Replacing a key you want out of circulation
 
-If a key ends up somewhere it should not be, **rotate** it rather than revoking it. Rotating issues a new secret for the same key, keeping its name, description, projects and expiry, so only the snippet has to change:
+A preview key appearing somewhere public is not, by itself, a breach: it is in the `src` of every embed already, so being readable is how it works. What restricts it is the owning project's allowed domain list - but that list is enforced by the browser sending a `Referer`, not by the server proving one, so it does not stop a determined holder of the key from reading the published scenes it points at. Replace a key when you want the old value refused, not merely because it was seen.
+
+So the reason to replace one is that you want the old value refused - not that it was seen. **Rotate** rather than revoke: rotating issues a new secret for the same key, keeping its name, description, projects and expiry, so only the snippet has to change:
 
 1. Go to [Dashboard → API Keys](/dashboard/api-keys).
 2. Open the row menu on the key and choose **Rotate**.

--- a/apps/vectreal-platform/tests/documented-claims.spec.ts
+++ b/apps/vectreal-platform/tests/documented-claims.spec.ts
@@ -95,7 +95,16 @@ const skillFiles = readdirSync(SKILLS_DIR)
  * page here is a visible diff, and so is removing one.
  */
 const CLAIM_CARRYING_DOCS = [
-	'apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx'
+	'apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx',
+	/*
+	  The SDK page's Security section makes the load-bearing claims about what a
+	  preview key is: that it rides in the iframe `src`, that `Bearer` is the
+	  server-side alternative, that the allowed-domain list lives on the project
+	  and not on the key, that the app's own host is exempt from it, and that the
+	  editor payload is refused to a key. Each of those is a sentence a reader
+	  acts on, and each has a line of code that decides it.
+	*/
+	'apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx'
 ]
 
 const documentFiles = [...skillFiles, ...CLAIM_CARRYING_DOCS]


### PR DESCRIPTION
## Root cause

`encrypted_key` (#760) and the embed panel rebuild (#761) changed what the preview key *is*, and only `publish-embed.mdx` was updated — so the other two pages still described a credential, disagreeing with the schema and with each other.

## The two wrong claims

**`embed-sdk.mdx`: "keep the key server-side or in environment variables."** Not achievable for the thing that page documents. `buildEmbedUrl` puts the token in the iframe `src`, and an iframe cannot set request headers, so no placement keeps an embedded key off the page. It also reads as a reassurance where the real control is the allowed-domain list.

**`first-model.mdx`: "the embedding domain must be on that key's allowlist."** The allowlist is a column on `projects`, not `api_keys`. Every key scoped to a project shares one list, and scoping a key elsewhere changes which list applies. `publish-embed.mdx` already said this correctly, so the two pages contradicted each other.

## What review caught in my own replacement text

This is the failure mode this area has form for — a confidently wrong doc costs more than a missing one. Two absolutes in the first draft were not supported by the code:

- *"no server-side placement changes this"* was **false**. `getPreviewTokenFromRequest` accepts `Authorization: Bearer`, and `publish-embed.mdx` documents exactly that — so my sentence contradicted a live page in the same directory. Now scoped to the iframe, where it is true, with the header named as the exception.
- *"it cannot write anything"* was **false**. A successful validation writes `lastUsedAt` — which is precisely what the rotation guidance tells people to read to confirm an update landed. Now: it cannot modify your scenes or project data.

Also added, because the SDK page was the only one missing it: the **same-host exemption**. A request whose referer is the Vectreal app is allowed whatever the list says, which is why testing an embed from the dashboard proves nothing about your domains.

## Leak section reframed

A preview key appearing in public is not by itself a breach — it is in the `src` of every embed already. The reason to replace one is that you want the old value refused. The section now also says the domain list is browser-enforced rather than an authorization boundary, instead of handing the reader only the reassuring half.

## Made checkable

`embed-sdk.mdx` joins `CLAIM_CARRYING_DOCS` with a claims block covering: the token in the `src`, `Bearer` as the alternative, the allowlist on `projects` and **absent** from `api_keys`, the same-host exemption, and the editor payload refused to a key.

The block was inert when first added — `CLAIM_CARRYING_DOCS` is an explicit allowlist and the page was not on it, so a deliberately broken claim still passed. Registering the page took the suite from 68 to 75 claims, and two mutations (`bearer` → `basic`, and asserting the allowlist *is* on `api_keys`) now turn it red.

## Verification

- `pnpm nx run-many --target=typecheck,lint -p vectreal-platform` — green
- `npx vitest run --root .` — 137 files, 1727 tests, green
- Every claim in the diff verified against the code by a reviewer working from the source, not from the prose