### PR TITLE
fix(billing): measure organization storage by ownership

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
@@ -4,10 +4,8 @@ import Stripe from 'stripe'
 import { getOrgSubscription, getQuotaLimit } from './entitlement-service.server'
 import { getCurrentUsage } from './usage-service.server'
 import { getDbClient } from '../../../db/client'
-import { assets, scenePublished } from '../../../db/schema'
+import { assets, folders, projects, scenePublished } from '../../../db/schema'
 import { orgSubscriptions } from '../../../db/schema/billing/subscriptions'
-import { sceneAssets } from '../../../db/schema/project/scene-assets'
-import { sceneSettings } from '../../../db/schema/project/scene-settings'
 import { getStripeClient } from '../../stripe.server'
 import { loadAuthenticatedUser } from '../auth/auth-loader.server'
 import { getUserProjects } from '../project/project-repository.server'
@@ -169,20 +167,27 @@ export async function loadOrgUsage(
 	  billing page and anywhere else it was shown. Summing `assets.file_size`
 	  reports what is actually stored, the same way published scenes are counted
 	  from `scene_published` rather than from a counter.
+
+	  Measured by ownership rather than through `scene_assets`, which got two
+	  things wrong. It could not see an asset that no scene links - a published
+	  GLB lives in `scene_published`, and an upload whose commit failed lives in
+	  neither - so real bytes in the bucket were reported as zero. And because
+	  the sum ran over join rows, an asset shared by several scenes (uploads are
+	  content-addressed and deduplicated per project, so sharing is normal) was
+	  counted once per scene.
+
+	  Walking `assets -> folders -> projects` fixes both at once, and needs no
+	  `distinct` to do it: an asset has exactly one folder and a folder exactly
+	  one project, so every row appears once by construction. The duplicate was
+	  never a property of the asset, only of the join that used to be here.
 	*/
-	const storageRows =
-		allSceneIds.length > 0
-			? await db
-					.select({ total: sql<null | string>`sum(${assets.fileSize})` })
-					.from(assets)
-					.innerJoin(sceneAssets, eq(sceneAssets.assetId, assets.id))
-					.innerJoin(
-						sceneSettings,
-						eq(sceneSettings.id, sceneAssets.sceneSettingsId)
-					)
-					.where(inArray(sceneSettings.sceneId, allSceneIds))
-			: []
-	const storageBytesTotalUsage = Number(storageRows[0]?.total ?? 0)
+	const [storageRow] = await db
+		.select({ total: sql<null | string>`sum(${assets.fileSize})` })
+		.from(assets)
+		.innerJoin(folders, eq(folders.id, assets.folderId))
+		.innerJoin(projects, eq(projects.id, folders.projectId))
+		.where(eq(projects.organizationId, organizationId))
+	const storageBytesTotalUsage = Number(storageRow?.total ?? 0)
 
 	// Published is counted from `scene_published`, not `scenes.status`. The two
 	// can disagree, and the quota is enforced against this table.

--- a/apps/vectreal-platform/tests/integration/billing-storage-usage.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/billing-storage-usage.integration.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Asks a real Postgres what an organization is actually storing.
+ *
+ * Both defects here are shapes of a join, so they only appear against a real
+ * planner. Measuring through `scene_assets` could not see an asset no scene
+ * links - a published GLB lives in `scene_published`, an abandoned upload lives
+ * in neither - and it summed over join rows, so an asset shared by two scenes
+ * was billed twice. Uploads are content-addressed and deduplicated per project,
+ * so that sharing is the normal case rather than an edge one.
+ *
+ * Opt-in:
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+type Schema = typeof import('../../app/db/schema')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+type Loader =
+	typeof import('../../app/lib/domain/billing/billing-dashboard-loader.server')
+
+describe('organization storage usage', () => {
+	let schema: Schema
+	let db: Db
+	let loadOrgUsage: Loader['loadOrgUsage']
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+	const assetFolderId = randomUUID()
+
+	// A second organization owned by the same user. Without it the query would
+	// measure identically with or without its `organizationId` predicate on any
+	// database that happens to hold no other assets.
+	const otherOrganizationId = randomUUID()
+	const otherProjectId = randomUUID()
+	const otherFolderId = randomUUID()
+	const OTHER_ORG_BYTES = 999_999
+
+	const SHARED_BYTES = 1000
+	const PUBLISHED_BYTES = 200
+	const ORPHAN_BYTES = 30
+
+	const sceneIds: string[] = []
+
+	const addAsset = async (
+		name: string,
+		fileSize: number,
+		folderId: string = assetFolderId
+	) => {
+		const assetId = randomUUID()
+		await db.insert(schema.assets).values({
+			id: assetId,
+			folderId,
+			name,
+			type: 'model',
+			filePath: `scenes/${randomUUID()}/assets/${assetId}/${name}`,
+			fileSize,
+			ownerId
+		})
+		return assetId
+	}
+
+	const addScene = async (name: string) => {
+		const sceneId = randomUUID()
+		await db
+			.insert(schema.scenes)
+			.values({ id: sceneId, projectId, folderId: null, name })
+		const settingsId = randomUUID()
+		await db
+			.insert(schema.sceneSettings)
+			.values({ id: settingsId, sceneId, createdBy: ownerId })
+		sceneIds.push(sceneId)
+		return { sceneId, settingsId }
+	}
+
+	beforeAll(async () => {
+		schema = await import('../../app/db/schema')
+		db = (await import('../../app/db/client')).getDbClient()
+		;({ loadOrgUsage } =
+			await import('../../app/lib/domain/billing/billing-dashboard-loader.server'))
+
+		await db.insert(schema.users).values({
+			id: ownerId,
+			email: `owner-${ownerId}@smoke.test`,
+			name: 'Owner'
+		})
+		await db
+			.insert(schema.organizations)
+			.values({ id: organizationId, name: `smoke-${organizationId}`, ownerId })
+		await db.insert(schema.organizationMemberships).values({
+			userId: ownerId,
+			organizationId,
+			role: 'owner'
+		})
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Smoke project',
+			slug: `smoke-${projectId}`
+		})
+		await db
+			.insert(schema.folders)
+			.values({ id: assetFolderId, projectId, name: 'Scene Assets' })
+
+		// One deduplicated asset linked by two scenes. Stored once, so billed once.
+		const shared = await addAsset('shared.bin', SHARED_BYTES)
+		const first = await addScene('first')
+		const second = await addScene('second')
+		await db.insert(schema.sceneAssets).values([
+			{ sceneSettingsId: first.settingsId, assetId: shared },
+			{ sceneSettingsId: second.settingsId, assetId: shared }
+		])
+
+		// A published GLB, which no `scene_assets` row ever points at.
+		const publishedAsset = await addAsset('published.glb', PUBLISHED_BYTES)
+		await db.insert(schema.scenePublished).values({
+			sceneId: first.sceneId,
+			assetId: publishedAsset,
+			publishedBy: ownerId
+		})
+
+		// An upload no commit ever linked. It occupies the bucket regardless.
+		await addAsset('abandoned.bin', ORPHAN_BYTES)
+
+		// Belongs to a different organization, so it must not appear in the total.
+		await db.insert(schema.organizations).values({
+			id: otherOrganizationId,
+			name: `other-${otherOrganizationId}`,
+			ownerId
+		})
+		await db.insert(schema.organizationMemberships).values({
+			userId: ownerId,
+			organizationId: otherOrganizationId,
+			role: 'owner'
+		})
+		await db.insert(schema.projects).values({
+			id: otherProjectId,
+			organizationId: otherOrganizationId,
+			name: 'Other project',
+			slug: `other-${otherProjectId}`
+		})
+		await db.insert(schema.folders).values({
+			id: otherFolderId,
+			projectId: otherProjectId,
+			name: 'Scene Assets'
+		})
+		await addAsset('elsewhere.bin', OTHER_ORG_BYTES, otherFolderId)
+	})
+
+	afterAll(async () => {
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, organizationId))
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, otherOrganizationId))
+		await db.delete(schema.users).where(eq(schema.users.id, ownerId))
+	})
+
+	it('counts every stored byte once', async () => {
+		const usage = await loadOrgUsage(
+			organizationId,
+			[{}],
+			sceneIds.map((id) => ({ id }))
+		)
+
+		// The other organization's asset is deliberately far larger than the
+		// total, so leaking it in cannot be mistaken for a rounding difference.
+		expect(usage.storageBytesTotal).toBe(
+			SHARED_BYTES + PUBLISHED_BYTES + ORPHAN_BYTES
+		)
+	})
+})


### PR DESCRIPTION
## Summary

Reported storage usage could not see published GLBs or orphaned uploads, and
double-counted every deduplicated asset. Seventh of the asset-lifecycle stack.

**Targets `main` directly** — independent of the rest of the asset-lifecycle work.

## Root cause

The figure summed `assets.file_size` joined through `scene_assets`, so its
population was "assets some scene's settings link to" rather than "assets this
organization stores". Two consequences from one wrong join:

- A published GLB lives in `scene_published` and an uncommitted upload lives in
  neither table, so real bytes in the bucket reported as zero.
- The sum ran over join rows, so an asset linked by N scenes counted N times —
  and since uploads are deduplicated per project by content hash, sharing is the
  normal case.

Measuring by ownership removes both, because ownership is what storage actually
bills on.

## Changes

- Sum over `assets -> folders -> projects` filtered by organization.
- Extend the comment already there explaining why storage is measured rather
  than counted.

No `distinct`: an asset has exactly one folder and a folder exactly one project,
so each row appears once by construction. I mutated a `distinct` back out and
every test stayed green, which is what established that the duplicate was a
property of the old join and not of the data.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

One integration test covering all three populations at once: an asset linked by
two scenes counts once, a published GLB counts at all, an abandoned upload
counts at all. A second organization holds a deliberately oversized asset, so a
leak across the organization filter cannot be mistaken for a rounding
difference — without it the query would measure identically with or without its
`organizationId` predicate on any database holding no other assets.

**Mutation gate.** Restoring the `scene_assets` join turns *"counts every stored
byte once"* red (1000 against an expected 1230).

## Note

This scopes storage to the current organization while `projectsTotal`,
`scenesTotal` and `publishedScenes` beside it still come from `getUserProjects`,
which spans every organization the user belongs to. The new scope is the correct
one for a per-org quota, so this exposes a pre-existing mismatch in the other
three rather than introducing one. Filed separately.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [ ] I updated documentation where needed
- [ ] I linked the related issue above

