### PR TITLE
fix(assets): collect the superseded GLB when a scene is republished

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
@@ -697,8 +697,16 @@ class SceneSettingsService {
 
 		await this.assertAssetsBelongToProject([publishedAssetId], projectId)
 
-		return await this.db.transaction(async (tx) => {
+		const published = await this.db.transaction(async (tx) => {
 			const latestSettings = await getSceneSettingsBySceneId(tx, sceneId)
+
+			// Captured before the delete: once the row is gone the outgoing GLB has
+			// no reference left anywhere, so nothing would ever collect it.
+			const [outgoing] = await tx
+				.select({ assetId: scenePublished.assetId })
+				.from(scenePublished)
+				.where(eq(scenePublished.sceneId, sceneId))
+				.limit(1)
 
 			await tx.delete(scenePublished).where(eq(scenePublished.sceneId, sceneId))
 
@@ -733,10 +741,21 @@ class SceneSettingsService {
 				.limit(1)
 
 			return {
-				...publishedRecord,
-				asset: assetRecord ?? null
+				record: { ...publishedRecord, asset: assetRecord ?? null },
+				previousAssetId: outgoing?.assetId ?? null
 			}
 		})
+
+		// No same-id special case: republishing byte-identical content dedupes to
+		// the row we just re-published, so `selectUnreferencedAssetIds` sees the
+		// new `scene_published` row and reports it as still referenced. Guarding
+		// on `previousAssetId !== publishedAssetId` here would put a second copy
+		// of that rule in front of the one function that owns it.
+		if (published.previousAssetId) {
+			await this.garbageCollectUnreferencedAssets([published.previousAssetId])
+		}
+
+		return published.record
 	}
 
 	async revokeScenePublication(params: { sceneId: string; userId: string }) {

--- a/apps/vectreal-platform/tests/integration/publish-asset-lifecycle.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/publish-asset-lifecycle.integration.spec.ts
@@ -1,10 +1,10 @@
 /**
- * Asks a real Postgres whether revoking a publish collects the right asset.
+ * Asks a real Postgres whether the publish lifecycle collects the right assets.
  *
- * This is a reference-counting question, and reference counting is three joins
- * over a column that holds a URL rather than a foreign key. A mocked
- * `selectUnreferencedAssetIds` would only prove the mock agrees with itself, so
- * it runs for real against the local database.
+ * Both behaviours here are reference-counting questions, and reference counting
+ * is three joins over a column that holds a URL rather than a foreign key. A
+ * mocked `selectUnreferencedAssetIds` would only prove the mock agrees with
+ * itself, so it runs for real against the local database.
  *
  * `deleteAssets` is spied rather than executed: it is the one step that leaves
  * Postgres for Supabase Storage, and what these tests need to observe is which
@@ -51,7 +51,7 @@ type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
 type Service =
 	typeof import('../../app/lib/domain/scene/server/scene-settings-service.server')
 
-describe('publish revocation', () => {
+describe('publish asset lifecycle', () => {
 	let schema: Schema
 	let db: Db
 	let sceneSettingsService: Service['sceneSettingsService']
@@ -170,4 +170,43 @@ describe('publish revocation', () => {
 		expect(deleteAssetsSpy).toHaveBeenCalledWith([assetId])
 	})
 
+	it('collects the superseded GLB when a scene is republished', async () => {
+		const firstAssetId = await makeAsset('v1.glb')
+		const secondAssetId = await makeAsset('v2.glb')
+		const sceneId = await makeScene('republished')
+		await publishRow(sceneId, firstAssetId)
+
+		await sceneSettingsService.publishSceneFromAssetId({
+			sceneId,
+			projectId,
+			userId: ownerId,
+			publishedAssetId: secondAssetId
+		})
+
+		expect(deleteAssetsSpy).toHaveBeenCalledWith([firstAssetId])
+	})
+
+	it('keeps the GLB when a republish dedupes to the same asset row', async () => {
+		// Republishing byte-identical content returns the existing row, so the
+		// outgoing and incoming ids are the same. Collecting it would delete the
+		// GLB that was just published.
+		const assetId = await makeAsset('stable.glb')
+		const sceneId = await makeScene('stable')
+		await publishRow(sceneId, assetId)
+
+		await sceneSettingsService.publishSceneFromAssetId({
+			sceneId,
+			projectId,
+			userId: ownerId,
+			publishedAssetId: assetId
+		})
+
+		expect(deleteAssetsSpy).not.toHaveBeenCalled()
+
+		const stillPublished = await db
+			.select({ assetId: schema.scenePublished.assetId })
+			.from(schema.scenePublished)
+			.where(eq(schema.scenePublished.sceneId, sceneId))
+		expect(stillPublished).toEqual([{ assetId }])
+	})
 })


### PR DESCRIPTION
## Summary

Every republish stranded the previous GLB — a full model file plus its storage
object — permanently. Second of the asset-lifecycle stack.

**Targets `main` directly** — independent of the rest of the asset-lifecycle work.

rebase.

## Root cause

`publishSceneFromAssetId` deleted the `scene_published` row and inserted the new
one without ever reading the outgoing `assetId`, so the id was gone before
anything could collect it. A published GLB is not in `scene_assets` either, so
the save-path collector never had it as a candidate — nothing in the system
could reach it again.

The capture belongs inside that transaction rather than at the call site,
because the delete is what destroys the last reference to the id.

## Changes

- Read the outgoing `assetId` before the delete, and reference-check it
  post-commit through `garbageCollectUnreferencedAssets`.
- Extend `publish-asset-lifecycle.integration.spec.ts` with the republish pair.

Deliberately no `previousAssetId !== publishedAssetId` guard: republishing
byte-identical content dedupes to the row just published, which
`selectUnreferencedAssetIds` already reports as referenced. Mutating that guard
out left every test green — it was a second copy of a rule that has one owner,
so it is not there.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

**Mutation gate.** Forcing the captured id to `null` turns *"collects the
superseded GLB when a scene is republished"* red, and nothing else.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [ ] I updated documentation where needed
- [ ] I linked the related issue above

