### PR TITLE
test(core): let the compiler see the optimization report fixtures

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/optimization/model/simplification-outcome.spec.ts
+++ b/apps/vectreal-platform/app/components/publisher/optimization/model/simplification-outcome.spec.ts
@@ -1,11 +1,21 @@
 import { resolveSimplificationOutcome } from '.'
+import {
+	buildOptimizationReport,
+	buildOptimizationStats
+} from '../../../../../tests/fixtures/optimization-report'
 
-import type { OptimizationReport } from '@vctrl/core'
-
+/**
+ * Only the vertex counts matter here; everything else is the shared fixture.
+ *
+ * This used to cast a two-field object through `as unknown as
+ * OptimizationReport`, which hid it from the compiler entirely - renaming
+ * `vertices` to `verticesCount` in `@vctrl/core` was not a type error here, and
+ * only the suite caught it.
+ */
 const reportWith = (before: number, after: number) =>
-	({
-		stats: { verticesCount: { before, after } }
-	}) as unknown as OptimizationReport
+	buildOptimizationReport({
+		stats: buildOptimizationStats({ verticesCount: { before, after } })
+	})
 
 describe('resolveSimplificationOutcome', () => {
 	it('measures what actually happened rather than projecting from the ratio', () => {

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-metrics-draco.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-metrics-draco.spec.ts
@@ -1,6 +1,5 @@
 import { resolveSceneMetrics } from '.'
-
-import type { OptimizationReport } from '@vctrl/core'
+import { buildOptimizationReport } from '../../../../tests/fixtures/optimization-report'
 
 /**
  * Regression cover for the worker boundary: the geometry worker's optimizer is
@@ -9,25 +8,7 @@ import type { OptimizationReport } from '@vctrl/core'
  * geometry-only pass produced an empty `appliedOptimizations`, which silently
  * disabled every report-derived baseline below.
  */
-const buildReport = (
-	overrides: Partial<OptimizationReport> = {}
-): OptimizationReport => ({
-	originalSize: 8_000_000,
-	optimizedSize: 5_000_000,
-	compressionRatio: 1.6,
-	appliedOptimizations: ['simplification', 'draco compression'],
-	stats: {
-		verticesCount: { before: 100_000, after: 60_000 },
-		primitivesCount: { before: 50_000, after: 30_000 },
-		materialsCount: { before: 3, after: 3 },
-		textureBytes: { before: 2_000_000, after: 2_000_000 },
-		texturesCount: { before: 4, after: 4 },
-		textureResolutions: { before: [], after: [] },
-		meshBytes: { before: 6_000_000, after: 3_000_000 },
-		meshesCount: { before: 12, after: 12 }
-	},
-	...overrides
-})
+const buildReport = buildOptimizationReport
 
 describe('resolveSceneMetrics with worker-sourced optimizations', () => {
 	it('uses report baselines once the worker result carries applied steps', () => {

--- a/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.spec.ts
+++ b/apps/vectreal-platform/app/lib/utils/scene-stats-helpers.spec.ts
@@ -15,30 +15,14 @@
 import { describe, expect, it } from 'vitest'
 
 import { createSceneStatsFromReport } from './scene-stats-helpers'
-
-import type { OptimizationReport } from '@vctrl/core'
+import { buildOptimizationReport } from '../../../tests/fixtures/optimization-report'
 
 /*
-  Deliberately far apart in magnitude. A fixture where the count and the byte
-  size are close would let the two be swapped without the assertions moving,
-  which is the whole failure being pinned.
+  The shared fixture, which keeps every size far from every count on purpose: a
+  fixture where the two were close would let them be swapped with the assertions
+  below still passing, and that is the exact defect this file pins.
 */
-const REPORT = {
-	originalSize: 8_000_000,
-	optimizedSize: 5_000_000,
-	compressionRatio: 1.6,
-	appliedOptimizations: ['draco compression'],
-	stats: {
-		verticesCount: { before: 100_000, after: 60_000 },
-		primitivesCount: { before: 50_000, after: 30_000 },
-		materialsCount: { before: 3, after: 3 },
-		textureBytes: { before: 2_000_000, after: 1_000_000 },
-		texturesCount: { before: 4, after: 4 },
-		textureResolutions: { before: [], after: [] },
-		meshBytes: { before: 6_000_000, after: 3_000_000 },
-		meshesCount: { before: 12, after: 9 }
-	}
-} as unknown as OptimizationReport
+const REPORT = buildOptimizationReport()
 
 describe('the persisted mesh count', () => {
 	it('stores the count, not the payload size', () => {

--- a/apps/vectreal-platform/tests/fixtures/optimization-report.ts
+++ b/apps/vectreal-platform/tests/fixtures/optimization-report.ts
@@ -1,0 +1,53 @@
+import type { OptimizationReport, OptimizationStats } from '@vctrl/core'
+
+/**
+ * A complete, typed `OptimizationReport` for specs to vary.
+ *
+ * Every consumer used to build its own, and two of them reached the shape by
+ * casting through `as unknown as OptimizationReport` so they could name only the
+ * one or two fields they cared about. That cast is the problem: it makes the
+ * fixture invisible to the compiler, so a field renamed in `@vctrl/core` is not
+ * a type error anywhere - it is a runtime failure in whichever assertion happens
+ * to read the missing property, if any assertion does.
+ *
+ * That is not hypothetical. Renaming the metric fields to say their units broke
+ * both cast fixtures, and `tsc` reported neither; only the suite caught them,
+ * and only because an assertion happened to read the renamed field.
+ *
+ * So this is fully typed and complete on purpose. Adding a field to
+ * `OptimizationStats` fails to compile *here*, once, instead of silently
+ * leaving every spec asserting against a shape the type can no longer produce.
+ *
+ * The numbers are deliberately far apart in magnitude, and a size never equals
+ * a count. A fixture where `meshBytes` and `meshesCount` were close would let
+ * the two be swapped with every assertion still passing - which is the exact
+ * defect this shape has already had once.
+ */
+export function buildOptimizationStats(
+	overrides: Partial<OptimizationStats> = {}
+): OptimizationStats {
+	return {
+		verticesCount: { before: 100_000, after: 60_000 },
+		primitivesCount: { before: 50_000, after: 30_000 },
+		materialsCount: { before: 3, after: 3 },
+		textureBytes: { before: 2_000_000, after: 1_000_000 },
+		texturesCount: { before: 4, after: 4 },
+		textureResolutions: { before: [], after: [] },
+		meshBytes: { before: 6_000_000, after: 3_000_000 },
+		meshesCount: { before: 12, after: 9 },
+		...overrides
+	}
+}
+
+export function buildOptimizationReport(
+	overrides: Partial<OptimizationReport> = {}
+): OptimizationReport {
+	return {
+		originalSize: 8_000_000,
+		optimizedSize: 5_000_000,
+		compressionRatio: 1.6,
+		appliedOptimizations: ['simplification', 'draco compression'],
+		stats: buildOptimizationStats(),
+		...overrides
+	}
+}


### PR DESCRIPTION
## Summary

Two specs built an `OptimizationReport` by casting a partial object through `as unknown as OptimizationReport`. That cast makes the fixture invisible to `tsc`, so a field renamed or added in `@vctrl/core` is not a type error anywhere.

## Root cause

A cast is a promise to the compiler that it should stop checking. These fixtures made that promise about the one type in the codebase whose fields are all interchangeable numbers — so nothing downstream could tell a size from a count, and neither could the compiler.

Not hypothetical: #784 renamed the metric fields and **`tsc` reported neither fixture**. Only the suite caught them, and only because an assertion happened to read a renamed field. A fixture that named a field no assertion touched would have gone through silently, still claiming to describe `OptimizationReport`.

## Changes

- One typed builder in `tests/fixtures/optimization-report.ts` — complete, un-cast, with `Partial` overrides for the one or two fields a spec varies.
- The three specs that built their own now share it, including `scene-metrics-draco.spec.ts`, which already had a correctly typed local copy and is the pattern the other two should have followed.

The numbers stay deliberately far apart, with no size equal to any count: a fixture where `meshBytes` and `meshesCount` were close would let the two be swapped with every assertion still green — the defect this shape has already had once.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] `pnpm nx affected --target=test` passes (1720), typecheck + lint green.

Verified by mutation: adding a required field to `OptimizationStats` now fails to compile **in the fixture**, once —

```
tests/fixtures/optimization-report.ts(29,2): error TS2322:
  Type '{ ... nodesCount?: BeforeAfterMetric | undefined; }'
  is not assignable to type 'OptimizationStats'.
```

Previously that produced no error in any spec at all.

## Filed, not fixed

`scene-settings.parser.server.ts:736` casts a **client-supplied** `optimizationReport` to the trusted type on nothing but `typeof === 'object'`, and the string branch only checks `JSON.parse` returned a non-null object. Every metric persisted to `scene_stats` is therefore client-controlled rather than server-derived. That is production input validation, a different sentence from this PR, and worth its own change.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes