### PR TITLE
fix(assets): key asset reuse on the content hash, and only share referenced rows

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto'
 import { createHash } from 'node:crypto'
 
 import { createClient } from '@supabase/supabase-js'
-import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNotNull, sql } from 'drizzle-orm'
 
 import { getDbClient } from '../../../db/client'
 import {
@@ -135,6 +135,13 @@ async function ensureAssetFolder(projectId: string) {
 }
 
 /**
+ * How many same-bytes rows to consider before giving up on reuse. Duplicates
+ * are the pathology this lookup exists to stop creating, so the list is short
+ * by design.
+ */
+const REUSE_CANDIDATE_LIMIT = 25
+
+/**
  * Computes a deterministic content hash used for de-duplication.
  */
 export function computeAssetHash(data: Uint8Array): string {
@@ -142,29 +149,67 @@ export function computeAssetHash(data: Uint8Array): string {
 }
 
 /**
- * Finds an existing asset with the same project folder + filename and validates
- * it against the content hash stored in metadata.
+ * Finds an already-uploaded asset in this project's folder holding these exact
+ * bytes, which some scene already references.
+ *
+ * Two rules, and both are load-bearing.
+ *
+ * The content hash is the identity, so it belongs in the predicate. Matching on
+ * `(folderId, name)` and checking the hash afterwards looks equivalent but is
+ * not: the asset folder is one per project, so every scene writes `scene.gltf`
+ * and `scene-thumbnail.webp` into it. Once two rows share a name, an unordered
+ * `limit(1)` returns an arbitrary one, the hash check fails against a row that
+ * was never the right candidate, and another duplicate is written - which makes
+ * the next lookup likelier to miss. That is how one folder came to hold 103
+ * rows named `scene.gltf`.
+ *
+ * An unreferenced row is never reused, even when its bytes match. Such a row
+ * belongs to an upload batch that has not committed yet, and handing it to a
+ * second batch puts one row under two owners: whichever batch fails first
+ * reclaims it, deleting an asset the other is about to link, and because
+ * `scene_assets.asset_id` cascades the loser can end up returning success with
+ * its glTF silently unlinked. No grace window fixes that, because the two
+ * batches overlap for as long as the slower one takes. Sharing only what is
+ * already referenced removes that case: a referenced row is one
+ * `selectUnreferencedAssetIds` will never let anything delete.
+ *
+ * It narrows rather than eliminates. A row referenced when it is handed out can
+ * lose its last reference before the reusing batch commits - re-save the scene
+ * that held it, or delete that scene - and then it is collectable again. That
+ * window needs a concurrent unlink of the same asset and costs a failed save
+ * that succeeds on retry, where the shared-in-flight case cost a silently
+ * unlinked scene. Closing it needs the reuse to take a reference rather than
+ * observe one, which is a schema change and is filed, not done here.
+ *
+ * The cost is a duplicate row when two saves upload identical new bytes at the
+ * same time, which is rare and self-correcting. The common case - re-saving a
+ * scene whose assets are already linked - still deduplicates.
  */
 async function findExistingAsset(
 	hash: string,
 	fileName: string,
 	folderId: string
 ): Promise<typeof assets.$inferSelect | null> {
-	const existingAssets = await db
+	const matches = await db
 		.select()
 		.from(assets)
-		.where(and(eq(assets.folderId, folderId), eq(assets.name, fileName)))
-		.limit(1)
+		.where(
+			and(
+				eq(assets.folderId, folderId),
+				eq(assets.name, fileName),
+				sql`${assets.metadata}->>'contentHash' = ${hash}`
+			)
+		)
+		.orderBy(desc(assets.createdAt))
+		.limit(REUSE_CANDIDATE_LIMIT)
 
-	if (existingAssets.length > 0) {
-		const asset = existingAssets[0]
-		const metadata = asset.metadata as { contentHash?: string } | null
-		if (metadata?.contentHash === hash) {
-			return asset
-		}
-	}
+	if (matches.length === 0) return null
 
-	return null
+	const unreferenced = new Set(
+		await selectUnreferencedAssetIds(matches.map((asset) => asset.id))
+	)
+
+	return matches.find((asset) => !unreferenced.has(asset.id)) ?? null
 }
 
 function getErrorMessage(error: unknown): string {

--- a/apps/vectreal-platform/tests/integration/asset-upload-dedup.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/asset-upload-dedup.integration.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Asks a real Postgres whether an upload reuses the row holding the same bytes.
+ *
+ * The defect this pins needs duplicate rows to exist before it shows, so it
+ * cannot be reproduced against a mock that returns whatever it was told to.
+ * The asset folder is one per project, so every scene writes `scene.gltf` and
+ * `scene-thumbnail.webp` into it; a lookup keyed on `(folder, name)` then
+ * returns an arbitrary row, misses on the hash, and writes another duplicate,
+ * which makes the next lookup likelier to miss. One local folder reached 103
+ * rows named `scene.gltf` this way.
+ *
+ * Storage is faked at the `createClient` boundary; nothing here depends on
+ * bytes actually moving.
+ *
+ * Opt-in:
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { and, eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: () => ({
+		storage: {
+			getBucket: async () => ({ data: { name: 'assets' }, error: null }),
+			createBucket: async () => ({ data: null, error: null }),
+			from: () => ({
+				upload: async (path: string) => ({ data: { path }, error: null }),
+				remove: async () => ({ data: null, error: null })
+			})
+		}
+	})
+}))
+
+type Schema = typeof import('../../app/db/schema')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+type Storage = typeof import('../../app/lib/domain/asset/asset-storage.server')
+
+describe('asset upload de-duplication', () => {
+	let schema: Schema
+	let db: Db
+	let uploadSceneAssets: Storage['uploadSceneAssets']
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+	const assetFolderId = randomUUID()
+	const fileName = 'collides.bin'
+
+	const upload = async (data: Uint8Array, name: string = fileName) => {
+		const [result] = await uploadSceneAssets(
+			randomUUID(),
+			ownerId,
+			projectId,
+			[
+				{
+					fileName: name,
+					data,
+					mimeType: 'application/octet-stream',
+					type: 'buffer'
+				}
+			]
+		)
+		return result.assetId
+	}
+
+	/**
+	 * Links an asset to a throwaway scene. Reuse is only offered for rows
+	 * something already references, so an unreferenced fixture would never be a
+	 * dedupe candidate and the test would prove nothing.
+	 */
+	const reference = async (assetId: string) => {
+		const sceneId = randomUUID()
+		await db
+			.insert(schema.scenes)
+			.values({ id: sceneId, projectId, folderId: null, name: `s-${sceneId}` })
+		const settingsId = randomUUID()
+		await db
+			.insert(schema.sceneSettings)
+			.values({ id: settingsId, sceneId, createdBy: ownerId })
+		await db
+			.insert(schema.sceneAssets)
+			.values({ sceneSettingsId: settingsId, assetId })
+	}
+
+	const contentHashOf = async (assetId: string) => {
+		const [row] = await db
+			.select({ metadata: schema.assets.metadata })
+			.from(schema.assets)
+			.where(eq(schema.assets.id, assetId))
+		return (row?.metadata as { contentHash?: string } | null)?.contentHash
+	}
+
+	const rowsNamed = async () =>
+		db
+			.select({ id: schema.assets.id })
+			.from(schema.assets)
+			.where(
+				and(
+					eq(schema.assets.folderId, assetFolderId),
+					eq(schema.assets.name, fileName)
+				)
+			)
+
+	beforeAll(async () => {
+		process.env.SUPABASE_URL ??= 'http://127.0.0.1:54321'
+		process.env.SUPABASE_SECRET_KEY ??= 'integration-test-key'
+
+		schema = await import('../../app/db/schema')
+		db = (await import('../../app/db/client')).getDbClient()
+		;({ uploadSceneAssets } =
+			await import('../../app/lib/domain/asset/asset-storage.server'))
+
+		await db.insert(schema.users).values({
+			id: ownerId,
+			email: `owner-${ownerId}@smoke.test`,
+			name: 'Owner'
+		})
+		await db
+			.insert(schema.organizations)
+			.values({ id: organizationId, name: `smoke-${organizationId}`, ownerId })
+		await db.insert(schema.organizationMemberships).values({
+			userId: ownerId,
+			organizationId,
+			role: 'owner'
+		})
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Smoke project',
+			slug: `smoke-${projectId}`
+		})
+		await db
+			.insert(schema.folders)
+			.values({ id: assetFolderId, projectId, name: 'Scene Assets' })
+	})
+
+	afterAll(async () => {
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, organizationId))
+		await db.delete(schema.users).where(eq(schema.users.id, ownerId))
+	})
+
+	it('does not share a row that no scene references yet', async () => {
+		// An unreferenced row belongs to an upload batch that has not committed.
+		// Handing it to a second batch would put one row under two owners, and
+		// whichever batch failed first would collect it out from under the other.
+		// Two uploads of identical bytes must therefore produce two rows.
+		const bytes = new Uint8Array([4, 4, 4, 4])
+
+		const first = await upload(bytes, 'in-flight.bin')
+		const second = await upload(bytes, 'in-flight.bin')
+
+		expect(second).not.toBe(first)
+	})
+
+	it('reuses a row once a scene references it', async () => {
+		// The other half. Deduplication still has to work, or every save rewrites
+		// every unchanged texture; a referenced row is one
+		// `selectUnreferencedAssetIds` will never let a collector delete, so
+		// sharing it is safe.
+		const bytes = new Uint8Array([5, 5, 5, 5])
+
+		const created = await upload(bytes, 'reusable.bin')
+		await reference(created)
+
+		expect(await upload(bytes, 'reusable.bin')).toBe(created)
+	})
+
+	it('reuses the row holding these bytes, not an arbitrary namesake', async () => {
+		// Several same-named rows with different bytes go in first, so a lookup
+		// keyed on the name alone has to walk past a wrong answer before it could
+		// reach the right one. With a single decoy the old implementation passed
+		// or failed on whichever row the planner happened to return first; the
+		// assertion was about the query plan rather than about the code.
+		const decoys: string[] = []
+		for (const byte of [9, 8, 7, 6]) {
+			const decoy = await upload(new Uint8Array([byte, byte, byte]))
+			await reference(decoy)
+			decoys.push(decoy)
+		}
+
+		const wantedBytes = new Uint8Array([1, 2, 3])
+		const wanted = await upload(wantedBytes)
+		await reference(wanted)
+
+		expect(decoys).not.toContain(wanted)
+		expect(await rowsNamed()).toHaveLength(decoys.length + 1)
+
+		const reused = await upload(wantedBytes)
+
+		// Identity is the hash, so assert on the hash rather than only on the id.
+		expect(reused).toBe(wanted)
+		expect(await contentHashOf(reused)).toBe(await contentHashOf(wanted))
+		expect(await rowsNamed()).toHaveLength(decoys.length + 1)
+	})
+})


### PR DESCRIPTION
## Summary

Deduplication returned the wrong row when filenames collide, and shared rows
that no scene references yet. Fourth of the asset-lifecycle stack, and the
safety prerequisite for the reclaim in the next PR.

**Targets `main` directly** — independent of the rest of the asset-lifecycle work.

## Root cause

`findExistingAsset` asked `(folderId, name)` with an unordered `limit(1)` and
checked the content hash in JavaScript afterwards. The asset folder is one per
project, so once two rows share a name the query returns an arbitrary one, the
hash check fails against a row that was never the right candidate, and a fresh
duplicate is written — which makes the next lookup likelier to miss. It is
self-amplifying: one local folder holds 103 rows named `scene.gltf`.

Adding an `ORDER BY` would have been a tie-break on a broken key, so the hash
moved into the predicate instead, where the identity actually lives.

## Changes

- Match on the content hash in the query; drop the JavaScript recheck.
- Never reuse a row nothing references. An unreferenced row belongs to an
  in-flight batch, and sharing it puts one row under two owners — whichever
  batch fails first collects it out from under the other, and because
  `scene_assets.asset_id` cascades, the loser can return success with its glTF
  silently unlinked.

The second rule is what makes the reclaim in the next PR safe with no timing
assumption. No grace window fixes the shared case, because the two batches
overlap for exactly as long as the slower one runs.

Known limit, documented at the function: a row can lose its last reference
before the reusing batch commits, costing a failed save that succeeds on retry.
Closing that needs reuse to take a reference rather than observe one, which is a
schema change — filed, not done here.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

The defect only appears once duplicate rows exist, so it cannot be reproduced
against a mock. The namesake test seeds four same-named decoys before the wanted
row, so a name-keyed lookup has to walk past a wrong answer — with a single
decoy the old code passed or failed on whichever row the planner happened to
return, which made the assertion about the query plan rather than the code.

**Mutation gates.** Reverting to the name-only lookup turns *"reuses the row
holding these bytes, not an arbitrary namesake"* red. Reusing unreferenced rows
again turns *"does not share a row that no scene references yet"* red.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [ ] I updated documentation where needed
- [ ] I linked the related issue above

