### PR TITLE
fix(scene): check the optimization report before trusting it

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/scene/optimization-report-guard.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/optimization-report-guard.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * The optimization report, checked before it is believed.
+ *
+ * It arrives from the browser and is persisted into `scene_stats` verbatim. It
+ * used to be accepted on `typeof value === 'object'` alone and cast to
+ * `OptimizationReport` - a promise to the compiler that it may stop checking,
+ * made about a shape nothing had verified.
+ *
+ * Two consequences, and the second is the one that bites without an attacker:
+ * every metric on the scene detail page was client-controlled rather than
+ * server-derived, and a payload merely *missing* a field crashed the endpoint,
+ * because `createSceneStatsFromReport` dereferences two levels deep. `{}` was a
+ * 500 anyone could trigger on their own scene.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { parseOptimizationReport } from './optimization-report-guard'
+import { buildOptimizationReport } from '../../../../tests/fixtures/optimization-report'
+
+/** The report a real client sends, as JSON would deliver it. */
+const valid = () => JSON.parse(JSON.stringify(buildOptimizationReport()))
+
+describe('a report the server can trust', () => {
+	it('accepts what the optimizer actually produces', () => {
+		/*
+		  Round-tripped through JSON on purpose: the payload arrives parsed from a
+		  request body, not as the in-memory object, and a guard that only accepts
+		  the latter would reject every real save.
+		*/
+		expect(parseOptimizationReport(valid())).not.toBeNull()
+	})
+
+	it('keeps extra properties rather than rejecting them', () => {
+		/*
+		  `@vctrl/core` gains metrics over time, and an older client posting a
+		  smaller report is a real case. This checks that everything the
+		  persistence path reads is present and sane, not that nothing else is.
+		*/
+		const withExtra = { ...valid(), somethingNew: { before: 1, after: 2 } }
+
+		expect(parseOptimizationReport(withExtra)).not.toBeNull()
+	})
+})
+
+describe('what it refuses', () => {
+	it('refuses a body with no stats at all', () => {
+		/*
+		  The crash, not the attack. `createSceneStatsFromReport` reads
+		  `report.stats.verticesCount.before`, so this was a `TypeError` and a 500.
+		*/
+		expect(parseOptimizationReport({})).toBeNull()
+	})
+
+	it.each([
+		'verticesCount',
+		'primitivesCount',
+		'materialsCount',
+		'textureBytes',
+		'texturesCount',
+		'meshBytes',
+		'meshesCount'
+	])('refuses a report missing %s', (field) => {
+		/*
+		  Every one, not a representative sample. Each is dereferenced two levels
+		  deep on the persistence path, so any single omission is its own 500 - and
+		  a guard checking six of seven reads exactly like one checking all seven.
+		*/
+		const report = valid()
+		delete report.stats[field]
+
+		expect(parseOptimizationReport(report)).toBeNull()
+	})
+
+	it('refuses a metric that is half a number', () => {
+		const report = valid()
+		report.stats.meshesCount = { before: 12 }
+
+		expect(parseOptimizationReport(report)).toBeNull()
+	})
+
+	it.each([Number.NaN, Number.POSITIVE_INFINITY])(
+		'refuses %s, which typeof calls a number',
+		(value) => {
+			/*
+			  Both pass a bare `typeof x === 'number'`, and both reach an integer
+			  column and a metrics tile. This is the case a schema check written as
+			  "is it a number" still lets through.
+			*/
+			const report = valid()
+			report.stats.verticesCount = { before: value, after: 10 }
+
+			expect(parseOptimizationReport(report)).toBeNull()
+		}
+	)
+
+	it('refuses a string where a metric belongs', () => {
+		const report = valid()
+		report.originalSize = '8000000'
+
+		expect(parseOptimizationReport(report)).toBeNull()
+	})
+
+	it('refuses an array, which is also typeof object', () => {
+		/*
+		  Behaviour, not the line that produces it: an array has no `originalSize`
+		  either, so it would fall at the field checks even without the explicit
+		  `Array.isArray`. Asserted because the answer matters, not because it
+		  pins one branch.
+		*/
+		expect(parseOptimizationReport([])).toBeNull()
+	})
+
+	it.each([null, undefined, 'a string', 42])('refuses %s', (value) => {
+		expect(parseOptimizationReport(value)).toBeNull()
+	})
+
+	it('refuses applied optimizations that are not strings', () => {
+		const report = valid()
+		report.appliedOptimizations = [{ name: 'draco' }]
+
+		expect(parseOptimizationReport(report)).toBeNull()
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/scene/optimization-report-guard.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/optimization-report-guard.ts
@@ -1,0 +1,131 @@
+import type {
+	BeforeAfterMetric,
+	OptimizationReport,
+	OptimizationStats
+} from '@vctrl/core'
+
+/**
+ * A finite number, which `typeof x === 'number'` is not.
+ *
+ * `NaN` and `Infinity` both pass a bare typeof check and both survive
+ * `JSON.parse` as `null` only when serialized - a client posting them directly
+ * gets them through. They then reach an integer column and a metrics tile.
+ */
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === 'number' && Number.isFinite(value)
+}
+
+function isBeforeAfterMetric(value: unknown): value is BeforeAfterMetric {
+	if (!value || typeof value !== 'object') {
+		return false
+	}
+
+	const metric = value as { before?: unknown; after?: unknown }
+	return isFiniteNumber(metric.before) && isFiniteNumber(metric.after)
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return (
+		Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+	)
+}
+
+/**
+ * Every metric the persistence path reads, by name.
+ *
+ * Listed rather than inferred, because the list is the point: each of these is
+ * dereferenced two levels deep by `createSceneStatsFromReport` and the byte
+ * scopes beside it, so a payload missing any one of them is not a degraded
+ * report - it is a `TypeError` on the server.
+ */
+const REQUIRED_METRICS = [
+	'verticesCount',
+	'primitivesCount',
+	'materialsCount',
+	'textureBytes',
+	'texturesCount',
+	'meshBytes',
+	'meshesCount'
+] as const satisfies readonly (keyof OptimizationStats)[]
+
+function isOptimizationStats(value: unknown): value is OptimizationStats {
+	if (!value || typeof value !== 'object') {
+		return false
+	}
+
+	const stats = value as Record<string, unknown>
+
+	if (!REQUIRED_METRICS.every((key) => isBeforeAfterMetric(stats[key]))) {
+		return false
+	}
+
+	const resolutions = stats.textureResolutions as
+		{ before?: unknown; after?: unknown } | undefined
+
+	return (
+		Boolean(resolutions) &&
+		typeof resolutions === 'object' &&
+		isStringArray(resolutions?.before) &&
+		isStringArray(resolutions?.after)
+	)
+}
+
+/**
+ * The optimization report as the client sends it, checked before it is believed.
+ *
+ * This payload arrives from the browser and is persisted into `scene_stats`
+ * verbatim. It used to be accepted on `typeof value === 'object'` alone and cast
+ * to `OptimizationReport`, which is a promise to the compiler that it may stop
+ * checking - made about a shape nothing had verified.
+ *
+ * Two things followed from that. Every metric on the scene detail page was
+ * client-controlled rather than server-derived, so any number could be posted
+ * for any scene. And a payload merely *missing* a field was worse than a
+ * malicious one: `createSceneStatsFromReport` dereferences two levels deep, so
+ * `{}` reached the server as a 500 rather than a 400 - a crash anyone could
+ * trigger on their own scene by sending a truncated body.
+ *
+ * Returns `null` rather than throwing, so the caller decides the status code.
+ *
+ * Deliberately not a schema library. `zod` is a dependency of this app but no
+ * parser in this file uses it, and `parseSceneMeta` directly above narrows by
+ * hand; one file with two validation idioms is worse than either idiom.
+ *
+ * Unknown extra properties are allowed through. `@vctrl/core` adds metrics over
+ * time and an older client posting a smaller report is a real case, so this
+ * checks that everything the persistence path reads is present and sane rather
+ * than that nothing else is.
+ */
+export function parseOptimizationReport(
+	value: unknown
+): OptimizationReport | null {
+	/*
+	  `Array.isArray` is stated rather than relied on: an array falls at the
+	  field checks below anyway, since it has no `originalSize`. It is here to
+	  say what this accepts, and because `parseSceneMeta` beside it rejects the
+	  same shape the same way.
+	*/
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return null
+	}
+
+	const candidate = value as Record<string, unknown>
+
+	if (
+		!isFiniteNumber(candidate.originalSize) ||
+		!isFiniteNumber(candidate.optimizedSize) ||
+		!isFiniteNumber(candidate.compressionRatio)
+	) {
+		return null
+	}
+
+	if (!isStringArray(candidate.appliedOptimizations)) {
+		return null
+	}
+
+	if (!isOptimizationStats(candidate.stats)) {
+		return null
+	}
+
+	return candidate as unknown as OptimizationReport
+}

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
@@ -9,6 +9,7 @@ import {
 
 import { UUID_REGEX } from '../../../../constants/utility-constants'
 import { parseActionRequest } from '../../../http/requests.server'
+import { parseOptimizationReport } from '../optimization-report-guard'
 import {
 	applyDefaultCameraFlag,
 	resolveDefaultSceneCameraId
@@ -710,7 +711,17 @@ export class SceneSettingsParser {
 	}
 
 	/**
-	 * Parses optimization report from request.
+	 * Parses the optimization report from the request, and checks it.
+	 *
+	 * This payload comes from the browser and is persisted into `scene_stats`
+	 * verbatim. The object branch used to accept it on `typeof === 'object'` and
+	 * cast, and the string branch checked only that `JSON.parse` returned a
+	 * non-null object - so a truncated body reached
+	 * `createSceneStatsFromReport`, which dereferences two levels deep, and came
+	 * back as a 500 rather than a 400.
+	 *
+	 * Both branches now go through the same guard, because they were two spellings
+	 * of one payload and only one of them was ever checked.
 	 */
 	private static parseOptimizationReport(
 		requestData: Record<string, unknown>
@@ -719,24 +730,24 @@ export class SceneSettingsParser {
 			return undefined
 		}
 
-		if (typeof requestData.optimizationReport === 'string') {
+		let payload: unknown = requestData.optimizationReport
+
+		if (typeof payload === 'string') {
 			try {
-				const parsed = JSON.parse(requestData.optimizationReport)
-				if (typeof parsed !== 'object' || parsed === null) {
-					return ApiResponse.badRequest('Invalid optimization report format')
-				}
-				return parsed
+				payload = JSON.parse(payload)
 			} catch (error) {
 				console.warn('Failed to parse optimizationReport:', error)
 				return ApiResponse.badRequest('Invalid optimization report format')
 			}
 		}
 
-		if (typeof requestData.optimizationReport === 'object') {
-			return requestData.optimizationReport as OptimizationReport
+		const report = parseOptimizationReport(payload)
+
+		if (!report) {
+			return ApiResponse.badRequest('Invalid optimization report format')
 		}
 
-		return undefined
+		return report
 	}
 
 	private static parseOptimizationSettings(


### PR DESCRIPTION
## Summary

The optimization report arrives from the browser and is persisted into `scene_stats` verbatim. It was accepted on `typeof value === 'object'` and cast to `OptimizationReport`.

## Root cause

Two spellings of one payload, and only one of them was ever checked — so the check that existed guarded the wrong thing. The string branch verified `JSON.parse` returned a non-null object; the object branch verified nothing and cast. A cast is a promise to the compiler that it may stop checking, made here about a shape nothing had verified.

**The consequence that bites without an attacker is the second one.** Client-controlled metrics are a lie a user can tell about their own scene, and not much more. But a payload merely *missing* a field was worse: `createSceneStatsFromReport` dereferences two levels deep, so `{}` was a `TypeError` and a **500 anyone could trigger** by sending a truncated body.

## Changes

- One guard both branches go through, rejecting with `badRequest` instead of casting.
- It lives in a **pure module**, not the `.server` parser, because a route module cannot be imported by a test — `getDbClient()` runs at module scope and throws. `scene-route-params.ts` is the pattern.
- Required metrics are listed by name, `satisfies readonly (keyof OptimizationStats)[]`, so the list cannot drift from the type.

**Deliberately not a schema library.** `zod` is a dependency of this app, but no parser in this file uses one and `parseSceneMeta` directly above narrows by hand. One file with two validation idioms is worse than either idiom.

**Extra properties pass.** `@vctrl/core` gains metrics over time and an older client posting a smaller report is a real case, so this checks that everything the persistence path reads is present and finite — not that nothing else is.

**`NaN` and `Infinity` are rejected explicitly.** Both pass a bare `typeof x === 'number'`, and both reach an integer column and a metrics tile. That is the case a check written as "is it a number" still lets through.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit tests added (20), typecheck + lint green, 1773 tests pass.

The valid-payload fixture is round-tripped through `JSON.parse(JSON.stringify(...))` on purpose: the payload arrives parsed from a request body, and a guard that only accepted the in-memory object would reject every real save.

Every required metric gets its own `it.each` case rather than a representative sample — each is dereferenced two levels deep on the persistence path, so any single omission is its own 500, and a guard checking six of seven reads exactly like one checking all seven.

Mutations verified red: the original bug reinstated (skip the stats check); `Number.isFinite` downgraded to `typeof`; one metric dropped from the required list.

**One mutation deliberately survived**, and the code says so: removing the explicit `Array.isArray` guard changes nothing, because an array has no `originalSize` and falls at the field checks anyway. It is kept to state intent and to match `parseSceneMeta` beside it, and the test asserts the behaviour rather than claiming to pin that branch.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes