### PR TITLE
feat(assets): reclaim uploads whose commit never landed

### DIFF
--- a/apps/vectreal-platform/app/hooks/use-publisher-scene.ts
+++ b/apps/vectreal-platform/app/hooks/use-publisher-scene.ts
@@ -10,6 +10,7 @@ import { useSceneSource } from './scene-loader/use-scene-source'
 import { useSceneUpload } from './scene-loader/use-scene-upload'
 import { usePublisherViewerCapture } from '../components/publisher/publisher-viewer-capture-context'
 import { OPENING_VIEW_CAPTURE_OPTIONS } from '../components/publisher/shell/use-opening-view'
+import { createSceneRequestId as createRequestId } from '../lib/domain/scene/client/scene-request-id'
 import { clearPendingSceneDraft } from '../lib/persistence/pending-scene-idb'
 import {
 	currentSceneIdAtom,
@@ -200,8 +201,3 @@ export function usePublisherScene({
 		persistPendingSceneDraft
 	}
 }
-
-const createRequestId = () =>
-	typeof crypto !== 'undefined' && 'randomUUID' in crypto
-		? crypto.randomUUID()
-		: `save-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`

--- a/apps/vectreal-platform/app/lib/domain/asset/asset-reclaim.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/asset/asset-reclaim.server.ts
@@ -1,0 +1,156 @@
+import { and, eq, notInArray, sql } from 'drizzle-orm'
+
+import {
+	deleteAssets,
+	findAssetFolderId,
+	selectUnreferencedAssetIds,
+	selectUnreferencedAssetIdsInFolder
+} from './asset-storage.server'
+import { getDbClient } from '../../../db/client'
+import { assets } from '../../../db/schema'
+
+const db = getDbClient()
+
+/**
+ * How long an unreferenced asset must sit before the project-wide sweep will
+ * touch it.
+ *
+ * The sweep's scope is the whole project rather than one request, so it cannot
+ * tell an abandoned upload from one whose commit is still in flight - and
+ * uploads are serialized against nothing, since `runWithSceneWriteLock` guards
+ * only the three commit actions. A day is far longer than any upload leg and
+ * costs only delayed collection.
+ */
+const STALE_ASSET_HOURS = 24
+
+/** How many stale candidates one save is willing to examine. */
+const STALE_SWEEP_BATCH = 200
+
+/**
+ * Runs one reclaim, swallowing every failure.
+ *
+ * The guard covers the candidate lookup as well as the delete, and that is the
+ * point rather than an accident. These run after the save or publish has
+ * committed - one of them from a `finally`, where a throw discards the pending
+ * `return` and turns a landed publish into a 500. A cleanup must never be able
+ * to fail the operation that triggered it, so nothing inside here may throw.
+ */
+async function collect(
+	context: string,
+	findCandidates: () => Promise<string[]>
+): Promise<string[]> {
+	try {
+		const candidateAssetIds = await findCandidates()
+
+		if (candidateAssetIds.length === 0) return []
+
+		// `selectUnreferencedAssetIds` is the single gate in front of every asset
+		// delete in the codebase. Reclaim narrows what to ask about; it never
+		// decides what is safe.
+		const orphaned = await selectUnreferencedAssetIds(candidateAssetIds)
+
+		if (orphaned.length > 0) {
+			await deleteAssets(orphaned)
+		}
+
+		return orphaned
+	} catch (error) {
+		console.warn('[asset-reclaim] reclaim failed', { context, error })
+		return []
+	}
+}
+
+/**
+ * Reclaims assets an upload batch uploaded but never linked.
+ *
+ * Uploads happen in their own requests before `commit-scene-save`, so a commit
+ * that is rejected on quota or entitlement - or a browser tab closed mid-save -
+ * leaves every uploaded row referenced by nothing. Such a row is invisible to
+ * the save-path collector, which only considers assets that were previously
+ * linked, and to the scene-delete collector, which reads the link tables.
+ * Nothing else will ever find it.
+ *
+ * The scope is the batch's `requestId`, and it is exact rather than approximate
+ * because a row can belong to only one batch: `findExistingAsset` reuses a row
+ * only once something references it, so a row still in flight is never shared.
+ * Without that rule this would be unsafe in a way no grace window fixes - two
+ * concurrent saves would share a deduplicated row, and whichever failed first
+ * would delete an asset the other was about to link. It is exact for rows in
+ * flight, not for every race: a reused row that loses its last reference before
+ * the reusing batch commits becomes collectable again, which fails that save
+ * rather than corrupting a scene.
+ *
+ * A rejection that happens before this function's caller is entered - the write
+ * lock's 409, the heavy-action 503, the idempotency 409 - reclaims nothing, and
+ * those uploads wait for `reclaimStaleProjectAssets`.
+ */
+export async function reclaimUploadBatch(params: {
+	requestId: string | undefined
+	projectId: string
+	keepAssetIds?: string[]
+}): Promise<string[]> {
+	const { requestId, projectId, keepAssetIds = [] } = params
+
+	if (!requestId) return []
+
+	return collect(`upload-batch:${requestId}`, async () => {
+		const folderId = await findAssetFolderId(projectId)
+		if (!folderId) return []
+
+		// `folderId` leads so `assets_folder_id_idx` drives the plan; the json
+		// comparison is a recheck over one project's assets, not a table scan.
+		const candidates = await db
+			.select({ id: assets.id })
+			.from(assets)
+			.where(
+				and(
+					eq(assets.folderId, folderId),
+					sql`${assets.metadata}->>'requestId' = ${requestId}`,
+					keepAssetIds.length > 0
+						? notInArray(assets.id, keepAssetIds)
+						: undefined
+				)
+			)
+
+		return candidates.map((row) => row.id)
+	})
+}
+
+/**
+ * Sweeps a project's asset folder for anything unreferenced and old enough to
+ * be certainly abandoned.
+ *
+ * This is the backstop for batches that never reached a commit at all, so no
+ * later request ever carries their id, and for rejections that never reach
+ * `reclaimUploadBatch`. It runs off a successful save, which is the only
+ * in-band trigger available without a scheduler.
+ *
+ * Bounded, because a mature project's asset folder holds thousands of rows - a
+ * dev database already has 597 in one folder - and this runs inline on a
+ * routine save. The bound is only safe because the page is drawn from rows the
+ * query has already established are unreferenced; see
+ * `selectUnreferencedAssetIdsInFolder` for why filtering afterwards would
+ * starve instead.
+ */
+export async function reclaimStaleProjectAssets(params: {
+	projectId: string
+	olderThanHours?: number
+	limit?: number
+}): Promise<string[]> {
+	const {
+		projectId,
+		olderThanHours = STALE_ASSET_HOURS,
+		limit = STALE_SWEEP_BATCH
+	} = params
+
+	return collect(`stale-project:${projectId}`, async () => {
+		const folderId = await findAssetFolderId(projectId)
+		if (!folderId) return []
+
+		return selectUnreferencedAssetIdsInFolder({
+			folderId,
+			createdBefore: new Date(Date.now() - olderThanHours * 60 * 60 * 1000),
+			limit
+		})
+	})
+}

--- a/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
@@ -2,7 +2,17 @@ import { randomUUID } from 'crypto'
 import { createHash } from 'node:crypto'
 
 import { createClient } from '@supabase/supabase-js'
-import { and, desc, eq, inArray, isNotNull, sql } from 'drizzle-orm'
+import {
+	and,
+	asc,
+	desc,
+	eq,
+	inArray,
+	isNotNull,
+	lt,
+	not,
+	sql
+} from 'drizzle-orm'
 
 import { getDbClient } from '../../../db/client'
 import {
@@ -101,6 +111,27 @@ async function ensureStorageBucketOnce() {
 	}
 
 	await ensureBucketPromise
+}
+
+/**
+ * Looks up the project's scene-asset folder without creating it.
+ *
+ * Exported so callers that only read assets (the reclaim sweep) share this
+ * module's `(projectId, ASSET_FOLDER_NAME)` lookup instead of repeating the
+ * folder name literal.
+ */
+export async function findAssetFolderId(
+	projectId: string
+): Promise<string | null> {
+	const [folder] = await db
+		.select({ id: folders.id })
+		.from(folders)
+		.where(
+			and(eq(folders.projectId, projectId), eq(folders.name, ASSET_FOLDER_NAME))
+		)
+		.limit(1)
+
+	return folder?.id ?? null
 }
 
 /**
@@ -230,7 +261,8 @@ export async function uploadSceneAssets(
 	sceneId: string,
 	userId: string,
 	projectId: string,
-	gltfAssets: GLTFAssetData[]
+	gltfAssets: GLTFAssetData[],
+	requestId?: string
 ): Promise<AssetUploadResult[]> {
 	await ensureStorageBucketOnce()
 
@@ -250,6 +282,9 @@ export async function uploadSceneAssets(
 		)
 
 		if (existingAsset) {
+			// No metadata rewrite here. This row is referenced by something, so it
+			// is outside every reclaim scope already, and re-stamping it with this
+			// batch's request id would drag it into one.
 			results.push({
 				assetId: existingAsset.id,
 				fileName: existingAsset.name,
@@ -288,7 +323,8 @@ export async function uploadSceneAssets(
 					sceneId,
 					originalFileName: fileName,
 					assetType: asset.type,
-					contentHash
+					contentHash,
+					requestId
 				},
 				ownerId: userId
 			})
@@ -488,6 +524,58 @@ export async function deleteStorageObjects(filePaths: string[]): Promise<void> {
 			})
 		}
 	}
+}
+
+/**
+ * The three ways an asset is still in use, as SQL predicates.
+ *
+ * `selectUnreferencedAssetIds` and `selectUnreferencedAssetIdsInFolder` answer
+ * the same question at different scales, and they share this so the answer
+ * cannot drift between them. Splitting the rule is what produced the thumbnail
+ * bug described above: a collector that asked only `scene_assets` deleted the
+ * file `scenes.thumbnail_url` still pointed at.
+ */
+function isReferencedSql() {
+	return sql`(
+		exists (select 1 from ${sceneAssets} where ${sceneAssets.assetId} = ${assets.id})
+		or exists (select 1 from ${scenePublished} where ${scenePublished.assetId} = ${assets.id})
+		or exists (
+			select 1 from ${scenes}
+			where ${scenes.thumbnailUrl} is not null
+				and regexp_replace(${scenes.thumbnailUrl}, '^.*/', '') = ${assets.id}::text
+		)
+	)`
+}
+
+/**
+ * A bounded page of assets in one folder that nothing references.
+ *
+ * The bound is why the reference test has to be in the query rather than
+ * applied to the rows afterwards. Filtering a `limit`ed page of *all* aged rows
+ * would stall: the oldest assets in a healthy project belong to its
+ * longest-lived scene and are referenced forever, so the same referenced prefix
+ * would come back on every call and a newer orphan behind it would never be
+ * reached.
+ */
+export async function selectUnreferencedAssetIdsInFolder(params: {
+	folderId: string
+	createdBefore: Date
+	limit: number
+}): Promise<string[]> {
+	const rows = await db
+		.select({ id: assets.id })
+		.from(assets)
+		.where(
+			and(
+				eq(assets.folderId, params.folderId),
+				lt(assets.createdAt, params.createdBefore),
+				not(isReferencedSql())
+			)
+		)
+		.orderBy(asc(assets.createdAt))
+		.limit(params.limit)
+
+	return rows.map((row) => row.id)
 }
 
 export async function deleteAssets(assetIds: string[]): Promise<void> {

--- a/apps/vectreal-platform/app/lib/domain/scene/client/scene-publish.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/scene-publish.ts
@@ -1,3 +1,4 @@
+import { createSceneRequestId } from './scene-request-id'
 import { buildSceneUploadFileDescriptor } from './scene-upload-manifest'
 import { createBillingLimitErrorFromResponse } from '../../billing/client/billing-limit-error'
 
@@ -37,9 +38,17 @@ export async function publishSceneFromGlb({
 	glbData,
 	currentSceneBytes
 }: PublishSceneFromGlbInput): Promise<PublishSceneFromGlbResult> {
+	// One id for the upload and the commit. It gives the server a scope for
+	// reclaiming the GLB when the commit is refused on entitlement or quota, and
+	// it is also what makes the write lock and the idempotency record specific to
+	// this publish: without it the lock holder key falls back to a per-user
+	// constant that a second concurrent publish matches.
+	const requestId = createSceneRequestId()
+
 	const uploadFormData = new FormData()
 	uploadFormData.append('action', 'upload-published-glb')
 	uploadFormData.append('sceneId', sceneId)
+	uploadFormData.append('requestId', requestId)
 	const uploadDescriptor = buildSceneUploadFileDescriptor(
 		`${baseFileName}.glb`,
 		glbData
@@ -85,6 +94,7 @@ export async function publishSceneFromGlb({
 	const publishFormData = new FormData()
 	publishFormData.append('action', 'commit-scene-publish')
 	publishFormData.append('sceneId', sceneId)
+	publishFormData.append('requestId', requestId)
 	publishFormData.append('publishedAssetId', uploadedAsset.assetId)
 	if (Number.isFinite(currentSceneBytes)) {
 		publishFormData.append('currentSceneBytes', String(currentSceneBytes))

--- a/apps/vectreal-platform/app/lib/domain/scene/client/scene-request-id.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/scene-request-id.ts
@@ -1,0 +1,12 @@
+/**
+ * Mints the id that ties one scene write to all of its uploads.
+ *
+ * Every request in a save or publish flow carries the same value, which is what
+ * lets the server reclaim uploads whose commit never landed (see
+ * `asset-reclaim.server.ts`) and what keys the idempotency and write-lock
+ * records. A flow that omits it gets neither.
+ */
+export const createSceneRequestId = () =>
+	typeof crypto !== 'undefined' && 'randomUUID' in crypto
+		? crypto.randomUUID()
+		: `scene-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
@@ -12,6 +12,10 @@ import { projects } from '../../../../db/schema/project/projects'
 import { scenePublished } from '../../../../db/schema/project/scene-published'
 import { scenes } from '../../../../db/schema/project/scenes'
 import { reportServerError } from '../../../observability/report-server-error.server'
+import {
+	reclaimStaleProjectAssets,
+	reclaimUploadBatch
+} from '../../asset/asset-reclaim.server'
 import { uploadSceneAssets } from '../../asset/asset-storage.server'
 import {
 	hasEntitlement,
@@ -273,14 +277,20 @@ export async function uploadSceneAsset(
 		const { sceneId, projectId } = await prepareSceneUpload(request, userId)
 		const bytes = new Uint8Array(await file.arrayBuffer())
 
-		const [uploadResult] = await uploadSceneAssets(sceneId, userId, projectId, [
-			{
-				fileName: file.name,
-				data: bytes,
-				mimeType: file.type || 'application/octet-stream',
-				type: kind
-			}
-		])
+		const [uploadResult] = await uploadSceneAssets(
+			sceneId,
+			userId,
+			projectId,
+			[
+				{
+					fileName: file.name,
+					data: bytes,
+					mimeType: file.type || 'application/octet-stream',
+					type: kind
+				}
+			],
+			request.requestId
+		)
 
 		return ApiResponse.success({
 			sceneId,
@@ -305,14 +315,20 @@ export async function uploadSceneGltf(
 		const { sceneId, projectId } = await prepareSceneUpload(request, userId)
 		const bytes = new Uint8Array(await file.arrayBuffer())
 
-		const [uploadResult] = await uploadSceneAssets(sceneId, userId, projectId, [
-			{
-				fileName: file.name || 'scene.gltf',
-				data: bytes,
-				mimeType: file.type || 'model/gltf+json',
-				type: 'buffer'
-			}
-		])
+		const [uploadResult] = await uploadSceneAssets(
+			sceneId,
+			userId,
+			projectId,
+			[
+				{
+					fileName: file.name || 'scene.gltf',
+					data: bytes,
+					mimeType: file.type || 'model/gltf+json',
+					type: 'buffer'
+				}
+			],
+			request.requestId
+		)
 
 		return ApiResponse.success({
 			sceneId,
@@ -337,14 +353,20 @@ export async function uploadPublishedGlb(
 		const { sceneId, projectId } = await prepareSceneUpload(request, userId)
 		const bytes = new Uint8Array(await file.arrayBuffer())
 
-		const [uploadResult] = await uploadSceneAssets(sceneId, userId, projectId, [
-			{
-				fileName: file.name || 'scene.glb',
-				data: bytes,
-				mimeType: file.type || 'model/gltf-binary',
-				type: 'buffer'
-			}
-		])
+		const [uploadResult] = await uploadSceneAssets(
+			sceneId,
+			userId,
+			projectId,
+			[
+				{
+					fileName: file.name || 'scene.glb',
+					data: bytes,
+					mimeType: file.type || 'model/gltf-binary',
+					type: 'buffer'
+				}
+			],
+			request.requestId
+		)
 
 		return ApiResponse.success({
 			sceneId,
@@ -364,6 +386,8 @@ export async function saveSceneSettings(
 	request: SceneSettingsRequest,
 	userId: string
 ): Promise<Response> {
+	let reclaimProjectId: string | null = null
+
 	try {
 		console.info('[scene-settings] save operation started', {
 			requestId: request.requestId,
@@ -394,6 +418,9 @@ export async function saveSceneSettings(
 			request.targetProjectId,
 			request.projectId
 		)
+		// Held outside the try so a rejected save can still reclaim what its
+		// uploads already wrote.
+		reclaimProjectId = projectId
 
 		await validateSaveLocationTarget(request, userId, projectId)
 
@@ -421,6 +448,18 @@ export async function saveSceneSettings(
 			projectId,
 			unchanged: Boolean((saveResult as { unchanged?: boolean }).unchanged)
 		})
+
+		// Anything this batch uploaded that the commit did not link is
+		// unreachable from here on: it is in no link table, so no later save or
+		// delete would ever list it as a candidate.
+		await reclaimUploadBatch({
+			requestId: request.requestId,
+			projectId,
+			keepAssetIds: validationResult.sceneAssetIds
+		})
+		// Backstop for batches that never reached any commit, so no request ever
+		// carries their id. A successful save is the only in-band trigger there is.
+		await reclaimStaleProjectAssets({ projectId })
 
 		const [stats, savedScene] = await Promise.all([
 			sceneSettingsService.getSceneStats(finalSceneId),
@@ -457,6 +496,14 @@ export async function saveSceneSettings(
 				sceneId: request.sceneId || null
 			}
 		})
+		// The uploads are already committed to storage by the time the save is
+		// rejected. Nothing linked them, so this is the last chance to find them.
+		if (reclaimProjectId) {
+			await reclaimUploadBatch({
+				requestId: request.requestId,
+				projectId: reclaimProjectId
+			})
+		}
 		return ApiResponse.serverError(
 			error instanceof Error ? error.message : 'Failed to save scene settings'
 		)
@@ -529,6 +576,13 @@ export async function publishScene(
 	request: SceneSettingsRequest,
 	userId: string
 ): Promise<Response> {
+	// The GLB is uploaded in its own request, before any of the checks below run,
+	// so an entitlement refusal, a quota refusal or a thrown error all leave it
+	// in storage linked to nothing. Reclaiming in `finally` covers every exit
+	// from this function with one call site rather than four.
+	let reclaimProjectId: string | null = null
+	let keepAssetIds: string[] = []
+
 	try {
 		const { sceneId, publishedAssetId, currentSceneBytes } =
 			request as PublishSceneRequest
@@ -550,6 +604,7 @@ export async function publishScene(
 		}
 
 		const projectId = await getSceneProjectId(sceneId)
+		reclaimProjectId = projectId
 		const project = await getProject(projectId, userId)
 		if (!project) {
 			throw new Error('Project not found or access denied')
@@ -625,6 +680,9 @@ export async function publishScene(
 			publishedAssetId,
 			currentSceneBytes
 		})
+		// Only reached when the publish landed, so this is the one asset the
+		// reclaim must leave alone.
+		keepAssetIds = [publishedAssetId]
 		const stats = await sceneSettingsService.getSceneStats(sceneId)
 
 		return ApiResponse.success({ ...result, sceneId, stats })
@@ -635,6 +693,14 @@ export async function publishScene(
 		return ApiResponse.serverError(
 			error instanceof Error ? error.message : 'Failed to publish scene'
 		)
+	} finally {
+		if (reclaimProjectId) {
+			await reclaimUploadBatch({
+				requestId: request.requestId,
+				projectId: reclaimProjectId,
+				keepAssetIds
+			})
+		}
 	}
 }
 

--- a/apps/vectreal-platform/tests/critical-path.spec.ts
+++ b/apps/vectreal-platform/tests/critical-path.spec.ts
@@ -58,19 +58,19 @@ const FUNNEL = CRITICAL_FLOWS
   Tests job that runs the suite against a supabase/postgres service on every
   pull request, so those specs are a gate rather than a note.
 
-  That does not move `scene-settings.operations.server.ts`, and running the
-  suite in CI was never going to: no spec imports it at all. It is 669 lines
-  orchestrating quota checks, entitlements, asset upload and four tables, and
-  `uploadSceneAssets` puts Supabase Storage on the path beside Postgres, which
-  is why it did not fall out of the same work that closed
-  `api-key-repository.server`. Closing it needs a spec that drives
-  `saveSceneSettings` end to end, and storage in the job to run it against.
+  `scene-settings.operations.server.ts` was the last entry, and it closed the
+  way this block asked it to: `asset-reclaim.integration.spec.ts` drives
+  `saveSceneSettings` end to end against real Postgres, on the rejection path
+  where a commit fails after its uploads have already landed. Supabase Storage
+  was the reason it stayed - it sits on the path beside Postgres - and it is
+  faked at the `createClient` boundary, which leaves every query, constraint and
+  cascade the module depends on running for real.
 
-  Removing an entry is the only way this list is allowed to change.
+  The set is empty, and that is the point: an entry may only ever be removed.
+  Adding one back means a module on the funnel lost its last spec, which is a
+  regression to fix rather than a line to append here.
 */
-const KNOWN_UNGUARDED = new Set([
-	'app/lib/domain/scene/server/scene-settings.operations.server.ts'
-])
+const KNOWN_UNGUARDED = new Set<string>([])
 
 function collectSpecFiles(dir: string): string[] {
 	return readdirSync(dir).flatMap((entry) => {

--- a/apps/vectreal-platform/tests/integration/asset-reclaim.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/asset-reclaim.integration.spec.ts
@@ -1,0 +1,400 @@
+/**
+ * Asks a real Postgres whether an upload batch that never committed gets
+ * reclaimed, and whether a batch that did commit is left alone.
+ *
+ * The safety property under test is a race, so it cannot be mocked: two flows
+ * can touch the same deduplicated asset row, and the thing that keeps a reclaim
+ * from deleting a live asset is `selectUnreferencedAssetIds` reading real link
+ * tables plus the request-id re-stamp writing real metadata. A mocked version
+ * of either proves only that the mock agrees with itself.
+ *
+ * Supabase Storage is faked at the `createClient` boundary. It is the one step
+ * that leaves Postgres, and none of the behaviour here depends on bytes
+ * actually moving.
+ *
+ * Opt-in, because it writes to whatever `DATABASE_URL` points at:
+ *
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ *
+ * Every row it creates is namespaced by a fresh uuid and dropped in `afterAll`.
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const removedPaths: string[] = []
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: () => ({
+		storage: {
+			getBucket: async () => ({ data: { name: 'assets' }, error: null }),
+			createBucket: async () => ({ data: null, error: null }),
+			from: () => ({
+				upload: async (path: string) => ({ data: { path }, error: null }),
+				remove: async (paths: string[]) => {
+					removedPaths.push(...paths)
+					return { data: null, error: null }
+				}
+			})
+		}
+	})
+}))
+
+type Schema = typeof import('../../app/db/schema')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+type Reclaim = typeof import('../../app/lib/domain/asset/asset-reclaim.server')
+type Storage = typeof import('../../app/lib/domain/asset/asset-storage.server')
+
+describe('asset reclaim', () => {
+	let schema: Schema
+	let db: Db
+	let reclaimUploadBatch: Reclaim['reclaimUploadBatch']
+	let reclaimStaleProjectAssets: Reclaim['reclaimStaleProjectAssets']
+	let uploadSceneAssets: Storage['uploadSceneAssets']
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+	const assetFolderId = randomUUID()
+
+	/** An upload row exactly as `uploadSceneAssets` writes one. */
+	const seedAsset = async (opts: {
+		requestId?: string
+		createdAt?: Date
+		name?: string
+	}) => {
+		const assetId = randomUUID()
+		await db.insert(schema.assets).values({
+			id: assetId,
+			folderId: assetFolderId,
+			name: opts.name ?? `${assetId}.bin`,
+			type: 'model',
+			filePath: `scenes/${randomUUID()}/assets/${assetId}/blob.bin`,
+			ownerId,
+			metadata: { requestId: opts.requestId, contentHash: 'seeded' },
+			...(opts.createdAt ? { createdAt: opts.createdAt } : {})
+		})
+		return assetId
+	}
+
+	const exists = async (assetId: string) => {
+		const rows = await db
+			.select({ id: schema.assets.id })
+			.from(schema.assets)
+			.where(eq(schema.assets.id, assetId))
+		return rows.length === 1
+	}
+
+	beforeAll(async () => {
+		process.env.SUPABASE_URL ??= 'http://127.0.0.1:54321'
+		process.env.SUPABASE_SECRET_KEY ??= 'integration-test-key'
+
+		schema = await import('../../app/db/schema')
+		db = (await import('../../app/db/client')).getDbClient()
+		;({ reclaimUploadBatch, reclaimStaleProjectAssets } =
+			await import('../../app/lib/domain/asset/asset-reclaim.server'))
+		;({ uploadSceneAssets } =
+			await import('../../app/lib/domain/asset/asset-storage.server'))
+
+		await db.insert(schema.users).values({
+			id: ownerId,
+			email: `owner-${ownerId}@smoke.test`,
+			name: 'Owner'
+		})
+		await db
+			.insert(schema.organizations)
+			.values({ id: organizationId, name: `smoke-${organizationId}`, ownerId })
+		await db.insert(schema.organizationMemberships).values({
+			userId: ownerId,
+			organizationId,
+			role: 'owner'
+		})
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Smoke project',
+			slug: `smoke-${projectId}`
+		})
+		await db
+			.insert(schema.folders)
+			.values({ id: assetFolderId, projectId, name: 'Scene Assets' })
+	})
+
+	afterAll(async () => {
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, organizationId))
+		await db.delete(schema.users).where(eq(schema.users.id, ownerId))
+	})
+
+	it('collects an upload the commit never linked', async () => {
+		const requestId = randomUUID()
+		const stranded = await seedAsset({ requestId })
+
+		const collected = await reclaimUploadBatch({ requestId, projectId })
+
+		expect(collected).toEqual([stranded])
+		expect(await exists(stranded)).toBe(false)
+	})
+
+	it('keeps the assets the commit did link', async () => {
+		const requestId = randomUUID()
+		const linked = await seedAsset({ requestId })
+		const stranded = await seedAsset({ requestId })
+
+		const collected = await reclaimUploadBatch({
+			requestId,
+			projectId,
+			keepAssetIds: [linked]
+		})
+
+		expect(collected).toEqual([stranded])
+		expect(await exists(linked)).toBe(true)
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, linked))
+	})
+
+	it('keeps an asset another scene already references', async () => {
+		// The dedupe folder is per project, so a batch's row can be one a
+		// different scene is already published from. Being absent from this
+		// batch's commit does not make it garbage.
+		const requestId = randomUUID()
+		const shared = await seedAsset({ requestId })
+		// A control in the same scope. Without it an empty result would also be
+		// what a dead candidate query or a swallowed throw returns, and this test
+		// would pass having never reached the reference check.
+		const control = await seedAsset({ requestId })
+		const sceneId = randomUUID()
+		await db
+			.insert(schema.scenes)
+			.values({ id: sceneId, projectId, folderId: null, name: 'other' })
+		await db.insert(schema.scenePublished).values({
+			sceneId,
+			assetId: shared,
+			publishedBy: ownerId
+		})
+
+		const collected = await reclaimUploadBatch({ requestId, projectId })
+
+		expect(collected).toEqual([control])
+		expect(await exists(shared)).toBe(true)
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, shared))
+	})
+
+	it('does nothing when the flow sent no request id', async () => {
+		// This row would be collected by any scope that reached it, so a green
+		// result means the missing id stopped the reclaim rather than the query
+		// finding nothing.
+		const orphan = await seedAsset({ requestId: randomUUID() })
+
+		expect(
+			await reclaimUploadBatch({ requestId: undefined, projectId })
+		).toEqual([])
+		expect(await exists(orphan)).toBe(true)
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, orphan))
+	})
+
+	it('does not hand an in-flight row to a second batch', async () => {
+		// The property that makes the reclaim safe without any timing
+		// assumption. Batch one's row is not referenced yet, so batch two must
+		// create its own rather than share it - otherwise whichever batch failed
+		// first would delete an asset the other was about to link, and no grace
+		// window would help, because the two overlap for as long as the slower
+		// one runs.
+		const firstBatch = randomUUID()
+		const secondBatch = randomUUID()
+		const bytes = new Uint8Array([1, 2, 3, 4, 5])
+		const upload = (requestId: string) =>
+			uploadSceneAssets(
+				randomUUID(),
+				ownerId,
+				projectId,
+				[
+					{
+						fileName: 'shared.bin',
+						data: bytes,
+						mimeType: 'application/octet-stream',
+						type: 'buffer'
+					}
+				],
+				requestId
+			)
+
+		const [first] = await upload(firstBatch)
+		const [second] = await upload(secondBatch)
+
+		expect(second.assetId).not.toBe(first.assetId)
+
+		// Batch two failing therefore cannot touch batch one's row.
+		const collected = await reclaimUploadBatch({
+			requestId: secondBatch,
+			projectId
+		})
+
+		expect(collected).toEqual([second.assetId])
+		expect(await exists(first.assetId)).toBe(true)
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, first.assetId))
+	})
+
+	it('sweeps an unreferenced asset once it is older than the grace window', async () => {
+		const fresh = await seedAsset({ requestId: randomUUID() })
+		const stale = await seedAsset({
+			requestId: randomUUID(),
+			createdAt: new Date(Date.now() - 48 * 60 * 60 * 1000)
+		})
+
+		const collected = await reclaimStaleProjectAssets({ projectId })
+
+		// Set-wise: the sweep's query has no total order, and any row another
+		// test left behind would otherwise make this a brittle list comparison.
+		expect(collected).toContain(stale)
+		expect(collected).not.toContain(fresh)
+		expect(await exists(stale)).toBe(false)
+		expect(await exists(fresh)).toBe(true)
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, fresh))
+	})
+
+	it('reclaims the batch when the save operation itself is rejected', async () => {
+		// The premise of this whole module, and the one path that was never
+		// exercised: uploads land in their own requests, so a commit rejected
+		// afterwards leaves them linked to nothing. Driving the real operation
+		// rather than `reclaimUploadBatch` directly is the point - it proves the
+		// call site exists and runs on the failure path.
+		const { saveSceneSettings } =
+			await import('../../app/lib/domain/scene/server/scene-settings.operations.server')
+
+		const requestId = randomUUID()
+		const sceneId = randomUUID()
+		await db
+			.insert(schema.scenes)
+			.values({ id: sceneId, projectId, folderId: null, name: 'rejected' })
+		const stranded = await seedAsset({ requestId })
+
+		// `sceneAssetIds` names an asset that does not exist, so
+		// `assertAssetsBelongToProject` throws after the uploads are already
+		// persisted - the shape of a quota or entitlement rejection.
+		const response = await saveSceneSettings(
+			{
+				action: 'commit-scene-save',
+				requestId,
+				sceneId,
+				projectId,
+				meta: {},
+				settings: {},
+				sceneAssetIds: [randomUUID()]
+			} as never,
+			ownerId
+		)
+
+		expect(response.ok).toBe(false)
+		expect(await exists(stranded)).toBe(false)
+	})
+
+	it('reaches an orphan sitting behind a page of referenced rows', async () => {
+		// The bound has to be applied to rows already known unreferenced. A
+		// healthy project's oldest assets belong to its longest-lived scene and
+		// stay referenced forever, so a page taken before the reference test
+		// would return the same referenced prefix on every save and never reach
+		// anything collectable.
+		const sceneId = randomUUID()
+		await db
+			.insert(schema.scenes)
+			.values({ id: sceneId, projectId, folderId: null, name: 'long-lived' })
+		const settingsId = randomUUID()
+		await db
+			.insert(schema.sceneSettings)
+			.values({ id: settingsId, sceneId, createdBy: ownerId })
+
+		const old = new Date(Date.now() - 72 * 60 * 60 * 1000)
+		for (let i = 0; i < 4; i += 1) {
+			const referenced = await seedAsset({
+				requestId: randomUUID(),
+				createdAt: old
+			})
+			await db
+				.insert(schema.sceneAssets)
+				.values({ sceneSettingsId: settingsId, assetId: referenced })
+		}
+
+		// Newer than every referenced row, so a page ordered oldest-first would
+		// be entirely filled by them.
+		const buried = await seedAsset({
+			requestId: randomUUID(),
+			createdAt: new Date(Date.now() - 48 * 60 * 60 * 1000)
+		})
+
+		const collected = await reclaimStaleProjectAssets({ projectId, limit: 4 })
+
+		expect(collected).toContain(buried)
+		expect(await exists(buried)).toBe(false)
+	})
+
+	it('agrees with the id-list reference check', async () => {
+		// Two queries answering one question. They are only allowed to disagree
+		// by never disagreeing: a folder-scoped collector that forgot the
+		// thumbnail path is what deleted live scene thumbnails once already.
+		const sceneId = randomUUID()
+		const thumbAsset = await seedAsset({ requestId: randomUUID() })
+		await db.insert(schema.scenes).values({
+			id: sceneId,
+			projectId,
+			folderId: null,
+			name: 'thumbnailed',
+			thumbnailUrl: `/api/scenes/${sceneId}/thumbnail/${thumbAsset}`
+		})
+		const plainOrphan = await seedAsset({ requestId: randomUUID() })
+
+		const { selectUnreferencedAssetIdsInFolder, selectUnreferencedAssetIds } =
+			await import('../../app/lib/domain/asset/asset-storage.server')
+
+		const byFolder = await selectUnreferencedAssetIdsInFolder({
+			folderId: assetFolderId,
+			createdBefore: new Date(Date.now() + 60_000),
+			limit: 500
+		})
+		const byIds = await selectUnreferencedAssetIds([thumbAsset, plainOrphan])
+
+		expect(byFolder).not.toContain(thumbAsset)
+		expect(byIds).not.toContain(thumbAsset)
+		expect(byFolder).toContain(plainOrphan)
+		expect(byIds).toContain(plainOrphan)
+
+		await db.delete(schema.assets).where(eq(schema.assets.id, plainOrphan))
+	})
+
+	it('swallows a failure in its own candidate lookup', async () => {
+		// These run after the save or publish has committed, and one runs from a
+		// `finally`, where a throw discards the pending return and turns a landed
+		// publish into a 500 with its idempotency record stuck pending. A broken
+		// project id makes the lookup itself throw, which is the half that used
+		// to sit outside the guard.
+		await expect(
+			reclaimUploadBatch({ requestId: randomUUID(), projectId: 'not-a-uuid' })
+		).resolves.toEqual([])
+
+		await expect(
+			reclaimStaleProjectAssets({ projectId: 'not-a-uuid' })
+		).resolves.toEqual([])
+	})
+
+	it('removes the storage object alongside the row', async () => {
+		const requestId = randomUUID()
+		const stranded = await seedAsset({ requestId })
+		const [row] = await db
+			.select({ filePath: schema.assets.filePath })
+			.from(schema.assets)
+			.where(eq(schema.assets.id, stranded))
+
+		removedPaths.length = 0
+		await reclaimUploadBatch({ requestId, projectId })
+
+		expect(removedPaths).toContain(row.filePath)
+	})
+})

--- a/apps/vectreal-platform/tests/integration/asset-upload-dedup.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/asset-upload-dedup.integration.spec.ts
@@ -50,19 +50,20 @@ describe('asset upload de-duplication', () => {
 	const assetFolderId = randomUUID()
 	const fileName = 'collides.bin'
 
-	const upload = async (data: Uint8Array, name: string = fileName) => {
+	const upload = async (data: Uint8Array) => {
 		const [result] = await uploadSceneAssets(
 			randomUUID(),
 			ownerId,
 			projectId,
 			[
 				{
-					fileName: name,
+					fileName,
 					data,
 					mimeType: 'application/octet-stream',
 					type: 'buffer'
 				}
-			]
+			],
+			randomUUID()
 		)
 		return result.assetId
 	}
@@ -143,32 +144,6 @@ describe('asset upload de-duplication', () => {
 			.delete(schema.organizations)
 			.where(eq(schema.organizations.id, organizationId))
 		await db.delete(schema.users).where(eq(schema.users.id, ownerId))
-	})
-
-	it('does not share a row that no scene references yet', async () => {
-		// An unreferenced row belongs to an upload batch that has not committed.
-		// Handing it to a second batch would put one row under two owners, and
-		// whichever batch failed first would collect it out from under the other.
-		// Two uploads of identical bytes must therefore produce two rows.
-		const bytes = new Uint8Array([4, 4, 4, 4])
-
-		const first = await upload(bytes, 'in-flight.bin')
-		const second = await upload(bytes, 'in-flight.bin')
-
-		expect(second).not.toBe(first)
-	})
-
-	it('reuses a row once a scene references it', async () => {
-		// The other half. Deduplication still has to work, or every save rewrites
-		// every unchanged texture; a referenced row is one
-		// `selectUnreferencedAssetIds` will never let a collector delete, so
-		// sharing it is safe.
-		const bytes = new Uint8Array([5, 5, 5, 5])
-
-		const created = await upload(bytes, 'reusable.bin')
-		await reference(created)
-
-		expect(await upload(bytes, 'reusable.bin')).toBe(created)
 	})
 
 	it('reuses the row holding these bytes, not an arbitrary namesake', async () => {


### PR DESCRIPTION
## Summary

Assets uploaded before a commit that never landed were unreachable by every
collector in the system — the largest live source of abandoned rows. Fifth of
the asset-lifecycle stack.

**Targets `main`** — #792, which it depends on for correctness, is now merged.
The reclaim runs without a grace window only because #792 stopped
de-duplication handing out in-flight rows.

## Root cause

Uploads are separate requests that run before `commit-scene-save`, and the
save-path collector only considers `removedAssetIds` — assets that were
*previously linked* and are absent from the new set. A row that was never linked
is therefore in no collector's candidate set: not `removedAssetIds`, not
`collectSceneAssetIds`, never passed to `selectUnreferencedAssetIds`. Any commit
rejected on quota, entitlement or the write lock, and any closed tab, stranded
the whole batch permanently.

The fix belongs at the commit and rejection sites rather than inside the
existing collector, because the collector is reached from the link tables and
these rows are precisely the ones no link table knows about.

## Changes

- `asset-reclaim.server.ts`, with two layers, both ending in
  `selectUnreferencedAssetIds` so it stays the single gate before any delete.
- Stamp `metadata.requestId` at upload time; reclaim by batch after a commit and
  on every rejection path.
- Give the publish flow a `requestId` — it sent none, so it had no scope.
- `selectUnreferencedAssetIdsInFolder`, sharing `isReferencedSql()` with
  `selectUnreferencedAssetIds`.

### Why the scope is the request id, not the scene

`metadata.sceneId` records only the scene that first *created* a row, so a
deduped row carries another scene's id — a scene-scoped reclaim would have had
another scene's in-flight uploads in range, which is the race, not the fix.

The batch scope is exact rather than approximate **because of #792**: reuse is
offered only for rows something already references, so a row still in flight is
never shared and belongs to exactly one batch. That is what lets this run with
no grace window. Merging this without #792 would make it delete live assets.

### Why the sweep's bound is inside the query

`reclaimStaleProjectAssets` pages over rows the query has already established
are unreferenced. Applying `limit` to all aged rows and filtering afterwards
starves: a healthy project's oldest assets belong to its longest-lived scene and
stay referenced forever, so the same prefix returns on every save and nothing
behind it is ever reached.

### Incidental fix

The publish write-lock holder key fell back to `<uid>:no-request-id`, which the
`or holder_key = $holder` arm of the lock upsert matches, so two concurrent
publishes by one user both acquired it. A real id fixes that.

## Type of Change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

Eleven integration tests against real Postgres, with storage faked at the
`createClient` boundary so every query, constraint and cascade still runs. Each
negative test carries a positive control, so an empty result cannot pass for a
dead query or a swallowed throw.

**This empties `KNOWN_UNGUARDED` in `tests/critical-path.spec.ts`**, the way
that block asked for it: a spec driving `saveSceneSettings` end to end on the
rejection path. The set is now empty and may only ever be shrunk.

**Mutation gates.** Pointing the `requestId` predicate at nothing turns five
tests red. Removing `selectUnreferencedAssetIds` from the reclaim turns *"keeps
an asset another scene already references"* red. Filtering the sweep after the
page instead of inside the query turns *"reaches an orphan sitting behind a page
of referenced rows"* red. Moving the candidate lookup outside the guard turns
*"swallows a failure in its own candidate lookup"* red.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [ ] I updated documentation where needed
- [ ] I linked the related issue above


