### PR TITLE
test: move module-bound specs beside their modules

### DIFF
--- a/.agents/skills/vectreal-brand-ux-design/SKILL.md
+++ b/.agents/skills/vectreal-brand-ux-design/SKILL.md
@@ -7,11 +7,11 @@ description: 'Use for any change a user can see in Vectreal: component styling, 
 
 ## Tokens: the three that are most often confused
 
-| Want | Use | Never |
-| --- | --- | --- |
-| The brand color | `--orange` (`#fc6c18`), or `bg-orange` / `text-orange` | `--accent`, `--primary` |
-| Brand at partial alpha | `rgb(var(--orange-rgb) / <alpha>)` | `hsl(var(--orange)/…)`, `color-mix` with `--orange` |
-| Hover/focus background for menus, options, ghost controls | `--accent` | a hand-picked gray |
+| Want                                                      | Use                                                    | Never                                               |
+| --------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------- |
+| The brand color                                           | `--orange` (`#fc6c18`), or `bg-orange` / `text-orange` | `--accent`, `--primary`                             |
+| Brand at partial alpha                                    | `rgb(var(--orange-rgb) / <alpha>)`                     | `hsl(var(--orange)/…)`, `color-mix` with `--orange` |
+| Hover/focus background for menus, options, ghost controls | `--accent`                                             | a hand-picked gray                                  |
 
 `--accent` is **not** the brand. It is the hover/focus background, near-white in
 light mode and dark gray in dark mode. It used to point at `--orange`, which made
@@ -56,15 +56,15 @@ Named tiers in `globals.css`, each with a comment saying what belongs there.
 They generate the matching utilities, so a call site names a layer instead of
 picking a number.
 
-| Tier | Value | What sits there |
-| --- | --- | --- |
-| `z-page-chrome` | 20 | Chrome owned by one route: the docs breadcrumb bar, the internal preview overlay, a sticky summary card |
-| `z-nav` | 50 | Site chrome fixed for the whole session: desktop and mobile nav, consent banner |
-| `z-overlay` | 50 | Radix's portal layer: dialog, alert dialog, sheet, drawer, menus, popovers, hover cards |
-| `z-above-nav` | 60 | Must cover the nav: the route loading bar, an embed viewer gone fullscreen |
-| `z-tooltip` | 80 | Tooltips, above the overlay layer so they still show inside a dialog |
-| `z-overlay-raised` | 100 | One overlay that has to clear another |
-| `z-select` | 120 | The select listbox, top of the ladder |
+| Tier               | Value | What sits there                                                                                         |
+| ------------------ | ----- | ------------------------------------------------------------------------------------------------------- |
+| `z-page-chrome`    | 20    | Chrome owned by one route: the docs breadcrumb bar, the internal preview overlay, a sticky summary card |
+| `z-nav`            | 50    | Site chrome fixed for the whole session: desktop and mobile nav, consent banner                         |
+| `z-overlay`        | 50    | Radix's portal layer: dialog, alert dialog, sheet, drawer, menus, popovers, hover cards                 |
+| `z-above-nav`      | 60    | Must cover the nav: the route loading bar, an embed viewer gone fullscreen                              |
+| `z-tooltip`        | 80    | Tooltips, above the overlay layer so they still show inside a dialog                                    |
+| `z-overlay-raised` | 100   | One overlay that has to clear another                                                                   |
+| `z-select`         | 120   | The select listbox, top of the ladder                                                                   |
 
 The nav and the overlay layer tie at 50 deliberately. Both land in the root
 stacking context, and Radix portals its overlays to the end of the document
@@ -140,7 +140,7 @@ guessing. Each rule carries a comment explaining the failure it prevents.
 Size full-viewport surfaces with `h-dvh` / `min-h-dvh`, or `h-svh` where a shell
 owns the height and scrolls its own content, as `dashboard-layout.tsx` does.
 
-Never Tailwind's screen-height utilities. They compile to `100vh`, the *large*
+Never Tailwind's screen-height utilities. They compile to `100vh`, the _large_
 viewport, which overhangs persistent mobile browser chrome: bottom-anchored UI
 goes behind the bar and the page is left scrolled with no way back when a canvas
 holds `touch-action: none`.
@@ -171,14 +171,14 @@ a hover step or a snap point survived is to look at it.
 
 ## Anti-patterns
 
-| Anti-pattern | Replacement |
-| --- | --- |
-| `--accent` or `--primary` used to mean "brand" | `--orange` / `bg-orange` / `text-orange` |
-| Alpha applied to `--orange` inline | `rgb(var(--orange-rgb) / <alpha>)` |
-| Hand-written hover background beside a `ds-*` class | `ds-raised-interactive` / `ds-overlay-interactive` |
-| Font size set inline from a `--text-*` token | The matching `text-*` class |
-| Loading, empty and error states added last | Designed with the happy path |
-| Accessibility retrofitted after review | Keyboard, focus ring, contrast, labels from the start |
+| Anti-pattern                                        | Replacement                                           |
+| --------------------------------------------------- | ----------------------------------------------------- |
+| `--accent` or `--primary` used to mean "brand"      | `--orange` / `bg-orange` / `text-orange`              |
+| Alpha applied to `--orange` inline                  | `rgb(var(--orange-rgb) / <alpha>)`                    |
+| Hand-written hover background beside a `ds-*` class | `ds-raised-interactive` / `ds-overlay-interactive`    |
+| Font size set inline from a `--text-*` token        | The matching `text-*` class                           |
+| Loading, empty and error states added last          | Designed with the happy path                          |
+| Accessibility retrofitted after review              | Keyboard, focus ring, contrast, labels from the start |
 
 ## Source of truth
 
@@ -214,7 +214,7 @@ present  shared/components/src/styles/globals.css                              -
 present  eslint.config.mts                                                     z-index outside the named scale
 exists   apps/vectreal-platform/tests/documented-claims.spec.ts
 exists   apps/vectreal-platform/tests/tooltip-copy-length.spec.ts
-exists   apps/vectreal-platform/tests/info-tooltip.spec.tsx
+exists   apps/vectreal-platform/app/components/info-tooltip.spec.tsx
 present  eslint.config.mts                                                     Build className with cn()
 present  eslint.config.mts                                                     Inline SVG
 present  apps/vectreal-platform/app/routes/layouts/dashboard-layout.tsx        h-svh

--- a/apps/vectreal-platform/app/components/embed/embed-key-select.spec.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-key-select.spec.tsx
@@ -17,16 +17,13 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-	describeKeyOption,
-	EmbedKeySelect
-} from '../app/components/embed/embed-key-select'
-import { DASHBOARD_OPERATION_ROLES } from '../app/lib/domain/dashboard/dashboard-operations'
-import { isEmbedKeyUsable } from '../app/lib/domain/embed/embed-key-options'
-import { EMBED_COPY } from '../app/lib/domain/embed/embed-snippet'
+import { describeKeyOption, EmbedKeySelect } from './embed-key-select'
+import { DASHBOARD_OPERATION_ROLES } from '../../lib/domain/dashboard/dashboard-operations'
+import { isEmbedKeyUsable } from '../../lib/domain/embed/embed-key-options'
+import { EMBED_COPY } from '../../lib/domain/embed/embed-snippet'
 
-import type { EmbedApiKeysApi } from '../app/components/embed/use-embed-api-keys'
-import type { EmbedApiKeyOption } from '../app/lib/domain/embed/embed-key-options'
+import type { EmbedApiKeysApi } from './use-embed-api-keys'
+import type { EmbedApiKeyOption } from '../../lib/domain/embed/embed-key-options'
 
 /*
   Radix needs three browser APIs jsdom does not ship before a `Select` will
@@ -84,8 +81,7 @@ function apiWith(overrides: Partial<EmbedApiKeysApi> = {}): EmbedApiKeysApi {
 		  selection - a payload the hook cannot produce - and the docblock above
 		  claimed fidelity it did not have.
 		*/
-		token:
-			selected && isEmbedKeyUsable(selected) ? (selected.value ?? '') : ''
+		token: selected && isEmbedKeyUsable(selected) ? (selected.value ?? '') : ''
 	}
 }
 

--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.spec.tsx
@@ -15,17 +15,17 @@ import { fileURLToPath } from 'node:url'
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { EmbedOptionsPanel } from '../app/components/embed/embed-options-panel'
+import { EmbedOptionsPanel } from './embed-options-panel'
 import {
 	isEmbedKeyUsable,
 	type EmbedApiKeyOption
-} from '../app/lib/domain/embed/embed-key-options'
+} from '../../lib/domain/embed/embed-key-options'
 import {
 	EMBED_COPY,
 	EMBED_DOCS_PATH
-} from '../app/lib/domain/embed/embed-snippet'
+} from '../../lib/domain/embed/embed-snippet'
 
-import type { EmbedApiKeysApi } from '../app/components/embed/use-embed-api-keys'
+import type { EmbedApiKeysApi } from './use-embed-api-keys'
 
 /*
   Radix's menu needs three browser APIs jsdom does not ship. Without them the
@@ -86,7 +86,7 @@ beforeEach(() => {
 	writeText.mockClear()
 })
 
-vi.mock('../app/components/embed/use-embed-api-keys', () => ({
+vi.mock('./use-embed-api-keys', () => ({
 	/*
 	  Return type annotated on purpose: without it a field added to the hook and
 	  read by the panel arrives `undefined` here with no type error, and every
@@ -452,7 +452,7 @@ describe('the drawer host does not label the panel a fourth time', () => {
 	const HOST = readFileSync(
 		join(
 			dirname(fileURLToPath(import.meta.url)),
-			'../app/components/dashboard/scene-detail/scene-share-drawer.tsx'
+			'../dashboard/scene-detail/scene-share-drawer.tsx'
 		),
 		'utf8'
 	)

--- a/apps/vectreal-platform/app/components/embed/embed-snippet-card.spec.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-snippet-card.spec.tsx
@@ -18,8 +18,8 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { EmbedSnippetCard } from '../app/components/embed/embed-snippet-card'
-import { EMBED_COPY } from '../app/lib/domain/embed/embed-snippet'
+import { EmbedSnippetCard } from './embed-snippet-card'
+import { EMBED_COPY } from '../../lib/domain/embed/embed-snippet'
 
 globalThis.ResizeObserver ??= class {
 	observe() {}

--- a/apps/vectreal-platform/app/components/embed/use-embed-api-keys.spec.tsx
+++ b/apps/vectreal-platform/app/components/embed/use-embed-api-keys.spec.tsx
@@ -13,10 +13,10 @@ import { act, render } from '@testing-library/react'
 import { StrictMode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useEmbedApiKeys } from '../app/components/embed/use-embed-api-keys'
+import { useEmbedApiKeys } from './use-embed-api-keys'
 
-import type { EmbedApiKeysApi } from '../app/components/embed/use-embed-api-keys'
-import type { EmbedApiKeyOption } from '../app/lib/domain/embed/embed-key-options'
+import type { EmbedApiKeysApi } from './use-embed-api-keys'
+import type { EmbedApiKeyOption } from '../../lib/domain/embed/embed-key-options'
 
 const { load, submit, setUpgradeModal, fetchers } = vi.hoisted(() => ({
 	load: vi.fn(),
@@ -70,7 +70,9 @@ vi.mock('jotai/react', () => ({ useSetAtom: () => setUpgradeModal }))
  * describes a row the loader cannot produce, and passes tests the real payload
  * would fail.
  */
-const option = (overrides: Partial<EmbedApiKeyOption> = {}): EmbedApiKeyOption =>
+const option = (
+	overrides: Partial<EmbedApiKeyOption> = {}
+): EmbedApiKeyOption =>
 	({
 		id: 'k1',
 		name: 'Embed key',
@@ -386,7 +388,9 @@ describe('recovering from a refused load', () => {
 		  was added to remove.
 		*/
 		fetchers[0] = { state: 'loading', data: { success: false, error: 'Boom' } }
-		expect(mount({ projectId: 'p1', enabled: true }).latest().loading).toBe(true)
+		expect(mount({ projectId: 'p1', enabled: true }).latest().loading).toBe(
+			true
+		)
 
 		fetchers[0] = { state: 'idle', data: { success: false, error: 'Boom' } }
 		expect(mount({ projectId: 'p2', enabled: true }).latest().loading).toBe(
@@ -562,7 +566,9 @@ describe('creating a key', () => {
 		const probe = mount({ projectId: 'p1', enabled: true })
 		expect(probe.latest().selectedKeyId).toBe('existing')
 
-		fetchers[1] = createPayload(option({ id: 'fresh', value: 'vctrl_freshab3x' }))
+		fetchers[1] = createPayload(
+			option({ id: 'fresh', value: 'vctrl_freshab3x' })
+		)
 		act(() => probe.rerender({ projectId: 'p1', enabled: true }))
 
 		expect(probe.latest().selectedKeyId).toBe('fresh')

--- a/apps/vectreal-platform/app/components/info-tooltip.spec.tsx
+++ b/apps/vectreal-platform/app/components/info-tooltip.spec.tsx
@@ -13,7 +13,7 @@
 import { act, render, screen } from '@testing-library/react'
 import { beforeAll, describe, expect, it } from 'vitest'
 
-import { InfoTooltip } from '../app/components/info-tooltip'
+import { InfoTooltip } from './info-tooltip'
 
 beforeAll(() => {
 	// Radix's popper measures the trigger with a ResizeObserver, which jsdom

--- a/apps/vectreal-platform/app/components/layout-components/detail-panel-section.spec.tsx
+++ b/apps/vectreal-platform/app/components/layout-components/detail-panel-section.spec.tsx
@@ -12,7 +12,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import { DetailPanelSection } from '../app/components/layout-components/detail-panel-section'
+import { DetailPanelSection } from './detail-panel-section'
 
 const sectionOf = (child: HTMLElement) => child.closest('section')
 

--- a/apps/vectreal-platform/app/hooks/use-dashboard-mutations.spec.tsx
+++ b/apps/vectreal-platform/app/hooks/use-dashboard-mutations.spec.tsx
@@ -18,13 +18,13 @@
 import { act, render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useDashboardMutations } from '../app/hooks/use-dashboard-mutations'
+import { useDashboardMutations } from './use-dashboard-mutations'
 
-import type { DashboardMutationsApi } from '../app/hooks/use-dashboard-mutations'
+import type { DashboardMutationsApi } from './use-dashboard-mutations'
 import type {
 	DashboardMutationRequest,
 	DashboardMutationResponse
-} from '../app/lib/domain/dashboard/dashboard-mutations'
+} from '../lib/domain/dashboard/dashboard-mutations'
 
 const router = vi.hoisted(() => ({
 	fetcher: { state: 'idle', data: undefined as unknown },
@@ -145,7 +145,10 @@ const deleted = () => ({
 	}
 })
 
-const rejected = () => ({ success: false as const, error: 'Invalid CSRF token' })
+const rejected = () => ({
+	success: false as const,
+	error: 'Invalid CSRF token'
+})
 
 beforeEach(() => {
 	router.fetcher = { state: 'idle', data: undefined }
@@ -169,7 +172,10 @@ describe('useDashboardMutations', () => {
 
 		expect(router.submissions).toHaveLength(1)
 		const [{ body, options }] = router.submissions
-		expect(options).toEqual({ method: 'post', action: '/api/dashboard/mutations' })
+		expect(options).toEqual({
+			method: 'post',
+			action: '/api/dashboard/mutations'
+		})
 		expect(body).toEqual({
 			verb: 'delete',
 			targets: JSON.stringify([{ type: 'scene', id: 'scene-1' }]),

--- a/apps/vectreal-platform/app/hooks/use-once-per-fetcher-response.spec.tsx
+++ b/apps/vectreal-platform/app/hooks/use-once-per-fetcher-response.spec.tsx
@@ -11,7 +11,7 @@
 import { render } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { useOncePerFetcherResponse } from '../app/hooks/use-once-per-fetcher-response'
+import { useOncePerFetcherResponse } from './use-once-per-fetcher-response'
 
 type Fetcher<T> = { state: string; data: T | undefined | null }
 

--- a/apps/vectreal-platform/app/hooks/use-resend-cooldown.spec.tsx
+++ b/apps/vectreal-platform/app/hooks/use-resend-cooldown.spec.tsx
@@ -11,11 +11,11 @@
 import { act, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useResendCooldown } from '../app/hooks/use-resend-cooldown'
+import { useResendCooldown } from './use-resend-cooldown'
 import {
 	RESEND_COOLDOWN_SECONDS,
 	resendCooldownFor
-} from '../app/lib/domain/auth/resend-cooldown'
+} from '../lib/domain/auth/resend-cooldown'
 
 type Result = {
 	sent?: boolean

--- a/apps/vectreal-platform/app/hooks/use-spend-turnstile-token.spec.tsx
+++ b/apps/vectreal-platform/app/hooks/use-spend-turnstile-token.spec.tsx
@@ -19,7 +19,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
 	useSpendTurnstileToken,
 	type TokenBearingSubmission
-} from '../app/hooks/use-spend-turnstile-token'
+} from './use-spend-turnstile-token'
 
 function submissionWith(token: string): TokenBearingSubmission {
 	const formData = new FormData()

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-lifecycle.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-lifecycle.spec.ts
@@ -8,7 +8,7 @@ import {
 	isApiKeyLive,
 	resolveApiKeyState,
 	type ApiKeyLifecycleRow
-} from '../app/lib/domain/auth/api-key-lifecycle'
+} from './api-key-lifecycle'
 
 /**
  * The contract between the two halves that decide whether an API key works.
@@ -23,7 +23,7 @@ import {
  * transcription over every combination of the three columns involved.
  */
 
-const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..')
 const AUTH_MODULE = join(
 	APP_ROOT,
 	'app/lib/domain/auth/preview-api-key-auth.server.ts'
@@ -76,9 +76,10 @@ function extractWhereClause(source: string): string {
 
 	const start = source.indexOf('.where(', fn)
 	const end = source.indexOf('.limit(', start)
-	expect(start, 'findLiveKeyForProject no longer has a .where(').toBeGreaterThan(
-		-1
-	)
+	expect(
+		start,
+		'findLiveKeyForProject no longer has a .where('
+	).toBeGreaterThan(-1)
 	expect(end, 'findLiveKeyForProject no longer has a .limit(').toBeGreaterThan(
 		start
 	)

--- a/apps/vectreal-platform/app/lib/domain/auth/signin-failure.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/signin-failure.spec.ts
@@ -13,7 +13,7 @@ import {
 	AUTH_ERROR_MESSAGES,
 	classifySigninFailure,
 	type AuthErrorCode
-} from '../app/lib/domain/auth/signin-failure'
+} from './signin-failure'
 
 const CASES: [string, AuthErrorCode][] = [
 	// The exact string from supabase/auth `internal/api/token.go`.

--- a/apps/vectreal-platform/app/lib/domain/auth/signup-failure.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/signup-failure.spec.ts
@@ -9,10 +9,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import {
-	classifySignupFailure,
-	type SignupFailureCode
-} from '../app/lib/domain/auth/signup-failure'
+import { classifySignupFailure, type SignupFailureCode } from './signup-failure'
 
 const CASES: [string, SignupFailureCode][] = [
 	// Cloudflare's own wording, via GoTrue, for a replayed or expired token.

--- a/apps/vectreal-platform/app/lib/domain/auth/signup-validation.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/signup-validation.spec.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { validateSignup } from '../app/lib/domain/auth/signup-validation'
+import { validateSignup } from './signup-validation'
 
 function form(fields: Record<string, string>): FormData {
 	const data = new FormData()

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.spec.ts
@@ -6,7 +6,7 @@ import {
 	isEmbedRequestHostAllowed,
 	resolveRequestHostContext,
 	type EmbedKeyMatch
-} from '../app/lib/domain/embed/embed-access-policy'
+} from './embed-access-policy'
 
 /**
  * The decision that lets a third-party page load a published scene.

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.spec.ts
@@ -5,7 +5,7 @@ import {
 	normalizeDomainPattern,
 	parseAllowedDomainPatterns,
 	validateAllowedDomainInput
-} from '../app/lib/domain/embed/embed-domain-policy'
+} from './embed-domain-policy'
 
 /**
  * This module decides who may embed a published scene, so it is the security
@@ -104,7 +104,9 @@ describe('embed domain policy', () => {
 		})
 
 		it('reports an invalid entry rather than silently dropping it', () => {
-			const result = validateAllowedDomainInput('example.com\nfoo.*.example.com')
+			const result = validateAllowedDomainInput(
+				'example.com\nfoo.*.example.com'
+			)
 			expect(result.ok).toBe(false)
 		})
 	})

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-key-options.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-key-options.spec.ts
@@ -5,7 +5,7 @@ import {
 	toEmbedApiKeyOptions,
 	type EmbedApiKeyOption,
 	type EmbedApiKeySource
-} from '../app/lib/domain/embed/embed-key-options'
+} from './embed-key-options'
 
 const PROJECT_ID = 'project-a'
 const NOW = new Date('2026-08-22T12:00:00.000Z')
@@ -60,7 +60,11 @@ describe('toEmbedApiKeyOptions', () => {
 		  field added here is a field published. `value` is on it deliberately;
 		  anything else appearing is not.
 		*/
-		const [option] = toEmbedApiKeyOptions([makeKey({ id: 'k' })], PROJECT_ID, NOW)
+		const [option] = toEmbedApiKeyOptions(
+			[makeKey({ id: 'k' })],
+			PROJECT_ID,
+			NOW
+		)
 
 		expect(Object.keys(option).sort()).toEqual([
 			'expired',
@@ -106,9 +110,15 @@ describe('toEmbedApiKeyOptions', () => {
 	it('treats expiry as of the given instant, boundary inclusive', () => {
 		const options = toEmbedApiKeyOptions(
 			[
-				makeKey({ id: 'past', expiresAt: new Date('2026-08-22T11:59:59.000Z') }),
+				makeKey({
+					id: 'past',
+					expiresAt: new Date('2026-08-22T11:59:59.000Z')
+				}),
 				makeKey({ id: 'exactly', expiresAt: NOW }),
-				makeKey({ id: 'future', expiresAt: new Date('2026-08-22T12:00:01.000Z') }),
+				makeKey({
+					id: 'future',
+					expiresAt: new Date('2026-08-22T12:00:01.000Z')
+				}),
 				makeKey({ id: 'never', expiresAt: null })
 			],
 			PROJECT_ID,

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-response-headers.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-response-headers.spec.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	EMBED_RESPONSE_HEADERS,
 	withEmbedResponseHeaders
-} from '../app/lib/domain/embed/embed-response-headers'
+} from './embed-response-headers'
 
 /**
  * An embed URL carries its API key in the query string, so the response must
@@ -102,7 +102,10 @@ describe('embed response headers', () => {
 	  into nothing.
 	*/
 	describe('the routes that use them actually propagate them', () => {
-		const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+		const APP_ROOT = resolve(
+			dirname(fileURLToPath(import.meta.url)),
+			'../../../..'
+		)
 
 		function collectRouteFiles(dir: string): string[] {
 			return readdirSync(dir).flatMap((entry) => {

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.spec.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
-import { docsPages } from '../app/lib/docs/docs-manifest'
 import {
 	buildEmbedPath,
 	buildEmbedUrl,
@@ -15,7 +14,8 @@ import {
 	EMBED_COPY,
 	EMBED_DOCS_PATH,
 	escapeHtmlAttributeValue
-} from '../app/lib/domain/embed/embed-snippet'
+} from './embed-snippet'
+import { docsPages } from '../../docs/docs-manifest'
 
 const ORIGIN = 'https://vectreal.com'
 const PROJECT_ID = '08db6be1-f87b-4278-abfc-d80ef549e3a7'
@@ -352,7 +352,7 @@ describe('the docs link the panel offers', () => {
 	  green with the route deleted.
 	*/
 	const ROUTES = readFileSync(
-		join(dirname(fileURLToPath(import.meta.url)), '../app/routes.tsx'),
+		join(dirname(fileURLToPath(import.meta.url)), '../../../routes.tsx'),
 		'utf8'
 	)
 
@@ -400,7 +400,7 @@ describe('the docs page and the builder agree on the default box', () => {
 	const GUIDE = readFileSync(
 		join(
 			dirname(fileURLToPath(import.meta.url)),
-			'../app/routes/docs/guides/publish-embed.mdx'
+			'../../../routes/docs/guides/publish-embed.mdx'
 		),
 		'utf8'
 	)

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-asset-policy.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-asset-policy.spec.ts
@@ -7,7 +7,7 @@ import {
 	isEmbedServableAssetId,
 	selectEmbedServableAssets,
 	type EmbedAssetRow
-} from '../app/lib/domain/scene/embed-asset-policy'
+} from './embed-asset-policy'
 
 /**
  * The production shape that broke embeds: `scene_published.asset_id` is written
@@ -170,9 +170,9 @@ describe('embed asset policy', () => {
 			})
 
 			expect(servable.bakeAssetId).toBeNull()
-			expect(buildEmbedAssetRefs(servable, SCENE_ASSETS, buildAssetUrl)).toEqual(
-				{}
-			)
+			expect(
+				buildEmbedAssetRefs(servable, SCENE_ASSETS, buildAssetUrl)
+			).toEqual({})
 		})
 	})
 

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { redactSettingsForEmbed } from '../app/lib/domain/scene/embed-settings-policy'
+import { redactSettingsForEmbed } from './embed-settings-policy'
 
 import type { SceneSettings } from '@vctrl/core'
 
@@ -38,7 +38,11 @@ function buildSettings(overrides: Partial<SceneSettings> = {}): SceneSettings {
 					position: [8, 8, 8],
 					target: [0, 0, 0]
 				},
-				{ cameraId: 'cam-orphan', name: 'Orphaned hotspot cam', kind: 'hotspot' }
+				{
+					cameraId: 'cam-orphan',
+					name: 'Orphaned hotspot cam',
+					kind: 'hotspot'
+				}
 			]
 		},
 		hotspots: [
@@ -97,8 +101,10 @@ function buildSettings(overrides: Partial<SceneSettings> = {}): SceneSettings {
 	} as SceneSettings
 }
 
-const redact = (settings: SceneSettings, bakeAssetId: string | null = BAKE_ASSET_ID) =>
-	redactSettingsForEmbed(settings, { bakeAssetId })
+const redact = (
+	settings: SceneSettings,
+	bakeAssetId: string | null = BAKE_ASSET_ID
+) => redactSettingsForEmbed(settings, { bakeAssetId })
 
 describe('embed settings policy', () => {
 	it('drops internalOnly hotspots', () => {
@@ -188,7 +194,9 @@ describe('embed settings policy', () => {
 
 	describe('baked shadow pointer', () => {
 		it('keeps the pointer the asset gate authorized', () => {
-			expect(redact(buildSettings()).shadows?.baked?.assetId).toBe(BAKE_ASSET_ID)
+			expect(redact(buildSettings()).shadows?.baked?.assetId).toBe(
+				BAKE_ASSET_ID
+			)
 		})
 
 		/**

--- a/apps/vectreal-platform/app/lib/email/auth-hook-response.spec.ts
+++ b/apps/vectreal-platform/app/lib/email/auth-hook-response.spec.ts
@@ -14,7 +14,7 @@ import {
 	buildHookErrorMessage,
 	hookErrorResponse,
 	redactAddresses
-} from '../app/lib/email/auth-hook-response'
+} from './auth-hook-response'
 
 describe('hookErrorResponse', () => {
 	/*

--- a/apps/vectreal-platform/app/lib/http/client-identity.spec.ts
+++ b/apps/vectreal-platform/app/lib/http/client-identity.spec.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-	resolveClientIp,
-	UNKNOWN_CLIENT
-} from '../app/lib/http/client-identity'
+import { resolveClientIp, UNKNOWN_CLIENT } from './client-identity'
 
 /**
  * Every assertion here is about not trusting the caller.

--- a/apps/vectreal-platform/app/lib/observability/error-report.spec.ts
+++ b/apps/vectreal-platform/app/lib/observability/error-report.spec.ts
@@ -4,11 +4,8 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
-import {
-	CRITICAL_FLOWS,
-	criticalFlowsForPathname
-} from '../app/lib/observability/critical-flows'
-import { buildErrorReport } from '../app/lib/observability/error-report'
+import { CRITICAL_FLOWS, criticalFlowsForPathname } from './critical-flows'
+import { buildErrorReport } from './error-report'
 
 /**
  * What the reporting rules actually do, tested without a PostHog client.
@@ -20,7 +17,10 @@ import { buildErrorReport } from '../app/lib/observability/error-report'
  * this file. Flows are referred to by id below for that reason.
  */
 
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const REPO_ROOT = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	'../../../../..'
+)
 
 describe('critical flow attribution', () => {
 	it('has a unique id per step', () => {

--- a/apps/vectreal-platform/app/lib/posthog/redact-embed-token.spec.ts
+++ b/apps/vectreal-platform/app/lib/posthog/redact-embed-token.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	redactEmbedTokenFromProperties,
 	redactEmbedToken
-} from '../app/lib/posthog/redact-embed-token'
+} from './redact-embed-token'
 
 /**
  * A live API key must not leave the browser inside an analytics event.
@@ -18,7 +18,7 @@ import {
  * wrote, and any added later.
  */
 
-const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 
 const EMBED_URL =
 	'https://vectreal.com/embed/395a09f0-9340/488bd4a1-46d3?token=vctrl_liveSecretab3x'

--- a/apps/vectreal-platform/tests/critical-path-guard.spec.ts
+++ b/apps/vectreal-platform/tests/critical-path-guard.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * The rule that decides whether the critical path is guarded.
+ *
+ * `critical-path.spec.ts` asserts that every funnel step is exercised by a
+ * spec, and this is what "exercised" means. It had no test of its own, which
+ * matters more than it sounds: a matcher that answers yes too readily reports
+ * the whole funnel as covered and fails silently forever.
+ *
+ * Written when colocating specs broke it. The matcher only understood a spec
+ * that named its subject by full path, so moving a spec next to its module -
+ * where it names it `./thing` - read as deleting the guard.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { isModuleGuarded, readSpecifiers } from './critical-path-guard'
+
+const PROJECT = '/repo/apps/vectreal-platform'
+const spec = (dir: string, source: string) => ({ dir, source })
+
+describe('readSpecifiers', () => {
+	it('separates what a spec imports from what it stubs out', () => {
+		const { imported, mocked } = readSpecifiers(
+			`import { a } from './thing'\nvi.mock('../other/thing', () => ({}))`
+		)
+
+		expect([...imported]).toEqual(['./thing'])
+		expect([...mocked]).toEqual(['../other/thing'])
+	})
+})
+
+describe('isModuleGuarded', () => {
+	it('sees a spec sitting beside its module', () => {
+		/*
+		  The case colocation introduced. `./embed-access-policy` names nothing
+		  until it is resolved against the directory the spec is in.
+		*/
+		expect(
+			isModuleGuarded(
+				'app/lib/domain/embed/embed-access-policy.ts',
+				[
+					spec(
+						`${PROJECT}/app/lib/domain/embed`,
+						`import { decide } from './embed-access-policy'`
+					)
+				],
+				PROJECT
+			)
+		).toBe(true)
+	})
+
+	it('still sees a spec that names the module by path', () => {
+		expect(
+			isModuleGuarded(
+				'app/lib/domain/embed/embed-access-policy.ts',
+				[
+					spec(
+						`${PROJECT}/tests`,
+						`import { decide } from '../app/lib/domain/embed/embed-access-policy'`
+					)
+				],
+				PROJECT
+			)
+		).toBe(true)
+	})
+
+	it('does not count a module the spec only stubs out', () => {
+		/*
+		  A spec that mocks a module is testing its caller. It still imports the
+		  module to configure the stub, so this cannot be done by ignoring the
+		  mock - the two have to be read separately.
+		*/
+		expect(
+			isModuleGuarded(
+				'app/lib/domain/auth/api-key-repository.server.ts',
+				[
+					spec(
+						`${PROJECT}/app/routes/dashboard-page`,
+						`import { getAll } from '../../lib/domain/auth/api-key-repository.server'\n` +
+							`vi.mock('../../lib/domain/auth/api-key-repository.server', () => ({}))`
+					)
+				],
+				PROJECT
+			)
+		).toBe(false)
+	})
+
+	it('does not count a same-named module in another directory', () => {
+		/*
+		  The reason a relative specifier is resolved rather than matched on its
+		  last segment: `embed-asset-policy` under `scene` and a hypothetical one
+		  under `embed` are different modules, and a filename that merely
+		  resembles the module's proves nothing about what runs.
+		*/
+		expect(
+			isModuleGuarded(
+				'app/lib/domain/scene/embed-asset-policy.ts',
+				[
+					spec(
+						`${PROJECT}/app/lib/domain/embed`,
+						`import { x } from './embed-asset-policy'`
+					)
+				],
+				PROJECT
+			)
+		).toBe(false)
+	})
+
+	it('reports a module nothing imports', () => {
+		expect(
+			isModuleGuarded(
+				'app/lib/domain/embed/embed-access-policy.ts',
+				[spec(`${PROJECT}/tests`, `import { y } from '../app/lib/other'`)],
+				PROJECT
+			)
+		).toBe(false)
+	})
+})

--- a/apps/vectreal-platform/tests/critical-path-guard.ts
+++ b/apps/vectreal-platform/tests/critical-path-guard.ts
@@ -1,0 +1,94 @@
+/**
+ * Deciding whether a spec really exercises a module.
+ *
+ * Extracted from `critical-path.spec.ts` so the rule can be tested directly.
+ * It is the gate for the whole funnel: if this says "guarded" too readily, the
+ * critical path reads as covered and nobody finds out until something on it
+ * breaks in production.
+ *
+ * It has to understand two spellings, because specs live in two places. One in
+ * `tests/` names its subject by path; one sitting beside its module names it
+ * `./thing`. Reading only the first is what made colocating a spec look like
+ * it removed a guard.
+ */
+
+import { relative, resolve } from 'node:path'
+
+/** Every module specifier a spec imports or mocks, split by which it was. */
+export function readSpecifiers(source: string): {
+	imported: Set<string>
+	mocked: Set<string>
+} {
+	const imported = new Set<string>()
+	const mocked = new Set<string>()
+
+	for (const match of source.matchAll(
+		/(?:from|import\(|vi\.mock\(\s*)\s*['"]([^'"]+)['"]/g
+	)) {
+		const [whole, specifier] = match
+		;(whole.includes('vi.mock') ? mocked : imported).add(specifier)
+	}
+
+	return { imported, mocked }
+}
+
+/**
+ * Which module a relative specifier names, as a path under the app directory.
+ *
+ * Resolved rather than pattern-matched, because `./embed-access-policy` says
+ * nothing about which module it is until it is read against the directory the
+ * spec sits in. Returns null for a bare or aliased specifier, which the caller
+ * compares by suffix instead.
+ */
+export function resolveSpecifier(
+	specifier: string,
+	specDir: string,
+	projectDir: string
+): string | null {
+	if (!specifier.startsWith('.')) return null
+
+	/*
+	  Relative to the project, not to `app/`, because that is the shape
+	  `CRITICAL_FLOWS` names a module in: `app/lib/domain/embed/x.ts`.
+	*/
+	return relative(projectDir, resolve(specDir, specifier)).replace(
+		/\.tsx?$/,
+		''
+	)
+}
+
+export interface SpecSource {
+	dir: string
+	source: string
+}
+
+/**
+ * Whether any of these specs imports `modulePath` for real.
+ *
+ * `vi.mock` does not count: it replaces the module with a stub, so a spec that
+ * mocks one is testing its caller. A spec that mocks a module still imports it
+ * to configure the stub, which is why the two sets are read separately rather
+ * than the mock simply being ignored.
+ */
+export function isModuleGuarded(
+	modulePath: string,
+	specs: readonly SpecSource[],
+	projectDir: string
+): boolean {
+	const suffix = modulePath.replace(/^app\//, '').replace(/\.tsx?$/, '')
+	const exact = modulePath.replace(/\.tsx?$/, '')
+
+	return specs.some(({ dir, source }) => {
+		const { imported, mocked } = readSpecifiers(source)
+
+		const names = (specifiers: Set<string>) =>
+			[...specifiers].some((specifier) => {
+				const resolved = resolveSpecifier(specifier, dir, projectDir)
+				return resolved !== null
+					? resolved === exact
+					: specifier.endsWith(suffix)
+			})
+
+		return names(imported) && !names(mocked)
+	})
+}

--- a/apps/vectreal-platform/tests/critical-path.spec.ts
+++ b/apps/vectreal-platform/tests/critical-path.spec.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
+import { isModuleGuarded } from './critical-path-guard'
 import { CRITICAL_FLOWS } from '../app/lib/observability/critical-flows'
 
 /**
@@ -92,32 +93,26 @@ const SPEC_SOURCES = [
 	  The first draft did exactly that.
 	*/
 	.filter((file) => !file.endsWith('critical-path.spec.ts'))
-	.map((file) => readFileSync(file, 'utf8'))
+	/*
+	  The directory is kept alongside the source, because a colocated spec names
+	  its subject relatively - `./embed-access-policy` - and that string says
+	  nothing about which module it is until it is resolved against the spec's
+	  own location.
+	*/
+	.map((file) => ({
+		dir: dirname(file),
+		source: readFileSync(file, 'utf8')
+	}))
 
 /**
  * A module counts as guarded when a spec actually imports it.
  *
- * Two things deliberately do not count. A filename that merely resembles the
- * module's proves nothing about what is exercised. And `vi.mock('...')` replaces
- * the module with a stub, so a spec that mocks a module is testing its caller,
- * not the module - `api-key-repository.server` is mocked by the key route spec
- * and has no test of its own.
+ * The rule lives in `critical-path-guard.ts` so it can be tested directly:
+ * it is what decides whether the funnel reads as covered, and a matcher that
+ * says yes too readily is worse than no check at all.
  */
 function isGuarded(modulePath: string): boolean {
-	const importPath = modulePath.replace(/^app\//, '').replace(/\.tsx?$/, '')
-	const escaped = importPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-	const realImport = new RegExp(
-		`(?:from|import\\()\\s*['"][^'"]*${escaped}['"]`
-	)
-	/*
-	  A spec that mocks the module still imports it, to configure the stub. The
-	  key route spec does exactly that, so importing alone would have counted a
-	  module with no test of its own as guarded.
-	*/
-	const mocked = new RegExp(`vi\\.mock\\(\\s*['"][^'"]*${escaped}['"]`)
-	return SPEC_SOURCES.some(
-		(source) => realImport.test(source) && !mocked.test(source)
-	)
+	return isModuleGuarded(modulePath, SPEC_SOURCES, join(REPO_ROOT, APP))
 }
 
 describe('critical path', () => {


### PR DESCRIPTION
## Root cause

Colocation was blocked by the guard-detector, not by the specs. `critical-path.spec.ts` decided a funnel module was guarded by finding a spec that named it **by full path** — but a colocated spec names its subject `./thing`, which matches nothing. So moving a spec next to its module read as *deleting its guard*, and three critical-path steps went red the moment I tried.

That is fixed at the cause rather than worked around by keeping specs in a bin to suit a regex.

## Change

25 specs that name a single module move beside it. Specs that assert over the whole tree stay in `tests/`, because they are not bound to anything to sit beside: `critical-path`, `documented-claims`, `eslint-house-rules`, `tooltip-copy-length`, `type-scale-adherence`, `z-index-tiers`, `container-scale`, `root-vitest-projects`, `embed-token-storage`, `embed-route-split`.

This is the tail of the 2026-08-08 rework, not a new convention: 71 specs were already colocated against 51 central.

## The matcher

A relative specifier is now **resolved** against the directory the spec sits in — the only thing that says what `./embed-access-policy` refers to. Resolved rather than matched on its last segment, because the file's own rule is that a filename resembling the module proves nothing, and a same-named module in another directory must still read as unguarded.

The rule moves to `critical-path-guard.ts` **with a spec of its own, which it never had.** It is the gate for the entire funnel; a matcher that answers yes too readily reports everything as covered and fails silently forever. Three mutations that survived before now each turn it red:

| Mutation | Result |
| --- | --- |
| Drop the `vi.mock` exclusion | red |
| Accept a bare filename match | red |
| Stop resolving relative specifiers | red |

## Incidental fixes the move surfaced

- Four moved specs read repository source to pin a cross-file invariant, so they knew how deep they sat. Their `..` counts are corrected.
- The brand skill's claims block named `tests/info-tooltip.spec.tsx`; `documented-claims` caught the stale path.

## Not moved

`one-time-key-dialog.spec.tsx` — it is moved *and rewritten* by #785, so moving it here would only produce a conflict. It lands colocated either way.

## Verification

- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — green
- `npx vitest run --root .` — 138 files, 1726 tests, green
- `prettier --check` on every changed file — clean

Test count is unchanged by the moves themselves; the +6 is the new matcher spec.