### PR TITLE
fix(seo): let a mirror deployment speak for itself in robots.txt

### DIFF
--- a/apps/vectreal-platform/app/lib/canonical-url.spec.ts
+++ b/apps/vectreal-platform/app/lib/canonical-url.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
+import {
+	isCanonicalDeployment,
+	resolveDeploymentOrigin
+} from './deployment-origin'
 import { SITE_URL, toCanonicalUrl } from './seo'
 import { loader as robotsLoader } from '../routes/robots[.]txt'
 import { loader as sitemapLoader } from '../routes/sitemap[.]xml'
@@ -44,9 +48,41 @@ describe('toCanonicalUrl', () => {
 	})
 })
 
+/**
+ * `APPLICATION_URL` is pinned for every case below.
+ *
+ * These loaders used to read a build-time constant, so ambient environment
+ * could not reach them and none of this was needed. They read
+ * `process.env.APPLICATION_URL` now, and `setup-fly-secrets.sh` sources
+ * `.env.development` under `set -a` - so a developer who ran that script in the
+ * same shell would otherwise get failures here from a spec unrelated to
+ * whatever they were changing.
+ */
+function withApplicationUrl<T>(value: string | undefined, run: () => T): T {
+	const previous = process.env.APPLICATION_URL
+
+	if (value === undefined) {
+		delete process.env.APPLICATION_URL
+	} else {
+		process.env.APPLICATION_URL = value
+	}
+
+	try {
+		return run()
+	} finally {
+		if (previous === undefined) {
+			delete process.env.APPLICATION_URL
+		} else {
+			process.env.APPLICATION_URL = previous
+		}
+	}
+}
+
 describe('sitemap', () => {
 	async function sitemapUrls(): Promise<string[]> {
-		const xml = await (await sitemapLoader()).text()
+		const xml = await withApplicationUrl(SITE_URL, () => sitemapLoader()).then(
+			(response) => response.text()
+		)
 
 		return Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) => m[1])
 	}
@@ -75,9 +111,186 @@ describe('sitemap', () => {
 
 describe('robots.txt', () => {
 	it('points at the real sitemap rather than the prerenderer origin', async () => {
-		const body = await (await robotsLoader()).text()
+		const body = await withApplicationUrl(SITE_URL, () => robotsLoader()).then(
+			(response) => response.text()
+		)
 
 		expect(body).toContain(`Sitemap: ${SITE_URL}/sitemap.xml`)
 		expect(body).not.toContain('localhost')
+	})
+})
+
+/**
+ * The one document that has to say something different per environment.
+ *
+ * Every page is built once and served by both Fly apps, so anything derived
+ * from `SITE_URL` is identical on staging and production by construction. That
+ * is right for a canonical tag and wrong here: staging shipped production's
+ * rules, told crawlers `Allow: /`, and advertised production's sitemap.
+ */
+describe('a mirror deployment does not invite crawlers', () => {
+	const STAGING = 'https://staging.vectreal.com'
+
+	const robotsFor = (applicationUrl: string | undefined) =>
+		withApplicationUrl(applicationUrl, () => robotsLoader()).then((response) =>
+			response.text()
+		)
+
+	const sitemapLocsFor = (applicationUrl: string | undefined) =>
+		withApplicationUrl(applicationUrl, () => sitemapLoader())
+			.then((response) => response.text())
+			.then((xml) =>
+				Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) => m[1])
+			)
+
+	/**
+	 * Compared line by line, not as substrings.
+	 *
+	 * `expect(body).toContain('Disallow: /')` passes against the *production*
+	 * body, because `Disallow: /dashboard` contains it - so the assertion that
+	 * looks like it pins the mirror rule is satisfied by the rule set it exists
+	 * to distinguish from.
+	 */
+	const linesOf = (body: string) =>
+		body
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean)
+
+	const hasLine = (body: string, prefix: string) =>
+		linesOf(body).some((line) => line.startsWith(prefix))
+
+	it('disallows everything when the origin is not the canonical site', async () => {
+		const body = await robotsFor(STAGING)
+
+		expect(linesOf(body)).toContain('Disallow: /')
+		expect(hasLine(body, 'Allow:')).toBe(false)
+		// Advertising production's sitemap from a mirror is what pointed
+		// crawlers at the wrong host in the first place.
+		expect(hasLine(body, 'Sitemap:')).toBe(false)
+		// A blanket disallow and a path list are different documents; shipping
+		// both would leave the path rules deciding nothing.
+		expect(hasLine(body, 'Disallow: /dashboard')).toBe(false)
+	})
+
+	it('serves the real rules on the canonical site', async () => {
+		const body = await robotsFor(SITE_URL)
+
+		expect(linesOf(body)).toContain('Allow: /')
+		expect(body).toContain(`Sitemap: ${SITE_URL}/sitemap.xml`)
+	})
+
+	/*
+	  The comparison is by host, so none of these spellings may read as a
+	  different site. Each one on production would otherwise serve `Disallow: /`
+	  - and since these responses carry `s-maxage=86400` and Cloudflare respects
+	  the origin, that answer would sit at the edge for a day.
+	*/
+	it.each([
+		['a trailing slash', `${SITE_URL}/`],
+		['surrounding whitespace', `  ${SITE_URL}  `],
+		['an uppercase host', 'https://VECTREAL.com'],
+		['a plain-http scheme', 'http://vectreal.com'],
+		['a stray path segment', `${SITE_URL}/app`]
+	])('still recognises the canonical site given %s', async (_label, value) => {
+		expect(linesOf(await robotsFor(value))).toContain('Allow: /')
+	})
+
+	/*
+	  The failure direction matters more than the check. If the value that
+	  decides this goes missing or arrives unparseable, the answer has to be
+	  "this is the real site" - a fail-closed default would have production
+	  serving `Disallow: /` and deindexing itself, silently, exactly the way a
+	  missing variable took the server error sink down.
+	*/
+	it.each([
+		['unset', undefined],
+		['empty', ''],
+		['not a URL at all', 'vectreal.com']
+	])(
+		'keeps the canonical site crawlable when the origin is %s',
+		async (_label, value) => {
+			const body = await robotsFor(value)
+
+			expect(linesOf(body)).toContain('Allow: /')
+			expect(body).toContain(`Sitemap: ${SITE_URL}/sitemap.xml`)
+		}
+	)
+
+	/*
+	  The sibling route spends a paragraph on why `Disallow` stops the crawl and
+	  not the indexing. A populated sitemap is the other means by which a URL
+	  gets discovered, so a mirror that disallowed everything and then handed
+	  over a full inventory would be fail-closed in one document and wide open
+	  in the next.
+	*/
+	it('gives a mirror an empty sitemap rather than an inventory', async () => {
+		expect(await sitemapLocsFor(STAGING)).toStrictEqual([])
+	})
+
+	it('still lists the site on the canonical deployment', async () => {
+		const locs = await sitemapLocsFor(SITE_URL)
+
+		expect(locs.length).toBeGreaterThan(0)
+		for (const loc of locs) {
+			expect(loc.startsWith(SITE_URL)).toBe(true)
+		}
+	})
+
+	it('never emits a loc without a scheme, whatever the origin holds', async () => {
+		for (const loc of await sitemapLocsFor('vectreal.com')) {
+			expect(loc).toMatch(/^https?:\/\//)
+		}
+	})
+})
+
+/**
+ * The resolver on its own, because the loaders cannot reach all of it.
+ *
+ * `resolveDeploymentOrigin` substitutes `SITE_URL` for anything unparseable
+ * before `isCanonicalDeployment` ever sees it, so going through robots.txt
+ * proves the fallback and never the fail-open branch behind it. A mutation
+ * making that branch fail *closed* left the whole suite green.
+ */
+describe('deployment origin resolution', () => {
+	it.each([
+		['unset', undefined, SITE_URL],
+		['empty', '', SITE_URL],
+		['whitespace only', '   ', SITE_URL],
+		['missing a scheme', 'vectreal.com', SITE_URL],
+		['a non-http scheme', 'ftp://vectreal.com', SITE_URL],
+		['a trailing slash', `${SITE_URL}/`, SITE_URL],
+		['a path', `${SITE_URL}/app`, SITE_URL],
+		['an uppercase host', 'https://VECTREAL.com', SITE_URL],
+		['a mirror', 'https://staging.vectreal.com', 'https://staging.vectreal.com']
+	])('resolves %s to a usable origin', (_label, value, expected) => {
+		expect(resolveDeploymentOrigin(value)).toBe(expected)
+	})
+
+	it('never returns something that cannot go in a sitemap loc', () => {
+		for (const value of [undefined, '', 'vectreal.com', 'ftp://x', '://']) {
+			expect(resolveDeploymentOrigin(value)).toMatch(/^https?:\/\/[^/]+$/)
+		}
+	})
+
+	/*
+	  Fail open, deliberately. These responses carry `s-maxage=86400` and
+	  Cloudflare respects the origin, so a deployment wrongly judged a mirror
+	  serves `Disallow: /` from the edge for a day.
+	*/
+	it.each([
+		['an unparseable origin', 'vectreal.com'],
+		['a non-http scheme', 'ftp://vectreal.com'],
+		['an empty string', '']
+	])('counts %s as the canonical site rather than a mirror', (_label, value) => {
+		expect(isCanonicalDeployment(value)).toBe(true)
+	})
+
+	it.each([
+		['a different host', 'https://staging.vectreal.com'],
+		['a subdomain', 'https://preview.vectreal.com'],
+		['a different domain entirely', 'https://example.com']
+	])('counts %s as a mirror', (_label, value) => {
+		expect(isCanonicalDeployment(value)).toBe(false)
 	})
 })

--- a/apps/vectreal-platform/app/lib/deployment-origin.ts
+++ b/apps/vectreal-platform/app/lib/deployment-origin.ts
@@ -1,0 +1,96 @@
+import { SITE_URL } from './seo'
+
+/**
+ * Which origin this particular deployment answers on, and whether it is the one
+ * the public is meant to find.
+ *
+ * `SITE_URL` cannot answer either question. It is `import.meta.env`, so Vite
+ * inlines it at build time, and one image is built per commit and deployed to
+ * both Fly apps - a build-time constant is the same value on staging and on
+ * production by construction. That is correct for canonical tags, which should
+ * always name the canonical host whichever environment served the page, and
+ * wrong for `robots.txt`, which is per-environment instruction to a crawler.
+ *
+ * `APPLICATION_URL` is a runtime Fly secret set per app by
+ * `setup-fly-secrets.sh`, so it is the one value that differs. Reading it needs
+ * these routes to render per request rather than being prerendered, which is
+ * why they are no longer in `react-router.config.ts`'s prerender list.
+ *
+ * Deliberately not `ENVIRONMENT`, though that is also set per app. The failure
+ * mode decides it: an unset or unreadable variable must never cause production
+ * to tell crawlers to go away. Everything below falls back to the canonical
+ * site, so the worst case is a mirror staying crawlable - what happens today -
+ * rather than production deindexing itself.
+ *
+ * That fallback has to cover more than "absent". `robots.txt` answers with
+ * `s-maxage=86400`, and those headers now reach Cloudflare (a prerendered
+ * resource route had its `Response` headers discarded, so they never did
+ * before). A wrong answer is therefore cached at the edge for a day and needs a
+ * manual purge, which is why the comparison below is by host rather than by
+ * string: a stray path, a `http://`, an uppercase letter or a trailing slash on
+ * production's `APPLICATION_URL` must not read as "this is a mirror".
+ */
+
+/**
+ * The origin of a URL-shaped string, or null when it is not one.
+ *
+ * `URL` does the normalizing that hand-rolled trimming kept missing: it
+ * lowercases the host, drops any path, query and trailing slash, and rejects a
+ * bare `vectreal.com` outright - which matters because the return value is
+ * interpolated straight into the sitemap's `<loc>` elements, and a `<loc>`
+ * without a scheme invalidates the whole document.
+ */
+function parseOrigin(value: string | undefined): string | null {
+	if (!value) {
+		return null
+	}
+
+	try {
+		const url = new URL(value.trim())
+
+		return url.protocol === 'http:' || url.protocol === 'https:'
+			? url.origin
+			: null
+	} catch {
+		return null
+	}
+}
+
+/** Host alone, so `http` vs `https` cannot read as a different site. */
+function hostOf(value: string): string | null {
+	const origin = parseOrigin(value)
+
+	return origin ? new URL(origin).host : null
+}
+
+/**
+ * The public origin of the running deployment.
+ *
+ * Falls back to the canonical site rather than to the request, because a
+ * request-derived origin is whatever host the caller sent - including one an
+ * attacker chose - and this value is emitted into documents crawlers trust.
+ * (`llms.txt` does derive its origin from the request and is untouched here;
+ * the three crawl documents do not yet agree on this.)
+ */
+export function resolveDeploymentOrigin(
+	applicationUrl: string | undefined = process.env.APPLICATION_URL
+): string {
+	return parseOrigin(applicationUrl) ?? SITE_URL
+}
+
+/**
+ * True when this deployment is the site the public should reach.
+ *
+ * Everything else - staging, a preview app, a developer's machine - is a
+ * mirror of it, and a crawled mirror competes with the real thing.
+ *
+ * An origin that cannot be parsed counts as canonical. That is the fail-open
+ * direction described above: misconfiguration leaves the site indexed.
+ */
+export function isCanonicalDeployment(
+	origin: string = resolveDeploymentOrigin()
+): boolean {
+	const host = hostOf(origin)
+
+	return host === null || host === hostOf(SITE_URL)
+}

--- a/apps/vectreal-platform/app/lib/seo.ts
+++ b/apps/vectreal-platform/app/lib/seo.ts
@@ -9,12 +9,23 @@ import type { MetaArgs, MetaDescriptor } from 'react-router'
 /**
  * Canonical base URL for the Vectreal platform.
  * Used to build absolute canonical links and og:url tags.
- * Falls back to the production URL when no env var is set.
+ *
+ * A constant on purpose, and always production. A canonical tag names the URL
+ * that should rank, which does not change with the host that happened to serve
+ * the page - staging pointing at production is what stops a mirror competing
+ * with the site as duplicate content.
+ *
+ * It used to read `VITE_PUBLIC_SITE_URL` and then `VITE_APPLICATION_URL` before
+ * this literal. Neither name was set anywhere - not the Dockerfile, the secrets
+ * script, the workflows or `.env.development.example` - so both branches were
+ * dead and every build resolved here anyway. They are gone rather than
+ * provisioned, because there is no environment that should answer differently.
+ *
+ * For the value that *is* per-environment, see `deployment-origin.ts`. That
+ * distinction is the whole of the bug this replaced: `robots.txt` was built
+ * from this constant and so told crawlers the same thing everywhere.
  */
-export const SITE_URL =
-	import.meta.env.VITE_PUBLIC_SITE_URL ||
-	import.meta.env.VITE_APPLICATION_URL ||
-	'https://vectreal.com'
+export const SITE_URL = 'https://vectreal.com'
 
 const DEFAULT_SITE_NAME = 'Vectreal'
 const DEFAULT_TITLE =

--- a/apps/vectreal-platform/app/routes/robots[.]txt.ts
+++ b/apps/vectreal-platform/app/routes/robots[.]txt.ts
@@ -1,4 +1,7 @@
-import { SITE_URL } from '../lib/seo'
+import {
+	isCanonicalDeployment,
+	resolveDeploymentOrigin
+} from '../lib/deployment-origin'
 
 /**
  * robots.txt endpoint.
@@ -10,12 +13,41 @@ import { SITE_URL } from '../lib/seo'
  * The Sitemap directive points crawlers to the XML sitemap so they can
  * discover all canonical URLs in one request.
  *
- * The origin comes from `SITE_URL` rather than the request. This route is
- * prerendered, so the request origin at build time is the prerenderer's
- * throwaway localhost port, and that is what would ship to production.
+ * Not prerendered, unlike the pages it describes. This is the one document that
+ * has to differ per environment, and a prerendered one cannot: it was built
+ * from `SITE_URL`, a build-time constant, so staging served production's rules
+ * and advertised production's sitemap while inviting crawlers in with
+ * `Allow: /`. `resolveDeploymentOrigin` reads a runtime value instead, which
+ * needs a request to render against.
+ *
+ * Cloudflare merges its own managed robots.txt over this response - the
+ * `Content-Signal` line and the AI-crawler blocks come from the edge, not from
+ * here - so what a crawler finally reads is this body plus those rules.
  */
 export async function loader() {
-	const origin = SITE_URL
+	const origin = resolveDeploymentOrigin()
+
+	/*
+	  A mirror competes with the site it mirrors. Staging carries the same
+	  content under a different host, so letting it be crawled splits the signal
+	  between two copies and can surface a half-finished build in search.
+
+	  Keyed on the origin rather than on an environment name: if the value that
+	  decides this ever goes missing, the fallback is the canonical origin, so
+	  the failure mode is staging staying crawlable rather than production
+	  telling every crawler to leave.
+	*/
+	if (!isCanonicalDeployment(origin)) {
+		return new Response(
+			['User-agent: *', 'Disallow: /', '', `# Mirror of ${origin}`].join('\n'),
+			{
+				headers: {
+					'Content-Type': 'text/plain; charset=utf-8',
+					'Cache-Control': 'public, max-age=86400, s-maxage=86400'
+				}
+			}
+		)
+	}
 
 	const robotsTxt = [
 		'User-agent: *',

--- a/apps/vectreal-platform/app/routes/sitemap[.]xml.ts
+++ b/apps/vectreal-platform/app/routes/sitemap[.]xml.ts
@@ -1,6 +1,9 @@
+import {
+	isCanonicalDeployment,
+	resolveDeploymentOrigin
+} from '../lib/deployment-origin'
 import { docsPages } from '../lib/docs/docs-manifest'
 import { getNewsArticles } from '../lib/news/news-manifest'
-import { SITE_URL } from '../lib/seo'
 
 interface SitemapEntry {
 	path: string
@@ -48,9 +51,34 @@ function buildXml(entries: SitemapEntry[], baseUrl: string): string {
  *
  * Cached at the CDN layer for one hour (s-maxage=3600) and revalidated in the
  * background for up to 24 hours.
+ *
+ * Not prerendered, for the same reason as robots.txt: the origin has to be the
+ * one this deployment actually answers on, so that a mirror's sitemap describes
+ * the mirror rather than claiming production's URLs as its own.
  */
 export async function loader() {
-	const origin = SITE_URL
+	const origin = resolveDeploymentOrigin()
+
+	/*
+	  A mirror lists nothing. Its robots.txt already answers `Disallow: /`, so
+	  anything obeying robots would never fetch this - but the sibling route
+	  spends a paragraph on why that is not the protection it looks like:
+	  disallowing a path stops the crawl, not the indexing, and a URL handed
+	  over by other means still gets listed. A populated sitemap is exactly
+	  those other means, at scale and in machine-readable form, for every
+	  scraper that skips robots.txt and every hand-submission to Search Console.
+
+	  Empty rather than 404, so the document stays valid for anything that has
+	  already been told the URL exists.
+	*/
+	if (!isCanonicalDeployment(origin)) {
+		return new Response(buildXml([], origin), {
+			headers: {
+				'Content-Type': 'application/xml; charset=utf-8',
+				'Cache-Control': 'public, max-age=3600, s-maxage=3600'
+			}
+		})
+	}
 
 	// ── 1. Static marketing / content pages ────────────────────────────────
 	const staticEntries: SitemapEntry[] = [

--- a/apps/vectreal-platform/react-router.config.ts
+++ b/apps/vectreal-platform/react-router.config.ts
@@ -18,8 +18,23 @@ const STATIC_PRERENDER_PATHS = [
 	'/privacy-policy',
 	'/terms-of-service',
 	'/imprint',
-	'/robots.txt',
-	'/sitemap.xml',
+	/*
+	  `/robots.txt` and `/sitemap.xml` are deliberately absent. One image is
+	  built per commit and deployed to both Fly apps, so anything prerendered
+	  holds the same bytes on staging and production - which is right for the
+	  pages above and wrong for the two documents whose entire job is to tell a
+	  crawler which host it is looking at. They render per request and read
+	  `APPLICATION_URL`; see `app/lib/deployment-origin.ts`.
+
+	  This makes their cache headers load-bearing for the first time. The
+	  prerenderer writes only a resource route's *body* to `build/client/`, so
+	  the `Response` headers were discarded and `express.static` answered with
+	  its own `max-age=0`. Now the loaders' own `s-maxage` reaches Cloudflare,
+	  which is set to `respect_origin` for both paths - the edge serves them and
+	  the origin sees one hit a day. It also means a wrong answer sticks for a
+	  day and needs a purge, which is why `deployment-origin.ts` fails toward
+	  "this is the canonical site" rather than toward `Disallow: /`.
+	*/
 	...NEWS_PRERENDER_PATHS,
 	...DOCS_PRERENDER_PATHS
 ]


### PR DESCRIPTION
## Summary

`staging.vectreal.com/robots.txt` served `Allow: /` and
`Sitemap: https://vectreal.com/sitemap.xml`. A staging mirror was inviting
crawlers in and handing them production's inventory. Verified live before the
change.

Phase 1a of the limits/claims cleanup plan.

## Root cause

`robots.txt` and `sitemap.xml` are per-environment documents that were rendered
as build-time artifacts. One image is built per commit and deployed to both Fly
apps, and both files derived their origin from `SITE_URL`, which is
`import.meta.env` and therefore inlined by Vite at build time — so every
environment shipped production's crawler directives by construction. The fix
belongs at the render boundary rather than at the constant: no value of a
build-time constant can differ between two deployments of one image.

The two env vars that chain read, `VITE_PUBLIC_SITE_URL` and
`VITE_APPLICATION_URL`, are set nowhere in the repo, so both branches were dead
and the hardcoded literal always won.

**The plan said something different and was wrong.** It said "read
`APPLICATION_URL` in `seo.ts`", which is impossible — that is a runtime Fly
secret and Vite never sees it. The plan file has been corrected.

## Changes

- **`react-router.config.ts`** — `/robots.txt` and `/sitemap.xml` leave the
  `prerender` list, so they render per request.
- **`app/lib/deployment-origin.ts`** (new) — resolves the origin this deployment
  actually answers on from `APPLICATION_URL`, and answers whether that is the
  canonical site.
- **`app/routes/robots[.]txt.ts`** — a non-canonical deployment answers
  `User-agent: * / Disallow: /` with no `Sitemap:` line.
- **`app/routes/sitemap[.]xml.ts`** — a mirror emits an empty `<urlset>`. The
  sibling route already argues that disallowing a path stops the *crawl* and not
  the *indexing*; a populated mirror sitemap is precisely the "discovered
  elsewhere" it warns about, in machine-readable form, for anything that skips
  robots.txt.
- **`app/lib/seo.ts`** — `SITE_URL` keeps the production literal and loses the
  two dead branches, with a comment on why it is deliberately constant: a
  canonical tag should name the host that ought to rank whichever environment
  served the page, so staging pointing at production is correct and is what
  stops a mirror competing as duplicate content.

### Failing open is deliberate

An unset, unparseable or oddly spelled `APPLICATION_URL` resolves to the
canonical site, so misconfiguration leaves a mirror crawlable rather than
deindexing production. The comparison is by **host**, so a trailing slash, an
uppercase letter, a stray path segment or plain `http` cannot read as a mirror.

That matters more than it first looks, and it is a behaviour change worth
stating: the prerenderer writes only a resource route's *body*, discarding its
`Response` headers, and `express.static` then answered `max-age=0`. These
loaders' own `s-maxage` reaches Cloudflare for the first time — which is
correct, and means a wrong answer would now sit at the edge for a day.
`terraform/cloudflare.tf` already lists both paths as `respect_origin`, so no
infrastructure change is needed.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [ ] No tests required (explain why)

**Gates.** 1832 tests across 144 files, `typecheck` + `lint` over 4 projects, and
`build-ci` with `--skip-nx-cache`. The build is the gate that matters here: it
confirms no static `robots.txt` / `sitemap.xml` is emitted into `build/client`,
so nothing shadows the SSR routes.

**Mutation gates — eleven, all red, restored green.** Deleting the mirror guard;
inverting the canonical comparison; ignoring `APPLICATION_URL`; failing closed on
an unset origin; reverting the sitemap to the build constant; serving the path
list instead of a blanket disallow; comparing full origins instead of hosts;
accepting any URL scheme; dropping the `SITE_URL` fallback.

Three of those found defects in the tests rather than the code:

1. `expect(body).toContain('Disallow: /')` was vacuous — the *production* body
   contains `Disallow: /dashboard`. Assertions are line-exact now.
2. The fail-open branch was unreachable through the loaders, because
   `resolveDeploymentOrigin` substitutes `SITE_URL` before
   `isCanonicalDeployment` sees anything. A mutation making it fail **closed**
   left the suite green. The module is now tested directly.
3. The "not a URL" case was `vectreal.com`, which `new URL()` rejects outright,
   so the scheme check never ran. `ftp://` covers it.

**Two pre-existing tests were made environment-dependent by this change** and are
fixed here: `sitemap > uses the same origin as the canonical tags` and
`robots.txt > points at the real sitemap` read ambient `APPLICATION_URL` through
the loaders once those stopped using a build constant. CI never sets it, but
`setup-fly-secrets.sh` sources `.env.development` under `set -a`, so a developer
who ran that script in the same shell would have seen unrelated failures. Both
pin the value now.

## Filed, not fixed

`app/routes/llms[.]txt.ts:21` derives its origin from `new URL(request.url)`,
which is the approach `deployment-origin.ts` explicitly argues against for
documents crawlers trust. It is the third crawl document and is untouched here,
so the repo now has three of them using three strategies. Noted in the new
module's comment so the next reader is not misled.
