### PR TITLE
feat(api-keys): make disclosing a key a decision the kind has to state

### DIFF
--- a/apps/vectreal-platform/app/db/schema/auth/api-keys.ts
+++ b/apps/vectreal-platform/app/db/schema/auth/api-keys.ts
@@ -2,6 +2,7 @@ import {
 	pgPolicy,
 	boolean,
 	index,
+	pgEnum,
 	pgTable,
 	text,
 	timestamp,
@@ -12,6 +13,22 @@ import { authenticatedRole } from 'drizzle-orm/supabase'
 import { organizations } from '../core/organizations'
 import { users } from '../core/users'
 import { canManageOrgApiKeys } from '../rls'
+
+/**
+ * What a key is for, which decides whether its owner may read it back.
+ *
+ * One value today, and the enum exists because of the second one. Every row in
+ * this table is an embed token: published by design into an `iframe src` on a
+ * customer's page, restricted by the allowed-domain list rather than by
+ * secrecy, and therefore safe to hand back to the owner who minted it.
+ *
+ * A key with write scope would not be. Without this column the default for such
+ * a row is whatever the reveal path happens to do - which is "show it" - and
+ * nothing would force the person adding that kind to notice. With it, adding a
+ * value is a migration and `api-key-disclosure.server.ts` is a compile-time
+ * stop, so the choice has to be made out loud.
+ */
+export const apiKeyKindEnum = pgEnum('api_key_kind', ['embed'])
 
 export const apiKeys = pgTable(
 	'api_keys',
@@ -25,6 +42,16 @@ export const apiKeys = pgTable(
 			.references(() => users.id, { onDelete: 'cascade' }),
 		name: text('name').notNull(),
 		description: text('description'),
+		/*
+		  Defaulted so the rows that predate this column are what they have always
+		  been. Every one of them is an embed token, minted by a form that could
+		  create nothing else, so backfilling them as `embed` states a fact rather
+		  than guessing one.
+
+		  `createApiKey` still passes it explicitly. A default is for existing
+		  rows; a mint site should say what it is minting.
+		*/
+		kind: apiKeyKindEnum('kind').notNull().default('embed'),
 		hashedKey: text('hashed_key').notNull(),
 		/*
 		  The same secret, kept readable, so the embed panel can offer a key the

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-disclosure.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-disclosure.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * The guard that stops a future key kind inheriting "show it".
+ *
+ * Nothing exercises the false branch today, and that is the point: every row is
+ * an `embed` key, so this is a rule written before it is needed rather than
+ * after something leaked. What the tests pin is the *shape* that makes the
+ * eventual second kind a decision - a total map that fails to compile until
+ * someone writes its rule, rather than an `if` a new value falls through.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	isApiKeyKindDisclosable,
+	KIND_IS_DISCLOSABLE
+} from './api-key-disclosure'
+import { apiKeyKindEnum } from '../../../db/schema/auth/api-keys'
+
+describe('API key disclosure', () => {
+	it('lets an embed token be read back', () => {
+		/*
+		  It is published by construction - `buildEmbedUrl` puts it in an
+		  `iframe src` on the customer's own page - so hiding it from the owner who
+		  minted it bought nothing.
+		*/
+		expect(isApiKeyKindDisclosable('embed')).toBe(true)
+	})
+
+	it('has a rule for every kind the column can hold', () => {
+		/*
+		  The assertion that makes the map load-bearing. A kind added to the enum
+		  without a rule is a compile error, and this catches the other direction:
+		  a rule quietly deleted, or a map that stopped being total.
+		*/
+		expect(Object.keys(KIND_IS_DISCLOSABLE).sort()).toEqual(
+			[...apiKeyKindEnum.enumValues].sort()
+		)
+	})
+
+	it('refuses any kind that is not marked disclosable', () => {
+		/*
+		  Driven through a cast because no such kind exists yet. Without this the
+		  function could `return true` outright and every test above would pass -
+		  which is exactly the failure the map is meant to prevent, so it has to be
+		  checkable before the second kind arrives, not after.
+		*/
+		const future = 'server-write' as (typeof apiKeyKindEnum.enumValues)[number]
+
+		expect(isApiKeyKindDisclosable(future)).toBeFalsy()
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-disclosure.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-disclosure.ts
@@ -1,0 +1,38 @@
+/**
+ * Whether a key of this kind may be handed back to its owner at all.
+ *
+ * Pure, and separate from the decrypting: the question "may we show this" is
+ * about what the key is *for*, and the question "can we still read it" is about
+ * what happened to the row. Folding them together is what produced a single
+ * null with four different meanings.
+ *
+ * Every key today is an embed token - published by design into an `iframe src`
+ * on a customer's page, restricted by the allowed-domain list rather than by
+ * secrecy - so `embed` is disclosable and the map has one entry. The map exists
+ * for the second entry, not the first.
+ */
+
+import type { apiKeyKindEnum } from '../../../db/schema/auth/api-keys'
+
+export type ApiKeyKind = (typeof apiKeyKindEnum.enumValues)[number]
+
+/**
+ * Which kinds may be read back, as a total `Record`.
+ *
+ * A map rather than an `if`, following `DASHBOARD_OPERATION_ROLES`: adding a
+ * value to `apiKeyKindEnum` makes this fail to compile until someone writes the
+ * rule for it. An `if` would let a new kind inherit whichever branch it fell
+ * into, and for a write-scoped key that branch is the one that hands out the
+ * secret.
+ *
+ * That is the whole point of the column. Without it the default for a
+ * server-side key with write scope is whatever the reveal path happens to do,
+ * and nothing would force the person adding it to notice.
+ */
+export const KIND_IS_DISCLOSABLE: Record<ApiKeyKind, boolean> = {
+	embed: true
+}
+
+export function isApiKeyKindDisclosable(kind: ApiKeyKind): boolean {
+	return KIND_IS_DISCLOSABLE[kind]
+}

--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
@@ -299,6 +299,13 @@ export async function createApiKey(
 			organizationId,
 			name,
 			description: description || null,
+			/*
+			  Stated, not defaulted. The column carries a default so existing rows
+			  are correct, but this is the only place a key is minted and it is the
+			  place that knows what it is minting - a kind added later has to come
+			  through here and say so.
+			*/
+			kind: 'embed',
 			hashedKey: hashed,
 			encryptedKey: encryptEmbedToken(plaintext),
 			keyPreview: preview,

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys.spec.ts
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys.spec.ts
@@ -139,6 +139,7 @@ function storedKey() {
 			name: 'Storefront key',
 			description: 'Pasted into a product page',
 			keyPreview: 'ab3x',
+			kind: 'embed' as const,
 			hashedKey: HASHED_KEY,
 			encryptedKey: ENCRYPTED_KEY,
 			active: true,
@@ -399,6 +400,31 @@ describe('the api keys loader payload', () => {
 			readable: false,
 			reason: 'undecryptable'
 		})
+	})
+
+	it('withholds the value of a kind that must not be disclosed', async () => {
+		/*
+		  Unreachable today - every row is an `embed` key - and asserted anyway,
+		  because the whole point of the `kind` column is that the day a
+		  write-scoped key exists, showing it has to be a decision rather than the
+		  default this loader would otherwise apply.
+
+		  Note it is withheld *before* the cipher runs: a key that must not be
+		  disclosed should not have its plaintext put in memory to then be
+		  discarded.
+		*/
+		vi.mocked(getAllUserApiKeys).mockResolvedValue([
+			{
+				...storedKey(),
+				apiKey: { ...storedKey().apiKey, kind: 'server-write' }
+			}
+		] as unknown as Awaited<ReturnType<typeof getAllUserApiKeys>>)
+
+		expect(firstRow((await load()).data)?.value).toEqual({
+			readable: false,
+			reason: 'withheld'
+		})
+		expect(decryptEmbedToken).not.toHaveBeenCalled()
 	})
 
 	it('still reads back an expired key', async () => {

--- a/apps/vectreal-platform/app/routes/dashboard-page/api-keys.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/api-keys.tsx
@@ -39,6 +39,7 @@ import { ConfirmDestructiveDialog } from '../../components/shared/confirm-destru
 import { FeatureUnavailablePanel } from '../../components/upgrade/feature-unavailable-panel'
 import { useDashboardTableState } from '../../hooks/use-dashboard-table-state'
 import { useOncePerFetcherResponse } from '../../hooks/use-once-per-fetcher-response'
+import { isApiKeyKindDisclosable } from '../../lib/domain/auth/api-key-disclosure'
 import { resolveApiKeyState } from '../../lib/domain/auth/api-key-lifecycle'
 import {
 	getAllUserApiKeys,
@@ -87,6 +88,17 @@ function resolveRowValue(
 	now: Date
 ): ApiKeyRowValue {
 	if (!canReadValue) {
+		return { readable: false, reason: 'withheld' }
+	}
+
+	/*
+	  Asked before anything is decrypted, because it is a different question from
+	  the three below it: those are reasons a value cannot be produced, this is a
+	  reason it must not be. Today it never fires - every row is an `embed` key -
+	  and it exists so that the day a write-scoped kind is added, showing it is a
+	  decision someone has to make rather than the default.
+	*/
+	if (!isApiKeyKindDisclosable(key.apiKey.kind)) {
 		return { readable: false, reason: 'withheld' }
 	}
 

--- a/apps/vectreal-platform/supabase/migrations/0020_dazzling_kang.sql
+++ b/apps/vectreal-platform/supabase/migrations/0020_dazzling_kang.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."api_key_kind" AS ENUM('embed');--> statement-breakpoint
+ALTER TABLE "api_keys" ADD COLUMN "kind" "api_key_kind" DEFAULT 'embed' NOT NULL;

--- a/apps/vectreal-platform/supabase/migrations/meta/0020_snapshot.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/0020_snapshot.json
@@ -1,0 +1,4389 @@
+{
+  "id": "9fb6ff6e-5640-452e-aa86-ef56980b899f",
+  "prevId": "f677c813-6bf1-4736-9ec3-206e3e56e969",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "users_select_self": {
+          "name": "users_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_insert_self": {
+          "name": "users_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_update_self": {
+          "name": "users_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())",
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference_code": {
+          "name": "reference_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "is_authenticated": {
+          "name": "is_authenticated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inquiry_type": {
+          "name": "inquiry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "failure_stage": {
+          "name": "failure_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "internal_message_id": {
+          "name": "internal_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_message_id": {
+          "name": "confirmation_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_users_id_fk": {
+          "name": "contact_submissions_user_id_users_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_submissions_reference_code_unique": {
+          "name": "contact_submissions_reference_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_owner_id_idx": {
+          "name": "organizations_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_id_users_id_fk": {
+          "name": "organizations_owner_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "organizations_select_member": {
+          "name": "organizations_select_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_insert_owner": {
+          "name": "organizations_insert_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"organizations\".\"owner_id\" = (select auth.uid())"
+        },
+        "organizations_update_owner": {
+          "name": "organizations_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_delete_owner": {
+          "name": "organizations_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_memberships_user_id_idx": {
+          "name": "organization_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_organization_id_idx": {
+          "name": "organization_memberships_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_invited_by_idx": {
+          "name": "organization_memberships_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_memberships_select_org_member": {
+          "name": "org_memberships_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_insert_org_admin": {
+          "name": "org_memberships_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_update_org_admin": {
+          "name": "org_memberships_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_delete_org_admin_or_self": {
+          "name": "org_memberships_delete_org_admin_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\n\t\t\t\t\texists (\n\t\t\t\t\t\tselect 1\n\t\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t\t)\n\t\t\t\t\tor \"organization_memberships\".\"user_id\" = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_embed_domains": {
+          "name": "allowed_embed_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "projects_select_org_member": {
+          "name": "projects_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "projects_insert_org_admin": {
+          "name": "projects_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"projects\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_update_org_admin": {
+          "name": "projects_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_delete_org_admin": {
+          "name": "projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_folders": {
+      "name": "scene_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_folders_project_id_idx": {
+          "name": "scene_folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_owner_id_idx": {
+          "name": "scene_folders_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_parent_folder_id_idx": {
+          "name": "scene_folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_folders_project_id_projects_id_fk": {
+          "name": "scene_folders_project_id_projects_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_owner_id_users_id_fk": {
+          "name": "scene_folders_owner_id_users_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_parent_folder_id_scene_folders_id_fk": {
+          "name": "scene_folders_parent_folder_id_scene_folders_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_folders_select_project_member": {
+          "name": "scene_folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_folders_insert_project_member_self_owner": {
+          "name": "scene_folders_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scene_folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_update_owner_or_admin": {
+          "name": "scene_folders_update_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_delete_owner_or_admin": {
+          "name": "scene_folders_delete_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {
+        "scene_folders_parent_not_self": {
+          "name": "scene_folders_parent_not_self",
+          "value": "\"scene_folders\".\"parent_folder_id\" is null or \"scene_folders\".\"parent_folder_id\" <> \"scene_folders\".\"id\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "folders_project_id_idx": {
+          "name": "folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "folders_parent_folder_id_idx": {
+          "name": "folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_project_id_projects_id_fk": {
+          "name": "folders_project_id_projects_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folders_parent_folder_id_folders_id_fk": {
+          "name": "folders_parent_folder_id_folders_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "folders_select_project_member": {
+          "name": "folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "folders_insert_project_admin": {
+          "name": "folders_insert_project_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_update_project_admin": {
+          "name": "folders_update_project_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_delete_project_admin": {
+          "name": "folders_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_folder_id_idx": {
+          "name": "assets_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_owner_id_idx": {
+          "name": "assets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_folder_id_folders_id_fk": {
+          "name": "assets_folder_id_folders_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_owner_id_users_id_fk": {
+          "name": "assets_owner_id_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "assets_select_project_member": {
+          "name": "assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "assets_insert_project_member_self_owner": {
+          "name": "assets_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"assets\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_update_project_member_owner": {
+          "name": "assets_update_project_member_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_delete_project_admin": {
+          "name": "assets_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scenes": {
+      "name": "scenes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scenes_project_id_idx": {
+          "name": "scenes_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_folder_id_idx": {
+          "name": "scenes_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scenes_project_id_projects_id_fk": {
+          "name": "scenes_project_id_projects_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scenes_folder_id_scene_folders_id_fk": {
+          "name": "scenes_folder_id_scene_folders_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scenes_select_project_member": {
+          "name": "scenes_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scenes_insert_project_member": {
+          "name": "scenes_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scenes\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_update_project_member": {
+          "name": "scenes_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_delete_project_admin": {
+          "name": "scenes_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_settings": {
+      "name": "scene_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera": {
+          "name": "camera",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controls": {
+          "name": "controls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactions": {
+          "name": "interactions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shadows": {
+          "name": "shadows",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalization": {
+          "name": "normalization",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_settings_created_by_idx": {
+          "name": "scene_settings_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_settings_scene_id_scenes_id_fk": {
+          "name": "scene_settings_scene_id_scenes_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_settings_created_by_users_id_fk": {
+          "name": "scene_settings_created_by_users_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_settings_scene_id_unique": {
+          "name": "scene_settings_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_settings_select_project_member": {
+          "name": "scene_settings_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_insert_project_member_self_creator": {
+          "name": "scene_settings_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_settings\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_settings_update_project_member": {
+          "name": "scene_settings_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_delete_project_admin": {
+          "name": "scene_settings_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_hotspots": {
+      "name": "scene_hotspots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "world_position_x": {
+          "name": "world_position_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_y": {
+          "name": "world_position_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_z": {
+          "name": "world_position_z",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_camera_id": {
+          "name": "linked_camera_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "internal_only": {
+          "name": "internal_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occlusion_enabled": {
+          "name": "occlusion_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_preset": {
+          "name": "style_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dot'"
+        },
+        "payload_url": {
+          "name": "payload_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_hotspots_scene_settings_id_idx": {
+          "name": "scene_hotspots_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_hotspots_sequence_index_idx": {
+          "name": "scene_hotspots_sequence_index_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_hotspots_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_hotspots_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_hotspots",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_hotspots_select_project_member": {
+          "name": "scene_hotspots_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_insert_project_member": {
+          "name": "scene_hotspots_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_update_project_member": {
+          "name": "scene_hotspots_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_delete_project_admin": {
+          "name": "scene_hotspots_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_stats": {
+      "name": "scene_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized": {
+          "name": "optimized",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_scene_bytes": {
+          "name": "initial_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_scene_bytes": {
+          "name": "current_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_optimizations": {
+          "name": "applied_optimizations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimization_settings": {
+          "name": "optimization_settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_metrics": {
+          "name": "additional_metrics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_stats_created_by_idx": {
+          "name": "scene_stats_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_stats_scene_id_scenes_id_fk": {
+          "name": "scene_stats_scene_id_scenes_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_stats_created_by_users_id_fk": {
+          "name": "scene_stats_created_by_users_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_stats_scene_id_unique": {
+          "name": "scene_stats_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_stats_select_project_member": {
+          "name": "scene_stats_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_insert_project_member_self_creator": {
+          "name": "scene_stats_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_stats\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_stats_update_project_member": {
+          "name": "scene_stats_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_delete_project_admin": {
+          "name": "scene_stats_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_assets": {
+      "name": "scene_assets",
+      "schema": "",
+      "columns": {
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_assets_scene_settings_id_idx": {
+          "name": "scene_assets_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_assets_asset_id_idx": {
+          "name": "scene_assets_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_assets_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_assets_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_assets_asset_id_assets_id_fk": {
+          "name": "scene_assets_asset_id_assets_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scene_assets_scene_settings_id_asset_id_pk": {
+          "name": "scene_assets_scene_settings_id_asset_id_pk",
+          "columns": [
+            "scene_settings_id",
+            "asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_assets_select_project_member": {
+          "name": "scene_assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_insert_project_member": {
+          "name": "scene_assets_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"scene_assets\".\"asset_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_delete_project_member": {
+          "name": "scene_assets_delete_project_member",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_published": {
+      "name": "scene_published",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_published_asset_id_idx": {
+          "name": "scene_published_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_scene_settings_id_idx": {
+          "name": "scene_published_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_published_by_idx": {
+          "name": "scene_published_published_by_idx",
+          "columns": [
+            {
+              "expression": "published_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_published_scene_id_scenes_id_fk": {
+          "name": "scene_published_scene_id_scenes_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_asset_id_assets_id_fk": {
+          "name": "scene_published_asset_id_assets_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_published_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scene_published_published_by_users_id_fk": {
+          "name": "scene_published_published_by_users_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_published_select_project_member": {
+          "name": "scene_published_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_insert_project_member_self_publisher": {
+          "name": "scene_published_insert_project_member_self_publisher",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand \"scene_published\".\"published_by\" = (select auth.uid())\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom assets a\n\t\t\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\t\t\tjoin projects p on p.id = f.project_id\n\t\t\t\t\tjoin scenes s on s.project_id = p.id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\t\t\tand a.id = \"scene_published\".\"asset_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_published_update_project_member": {
+          "name": "scene_published_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_delete_project_admin": {
+          "name": "scene_published_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_requests": {
+      "name": "scene_action_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_action_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_requests_status_idx": {
+          "name": "scene_action_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_scene_id_idx": {
+          "name": "scene_action_requests_scene_id_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_expires_at_idx": {
+          "name": "scene_action_requests_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_action_requests_request_key_unique": {
+          "name": "scene_action_requests_request_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_locks": {
+      "name": "scene_action_locks",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_key": {
+          "name": "holder_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_locks_expires_at_idx": {
+          "name": "scene_action_locks_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_runtime_limits": {
+      "name": "scene_runtime_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "in_flight": {
+          "name": "in_flight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "permission_entity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "permission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permissions_granted_by_idx": {
+          "name": "permissions_granted_by_idx",
+          "columns": [
+            {
+              "expression": "granted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_granted_by_users_id_fk": {
+          "name": "permissions_granted_by_users_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "permissions_select_recipient_or_granter": {
+          "name": "permissions_select_recipient_or_granter",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t\"permissions\".\"granted_by\" = (select auth.uid())\n\t\t\t\tor (\"permissions\".\"entity_type\" = 'user' and \"permissions\".\"entity_id\" = (select auth.uid()))\n\t\t\t\tor (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"permissions\".\"entity_id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "permissions_insert_self_or_group_owner": {
+          "name": "permissions_insert_self_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\"permissions\".\"granted_by\" = (select auth.uid())\n\t\t\t\tand (\n\t\t\t\t\t(\"permissions\".\"entity_type\" = 'user' and \"permissions\".\"entity_id\" = (select auth.uid()))\n\t\t\t\t\tor (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t)\n\t\t\t"
+        },
+        "permissions_update_granter_or_group_owner": {
+          "name": "permissions_update_granter_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)",
+          "withCheck": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)"
+        },
+        "permissions_delete_granter_or_group_owner": {
+          "name": "permissions_delete_granter_or_group_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"permissions\".\"granted_by\" = (select auth.uid()) or (\"permissions\".\"entity_type\" = 'group' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"permissions\".\"entity_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_id_idx": {
+          "name": "group_memberships_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "group_memberships_select_owner_or_member": {
+          "name": "group_memberships_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"group_memberships\".\"group_id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_insert_owner_or_self_join": {
+          "name": "group_memberships_insert_owner_or_self_join",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        },
+        "group_memberships_update_owner": {
+          "name": "group_memberships_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_delete_owner_or_self": {
+          "name": "group_memberships_delete_owner_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_id_idx": {
+          "name": "groups_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "groups_select_owner_or_member": {
+          "name": "groups_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid()) or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"groups\".\"id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "groups_insert_self_owner": {
+          "name": "groups_insert_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_update_owner": {
+          "name": "groups_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_delete_owner": {
+          "name": "groups_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {
+        "tags_select_authenticated": {
+          "name": "tags_select_authenticated",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null"
+        },
+        "tags_insert_authenticated": {
+          "name": "tags_insert_authenticated",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(select (select auth.uid())) is not null"
+        },
+        "tags_update_authenticated": {
+          "name": "tags_update_authenticated",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null",
+          "withCheck": "(select (select auth.uid())) is not null"
+        },
+        "tags_delete_authenticated": {
+          "name": "tags_delete_authenticated",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select (select auth.uid())) is not null"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tag_assignments": {
+      "name": "tag_assignments",
+      "schema": "",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tag_assignments_tag_id_idx": {
+          "name": "tag_assignments_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_assignments_tag_id_tags_id_fk": {
+          "name": "tag_assignments_tag_id_tags_id_fk",
+          "tableFrom": "tag_assignments",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tag_assignments_tag_id_target_type_target_id_pk": {
+          "name": "tag_assignments_tag_id_target_type_target_id_pk",
+          "columns": [
+            "tag_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "tag_assignments_select_target_member": {
+          "name": "tag_assignments_select_target_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "tag_assignments_insert_target_member": {
+          "name": "tag_assignments_insert_target_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t(select (select auth.uid())) is not null\n\t\t\t\tand (\n\t\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\t)\n\t\t\t"
+        },
+        "tag_assignments_delete_target_member": {
+          "name": "tag_assignments_delete_target_member",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\"tag_assignments\".\"target_type\" = 'asset' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'scene' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t\tor (\"tag_assignments\".\"target_type\" = 'folder' and \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"tag_assignments\".\"target_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "api_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'embed'"
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_preview": {
+          "name": "key_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_organization_id_idx": {
+          "name": "api_keys_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_organization_id_organizations_id_fk": {
+          "name": "api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "api_keys_select_org_admin": {
+          "name": "api_keys_select_org_admin",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_insert_org_admin": {
+          "name": "api_keys_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_update_org_admin": {
+          "name": "api_keys_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_delete_org_admin": {
+          "name": "api_keys_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_key_projects": {
+      "name": "api_key_projects",
+      "schema": "",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_projects_api_key_id_idx": {
+          "name": "api_key_projects_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_projects_project_id_idx": {
+          "name": "api_key_projects_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_projects_api_key_id_api_keys_id_fk": {
+          "name": "api_key_projects_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_projects_project_id_projects_id_fk": {
+          "name": "api_key_projects_project_id_projects_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_key_projects_api_key_id_project_id_pk": {
+          "name": "api_key_projects_api_key_id_project_id_pk",
+          "columns": [
+            "api_key_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "api_key_projects_select_org_admin_and_project_member": {
+          "name": "api_key_projects_select_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_insert_org_admin_and_project_member": {
+          "name": "api_key_projects_insert_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_delete_org_admin": {
+          "name": "api_key_projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "billing_state": {
+          "name": "billing_state",
+          "type": "billing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_stripe_subscription_id_idx": {
+          "name": "org_subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_customer_id_idx": {
+          "name": "org_subscriptions_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_billing_state_idx": {
+          "name": "org_subscriptions_billing_state_idx",
+          "columns": [
+            {
+              "expression": "billing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_subscriptions_organization_id_unique": {
+          "name": "org_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {
+        "org_subscriptions_select_org_member": {
+          "name": "org_subscriptions_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_subscriptions_insert_org_admin": {
+          "name": "org_subscriptions_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_update_org_admin": {
+          "name": "org_subscriptions_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_delete_org_admin": {
+          "name": "org_subscriptions_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_limit_overrides": {
+      "name": "org_limit_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_key": {
+          "name": "limit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_limit_overrides_org_key_uidx": {
+          "name": "org_limit_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "limit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_limit_overrides_organization_id_organizations_id_fk": {
+          "name": "org_limit_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_limit_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_limit_overrides_select_org_member": {
+          "name": "org_limit_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_limit_overrides_insert_org_admin": {
+          "name": "org_limit_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_update_org_admin": {
+          "name": "org_limit_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_delete_org_admin": {
+          "name": "org_limit_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_entitlement_overrides": {
+      "name": "org_entitlement_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_key": {
+          "name": "entitlement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_entitlement_overrides_org_key_uidx": {
+          "name": "org_entitlement_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_entitlement_overrides_organization_id_organizations_id_fk": {
+          "name": "org_entitlement_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_entitlement_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_entitlement_overrides_select_org_member": {
+          "name": "org_entitlement_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_insert_org_admin": {
+          "name": "org_entitlement_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_update_org_admin": {
+          "name": "org_entitlement_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_delete_org_admin": {
+          "name": "org_entitlement_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_usage_counters": {
+      "name": "org_usage_counters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter_key": {
+          "name": "counter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_usage_counters_org_key_window_uidx": {
+          "name": "org_usage_counters_org_key_window_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_usage_counters_window_end_idx": {
+          "name": "org_usage_counters_window_end_idx",
+          "columns": [
+            {
+              "expression": "window_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_usage_counters_organization_id_organizations_id_fk": {
+          "name": "org_usage_counters_organization_id_organizations_id_fk",
+          "tableFrom": "org_usage_counters",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_usage_counters_select_org_member": {
+          "name": "org_usage_counters_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_usage_counters_insert_org_admin": {
+          "name": "org_usage_counters_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_update_org_admin": {
+          "name": "org_usage_counters_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_delete_org_admin": {
+          "name": "org_usage_counters_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.billing_webhook_events": {
+      "name": "billing_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_webhook_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_webhook_events_provider_event_id_uidx": {
+          "name": "billing_webhook_events_provider_event_id_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_status_idx": {
+          "name": "billing_webhook_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_created_at_idx": {
+          "name": "billing_webhook_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.consent_records": {
+      "name": "consent_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "necessary": {
+          "name": "necessary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "functional": {
+          "name": "functional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_country": {
+          "name": "ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "consent_records_user_id_users_id_fk": {
+          "name": "consent_records_user_id_users_id_fk",
+          "tableFrom": "consent_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_records_user_id_unique": {
+          "name": "consent_records_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "consent_records_anonymous_id_unique": {
+          "name": "consent_records_anonymous_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anonymous_id"
+          ]
+        }
+      },
+      "policies": {
+        "consent_records_select_self": {
+          "name": "consent_records_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_insert_self": {
+          "name": "consent_records_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_update_self": {
+          "name": "consent_records_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())",
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.contact_submission_status": {
+      "name": "contact_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.membership_role": {
+      "name": "membership_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "texture",
+        "material",
+        "model",
+        "environment",
+        "other"
+      ]
+    },
+    "public.scene_status": {
+      "name": "scene_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.scene_action_request_status": {
+      "name": "scene_action_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.permission_entity": {
+      "name": "permission_entity",
+      "schema": "public",
+      "values": [
+        "user",
+        "group"
+      ]
+    },
+    "public.permission_type": {
+      "name": "permission_type",
+      "schema": "public",
+      "values": [
+        "read",
+        "write",
+        "admin",
+        "delete"
+      ]
+    },
+    "public.api_key_kind": {
+      "name": "api_key_kind",
+      "schema": "public",
+      "values": [
+        "embed"
+      ]
+    },
+    "public.billing_state": {
+      "name": "billing_state",
+      "schema": "public",
+      "values": [
+        "none",
+        "trialing",
+        "active",
+        "past_due",
+        "unpaid",
+        "canceled",
+        "paused",
+        "incomplete",
+        "incomplete_expired"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "business",
+        "enterprise"
+      ]
+    },
+    "public.billing_webhook_event_status": {
+      "name": "billing_webhook_event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/vectreal-platform/supabase/migrations/meta/_journal.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1787738787455,
       "tag": "0019_shocking_scorpion",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1788348972192,
+      "tag": "0020_dazzling_kang",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Salvaged from a parallel branch that solved the same problem a different way. Its UI is superseded by #785, but **this idea is not** — it is the one thing the shipped version was missing.

## Root cause

`resolveRowValue` decides whether to hand a key back by asking what happened to the row — revoked, never stored, no longer decrypting — and never asks what the key is **for**.

Every key today is an embed token, published by construction, so "show it" is right for all of them. The moment a server-side key with write scope exists (the Held *"Server-side API keys with write scope"* row), "show it" is *still what the code does*, and nothing forces whoever adds that kind to notice.

## Change

`api_key_kind` is an enum with one value, and the enum exists for the second one. `KIND_IS_DISCLOSABLE` is a total `Record` over it, following `DASHBOARD_OPERATION_ROLES`: **adding a kind fails to compile until someone writes its rule.** An `if` would let a new value inherit whichever branch it fell into — and for a write-scoped key, that branch is the one that hands out the secret.

The check runs **before** the cipher. It is a different question from the three below it: those are reasons a value cannot be produced, this is a reason it must not be, and a key that must not be disclosed should not have its plaintext put in memory to then be discarded.

## Two departures from the branch this came from

- **Disclosure is a pure module** with no cipher import, so the rule is testable without key material.
- **It feeds the existing `ApiKeyRowValue` union** rather than collapsing to `string | null`. That branch returned one null for four situations and rendered them identically — losing the distinction between "rotate this" and "replace this", which is the difference between an action that works and one that throws.

## Migration

Generated with `nx run vectreal-platform:drizzle-generate`, not hand-written. The column is defaulted, so rows predating it are what they have always been: every one was minted by a form that could create nothing else. `kind` is stated explicitly at the single mint site anyway, so a kind added later has to come through there and say so.

## Verification

| Mutation | Result |
| --- | --- |
| Disclosure returns true unconditionally | red |
| Loader skips the check | red |
| Map loses its `embed` rule | red |

The spec also asserts the map is total against `apiKeyKindEnum.enumValues`, which catches a rule quietly deleted — the direction the compiler cannot see.

- `pnpm nx run-many --target=typecheck,lint -p vectreal-platform` — green
- `npx vitest run --root .` — 140 files, 1757 tests, green