### PR TITLE
fix(infra): give the Fly secret list one home, and the four names it lacked

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -119,6 +119,12 @@ CONTACT_INBOX_EMAIL=info@vectreal.com
 
 # PostHog analytics (same project across all environments)
 # Set VITE_PUBLIC_POSTHOG_ENABLED=true locally only when testing the consent flow.
+#
+# The VITE_ prefix undersells TOKEN and HOST: they are read twice, for unrelated
+# reasons. Vite bakes them into the client bundle at build time, AND
+# posthog-client.server.ts reads the same names from process.env at runtime, so
+# both are required Fly secrets. See the manifest in setup-fly-secrets.sh for
+# what a deployment that does only the first loses.
 VITE_PUBLIC_POSTHOG_TOKEN=phc_your-posthog-project-api-key
 VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 VITE_PUBLIC_POSTHOG_UI_HOST=https://eu.posthog.com
@@ -165,6 +171,23 @@ CSRF_SECRET_STAGING=
 # Stripe test key for staging
 STRIPE_SECRET_KEY_STAGING=sk_test_your-staging-stripe-secret-key
 
+# Signing secret for the Stripe webhook endpoint. One per endpoint, so staging
+# and production hold different values - copy each from the endpoint's page in
+# the Stripe dashboard.
+#
+# Required: without it the webhook route 400s every delivery, and a portal
+# cancellation, a failed payment or an expired period all leave the
+# subscription reading `active`. The manifest in setup-fly-secrets.sh has the
+# detail.
+STRIPE_WEBHOOK_SECRET_STAGING=whsec_your-staging-webhook-signing-secret
+
+# Optional. Guards POST /api/billing/reconcile, which repairs local
+# subscription state against Stripe. The route is fail-closed and 401s
+# everything when unset, so blank turns the drift detector off rather than
+# opening it up. Set per environment; the sync skips whichever side is blank.
+# Generate: openssl rand -base64 32
+BILLING_RECONCILE_SECRET_STAGING=
+
 # Supabase send_email hook HMAC secret (format: v1,whsec_<base64>)
 # setup-fly-secrets.sh syncs this to both Fly.io and the Supabase project hook config.
 # Generate: openssl rand -base64 32 | tr -d '\n' | xargs -I{} echo "v1,whsec_{}"
@@ -204,6 +227,13 @@ CSRF_SECRET_PROD=
 
 # Use the live Stripe key for production
 STRIPE_SECRET_KEY_PROD=sk_live_your-production-stripe-secret-key
+
+# Signing secret for the production webhook endpoint - a different value from
+# the staging one. See the staging entry above for why it is required.
+STRIPE_WEBHOOK_SECRET_PROD=whsec_your-production-webhook-signing-secret
+
+# Optional. See the staging entry above.
+BILLING_RECONCILE_SECRET_PROD=
 
 # Supabase send_email hook HMAC secret - keep different from staging.
 # Rotate both here AND via setup-fly-secrets.sh (which syncs Supabase automatically).

--- a/.env.development.example
+++ b/.env.development.example
@@ -100,7 +100,10 @@ GITHUB_CLIENT_SECRET=
 # 3. SHARED DEPLOYMENT SECRETS
 # =============================================================================
 # These have a single value that is identical across staging and production.
-# setup-fly-secrets.sh reads FROM_EMAIL and CONTACT_INBOX_EMAIL from here.
+# setup-fly-secrets.sh reads FROM_EMAIL, CONTACT_INBOX_EMAIL and the two
+# VITE_PUBLIC_POSTHOG_* names below from here - the PostHog pair has no
+# _STAGING / _PROD variant because `resolve` falls back to the bare name, and
+# both environments report into the same project.
 
 # GitHub release automation (Release Please app)
 RELEASE_APP_ID=
@@ -125,8 +128,13 @@ CONTACT_INBOX_EMAIL=info@vectreal.com
 # posthog-client.server.ts reads the same names from process.env at runtime, so
 # both are required Fly secrets. See the manifest in setup-fly-secrets.sh for
 # what a deployment that does only the first loses.
+#
+# HOST is the ingestion endpoint and goes through our own subdomain: `go` is a
+# proxied CNAME to PostHog's managed reverse proxy (terraform/cloudflare.tf,
+# `posthog_proxy`), which is what keeps ad blockers from dropping client events.
+# UI_HOST is where links in the SDK point and stays the real dashboard origin.
 VITE_PUBLIC_POSTHOG_TOKEN=phc_your-posthog-project-api-key
-VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+VITE_PUBLIC_POSTHOG_HOST=https://go.vectreal.com
 VITE_PUBLIC_POSTHOG_UI_HOST=https://eu.posthog.com
 
 # Vectreal preview embeds - baked into the client bundle at Docker build time.

--- a/.github/workflows/cd-platform-secrets.yaml
+++ b/.github/workflows/cd-platform-secrets.yaml
@@ -70,6 +70,9 @@ jobs:
           APPLICATION_URL: ${{ secrets.APPLICATION_URL }}
           CSRF_SECRET: ${{ secrets.CSRF_SECRET }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          # Required. See the manifest in setup-fly-secrets.sh for what its
+          # absence costs; this block only decides which values reach it.
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           SEND_EMAIL_HOOK_SECRET: ${{ secrets.SEND_EMAIL_HOOK_SECRET }}
           CLOUDFLARE_TURNSTILE_SITE_KEY: ${{ secrets.CLOUDFLARE_TURNSTILE_SITE_KEY }}
           CLOUDFLARE_TURNSTILE_SECRET_KEY: ${{ secrets.CLOUDFLARE_TURNSTILE_SECRET_KEY }}
@@ -79,6 +82,14 @@ jobs:
           RESEND_WEBHOOK_SECRET: ${{ secrets.RESEND_WEBHOOK_SECRET }}
           CONTACT_INBOX_EMAIL: ${{ secrets.CONTACT_INBOX_EMAIL }}
           FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
+          # Required, and also a Docker build-arg in shared-fly-deploy.yaml.
+          # Both, deliberately: that one is the client bundle, these are the
+          # server's process env. The manifest says why the two are separate.
+          VITE_PUBLIC_POSTHOG_TOKEN: ${{ secrets.VITE_PUBLIC_POSTHOG_TOKEN }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
+          # Optional in the manifest, so a missing mapping here fails silently
+          # rather than at validation. It has to be listed for that reason.
+          BILLING_RECONCILE_SECRET: ${{ secrets.BILLING_RECONCILE_SECRET }}
           # Read as shell variables rather than interpolated into the script
           # body. Both are `type: choice` and so already constrained, but a
           # workflow_dispatch input is caller-supplied and inlining one into

--- a/apps/vectreal-platform/Dockerfile
+++ b/apps/vectreal-platform/Dockerfile
@@ -67,11 +67,21 @@ ENV NODE_ENV=${NODE_ENV}
 ENV PORT=8080
 ENV NODE_OPTIONS="--heapsnapshot-near-heap-limit=2"
 
-# Runtime secrets are injected by Fly.io (set via setup-fly-secrets.sh).
-# Required: DATABASE_URL, SUPABASE_URL, SUPABASE_KEY, STRIPE_SECRET_KEY,
-#           CSRF_SECRET, APPLICATION_URL, CLOUDFLARE_TURNSTILE_SITE_KEY,
-#           CLOUDFLARE_TURNSTILE_SECRET_KEY, RESEND_API_KEY, FROM_EMAIL,
-#           CONTACT_INBOX_EMAIL, SEND_EMAIL_HOOK_SECRET
+# Runtime secrets are injected by Fly.io. The authoritative list is the manifest
+# at the top of terraform/scripts/setup-fly-secrets.sh, and is deliberately not
+# repeated here: the copy that used to sit at this line named twelve while the
+# manifest requires seventeen, and nothing compared the two.
+#
+# What this stage does NOT inherit is the point. `build` is `FROM deps` and
+# `deps` is `FROM base`; `runner` is `FROM base` directly, so it is off that
+# branch entirely and inherits none of build's ENV - neither the VITE_PUBLIC_*
+# values Vite bakes into the client bundle nor the throwaway placeholders that
+# keep server-module env validation from throwing mid-build.
+#
+# So a name that appears as a build ARG above is not thereby available to the
+# running server: anything read from process.env at runtime has to be a Fly
+# secret in its own right. VITE_PUBLIC_POSTHOG_TOKEN is both, for two unrelated
+# reasons; the manifest explains what having only the build half cost.
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \

--- a/apps/vectreal-platform/Dockerfile
+++ b/apps/vectreal-platform/Dockerfile
@@ -37,7 +37,9 @@ ARG BUILD_SUPABASE_URL=https://build.invalid
 ARG BUILD_SUPABASE_KEY=build-only-supabase-key
 ARG BUILD_STRIPE_SECRET_KEY=sk_test_build_only
 ARG BUILD_VITE_PUBLIC_POSTHOG_TOKEN=
-ARG BUILD_VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# The ingestion proxy, not the PostHog origin. Only reached when the workflow
+# passes no value; the real one comes from the repo secret of the same name.
+ARG BUILD_VITE_PUBLIC_POSTHOG_HOST=https://go.vectreal.com
 ARG BUILD_VITE_PUBLIC_POSTHOG_UI_HOST=https://eu.posthog.com
 ARG BUILD_VITE_PUBLIC_VECTREAL_API_KEY_PROD=
 ARG BUILD_VITE_PUBLIC_DEMO_SCENE_URL=

--- a/apps/vectreal-platform/tests/embed-token-storage.spec.ts
+++ b/apps/vectreal-platform/tests/embed-token-storage.spec.ts
@@ -75,50 +75,87 @@ describe('the deployment that has to configure it', () => {
 	*/
 	const ENV_VAR = 'EMBED_TOKEN_ENCRYPTION_KEY'
 
-	it('is set by the script that provisions Fly secrets', () => {
-		const script = read('terraform/scripts/setup-fly-secrets.sh')
+	/*
+	  These used to pin the shape of the script - a local named `emb_key`, an
+	  array named `REQUIRED_PER_ENV`, a `for field in` list - which is why they
+	  broke when the four hand-written name lists became one manifest, even
+	  though the rule they exist to protect never moved. They pin the manifest
+	  now: membership in FLY_SECRETS_REQUIRED is the whole rule, and validation,
+	  --verify and sync all read it, so one assertion covers all three.
+	*/
+	const script = () => read('terraform/scripts/setup-fly-secrets.sh')
+	const manifestSection = (from: string, to: string) => {
+		const source = script()
+		return source.slice(source.indexOf(from), source.indexOf(to))
+	}
 
-		expect(script).toContain(`${ENV_VAR}="$emb_key"`)
+	it('is set by the script that provisions Fly secrets', () => {
+		expect(
+			manifestSection('FLY_SECRETS_REQUIRED=(', 'FLY_SECRETS_OPTIONAL=(')
+		).toContain(`"${ENV_VAR}"`)
+
+		/*
+		  A name in the manifest is only worth asserting if the *sync* reads it -
+		  the old hand-written argument list is exactly how a name could sit in a
+		  REQUIRED_ array and never reach `fly secrets set`.
+
+		  Scoped to sync_fly_secrets rather than searched for in the whole file,
+		  because --verify opens its loop with the same words plus a second
+		  array. An unscoped `toContain` here passes on that line instead, and a
+		  mutation replacing the sync loop's array with a literal survived it.
+		*/
+		const sync = manifestSection('sync_fly_secrets()', 'sync_supabase_hook()')
+
+		expect(sync).toContain('for name in "${FLY_SECRETS_REQUIRED[@]}"; do')
 		// Resolved per environment, so staging and production get their own.
-		expect(script).toContain(`resolve ${ENV_VAR} "$ENV"`)
+		expect(sync).toContain('value="$(resolve "$name" "$ENV")"')
+		expect(sync).toContain('args+=("${name}=${value}")')
 	})
 
 	it('fails the run when it is missing, rather than deploying without it', () => {
 		/*
-		  `REQUIRED_PER_ENV` is the list that `exit 1`s, and it is checked once
-		  per environment - so the bare name appearing there covers both. The
-		  earlier `${emb_key:+...}` form skipped a missing value without comment,
-		  so a forgotten key produced a *successful* deploy that minted keys
-		  nobody could ever be shown, which is the failure this whole change
-		  exists to end.
+		  Optional entries are skipped when they resolve to nothing. For this key
+		  that would be a *successful* deploy which mints keys nobody can ever be
+		  shown - the failure this whole change exists to end - so the assertion
+		  worth making is that it is not on that list.
 		*/
-		const script = read('terraform/scripts/setup-fly-secrets.sh')
-
-		const required = script.slice(
-			script.indexOf('REQUIRED_PER_ENV=('),
-			script.indexOf('MISSING=()')
-		)
-		expect(required).toContain(`"${ENV_VAR}"`)
+		expect(
+			manifestSection('FLY_SECRETS_OPTIONAL=(', 'FLY_SECRETS_SHARED=(')
+		).not.toContain(`"${ENV_VAR}"`)
 
 		// Checked for staging and for prod, not just once overall.
 		for (const env of ['STAGING', 'PROD']) {
-			expect(script, env).toContain(
-				`check_env_vars ${env} "\${REQUIRED_PER_ENV[@]}"`
+			expect(script(), env).toContain(
+				`check_env_vars ${env} "\${FLY_SECRETS_REQUIRED[@]}"`
 			)
 		}
-
-		expect(script).toContain(`${ENV_VAR}="$emb_key"`)
-		expect(script).not.toContain(`\${emb_key:+`)
 	})
 
 	it('is checked by verify mode too', () => {
-		const script = read('terraform/scripts/setup-fly-secrets.sh')
-		const checkList = script.slice(
-			script.indexOf('check_env_secrets()'),
-			script.indexOf('check_fly_secret "$app" "$field"')
+		/*
+		  Required names go through `check_fly_secret`, which records a failure;
+		  optional ones go through `warn_fly_secret`, which deliberately does
+		  not. Membership decides which, so the pair of assertions below is what
+		  makes this key's absence fail the gate rather than print a warning.
+		*/
+		const verify = manifestSection(
+			'check_env_secrets()',
+			'section "Supabase auth hook'
 		)
 
-		expect(checkList).toContain(ENV_VAR)
+		/*
+		  The two have to be asserted as a pair. Two independent `toContain`s
+		  both stay green when the loop bodies are swapped - required routed
+		  through `warn_fly_secret`, optional through `check_fly_secret` - which
+		  is precisely the state this test exists to catch, since it turns this
+		  key's absence into a warning that passes the gate.
+		*/
+		expect(verify).toMatch(
+			/for name in "\$\{FLY_SECRETS_REQUIRED\[@\]\}"[^\n]*\n\s*check_fly_secret "\$app" "\$name"/
+		)
+		expect(verify).toMatch(
+			/for name in "\$\{FLY_SECRETS_OPTIONAL\[@\]\}"[^\n]*\n\s*warn_fly_secret "\$app" "\$name"/
+		)
 	})
 
 	/*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -63,11 +63,24 @@ laptop, and inheriting whatever protection rules the Environment carries.
 | --- | --- |
 | `stage` | Writes the secrets with `--stage`. The app keeps running the old values until the next deploy applies them. The default, because a routine rotation should not bounce production. |
 | `immediate` | Writes and restarts now. For an urgent rotation, such as a leaked key. |
-| `verify` | Read-only, and a gate: exits non-zero when a secret is missing, when the `send_email` hook is disabled, or when its live URI does not match `APPLICATION_URL`. |
+| `verify` | Read-only, and a gate: exits non-zero when a *required* secret is missing, when the `send_email` hook is disabled, or when its live URI does not match `APPLICATION_URL`. An optional secret that is unset warns and passes, matching what the sync does with it. |
 
 Rotating a value is: change it in the GitHub Environment, run the workflow.
-Adding one is a PR - the name goes in the script's `REQUIRED_PER_ENV` list and
-the workflow's `env:` block - then the value goes in the Environment.
+
+Adding one is a PR, and the name goes in two places:
+
+1. `FLY_SECRETS_REQUIRED` or `FLY_SECRETS_OPTIONAL` in the manifest at the top
+   of `scripts/setup-fly-secrets.sh`. Validation, `--verify` and the sync all
+   read those arrays, so one entry covers all three.
+2. The `env:` block of `.github/workflows/cd-platform-secrets.yaml`, because a
+   GitHub Actions job only sees the secrets it maps by hand.
+
+Then the value goes in the Environment, for staging **and** production.
+
+Do not add a new array. A name in an array no loop reads is never validated,
+never verified and never sent, which is the failure this manifest exists to
+prevent - three secrets the app read at runtime reached production unset that
+way.
 
 The local path still works and is unchanged:
 

--- a/terraform/scripts/setup-fly-secrets.sh
+++ b/terraform/scripts/setup-fly-secrets.sh
@@ -20,8 +20,9 @@
 #   1. Fly.io app secrets (fly secrets set)
 #   2. Supabase send_email hook URI + secret (via Management API)
 #
-# --verify is a gate, not a report: it exits non-zero when a secret is missing
-# or the live hook URI does not match APPLICATION_URL.
+# --verify is a gate, not a report: it exits non-zero when a *required* secret
+# is missing or the live hook URI does not match APPLICATION_URL. An optional
+# one that is unset warns and passes, which is what the sync does with it.
 # =============================================================================
 
 RED='\033[0;31m'
@@ -135,15 +136,38 @@ resolve() {
 
 section "Validating required variables"
 
+# ---------------------------------------------------------------------------
+# The manifest
+# ---------------------------------------------------------------------------
+# Every runtime secret is named once, here. Validation, --verify and sync all
+# read these arrays, so a name added here reaches all three at once.
+#
+# It used to be four hand-written lists - two REQUIRED_* arrays, the --verify
+# field list, and the arguments to `fly secrets set` - and nothing compared them
+# to each other or to what the app reads. That is how STRIPE_WEBHOOK_SECRET,
+# VITE_PUBLIC_POSTHOG_TOKEN and BILLING_RECONCILE_SECRET reached production
+# unset: the app read all three at runtime, no list here mentioned any of them,
+# so validation had nothing to require and --verify had nothing to check. The
+# lists had drifted from each other too - --verify hard-failed on
+# CONTACT_DATA_ENCRYPTION_KEY and RESEND_WEBHOOK_SECRET while sync treated both
+# as optional.
+#
 # Logical names, not spellings. `resolve` decides whether a value arrives as
 # DATABASE_URL_PROD or as DATABASE_URL in a production Environment.
-REQUIRED_SHARED=(
-  "FROM_EMAIL"
-  "CONTACT_INBOX_EMAIL"
-  "SUPABASE_ACCESS_TOKEN"
-)
-REQUIRED_PER_ENV=(
-  "SUPABASE_PROJECT_REF"
+#
+# One enumeration this cannot absorb: the `env:` block in
+# cd-platform-secrets.yaml, because a GitHub Actions job only sees the secrets
+# it maps by hand. For a required name that drift is loud - `resolve` returns
+# empty and validation exits 1 - but for an optional one it is silent, so a
+# name added to FLY_SECRETS_OPTIONAL needs a line there in the same change.
+#
+# This file is the authoritative list. The Dockerfile and .env.development.example
+# point here rather than restating it, because the copy that used to live in the
+# Dockerfile went stale and nothing compared them.
+
+# Sent to Fly. Resolved per environment, and the sync refuses to run without
+# them.
+FLY_SECRETS_REQUIRED=(
   "DATABASE_URL"
   "SUPABASE_URL"
   "SUPABASE_KEY"
@@ -151,11 +175,58 @@ REQUIRED_PER_ENV=(
   "APPLICATION_URL"
   "CSRF_SECRET"
   "STRIPE_SECRET_KEY"
+  # Without this the webhook route rejects every delivery with a 400, and
+  # `billing_state` loses every backward transition - cancellation, payment
+  # failure, dunning, expiry. Nothing else carries them automatically:
+  # cancelSubscription is called only from the webhook processor, and the one
+  # other writer, reconcileStripeSubscriptions, is reachable only through
+  # /api/billing/reconcile, which needs BILLING_RECONCILE_SECRET below and has
+  # therefore never run. Unset in production until 2026-09, over which time
+  # `billing_webhook_events` recorded zero rows.
+  "STRIPE_WEBHOOK_SECRET"
   "SEND_EMAIL_HOOK_SECRET"
   "CLOUDFLARE_TURNSTILE_SITE_KEY"
   "CLOUDFLARE_TURNSTILE_SECRET_KEY"
   "RESEND_API_KEY"
   "EMBED_TOKEN_ENCRYPTION_KEY"
+  # Read at runtime by posthog-client.server.ts. The VITE_ prefix is a
+  # misnomer here and reads like a build-time-only name, which is part of why
+  # these were never provisioned: the Dockerfile sets them as build-stage ENV
+  # for the client bundle, the runner stage does not inherit that, and without
+  # them getPosthogClient() returns null - taking the server error sink, all
+  # server analytics and the billing-checkout kill switch down with it.
+  "VITE_PUBLIC_POSTHOG_TOKEN"
+  "VITE_PUBLIC_POSTHOG_HOST"
+)
+
+# Sent to Fly when a value exists, skipped when it does not, and --verify warns
+# rather than failing on one. This list is the sync's existing behaviour made
+# explicit, not a judgement that absence is harmless - it is per-secret:
+FLY_SECRETS_OPTIONAL=(
+  # Genuinely degrades: pii-encryption.server.ts falls back to CSRF_SECRET.
+  "CONTACT_DATA_ENCRYPTION_KEY"
+  # Does NOT degrade. resend-webhook-processor.server.ts throws when it is
+  # unset, so the route breaks rather than switching off. Optional only because
+  # the sync has always treated it that way; promoting it to required would
+  # fail the next run for any environment that has never had a value.
+  "RESEND_WEBHOOK_SECRET"
+  # Genuinely degrades: /api/billing/reconcile is fail-closed and 401s
+  # everything, which leaves the drift detector off but breaks nothing.
+  "BILLING_RECONCILE_SECRET"
+)
+
+# Sent to Fly. One value covers both environments.
+FLY_SECRETS_SHARED=(
+  "CONTACT_INBOX_EMAIL"
+  "FROM_EMAIL"
+)
+
+# Required by this script, never sent to Fly.
+SCRIPT_ONLY_SHARED=(
+  "SUPABASE_ACCESS_TOKEN"
+)
+SCRIPT_ONLY_PER_ENV=(
+  "SUPABASE_PROJECT_REF"
 )
 
 MISSING=()
@@ -169,11 +240,11 @@ check_env_vars() {
   done
 }
 
-check_shared "${REQUIRED_SHARED[@]}"
+check_shared "${FLY_SECRETS_SHARED[@]}" "${SCRIPT_ONLY_SHARED[@]}"
 [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "staging" ]] && \
-  check_env_vars STAGING "${REQUIRED_PER_ENV[@]}"
+  check_env_vars STAGING "${FLY_SECRETS_REQUIRED[@]}" "${SCRIPT_ONLY_PER_ENV[@]}"
 [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "prod"    ]] && \
-  check_env_vars PROD "${REQUIRED_PER_ENV[@]}"
+  check_env_vars PROD "${FLY_SECRETS_REQUIRED[@]}" "${SCRIPT_ONLY_PER_ENV[@]}"
 
 if [[ ${#MISSING[@]} -gt 0 ]]; then
   err "Missing required variables:"
@@ -196,11 +267,20 @@ if [[ "$MODE" == "verify" ]]; then
 
   section "Fly.io secrets (existence check)"
 
+  # One listing per app, held for the whole check. This used to make a network
+  # round trip per secret name, and the manifest is longer than the list it
+  # replaced.
+  FLY_SECRETS_LISTING=""
+
   # Presence only. `fly secrets list` reports digests, never values, so nothing
   # here can tell a correct secret from a wrong one - only a missing one.
+  #
+  # `$app` is for the message. The answer comes from FLY_SECRETS_LISTING, which
+  # check_env_secrets loads for the app it is about to check, so these two must
+  # not be called from anywhere that has not just set it.
   check_fly_secret() {
     local app="$1" name="$2"
-    if fly secrets list --app "$app" 2>/dev/null | grep -qw "$name"; then
+    if printf '%s' "$FLY_SECRETS_LISTING" | grep -qw "$name"; then
       ok "$app / $name"
     else
       err "$app / $name NOT FOUND"
@@ -208,22 +288,41 @@ if [[ "$MODE" == "verify" ]]; then
     fi
   }
 
+  # Optional secrets are reported but never fail the gate. Their absence turns a
+  # feature off by design; treating that as a failure is what made the old list
+  # disagree with the sync it was supposed to be checking.
+  warn_fly_secret() {
+    local app="$1" name="$2"
+    if printf '%s' "$FLY_SECRETS_LISTING" | grep -qw "$name"; then
+      ok "$app / $name"
+    else
+      warn "$app / $name not set - optional in the manifest; see its entry there for what that costs"
+    fi
+  }
+
   check_env_secrets() {
-    local env="$1" app="$2"
-    for field in DATABASE_URL SUPABASE_URL SUPABASE_KEY SUPABASE_SECRET_KEY \
-                 CSRF_SECRET STRIPE_SECRET_KEY APPLICATION_URL SEND_EMAIL_HOOK_SECRET \
-                 CLOUDFLARE_TURNSTILE_SITE_KEY CLOUDFLARE_TURNSTILE_SECRET_KEY \
-                 RESEND_API_KEY CONTACT_DATA_ENCRYPTION_KEY RESEND_WEBHOOK_SECRET \
-                 EMBED_TOKEN_ENCRYPTION_KEY \
-                 CONTACT_INBOX_EMAIL FROM_EMAIL; do
-      check_fly_secret "$app" "$field"
+    local app="$1"
+    local name
+
+    FLY_SECRETS_LISTING="$(fly secrets list --app "$app" 2>/dev/null)"
+    if [[ -z "$FLY_SECRETS_LISTING" ]]; then
+      err "$app - could not read the secret list"
+      VERIFY_FAILED+=("$app/listing")
+      return
+    fi
+
+    for name in "${FLY_SECRETS_REQUIRED[@]}" "${FLY_SECRETS_SHARED[@]}"; do
+      check_fly_secret "$app" "$name"
+    done
+    for name in "${FLY_SECRETS_OPTIONAL[@]}"; do
+      warn_fly_secret "$app" "$name"
     done
   }
 
   [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "staging" ]] && \
-    check_env_secrets staging "vectreal-platform-staging"
+    check_env_secrets "vectreal-platform-staging"
   [[ -z "$ENV_FILTER" || "$ENV_FILTER" == "prod" ]] && \
-    check_env_secrets prod "vectreal-platform"
+    check_env_secrets "vectreal-platform"
 
   section "Supabase auth hook (live value)"
 
@@ -301,47 +400,44 @@ sync_fly_secrets() {
   env_title="$(printf '%s' "$env" | sed 's/\(.\)/\u\1/')"
   section "${env_title} → $app"
 
-  local db_url;   db_url="$(resolve DATABASE_URL "$ENV")"
-  local sb_url;   sb_url="$(resolve SUPABASE_URL "$ENV")"
-  local sb_key;   sb_key="$(resolve SUPABASE_KEY "$ENV")"
-  local sb_secret_key; sb_secret_key="$(resolve SUPABASE_SECRET_KEY "$ENV")"
-  local app_url;  app_url="$(resolve APPLICATION_URL "$ENV")"
-  local csrf;     csrf="$(resolve CSRF_SECRET "$ENV")"
-  local stripe;   stripe="$(resolve STRIPE_SECRET_KEY "$ENV")"
-  local ts_site;  ts_site="$(resolve CLOUDFLARE_TURNSTILE_SITE_KEY "$ENV")"
-  local ts_sec;   ts_sec="$(resolve CLOUDFLARE_TURNSTILE_SECRET_KEY "$ENV")"
-  local resend;   resend="$(resolve RESEND_API_KEY "$ENV")"
-  local hook_raw; hook_raw="$(resolve SEND_EMAIL_HOOK_SECRET "$ENV")"
-  local hook; hook="$(strip_hook_prefix "$hook_raw")"
-  local enc_key;  enc_key="$(resolve CONTACT_DATA_ENCRYPTION_KEY "$ENV")"
-  local emb_key;  emb_key="$(resolve EMBED_TOKEN_ENCRYPTION_KEY "$ENV")"
-  local resend_wh; resend_wh="$(resolve RESEND_WEBHOOK_SECRET "$ENV")"
-
   local stage_flag=()
   if [[ "$STAGE_ONLY" == "true" ]]; then
     stage_flag=(--stage)
     warn "staged only - the next deploy applies these"
   fi
 
+  # Built from the manifest rather than spelled out a second time. A name added
+  # up there is validated, verified and set without another edit down here,
+  # which is the only reason the three can no longer disagree.
+  local args=()
+  local name value
+  for name in "${FLY_SECRETS_REQUIRED[@]}"; do
+    value="$(resolve "$name" "$ENV")"
+    case "$name" in
+      # Supabase issues this one as "v1,whsec_…" and Fly reads a comma as its
+      # own argument delimiter, so the prefix comes off before it is sent.
+      SEND_EMAIL_HOOK_SECRET) value="$(strip_hook_prefix "$value")" ;;
+    esac
+    args+=("${name}=${value}")
+  done
+  for name in "${FLY_SECRETS_SHARED[@]}"; do
+    args+=("${name}=$(resolve "$name")")
+  done
+  for name in "${FLY_SECRETS_OPTIONAL[@]}"; do
+    value="$(resolve "$name" "$ENV")"
+    if [[ -n "$value" ]]; then
+      args+=("${name}=${value}")
+    else
+      warn "$name has no value - skipping; see its manifest entry for what that costs"
+    fi
+  done
+
+  # Derived here rather than resolved: neither is a secret, and ENVIRONMENT is
+  # this script's own label for which app it is writing to.
+  args+=("NODE_ENV=production" "ENVIRONMENT=${env}")
+
   if fly secrets set \
-      DATABASE_URL="$db_url" \
-      SUPABASE_URL="$sb_url" \
-      SUPABASE_KEY="$sb_key" \
-      SUPABASE_SECRET_KEY="$sb_secret_key" \
-      APPLICATION_URL="$app_url" \
-      CSRF_SECRET="$csrf" \
-      STRIPE_SECRET_KEY="$stripe" \
-      CLOUDFLARE_TURNSTILE_SITE_KEY="$ts_site" \
-      CLOUDFLARE_TURNSTILE_SECRET_KEY="$ts_sec" \
-      RESEND_API_KEY="$resend" \
-      SEND_EMAIL_HOOK_SECRET="$hook" \
-      CONTACT_INBOX_EMAIL="$CONTACT_INBOX_EMAIL" \
-      FROM_EMAIL="$FROM_EMAIL" \
-      NODE_ENV=production \
-      ENVIRONMENT="$env" \
-      ${enc_key:+CONTACT_DATA_ENCRYPTION_KEY="$enc_key"} \
-      EMBED_TOKEN_ENCRYPTION_KEY="$emb_key" \
-      ${resend_wh:+RESEND_WEBHOOK_SECRET="$resend_wh"} \
+      "${args[@]}" \
       "${stage_flag[@]}" \
       --app "$app" 2>/dev/null; then
     SECRETS_SET+=("$app")


### PR DESCRIPTION
## Summary

Four secrets the app reads at runtime were never provisioned, because
`setup-fly-secrets.sh` named its secrets in four hand-maintained lists that
nothing compared. This collapses them into one manifest and adds the missing
names.

Found while verifying Phase 0 of the limits/claims cleanup. `STRIPE_WEBHOOK_SECRET`
being unset on production means **no Stripe webhook has ever verified** — the
route 400s every delivery, and `billing_webhook_events` holds 0 rows. Since
`billing_state` has no other automatic path off `active` and `currentPeriodEnd`
is never read for an access decision, an org that reaches `active` keeps its
entitlements permanently. Blast radius was zero customers (22 free orgs, 2
self-granted `pro`), so this is a mechanism that never worked rather than an
incident.

Setting the values is a separate, manual step — this PR only makes the
provisioning path capable of carrying them.

## Root cause

`setup-fly-secrets.sh` enumerated its secret names in four hand-maintained lists
— `REQUIRED_SHARED`, `REQUIRED_PER_ENV`, the `--verify` field list, and the
arguments to `fly secrets set` — and nothing compared them to each other or to
what the app reads, so a name could be absent from all four and no stage would
notice. The fix belongs in the script rather than in those four call sites,
because adding four names to four lists preserves the mechanism that lost them.

That the lists had *already* drifted is the evidence: `--verify` hard-failed on
`CONTACT_DATA_ENCRYPTION_KEY` and `RESEND_WEBHOOK_SECRET` while the sync
deliberately treated both as optional.

## Changes

- **`terraform/scripts/setup-fly-secrets.sh`** — one manifest
  (`FLY_SECRETS_REQUIRED` / `_OPTIONAL` / `_SHARED`, plus `SCRIPT_ONLY_*` for
  values the script needs but never sends), read by validation, `--verify` and
  sync alike. Adds `STRIPE_WEBHOOK_SECRET`, `VITE_PUBLIC_POSTHOG_TOKEN`,
  `VITE_PUBLIC_POSTHOG_HOST` as required and `BILLING_RECONCILE_SECRET` as
  optional.
- **`.github/workflows/cd-platform-secrets.yaml`** — the four names in `env:`.
  This block is a fifth enumeration that a manifest cannot absorb, since a
  GitHub Actions job only sees the secrets it maps by hand; the manifest header
  says so, and notes that drift is loud for a required name and silent for an
  optional one.
- **`apps/vectreal-platform/Dockerfile`** — the runtime-secret comment now points
  at the manifest rather than listing names (its copy had drifted to twelve
  against seventeen required), and states the trap this file creates: `runner` is
  `FROM base` while `build` is `FROM deps`, so the build stage's `VITE_PUBLIC_*`
  `ENV` lines reach the client bundle and never the running server.
- **`terraform/README.md`** — told contributors to add names to
  `REQUIRED_PER_ENV`, which this change removes. Following it would have created
  an array no loop reads: never validated, never verified, never sent.
- **`.env.development.example`** — documents the new names for both environments.
- **`apps/vectreal-platform/tests/embed-token-storage.spec.ts`** — repaired. It
  pinned the script's *shape* (a local named `emb_key`, `REQUIRED_PER_ENV`, a
  `for field in` list), so it broke on a refactor that never touched the rule it
  guards. It now pins manifest membership, which is the rule.

### Two behavior changes, both consequences of the single manifest

- `--verify` **warns** instead of failing for optional secrets. Forced: one
  manifest cannot hard-fail on names the sync intentionally skips, and this PR
  adds a deliberately-unset optional. Net effect is a real reduction in gate
  coverage for `CONTACT_DATA_ENCRYPTION_KEY` and `RESEND_WEBHOOK_SECRET`.
- `--verify` reads `fly secrets list` once per app rather than once per name. An
  unreadable listing is now one hard failure instead of N per-name NOT FOUNDs.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

**Gates.** `nx run-many typecheck,lint` across 4 projects (8/8 tasks, count
checked so it is not a silent no-op) and `vitest run --root .` at 143 files /
1799 tests, both green.

**Failure path exercised.** `--verify` against real production, read-only:
reports exactly the three missing secrets as failures and
`BILLING_RECONCILE_SECRET` as a warning, confirms the other seventeen present,
and exits non-zero. Validation names `STRIPE_WEBHOOK_SECRET (PROD)` before
anything reaches Fly — the gate that would have caught this in April.

**Mutation gates — eight, all red, restored green.** Three against a harness that
stubs `fly` and asserts on the argv `fly secrets set` would receive (dropped
manifest entry; skipped `v1,whsec_` strip; optionals sent empty), five against
the committed spec (name dropped from the manifest; name moved to optional;
verify warning instead of failing; sync no longer reading the manifest; verify
loop bodies swapped).

Two of those found defects in the new spec rather than confirming it. A
sync-loop assertion passed for the wrong reason — `for name in
"${FLY_SECRETS_REQUIRED[@]}"` is a substring of verify's line ending
`"${FLY_SECRETS_SHARED[@]}"; do` — and the verify assertions were two
independent `toContain`s that both stayed green when the loop bodies were
swapped, turning a required secret into a warning. Both now assert scoped and
paired.

**Equivalence.** Both script versions were run under macOS bash 3.2 with `fly`
stubbed and the resulting argv diffed: all 18 existing `name=value` pairs
reproduce byte-identically, four added. No bash 4+ constructs; the workflow's
`set -euo pipefail` does not reach the script, which is executed rather than
sourced.

## Before merging

The three newly-required names must exist as GitHub Environment secrets for
**staging and production**. Validation runs before any write, so a sync without
them exits 1 having written nothing — fail-closed and loud, but it will block.

## Filed, not fixed

`apps/vectreal-platform/app/routes/docs/operations/deployment.mdx:85` labels the
PostHog variables "(build-time)" — the exact misconception this PR corrects,
published on the docs site and now contradicted by it. Lines 53 and 90 of the
same file are stale since #767. Out of scope here.
