### PR TITLE
feat(api-keys): warn before a key expires, and filter the list by status

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/api-key-columns.spec.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/api-key-columns.spec.tsx
@@ -324,4 +324,67 @@ describe('ApiKeyNameCell', () => {
 		expect(screen.getByText('Storefront key')).not.toBeNull()
 		expect(screen.getByText('Pasted into a page')).not.toBeNull()
 	})
+
+	it('warns on the Status cell when a key is close to expiry', () => {
+		/*
+		  Rendered through the real column, not the cell helper, because the
+		  warning lives in the Status column and the wiring is the part that can
+		  silently not happen.
+		*/
+		const columns = createApiKeyColumns({
+			onEdit: vi.fn(),
+			onRevoke: vi.fn(),
+			onRotate: vi.fn()
+		})
+		const status = columns.find(
+			(column) => 'id' in column && column.id === 'status'
+		)
+
+		const soon = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000)
+		render(
+			(
+				status!.cell as (context: {
+					row: { original: ApiKeyRow }
+				}) => ReactElement
+			)({ row: { original: row({ expiresAt: soon }) } })
+		)
+
+		expect(screen.getByText(/expires in 3 days/i)).not.toBeNull()
+	})
+
+	it('says nothing about expiry on a key that is already dead', () => {
+		/*
+		  The contradiction the separate predicate exists to prevent: this row is
+		  inside the warning window by date and revoked, so the badge already says
+		  the useful thing and "expires in 3 days" would argue with it.
+		*/
+		const columns = createApiKeyColumns({
+			onEdit: vi.fn(),
+			onRevoke: vi.fn(),
+			onRotate: vi.fn()
+		})
+		const status = columns.find(
+			(column) => 'id' in column && column.id === 'status'
+		)
+
+		const soon = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000)
+		render(
+			(
+				status!.cell as (context: {
+					row: { original: ApiKeyRow }
+				}) => ReactElement
+			)({
+				row: {
+					original: row({
+						expiresAt: soon,
+						revokedAt: new Date('2026-02-01T00:00:00.000Z'),
+						active: false,
+						value: { readable: false, reason: 'revoked' }
+					})
+				}
+			})
+		)
+
+		expect(screen.queryByText(/expires in/i)).toBeNull()
+	})
 })

--- a/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/table-columns.tsx
@@ -44,6 +44,7 @@ import { StatusBreakdown, type SceneStatusCounts } from './status-breakdown'
 import { useClipboardCopy } from '../../hooks/use-clipboard-copy'
 import { useIsClientMounted } from '../../hooks/use-is-client-mounted'
 import {
+	isApiKeyExpiringSoon,
 	resolveApiKeyState,
 	type ApiKeyLifecycleRow,
 	type ApiKeyState
@@ -793,6 +794,26 @@ interface ApiKeyColumnsOptions {
  * way to tell from the dashboard that an embed somewhere is still carrying the
  * old key and being refused right now.
  */
+/**
+ * How long until a deadline, in the same register as `formatRelativeTime`.
+ *
+ * A separate function rather than a sign flip on that one: it reads dates in
+ * the past and answers "3d ago", and feeding it a future date produces a
+ * negative that formats as "0m ago". The two are not the same sentence.
+ */
+function formatRelativeDeadline(deadline: Date | null): string {
+	if (!deadline) return 'soon'
+
+	const days = Math.ceil(
+		(new Date(deadline).getTime() - Date.now()) / (24 * 60 * 60 * 1000)
+	)
+
+	if (days <= 0) return 'today'
+	if (days === 1) return 'tomorrow'
+
+	return `in ${days} days`
+}
+
 function isUnusedSinceRotation(row: ApiKeyRow): boolean {
 	if (!row.rotatedAt) return false
 	if (!row.lastUsedAt) return true
@@ -807,7 +828,7 @@ function isUnusedSinceRotation(row: ApiKeyRow): boolean {
  * file after serialization, and `formatRelativeTime` below has always guarded
  * the same way.
  */
-function toLifecycleRow(row: ApiKeyRow): ApiKeyLifecycleRow {
+export function toLifecycleRow(row: ApiKeyRow): ApiKeyLifecycleRow {
 	return {
 		active: row.active,
 		expiresAt: row.expiresAt ? new Date(row.expiresAt) : null,
@@ -992,9 +1013,10 @@ export function ApiKeyNameCell({ row }: { row: ApiKeyRow }) {
 
 					  `flex-1 min-w-0`, and the cap on the wrapper rather than on this
 					  element. A `max-width` here bounded the box and nothing else: the
-					  cell sits in an auto-layout table, so it sizes to this item's
-					  max-content, the flex item keeps claiming that width, and the text
-					  runs straight out of its own 24ch box and under the copy button.
+					  cell sits in an auto-layout table, so the column sizes to this
+					  item's max-content, the flex item keeps claiming that width, and
+					  the value ran straight out of its own box and under the copy
+					  button.
 
 					  `flex-1` sets the basis to zero so the item stops asking for
 					  max-content, `min-w-0` lets it shrink past min-content, and only
@@ -1180,10 +1202,24 @@ export function createApiKeyColumns(
 				const { label, variant, Icon } = getApiKeyStatus(row.original)
 
 				return (
-					<Badge variant={variant} className="gap-1">
-						<Icon className="size-3" />
-						{label}
-					</Badge>
+					<div className="flex flex-col items-start gap-1">
+						<Badge variant={variant} className="gap-1">
+							<Icon className="size-3" />
+							{label}
+						</Badge>
+						{/*
+						  A line under the badge rather than a fifth `ApiKeyState`. The
+						  key is still Active - Postgres says so, and `isApiKeyLive` has
+						  to keep agreeing with it - so this says how much longer rather
+						  than something else about now. Same shape the Last Used column
+						  uses for "Unused since rotating".
+						*/}
+						{isApiKeyExpiringSoon(toLifecycleRow(row.original), new Date()) && (
+							<span className="text-warning text-xs">
+								Expires {formatRelativeDeadline(row.original.expiresAt)}
+							</span>
+						)}
+					</div>
 				)
 			}
 		},

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-lifecycle.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-lifecycle.spec.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 import {
+	EXPIRY_WARNING_MS,
+	isApiKeyExpiringSoon,
 	isApiKeyLive,
 	resolveApiKeyState,
 	type ApiKeyLifecycleRow
@@ -233,6 +235,77 @@ describe('api key lifecycle', () => {
 					NOW
 				)
 			).toBe('active')
+		})
+	})
+
+	describe('isApiKeyExpiringSoon', () => {
+		const inDays = (days: number) =>
+			new Date(NOW.getTime() + days * 24 * 60 * 60 * 1000)
+
+		it('warns inside the window and stays quiet outside it', () => {
+			expect(
+				isApiKeyExpiringSoon(
+					{ active: true, expiresAt: inDays(3), revokedAt: null },
+					NOW
+				)
+			).toBe(true)
+			expect(
+				isApiKeyExpiringSoon(
+					{ active: true, expiresAt: inDays(30), revokedAt: null },
+					NOW
+				)
+			).toBe(false)
+		})
+
+		it('says nothing about a key that has no expiry', () => {
+			expect(
+				isApiKeyExpiringSoon(
+					{ active: true, expiresAt: null, revokedAt: null },
+					NOW
+				)
+			).toBe(false)
+		})
+
+		it('is asked only of a key that still works', () => {
+			/*
+			  The reason this is a separate predicate rather than a fifth
+			  `ApiKeyState`. Each of these rows is inside the warning window by
+			  date, and each is already dead - "expires in 3 days" over a Revoked
+			  badge is a contradiction, and the Status column has already said the
+			  useful thing.
+			*/
+			for (const dead of [
+				{ active: true, expiresAt: inDays(3), revokedAt: NOW },
+				{ active: false, expiresAt: inDays(3), revokedAt: null },
+				{ active: null, expiresAt: inDays(3), revokedAt: null }
+			]) {
+				expect(isApiKeyExpiringSoon(dead, NOW), JSON.stringify(dead)).toBe(
+					false
+				)
+			}
+		})
+
+		it('does not disagree with the state machine at the boundary', () => {
+			/*
+			  A key exactly at its expiry instant is already `expired`, because the
+			  SQL keeps one live while `expires_at > now`. So the warning has to stop
+			  before the state changes, not after - otherwise there is an instant
+			  where the row reads Expired and "expires today" at once.
+			*/
+			const atExpiry = { active: true, expiresAt: NOW, revokedAt: null }
+
+			expect(resolveApiKeyState(atExpiry, NOW)).toBe('expired')
+			expect(isApiKeyExpiringSoon(atExpiry, NOW)).toBe(false)
+		})
+
+		it('takes the window as an argument, defaulting to the shared one', () => {
+			const row = { active: true, expiresAt: inDays(20), revokedAt: null }
+
+			expect(isApiKeyExpiringSoon(row, NOW)).toBe(false)
+			expect(isApiKeyExpiringSoon(row, NOW, 30 * 24 * 60 * 60 * 1000)).toBe(
+				true
+			)
+			expect(EXPIRY_WARNING_MS).toBe(14 * 24 * 60 * 60 * 1000)
 		})
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-lifecycle.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-lifecycle.ts
@@ -71,3 +71,38 @@ export function resolveApiKeyState(
 export function isApiKeyLive(row: ApiKeyLifecycleRow, now: Date): boolean {
 	return resolveApiKeyState(row, now) === 'active'
 }
+
+/**
+ * How long before expiry a key starts warning.
+ *
+ * Fourteen days because the action it prompts is not instant: rotating refuses
+ * the old secret immediately, so the owner has to schedule the swap for when
+ * they can update the embedding pages. A warning that arrives the morning it
+ * dies is a warning about an outage rather than one that prevents it.
+ */
+export const EXPIRY_WARNING_MS = 14 * 24 * 60 * 60 * 1000
+
+/**
+ * Whether this key still works but is close enough to expiry to say so.
+ *
+ * Deliberately *not* a member of `ApiKeyState`. That union is pinned against
+ * the `WHERE` clause of `findLiveKeyForProject` - `isApiKeyLive` has to agree
+ * with what Postgres does, row for row, and `api-key-lifecycle.spec.ts` asserts
+ * exactly that. Splitting `active` would break the equivalence by construction,
+ * and it would also make `rotateApiKey` refuse the key its owner most needs to
+ * rotate, because that guard reads `state !== 'active'`.
+ *
+ * So this is a second, independent question asked of a key that is already
+ * active: not "does it work" but "for how much longer". A key that is revoked,
+ * expired, inactive, or has no expiry at all answers false.
+ */
+export function isApiKeyExpiringSoon(
+	row: ApiKeyLifecycleRow,
+	now: Date,
+	withinMs: number = EXPIRY_WARNING_MS
+): boolean {
+	if (resolveApiKeyState(row, now) !== 'active') return false
+	if (row.expiresAt === null) return false
+
+	return row.expiresAt.getTime() - now.getTime() <= withinMs
+}

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-key-status-filter.spec.ts
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-key-status-filter.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Which keys the Active / Revoked & expired tabs show.
+ *
+ * The rule is one line in `OrgApiKeysTable`, and it is the kind of line that is
+ * easy to get backwards without anyone noticing: both buckets render a
+ * plausible-looking table, and the Status badge keeps saying the right thing on
+ * every row it does show.
+ *
+ * It is pinned against `resolveApiKeyState` rather than re-implemented here, so
+ * the tabs and the badge cannot drift apart about what "revoked" means.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	matchesApiKeyStatusFilter,
+	type ApiKeyStatusFilter
+} from './api-key-status-filter'
+
+import type { ApiKeyLifecycleRow } from '../../lib/domain/auth/api-key-lifecycle'
+
+const NOW = new Date('2026-03-01T00:00:00.000Z')
+
+const live: ApiKeyLifecycleRow = {
+	active: true,
+	expiresAt: null,
+	revokedAt: null
+}
+const revoked: ApiKeyLifecycleRow = {
+	active: false,
+	expiresAt: null,
+	revokedAt: new Date('2026-02-01T00:00:00.000Z')
+}
+const expired: ApiKeyLifecycleRow = {
+	active: true,
+	expiresAt: new Date('2026-02-01T00:00:00.000Z'),
+	revokedAt: null
+}
+/* `active` is nullable, and the query requires `active = true`, so null is refused. */
+const inactive: ApiKeyLifecycleRow = {
+	active: null,
+	expiresAt: null,
+	revokedAt: null
+}
+
+describe('the API key status filter', () => {
+	const filters: ApiKeyStatusFilter[] = ['all', 'active', 'inactive']
+
+	it('names every bucket it can filter by', () => {
+		expect(filters).toHaveLength(3)
+	})
+
+	it('shows everything under All', () => {
+		for (const row of [live, revoked, expired, inactive]) {
+			expect(
+				matchesApiKeyStatusFilter(row, 'all', NOW),
+				JSON.stringify(row)
+			).toBe(true)
+		}
+	})
+
+	it('shows only a key that still authorizes under Active', () => {
+		expect(matchesApiKeyStatusFilter(live, 'active', NOW)).toBe(true)
+
+		for (const dead of [revoked, expired, inactive]) {
+			expect(
+				matchesApiKeyStatusFilter(dead, 'active', NOW),
+				JSON.stringify(dead)
+			).toBe(false)
+		}
+	})
+
+	it('folds expired and inactive in with revoked, and they are the remainder', () => {
+		/*
+		  Three spellings of "no". Someone opening this tab is asking which keys
+		  have stopped working, not which mechanism stopped them - the Status
+		  column names that. `inactive` in particular has to be here: it is the
+		  null-`active` row the SQL refuses, and leaving it out would put a key
+		  that authorizes nothing under Active.
+		*/
+		for (const dead of [revoked, expired, inactive]) {
+			expect(
+				matchesApiKeyStatusFilter(dead, 'inactive', NOW),
+				JSON.stringify(dead)
+			).toBe(true)
+		}
+		expect(matchesApiKeyStatusFilter(live, 'inactive', NOW)).toBe(false)
+	})
+
+	it('puts every key in exactly one of the two named buckets', () => {
+		for (const row of [live, revoked, expired, inactive]) {
+			const inActive = matchesApiKeyStatusFilter(row, 'active', NOW)
+			const inInactive = matchesApiKeyStatusFilter(row, 'inactive', NOW)
+
+			expect(inActive !== inInactive, JSON.stringify(row)).toBe(true)
+		}
+	})
+})

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-key-status-filter.ts
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-key-status-filter.ts
@@ -1,0 +1,45 @@
+/**
+ * Which keys the API Keys table shows.
+ *
+ * Pure, with no database import and no `.server` suffix, so a spec can pin the
+ * rule directly rather than re-stating it - the `scene-route-params.ts` pattern.
+ * A copy of this predicate living in the spec would pass whatever the route did
+ * with it, which is the failure this file exists to prevent.
+ */
+
+import {
+	resolveApiKeyState,
+	type ApiKeyLifecycleRow
+} from '../../lib/domain/auth/api-key-lifecycle'
+
+export type ApiKeyStatusFilter = 'all' | 'active' | 'inactive'
+
+export const STATUS_FILTER_LABELS: Record<ApiKeyStatusFilter, string> = {
+	all: 'All',
+	active: 'Active',
+	inactive: 'Revoked & expired'
+}
+
+/**
+ * Whether a row belongs in the selected bucket.
+ *
+ * Decided by `resolveApiKeyState`, so the tabs and the Status badge cannot
+ * disagree about what "revoked" means.
+ *
+ * Two buckets rather than one per state: someone opening this tab is asking
+ * which keys have stopped working, not which mechanism stopped them. `inactive`
+ * has to fall in with the dead ones in particular - it is the null-`active` row
+ * the authorization query refuses, and treating it as live would put a key that
+ * authorizes nothing under Active.
+ */
+export function matchesApiKeyStatusFilter(
+	row: ApiKeyLifecycleRow,
+	filter: ApiKeyStatusFilter,
+	now: Date
+): boolean {
+	if (filter === 'all') return true
+
+	const state = resolveApiKeyState(row, now)
+
+	return filter === 'active' ? state === 'active' : state !== 'active'
+}

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys.tsx
@@ -26,12 +26,18 @@ import { toast } from 'sonner'
 
 import { Route } from './+types/api-keys'
 import {
+	matchesApiKeyStatusFilter,
+	STATUS_FILTER_LABELS,
+	type ApiKeyStatusFilter
+} from './api-key-status-filter'
+import {
 	OneTimeKeyDialog,
 	type OneTimeKeyValue
 } from '../../components/api-keys/one-time-key-dialog'
 import {
 	DataTable,
 	createApiKeyColumns,
+	toLifecycleRow,
 	type ApiKeyRow,
 	type ApiKeyRowValue
 } from '../../components/dashboard'
@@ -370,6 +376,49 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 
 export { DashboardErrorBoundary as ErrorBoundary } from '../../components/errors'
 
+/**
+ * Which keys the table is showing.
+ *
+ * Three buckets rather than one per `ApiKeyState`: the question someone brings
+ * to this page is whether a key still works, and revoked, expired and inactive
+ * are three spellings of "no". The Status column still names which one.
+ *
+ * Counts on the first two only. "Revoked & expired" is the remainder, and
+ * showing its size next to it invites reading the page as an inventory of dead
+ * keys rather than a list of live ones.
+ */
+function ApiKeyStatusFilterTabs({
+	value,
+	onValueChange,
+	counts
+}: {
+	value: ApiKeyStatusFilter
+	onValueChange: (next: ApiKeyStatusFilter) => void
+	counts: { all: number; active: number }
+}) {
+	return (
+		<Tabs
+			value={value}
+			onValueChange={(next) => onValueChange(next as ApiKeyStatusFilter)}
+		>
+			<TabsList>
+				{(Object.keys(STATUS_FILTER_LABELS) as ApiKeyStatusFilter[]).map(
+					(option) => (
+						<TabsTrigger key={option} value={option}>
+							{STATUS_FILTER_LABELS[option]}
+							{option !== 'inactive' && (
+								<Badge variant="secondary" className="ml-2">
+									{option === 'all' ? counts.all : counts.active}
+								</Badge>
+							)}
+						</TabsTrigger>
+					)
+				)}
+			</TabsList>
+		</Tabs>
+	)
+}
+
 function OrgApiKeysTable({
 	namespace,
 	rows,
@@ -384,6 +433,26 @@ function OrgApiKeysTable({
 	onRotate: (keyId: string) => void
 }) {
 	const tableState = useDashboardTableState({ namespace })
+	const [statusFilter, setStatusFilter] = useState<ApiKeyStatusFilter>('all')
+
+	/*
+	  Filtered here rather than through `DataTable`, which derives its
+	  `columnFilters` from `searchKey`/`searchValue` alone and has no second slot.
+	  Adding one would change a component every dashboard table uses, for a
+	  control only this one needs.
+
+	  `resolveApiKeyState` decides it, so the filter and the Status badge cannot
+	  disagree about what "revoked" means - and `inactive` counts as revoked here
+	  for the same reason the embed picker folds it in: to the person looking, a
+	  key that does not authorize anything is one bucket.
+	*/
+	const visibleRows = useMemo(() => {
+		const now = new Date()
+
+		return rows.filter((row) =>
+			matchesApiKeyStatusFilter(toLifecycleRow(row), statusFilter, now)
+		)
+	}, [rows, statusFilter])
 
 	const columns = useMemo(
 		() =>
@@ -412,20 +481,33 @@ function OrgApiKeysTable({
 	}
 
 	return (
-		<DataTable
-			columns={columns}
-			data={rows}
-			searchKey="name"
-			searchPlaceholder="Search by name or last 4 characters..."
-			searchValue={tableState.searchValue}
-			onSearchValueChange={tableState.setSearchValue}
-			sorting={tableState.sorting}
-			onSortingChange={tableState.onSortingChange}
-			pagination={tableState.pagination}
-			onPaginationChange={tableState.onPaginationChange}
-			rowSelection={tableState.rowSelection}
-			onRowSelectionChange={tableState.onRowSelectionChange}
-		/>
+		<div className="space-y-3">
+			<ApiKeyStatusFilterTabs
+				value={statusFilter}
+				onValueChange={setStatusFilter}
+				counts={{
+					all: rows.length,
+					active: rows.filter(
+						(row) =>
+							resolveApiKeyState(toLifecycleRow(row), new Date()) === 'active'
+					).length
+				}}
+			/>
+			<DataTable
+				columns={columns}
+				data={visibleRows}
+				searchKey="name"
+				searchPlaceholder="Search by name or last 4 characters..."
+				searchValue={tableState.searchValue}
+				onSearchValueChange={tableState.setSearchValue}
+				sorting={tableState.sorting}
+				onSortingChange={tableState.onSortingChange}
+				pagination={tableState.pagination}
+				onPaginationChange={tableState.onPaginationChange}
+				rowSelection={tableState.rowSelection}
+				onRowSelectionChange={tableState.onRowSelectionChange}
+			/>
+		</div>
 	)
 }
 


### PR DESCRIPTION
Two catalogue rows that land in the same two files, so they ship together: *"Warn on API keys that are expiring soon"* and the first half of *"API key visibility: Active / Revoked / All filter"*.

## Root cause

Nothing asked the question. The Status column reports which lifecycle state a key is in, and `active` covers a key with three months left and one with three days equally — so the only notice an owner got was the embed breaking.

## Why this is not a fifth `ApiKeyState`

The union is the trap, and **only one of its five break sites is a compile error**:

| Site | How it breaks |
| --- | --- |
| `API_KEY_STATUS_PRESENTATION` | Compile error — the only one the type system catches |
| `isApiKeyLive` | **Silent and wrong.** It has to keep agreeing with `findLiveKeyForProject`'s `WHERE` clause row for row, and the spec asserts that equivalence — splitting `active` breaks it by construction |
| `rotateApiKey` (`state !== 'active'`) | Would refuse to rotate the key its owner most needs to rotate |
| `toEmbedApiKeyOptions` | Falls through as usable — correct by luck |
| `ApiKeyActionsCell` | Rotate silently disabled |

So `isApiKeyExpiringSoon` is a second, independent question asked of a key that is *already* active: not "does it work" but "for how much longer". Rendered as a line under the Status badge — the shape `isUnusedSinceRotation` already uses in the Last Used column.

**Fourteen days**, because the action it prompts is not instant: rotation refuses the old secret immediately, so the swap has to be scheduled for when the embedding pages can be updated. A warning that arrives the morning the key dies is a warning about an outage rather than one that prevents it. This is the repo's first expiry-threshold constant.

## The filter

Its predicate lives in a pure module rather than inline in the route — because the first version of its spec **re-stated the rule instead of importing it**, and would have passed whatever the route did with it. It reads `resolveApiKeyState`, so the tabs and the Status badge cannot disagree about what "revoked" means, and `inactive` falls in with the dead ones because that is the null-`active` row the authorization query refuses.

Filtered in `OrgApiKeysTable`, not through `DataTable`, which derives `columnFilters` from `searchKey` alone — adding a second slot would change a component every dashboard table uses, for a control only this one needs.

## Left on the catalogue row

The revoking **actor** and per-key **request counts**. All three are impossible without a migration: no `revokedBy` column (the actor is known at revoke time and discarded), no audit-log table, and `org_usage_counters` has no `api_key_id`.

## Verification

| Mutation | Result |
| --- | --- |
| Expiring-soon ignores lifecycle state | red |
| Warn on a key with no expiry | red |
| Widen the window | red |
| Invert the filter | red |
| Treat null-`active` as live | red |
| Unwire the warning from the Status cell | red |

- `pnpm nx run-many --target=typecheck,lint -p vectreal-platform` — green
- `npx vitest run --root .` — 140 files, 1765 tests, green