### PR TITLE
fix(assets): remove storage objects before an FK cascade drops their rows

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
@@ -407,6 +407,44 @@ export async function selectUnreferencedAssetIds(
 	return assetIds.filter((assetId) => !referenced.has(assetId))
 }
 
+/**
+ * Removes objects from the bucket by path, with no asset row involved.
+ *
+ * `deleteAssets` cannot serve every caller, because it reads the row to find
+ * the path. When a delete cascades - `organizations -> projects -> folders ->
+ * assets` is cascading the whole way down - the rows are gone before anything
+ * can react, and `file_path` goes with them. After that the objects cannot be
+ * located at all, so the paths have to be read before the delete and handed
+ * here after it.
+ *
+ * Chunked because Supabase caps the number of keys per `remove` call. Missing
+ * objects are not an error: the point is that the bucket ends up without them.
+ */
+export async function deleteStorageObjects(filePaths: string[]): Promise<void> {
+	if (filePaths.length === 0) return
+
+	await ensureStorageBucketOnce()
+
+	const storage = getStorageClient()
+	const CHUNK_SIZE = 100
+
+	for (let i = 0; i < filePaths.length; i += CHUNK_SIZE) {
+		const chunk = filePaths.slice(i, i + CHUNK_SIZE)
+
+		try {
+			const { error } = await storage.from(STORAGE_BUCKET).remove(chunk)
+
+			if (error && !/not found/i.test(error.message)) {
+				throw new Error(error.message)
+			}
+		} catch (error) {
+			reportServerError(error, {
+				properties: { objectCount: chunk.length, firstPath: chunk[0] }
+			})
+		}
+	}
+}
+
 export async function deleteAssets(assetIds: string[]): Promise<void> {
 	await ensureStorageBucketOnce()
 

--- a/apps/vectreal-platform/app/lib/domain/organization/organization-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/organization/organization-repository.server.ts
@@ -322,5 +322,11 @@ export async function deleteOrganization(
 		)
 	}
 
+	// No storage cleanup here, and this guard is why. Assets reach an
+	// organization only through `projects -> folders -> assets`, so an
+	// organization with no projects owns no assets, and `deleteProject` has
+	// already removed the objects for each project on the way out. Remove this
+	// check and organization deletion starts stranding storage that nothing can
+	// name afterwards.
 	await db.delete(organizations).where(eq(organizations.id, organizationId))
 }

--- a/apps/vectreal-platform/app/lib/domain/project/project-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/project/project-repository.server.ts
@@ -2,7 +2,10 @@ import { and, asc, eq } from 'drizzle-orm'
 
 import { getDbClient } from '../../../db/client'
 import { organizationMemberships } from '../../../db/schema/core/organization-memberships'
+import { assets } from '../../../db/schema/project/assets'
+import { folders } from '../../../db/schema/project/folders'
 import { projects } from '../../../db/schema/project/projects'
+import { deleteStorageObjects } from '../asset/asset-storage.server'
 import {
 	getOrgSubscription,
 	getQuotaLimit,
@@ -205,5 +208,21 @@ export async function deleteProject(
 
 	assertDashboardPermission('project:delete', { role: membership.role })
 
+	// Read before the delete, because there is nothing to read after it.
+	// `projects -> folders -> assets` cascades, so the asset rows - and the
+	// `file_path` on each of them - are gone the moment the project row is, and
+	// the objects they name become unreachable: no query can find them again and
+	// no later cleanup can name them.
+	const assetPaths = await db
+		.select({ filePath: assets.filePath })
+		.from(assets)
+		.innerJoin(folders, eq(folders.id, assets.folderId))
+		.where(eq(folders.projectId, projectId))
+
 	await db.delete(projects).where(eq(projects.id, projectId))
+
+	// After the delete and outside any transaction: a storage failure must not
+	// resurrect a project the user has already been told is gone. A stranded
+	// object is recoverable, a half-deleted project is not.
+	await deleteStorageObjects(assetPaths.map((row) => row.filePath))
 }

--- a/apps/vectreal-platform/app/lib/domain/user/user-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/user/user-repository.server.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm'
+import { and, eq, or } from 'drizzle-orm'
 
 export interface ProfileUpdateData {
 	role?: string | null
@@ -12,7 +12,10 @@ import { orgSubscriptions } from '../../../db/schema/billing/subscriptions'
 import { organizationMemberships } from '../../../db/schema/core/organization-memberships'
 import { organizations } from '../../../db/schema/core/organizations'
 import { users } from '../../../db/schema/core/users'
+import { assets } from '../../../db/schema/project/assets'
+import { folders } from '../../../db/schema/project/folders'
 import { projects } from '../../../db/schema/project/projects'
+import { deleteStorageObjects } from '../asset/asset-storage.server'
 
 import type { User } from '@supabase/supabase-js'
 
@@ -456,6 +459,17 @@ export async function updateUserProfile(
 }
 
 export async function deleteUserAndRelatedData(userId: string): Promise<void> {
+	// Two cascades reach assets from a user: `assets.owner_id` directly, and
+	// `organizations.owner_id -> projects -> folders -> assets`. Both drop the
+	// rows that hold `file_path`, so the paths are read while they still exist.
+	const assetPaths = await db
+		.selectDistinct({ filePath: assets.filePath })
+		.from(assets)
+		.leftJoin(folders, eq(folders.id, assets.folderId))
+		.leftJoin(projects, eq(projects.id, folders.projectId))
+		.leftJoin(organizations, eq(organizations.id, projects.organizationId))
+		.where(or(eq(assets.ownerId, userId), eq(organizations.ownerId, userId)))
+
 	const deletedUsers = await db.transaction(async (tx) => {
 		// `organization_memberships.invited_by` intentionally uses NO ACTION to
 		// preserve invite history, so clear references before deleting the user.
@@ -473,4 +487,9 @@ export async function deleteUserAndRelatedData(userId: string): Promise<void> {
 	if (deletedUsers.length === 0) {
 		throw new Error('User account not found')
 	}
+
+	// Outside the transaction and never fatal: the caller goes on to delete the
+	// Supabase auth user, and a half-deleted account is worse than a stranded
+	// object.
+	await deleteStorageObjects(assetPaths.map((row) => row.filePath))
 }

--- a/apps/vectreal-platform/tests/integration/project-delete-storage.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/project-delete-storage.integration.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Asks a real Postgres whether a project delete can still name its storage
+ * objects.
+ *
+ * The whole defect is a race with the FK cascade, and the cascade is the part a
+ * mock cannot reproduce: `projects -> folders -> assets` is cascading the whole
+ * way down, so the rows carrying `file_path` disappear inside the same
+ * statement that removes the project. Read them a moment too late and the
+ * objects are unnameable forever. The second test pins that premise directly,
+ * so the first one cannot quietly stop meaning anything.
+ *
+ * Opt-in:
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const deleteStorageObjectsSpy = vi.fn()
+
+vi.mock(
+	'../../app/lib/domain/asset/asset-storage.server',
+	async (importOriginal) => {
+		const actual =
+			await importOriginal<
+				typeof import('../../app/lib/domain/asset/asset-storage.server')
+			>()
+		return { ...actual, deleteStorageObjects: deleteStorageObjectsSpy }
+	}
+)
+
+type Schema = typeof import('../../app/db/schema')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+type Repo =
+	typeof import('../../app/lib/domain/project/project-repository.server')
+
+describe('project delete storage cleanup', () => {
+	let schema: Schema
+	let db: Db
+	let deleteProject: Repo['deleteProject']
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+
+	const seedProject = async () => {
+		const projectId = randomUUID()
+		const folderId = randomUUID()
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Doomed project',
+			slug: `doomed-${projectId}`
+		})
+		await db
+			.insert(schema.folders)
+			.values({ id: folderId, projectId, name: 'Scene Assets' })
+
+		const paths: string[] = []
+		for (const name of ['scene.gltf', 'buffer.bin']) {
+			const assetId = randomUUID()
+			const filePath = `scenes/${randomUUID()}/assets/${assetId}/${name}`
+			await db.insert(schema.assets).values({
+				id: assetId,
+				folderId,
+				name,
+				type: 'model',
+				filePath,
+				ownerId
+			})
+			paths.push(filePath)
+		}
+
+		return { projectId, folderId, paths }
+	}
+
+	beforeAll(async () => {
+		schema = await import('../../app/db/schema')
+		db = (await import('../../app/db/client')).getDbClient()
+		;({ deleteProject } =
+			await import('../../app/lib/domain/project/project-repository.server'))
+
+		await db.insert(schema.users).values({
+			id: ownerId,
+			email: `owner-${ownerId}@smoke.test`,
+			name: 'Owner'
+		})
+		await db
+			.insert(schema.organizations)
+			.values({ id: organizationId, name: `smoke-${organizationId}`, ownerId })
+		await db.insert(schema.organizationMemberships).values({
+			userId: ownerId,
+			organizationId,
+			role: 'owner'
+		})
+	})
+
+	afterAll(async () => {
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, organizationId))
+		await db.delete(schema.users).where(eq(schema.users.id, ownerId))
+	})
+
+	it('hands storage every path the project owned', async () => {
+		const { projectId, paths } = await seedProject()
+		deleteStorageObjectsSpy.mockClear()
+
+		await deleteProject(projectId, ownerId)
+
+		expect(deleteStorageObjectsSpy).toHaveBeenCalledTimes(1)
+		expect([...deleteStorageObjectsSpy.mock.calls[0][0]].sort()).toEqual(
+			[...paths].sort()
+		)
+	})
+
+	it('cascades the asset rows away, so the paths are unreadable afterwards', async () => {
+		const { projectId, folderId } = await seedProject()
+
+		const before = await db
+			.select({ id: schema.assets.id })
+			.from(schema.assets)
+			.where(eq(schema.assets.folderId, folderId))
+		expect(before).toHaveLength(2)
+
+		await deleteProject(projectId, ownerId)
+
+		const after = await db
+			.select({ id: schema.assets.id })
+			.from(schema.assets)
+			.where(eq(schema.assets.folderId, folderId))
+		expect(after).toEqual([])
+	})
+})


### PR DESCRIPTION
## Summary

Deleting a project or an account left every one of its storage objects behind,
permanently and unrecoverably. Sixth of the asset-lifecycle stack.

**Targets `main` directly** — independent of the rest of the asset-lifecycle work.

## Root cause

`deleteProject` was `db.delete(projects)` and nothing else. The FK chain
`organizations -> projects -> folders -> assets` is `ON DELETE CASCADE` the whole
way down, so every asset row vanishes inside that one statement — and `file_path`
goes with it. Once the rows are gone nothing can name the objects again: they
are invisible to every query and to every cleanup path, forever.

The fix has to read the paths *before* the delete, so it belongs in the delete
functions rather than in a collector downstream — downstream there is nothing
left to read.

## Changes

- Extract the storage half of `deleteAssets` into `deleteStorageObjects`, which
  works from paths rather than rows. `deleteAssets` cannot serve these callers:
  it looks a row up by id to find its path, and the rows are already gone.
- `deleteProject` and `deleteUserAndRelatedData` collect paths first, delete,
  then remove the objects.
- Record why `deleteOrganization` needs no change: it already refuses while the
  organization has any project, and assets reach an organization only through
  projects — so that guard is load-bearing, not incidental.

Account deletion reaches assets two ways, `assets.owner_id` and
`organizations.owner_id -> projects -> folders -> assets`; both are covered.

Removal is post-commit and never throws. A stranded object is recoverable; a
half-deleted project is not, and a half-deleted account is worse still, since
the caller goes on to delete the Supabase auth user.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

Two integration tests. The second pins the premise of the first — that the
cascade really does erase the rows — so the first cannot quietly stop meaning
anything.

**Mutation gate.** Moving the path collection to after the delete turns *"hands
storage every path the project owned"* red.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [ ] I updated documentation where needed
- [ ] I linked the related issue above

