### PR TITLE
feat(embed): say why an embed was refused instead of failing quietly

### DIFF
--- a/apps/vectreal-platform/app/components/scene-embed/embed-refusal.spec.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/embed-refusal.spec.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+/**
+ * What a refused embed says, and what it must not say.
+ *
+ * The second half is the load-bearing one. This is the only refusal on the
+ * embed route that explains itself, and it is allowed to because it is reached
+ * only after a live key matched the project - the caller has already proved
+ * they hold it. Everything it adds beyond that is a disclosure to whoever
+ * happens to be looking at someone else's broken page.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { EmbedRefusal } from './embed-refusal'
+
+describe('EmbedRefusal', () => {
+	it('says the site is not allowed, not that something went wrong', () => {
+		/*
+		  The whole point. Before this the viewer booted and showed "Unable to Load
+		  Scene Preview" - a message that describes a fault, for a server that made
+		  a decision.
+		*/
+		render(<EmbedRefusal reason="domain_not_allowed" />)
+
+		expect(screen.getByText(/not allowed to show this embed/i)).not.toBeNull()
+		expect(screen.queryByText(/unable to load/i)).toBeNull()
+	})
+
+	it('names the fix and where to make it', () => {
+		render(<EmbedRefusal reason="domain_not_allowed" />)
+
+		expect(screen.getByText(/allowed domains/i)).not.toBeNull()
+	})
+
+	it('says the key is valid, so nobody rotates a working key', () => {
+		/*
+		  Without this the obvious reading of a refused embed is "the key is
+		  broken", and the obvious action is to rotate it - which refuses the old
+		  secret everywhere else it is deployed and fixes nothing here.
+		*/
+		render(<EmbedRefusal reason="domain_not_allowed" />)
+
+		expect(screen.getByText(/key is valid/i)).not.toBeNull()
+	})
+
+	it('never echoes the allowed domain list back', () => {
+		/*
+		  The list is the inventory of every site this project embeds on. The owner
+		  can already read it where they would go to change it; an unknown visitor
+		  looking at someone else's broken page should not be handed it.
+		*/
+		const { container } = render(<EmbedRefusal reason="domain_not_allowed" />)
+
+		expect(container.textContent).not.toMatch(/https?:\/\//)
+		expect(container.textContent).not.toMatch(
+			/\b[a-z0-9-]+\.(com|io|dev|co)\b/i
+		)
+	})
+
+	it('offers no navigation, because there is nowhere to go inside an iframe', () => {
+		/*
+		  The panel this replaces had Retry and Go Back. Retry re-ran a request the
+		  server had already decided, and `history.back()` in an iframe moves the
+		  frame, not the page - so both looked like recovery and were not.
+		*/
+		render(<EmbedRefusal reason="domain_not_allowed" />)
+
+		expect(screen.queryByRole('button')).toBeNull()
+		expect(screen.queryByRole('link')).toBeNull()
+	})
+})
+
+describe('which refusals the embed route explains', () => {
+	/*
+	  Read from source rather than driven through the loader, which reaches
+	  `getDbClient()` on import and cannot be loaded without a database. The
+	  invariant is about which branches say what, and that is visible in the text.
+	*/
+	const layout = readFileSync(
+		join(
+			dirname(fileURLToPath(import.meta.url)),
+			'../../routes/layouts/embed-layout.tsx'
+		),
+		'utf8'
+	)
+
+	it('explains only the domain refusal', () => {
+		expect(layout).toContain("reason: 'domain_not_allowed'")
+	})
+
+	it('keeps every other refusal a flat, identical 404', () => {
+		/*
+		  Three branches answer 404: no credential, a token that matched nothing,
+		  and a scene that is not published. They must stay indistinguishable -
+		  telling them apart tells an unknown visitor whether a scene id exists,
+		  which is the id-oracle the architecture rules refuse.
+
+		  So: exactly one `notFound` string in this file, used by all three.
+		*/
+		const messages = [
+			...layout.matchAll(/ApiResponse\.notFound\(([^)]*)\)/g)
+		].map((match) => match[1].trim())
+
+		expect(messages.length).toBeGreaterThan(1)
+		expect(new Set(messages).size).toBe(1)
+	})
+
+	it('does not turn the rate limit into an explanation either', () => {
+		// A 429 says how many, never whose key or which project.
+		expect(layout).toContain("ApiResponse.error('Too many requests', 429)")
+	})
+})

--- a/apps/vectreal-platform/app/components/scene-embed/embed-refusal.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/embed-refusal.tsx
@@ -1,0 +1,65 @@
+/**
+ * What an embed shows when the server refused it, instead of a spinner.
+ *
+ * The refusals worth explaining are the ones the site owner can act on, and
+ * until now none of them said anything: the loader returned a 403 rather than
+ * throwing, so React Router treated it as data, no boundary ran, and the viewer
+ * booted anyway - a spinner, then a client fetch that failed its own auth, then
+ * "Unable to Load Scene Preview" with a Retry that retries nothing and a Go
+ * Back that does nothing inside an iframe.
+ *
+ * Sized for an iframe, which is the only place this renders. No navigation
+ * controls for the same reason: there is nowhere to go back to.
+ */
+
+import type { FC } from 'react'
+
+export type EmbedRefusalReason = 'domain_not_allowed'
+
+/**
+ * One entry per reason a refusal is explained rather than hidden.
+ *
+ * Deliberately not every failure. A bad token, a missing scene and an
+ * unpublished scene all answer 404 and stay unexplained, because the person
+ * looking at a broken embed is not always the person who owns it - and naming
+ * which of those it was tells an unknown visitor whether an id exists.
+ *
+ * `domain_not_allowed` is the exception, and only reachable after a live key
+ * matched this project: the caller already proved they hold it, so the message
+ * tells them nothing they had not established. It also fires before the scene
+ * is looked up, so it says nothing about whether that scene exists.
+ */
+const REFUSAL_COPY: Record<
+	EmbedRefusalReason,
+	{ title: string; detail: string; action: string }
+> = {
+	domain_not_allowed: {
+		title: 'This site is not allowed to show this embed',
+		detail:
+			'The key is valid, but the page requesting it is not on the allowed domain list for this project.',
+		/*
+		  Names the fix without naming the list. Echoing the allowed domains back
+		  would hand an unknown visitor the inventory of every site the owner
+		  embeds on, for no gain to the owner - who can already read it on the page
+		  where they would go to change it.
+		*/
+		action:
+			'If you own this project, add this site to its allowed domains in the Vectreal dashboard.'
+	}
+}
+
+export const EmbedRefusal: FC<{ reason: EmbedRefusalReason }> = ({
+	reason
+}) => {
+	const copy = REFUSAL_COPY[reason]
+
+	return (
+		<div className="bg-background flex h-dvh w-full items-center justify-center p-6">
+			<div className="border-border bg-card w-full max-w-md space-y-3 rounded-2xl border p-6">
+				<h1 className="text-h4">{copy.title}</h1>
+				<p className="text-muted-foreground text-sm">{copy.detail}</p>
+				<p className="text-muted-foreground text-sm">{copy.action}</p>
+			</div>
+		</div>
+	)
+}

--- a/apps/vectreal-platform/app/routes/layouts/embed-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/embed-layout.tsx
@@ -1,7 +1,14 @@
 import { ApiResponse } from '@shared/utils'
-import { data, Outlet, type MetaFunction } from 'react-router'
+import {
+	data,
+	isRouteErrorResponse,
+	Outlet,
+	useRouteError,
+	type MetaFunction
+} from 'react-router'
 
 import { Route } from './+types/embed-layout'
+import { EmbedRefusal } from '../../components/scene-embed/embed-refusal'
 import { validatePreviewApiKeyForProject } from '../../lib/domain/auth/preview-api-key-auth.server'
 import {
 	EMBED_RESPONSE_HEADERS,
@@ -12,6 +19,7 @@ import {
 	SCENE_ROUTE_PARAM_ERRORS
 } from '../../lib/domain/scene/scene-route-params'
 import { getPublishedScenePreview } from '../../lib/domain/scene/server/scene-preview-repository.server'
+import { useErrorReport } from '../../lib/observability/use-error-report'
 import { buildMeta } from '../../lib/seo'
 
 export const meta: MetaFunction = () =>
@@ -43,7 +51,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 	const url = new URL(request.url)
 	const tokenFromQuery = url.searchParams.get('token')?.trim() || null
 	const hasTokenCredential =
-		Boolean(tokenFromQuery) || Boolean(request.headers.get('authorization')?.trim())
+		Boolean(tokenFromQuery) ||
+		Boolean(request.headers.get('authorization')?.trim())
 
 	if (!hasTokenCredential) {
 		return withEmbedResponseHeaders(ApiResponse.notFound('Scene not found'))
@@ -56,10 +65,28 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 	if (!authResult.ok) {
 		if (authResult.error === 'rate_limited') {
-			return withEmbedResponseHeaders(ApiResponse.error('Too many requests', 429))
+			return withEmbedResponseHeaders(
+				ApiResponse.error('Too many requests', 429)
+			)
 		}
 		if (authResult.error === 'domain_not_allowed') {
-			return withEmbedResponseHeaders(ApiResponse.forbidden('Forbidden'))
+			/*
+			  Thrown, not returned. A returned `Response` is data to React Router:
+			  no boundary runs, the document renders at 403 with a payload nothing
+			  reads, and the viewer boots into a spinner and then a generic "unable
+			  to load" with a Retry that retries nothing. Throwing is what puts the
+			  explanation on screen.
+
+			  Safe to explain, unlike every other refusal here. This one is only
+			  reached after a live key matched this project, so the caller has
+			  already proved they hold it - and it fires before the scene is looked
+			  up, so it discloses nothing about whether that scene exists. The
+			  others stay a flat 404 for exactly that reason.
+			*/
+			throw data(
+				{ reason: 'domain_not_allowed' as const },
+				{ status: 403, headers: EMBED_RESPONSE_HEADERS }
+			)
 		}
 
 		return withEmbedResponseHeaders(ApiResponse.notFound('Scene not found'))
@@ -103,6 +130,48 @@ export async function loader({ request, params }: Route.LoaderArgs) {
  */
 export function headers({ loaderHeaders }: Route.HeadersArgs) {
 	return loaderHeaders
+}
+
+/**
+ * The refusal an owner can act on, rendered instead of a broken viewer.
+ *
+ * Only `domain_not_allowed` gets a message; anything else falls through to the
+ * generic boundary, because the other refusals are the ones that must not say
+ * which of them happened.
+ *
+ * `headers` above does not run for a thrown response - React Router builds the
+ * error response separately - so the status carries the headers itself, from
+ * the same constant the success path uses.
+ */
+export function ErrorBoundary() {
+	const error = useRouteError()
+	const isRefusal =
+		isRouteErrorResponse(error) &&
+		error.status === 403 &&
+		error.data?.reason === 'domain_not_allowed'
+
+	/*
+	  Called unconditionally, because a boundary is a component and the hook
+	  cannot move inside an `if` - and passed `undefined` for the refusal, which
+	  the hook documents as reporting nothing.
+
+	  That distinction is the point rather than a way around the ratchet. A
+	  refused domain is a decision this route made on purpose, and the site that
+	  triggers it will trigger it on every page load; reporting it would fill the
+	  exception feed with the one failure already visible on screen. Anything
+	  else reaching here is a real error and is reported before it is re-thrown.
+	*/
+	useErrorReport(isRefusal ? undefined : error)
+
+	if (isRefusal) {
+		return <EmbedRefusal reason="domain_not_allowed" />
+	}
+
+	/*
+	  Re-thrown so the root boundary renders it. This route only knows how to
+	  explain one thing; the rest are not its to present.
+	*/
+	throw error
 }
 
 const EmbedLayout = () => {


### PR DESCRIPTION
## Root cause

The loader **returned** the 403 rather than throwing it. A returned `Response` is *data* to React Router — so no boundary ran, the document rendered at 403 with a payload nothing reads, and the viewer booted anyway.

What a visitor actually saw: a spinner, then a client-side fetch that failed its own auth, then **"Unable to Load Scene Preview"** with a Retry that re-ran a decision the server had already made, and a Go Back that moves an iframe rather than the page. A message describing a fault, for a server that made a choice.

## Only one refusal is explained

`domain_not_allowed` is reached **only after a live key matched this project** — the caller has already proved they hold it, so the message tells them nothing they had not established. It also fires *before* the scene is looked up, so it discloses nothing about whether that scene exists.

Every other refusal stays a flat, identical 404. Telling a bad token apart from a missing scene apart from an unpublished one is exactly the id oracle the architecture rules refuse, and the person looking at a broken embed is not always the person who owns it. A spec reads the route source and asserts all the 404 branches still share one message.

## What the copy does and does not do

- **Names the fix without naming the list.** Echoing the allowed domains back hands a visitor the inventory of every site the owner embeds on, for no gain to the owner — who can already read it where they would change it.
- **Says the key is valid.** The obvious reading of a refused embed is "the key is broken", and the obvious action is to rotate it — which refuses the old secret everywhere *else* it is deployed and fixes nothing here.
- **No Retry, no Go Back.** Both looked like recovery and neither was.

## Reporting

The boundary goes through `useErrorReport` like every other, and passes `undefined` for the refusal — which the hook documents as reporting nothing. A refused domain is a deliberate decision that repeats on every page load of the offending site; reporting it would fill the exception feed with the one failure already visible on screen. Anything else is reported and re-thrown for the root boundary.

`tests/error-boundary-reporting.spec.ts` caught this omission on the first run — the ratchet works.

## Verification

| Mutation | Result |
| --- | --- |
| Return the bare 403 again | red |
| Make one 404 message distinguishable | red |
| Echo a domain into the copy | red |
| Re-add a Retry button | red |

- `pnpm nx run-many --target=typecheck,lint -p vectreal-platform` — green
- `npx vitest run --root .` — 140 files, 1763 tests, green