### PR TITLE
fix(embed): let the generated snippet fill a bare flex parent

### DIFF
--- a/apps/vectreal-platform/app/components/embed/embed-options-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/embed/embed-options-panel.spec.tsx
@@ -502,7 +502,17 @@ describe('the snippet without the size fields', () => {
 		  first version of this test.
 		*/
 		expect(snippet).toContain(
-			'<div style="width: 100%; max-width: 100%; height: 400px;">'
+			'<div class="vctrl-embed" style="width: 100%; max-width: 100%; height: 400px;">'
+		)
+
+		/*
+		  The stylesheet that lets the box fill a flex parent is part of what the
+		  panel hands over, not decoration on top of it. Copying the wrapper
+		  without it reproduces the 300px Shopify collapse, so a snippet that lost
+		  it here would look correct in this assertion and be broken in a theme.
+		*/
+		expect(snippet).toContain(
+			'div:not([class]):not([style]):has(> .vctrl-embed) { flex-grow: 1; }'
 		)
 	})
 

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.spec.ts
@@ -43,6 +43,28 @@ function readParsedSrc(snippet: string): string {
 	return parseIframe(snippet).getAttribute('src') ?? ''
 }
 
+/**
+ * Every element the snippet produces, in tree order.
+ *
+ * The whole document, not `body`: a parser hoists a leading `<script>` into
+ * `<head>`, so scoping this to the body would stop looking exactly where an
+ * injected element could land unseen.
+
+ */
+const STRUCTURAL = new Set(['html', 'head', 'body'])
+const elementsOf = (snippet: string) =>
+	Array.from(
+		new DOMParser().parseFromString(snippet, 'text/html').querySelectorAll('*')
+	)
+		.map((element) => element.tagName.toLowerCase())
+		.filter((tag) => !STRUCTURAL.has(tag))
+
+/** What each builder is supposed to emit, so a breakout shows up as an extra tag. */
+const EXPECTED_ELEMENTS: Record<string, string[]> = {
+	buildResponsiveEmbedSnippet: ['style', 'div', 'iframe'],
+	buildSdkEmbedSnippet: ['script', 'style', 'div', 'iframe', 'script']
+}
+
 describe('buildEmbedUrl', () => {
 	it('omits the token parameter entirely when there is no token', () => {
 		const url = buildEmbedUrl({
@@ -158,25 +180,16 @@ describe('the width and height options cannot break the snippet', () => {
 		'400px"><img src=x onerror=alert(1)>',
 		// Injects the tag the snippet legitimately contains: caught by counting
 		// elements, invisible to a `querySelector('iframe')` check.
-		'100%"><iframe src="https://evil.example"></iframe><div style="'
+		'100%"><iframe src="https://evil.example"></iframe><div style="',
+		/*
+		  Raw-text breakout. `escapeHtmlAttributeValue` replaces `<` and `>`, so
+		  this arrives as `&lt;/style&gt;` and cannot be markup in any position -
+		  which is the point: it is the only payload here that goes red when a
+		  caller value reaches the stylesheet unescaped. The four above cannot,
+		  because inside a `<style>` element none of them are markup at all.
+		*/
+		'100%</style><img src=x onerror=alert(1)><style>'
 	]
-
-	/**
-	 * Every element the snippet produces, in tree order.
-	 *
-	 * The whole document, not `body`: a parser hoists a leading `<script>` into
-	 * `<head>`, so scoping this to the body would stop looking exactly where an
-	 * injected element could land unseen.
-	 */
-	const STRUCTURAL = new Set(['html', 'head', 'body'])
-	const elementsOf = (snippet: string) =>
-		Array.from(
-			new DOMParser()
-				.parseFromString(snippet, 'text/html')
-				.querySelectorAll('*')
-		)
-			.map((element) => element.tagName.toLowerCase())
-			.filter((tag) => !STRUCTURAL.has(tag))
 
 	for (const value of HOSTILE) {
 		it(`survives a width of ${JSON.stringify(value)}`, () => {
@@ -199,10 +212,12 @@ describe('the width and height options cannot break the snippet', () => {
 			  correctly escaped snippet still contains those characters. What
 			  matters is that the parser reads them as text, not as markup.
 			*/
-			expect(elementsOf(snippet)).toEqual(['div', 'iframe'])
+			expect(elementsOf(snippet)).toEqual(
+				EXPECTED_ELEMENTS.buildResponsiveEmbedSnippet
+			)
 
 			const wrapper = doc.querySelector('div') as HTMLElement
-			expect(wrapper.getAttributeNames()).toEqual(['style'])
+			expect(wrapper.getAttributeNames()).toEqual(['class', 'style'])
 			expect(wrapper.style.width).toBe('')
 		})
 
@@ -221,10 +236,12 @@ describe('the width and height options cannot break the snippet', () => {
 			  attributes, leaving that assertion green with `alert(1)` live in the
 			  document.
 			*/
-			expect(elementsOf(snippet)).toEqual(['script', 'div', 'iframe', 'script'])
+			expect(elementsOf(snippet)).toEqual(
+				EXPECTED_ELEMENTS.buildSdkEmbedSnippet
+			)
 			expect(
 				(doc.querySelector('div') as HTMLElement).getAttributeNames()
-			).toEqual(['style'])
+			).toEqual(['class', 'style'])
 		})
 	}
 
@@ -406,16 +423,131 @@ describe('the docs page and the builder agree on the default box', () => {
 	)
 
 	it('quotes the box the snippet is actually generated with', () => {
+		/*
+		  Found by prefix rather than by line index. The snippet now opens with the
+		  parent-fix stylesheet, and `split('\n')[0]` silently became a test that
+		  the guide contains the string `<style>`, which every page with a fence
+		  does.
+		*/
 		const wrapper = buildResponsiveEmbedSnippet({
 			src: `${ORIGIN}/embed/p/s`
-		}).split('\n')[0]
+		})
+			.split('\n')
+			.find((line) => line.startsWith('<div '))
 
 		expect(wrapper).toBe(
-			'<div style="width: 100%; max-width: 100%; height: 400px;">'
+			'<div class="vctrl-embed" style="width: 100%; max-width: 100%; height: 400px;">'
 		)
 		expect(GUIDE).toContain(wrapper)
 		expect(GUIDE).toContain('The box is `100%` wide and `400px` tall')
 	})
+
+	it('quotes the parent fix the snippet actually ships', () => {
+		/*
+		  The guide explains the Shopify case in prose. If the rule changes and the
+		  page does not, the page teaches a selector the panel no longer emits -
+		  the `*.example.com` drift, one file over.
+		*/
+		const rule = buildResponsiveEmbedSnippet({ src: `${ORIGIN}/embed/p/s` })
+			.split('\n')
+			.find((line) => line.includes(':has('))
+
+		expect(rule?.trim()).toBe(
+			'@layer { div:not([class]):not([style]):has(> .vctrl-embed) { flex-grow: 1; } }'
+		)
+		expect(GUIDE).toContain(rule?.trim())
+
+		/*
+		  Matched by line, so the fence could lose the element around it and still
+		  satisfy the line above - leaving a bare CSS declaration inside an `html`
+		  fence for a reader to copy. Pin the wrapper too.
+		*/
+		const open = GUIDE.indexOf('<style>')
+		const close = GUIDE.indexOf('</style>', open)
+		expect(open, 'the guide fence opens a <style> element').toBeGreaterThan(-1)
+		expect(close, 'and closes it').toBeGreaterThan(open)
+
+		expect(GUIDE.slice(open, close)).toContain(rule?.trim())
+	})
+})
+
+describe('the parent fix and the wrapper it targets cannot drift apart', () => {
+	/*
+	  The rule and the class are written in two places in one module, and nothing
+	  about a rename fails to compile. Renaming either half alone leaves a snippet
+	  that parses, renders, passes every assertion above, and quietly stops doing
+	  the one thing it was added for - which is invisible until someone pastes it
+	  into a flex layout.
+
+	  So this reads the class back out of the selector the snippet ships and
+	  checks the wrapper actually carries it, rather than asserting either
+	  literal twice.
+	*/
+	for (const builder of [buildResponsiveEmbedSnippet, buildSdkEmbedSnippet]) {
+		it(`${builder.name} targets the class its own wrapper carries`, () => {
+			const doc = new DOMParser().parseFromString(
+				builder({ src: `${ORIGIN}/embed/p/s` }),
+				'text/html'
+			)
+
+			const selector = doc.querySelector('style')?.textContent ?? ''
+			const targeted = selector.match(/:has\(>\s*\.([\w-]+)\)/)?.[1]
+
+			expect(targeted, 'the stylesheet targets a class').toBeDefined()
+			expect(
+				(doc.querySelector('div') as HTMLElement).classList.contains(
+					targeted as string
+				)
+			).toBe(true)
+		})
+
+		it(`${builder.name} keeps every caller value out of the stylesheet`, () => {
+			/*
+			  `<style>` is a raw-text element, so the attribute escaper that guards
+			  `width` and `height` does not apply inside it. The fix is that nothing
+			  interpolated ever lands there; this is what says so out loud.
+			*/
+			const snippet = builder({
+				src: `${ORIGIN}/embed/p/s?token=SRC_MARKER`,
+				width: 'WIDTH_MARKER',
+				height: 'HEIGHT_MARKER'
+			})
+			const doc = new DOMParser().parseFromString(snippet, 'text/html')
+
+			const stylesheet = doc.querySelector('style')
+			expect(stylesheet, 'the snippet ships a stylesheet').not.toBeNull()
+
+			/*
+			  Against the raw string, not the parsed element's `textContent`.
+			  A `<style>` element ends at the first `</style>`, so a value that
+			  really breaks out of the raw-text context lands OUTSIDE the element
+			  this test would otherwise inspect: reading `textContent` reported a
+			  clean stylesheet while a live `<img onerror>` sat in the document
+			  next to it. The element list below is what catches that shape; the
+			  markers here catch the quieter case of a value interpolated into the
+			  rule without escaping anything at all.
+			*/
+			/*
+			  Anchored on `<style`, not `<style>`, and asserted before slicing.
+			  `indexOf` returns -1 for any other spelling of the open tag, and
+			  `slice(-1, end)` then yields the empty string, which satisfies every
+			  `not.toMatch` below - so adding an attribute to the tag was enough to
+			  retire this guard silently while a caller value sat live inside it.
+			*/
+			const open = snippet.indexOf('<style')
+			const close = snippet.indexOf('</style>')
+			expect(
+				open,
+				'the raw snippet carries a <style> open tag'
+			).toBeGreaterThan(-1)
+			expect(close, 'and closes it').toBeGreaterThan(open)
+
+			const stylesheetSource = snippet.slice(open, close)
+
+			expect(stylesheetSource).not.toMatch(/(WIDTH|HEIGHT|SRC)_MARKER/)
+			expect(elementsOf(snippet)).toEqual(EXPECTED_ELEMENTS[builder.name])
+		})
+	}
 })
 
 describe('the two link targets stay distinct', () => {

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-snippet.ts
@@ -105,6 +105,68 @@ type EmbedSnippetOptions = {
 const DEFAULT_WIDTH = '100%'
 const DEFAULT_HEIGHT = '400px'
 
+/** Marks the wrapper so the rule below can find it, and only it. */
+const EMBED_WRAPPER_CLASS = 'vctrl-embed'
+
+/**
+ * The one rule the snippet needs that an inline style cannot express.
+ *
+ * `width: 100%` on the wrapper only resolves against a parent with a definite
+ * width, and the snippet does not own its parent. Shopify's Horizon renders a
+ * Custom Liquid *block* into a `<div>` with no attributes at all. Where the
+ * merchant has set that section's direction to Horizontal - `row` is the
+ * option, `column` the default - that `<div>` is a row flex item, and a flex
+ * item sizes to its content. The only content-derived width an iframe has is
+ * the 300px every iframe defaults to, so the scene renders 300px wide inside a
+ * full-width section. (Horizon's Custom Liquid *section* is a different
+ * element, carrying a class and an inline style, and never had this problem.)
+ *
+ * Only that parent can fix it, and only a stylesheet can reach a parent, which
+ * is why this is a `<style>` element rather than one more attribute.
+ *
+ * Two things keep a rule aimed at an element we do not own from doing harm.
+ *
+ * `@layer` puts it in an anonymous cascade layer, which loses to every
+ * unlayered declaration on the page regardless of specificity. Measured, a
+ * theme's own `.row > div { flex: 0 0 220px }` keeps its 220px, so the rule
+ * applies only where the theme said nothing. The gap is a theme rule inside its
+ * own named layer, since ours is declared later and wins; Horizon's layered
+ * sizing targets classed elements, which the selector below skips anyway.
+ *
+ * `div:not([class]):not([style])` skips any wrapper the theme marked up itself.
+ * Both filters fail closed - the embed stays 300px, which is visible and
+ * documented, rather than quietly resizing part of somebody's page. So does a
+ * host interposing another element, which defeats the child combinator.
+ *
+ * `flex-grow` alone: growing never reaches the automatic minimum, so the
+ * `min-width: 0` this once carried did nothing for the bug while changing grid
+ * items, where `min-width` is not initially `0`.
+ *
+ * Measured in a 900px container, parent width before and after: a bare parent
+ * in a row 300 to 900, or 300 to 800 beside a 100px sibling. A theme-sized
+ * parent, a column at content height, a grid track and a block parent are all
+ * unchanged. The residual is that `flex-grow` acts on the main axis, so a
+ * column parent with a definite height grows in HEIGHT instead - 400 to 500 in
+ * a 600px shell beside a 100px sibling, 400 to 600 alone. Horizon is in scope:
+ * `layout-panel-flex` sets `height: 100%` and only the row direction resets it
+ * to `auto`, so a column panel keeps that height at every viewport width. A
+ * column also only escapes the width collapse through the default
+ * `align-items: stretch`; under `flex-start` or `center` the parent is 300px
+ * wide and this rule cannot help, the width being the cross axis there.
+ *
+ * Nothing here is interpolated, deliberately. `width` and `height` stay in the
+ * `style` attribute below, where `escapeHtmlAttributeValue` is the correct
+ * escaper; `<style>` is a raw-text element and needs a different one, so no
+ * caller-controlled value may reach it.
+ *
+ * A browser without `:has()` or `@layer` drops the rule and renders what it
+ * rendered before.
+ */
+const EMBED_PARENT_FIX = `<style>
+  /* Lets the embed fill a bare flex parent, such as a Shopify Custom Liquid block. */
+  @layer { div:not([class]):not([style]):has(> .${EMBED_WRAPPER_CLASS}) { flex-grow: 1; } }
+</style>`
+
 /** External embed target. Token-authenticated, never renders internal chrome. */
 export function buildEmbedPath(params: {
 	projectId: string
@@ -203,7 +265,8 @@ export function buildResponsiveEmbedSnippet(
 ): string {
 	const { width, height, src } = escapeSnippetValues(options)
 
-	return `<div style="width: ${width}; max-width: 100%; height: ${height};">
+	return `${EMBED_PARENT_FIX}
+<div class="${EMBED_WRAPPER_CLASS}" style="width: ${width}; max-width: 100%; height: ${height};">
   <iframe
     src="${src}"
     style="width: 100%; height: 100%; border: 0;"
@@ -219,8 +282,9 @@ export function buildSdkEmbedSnippet(options: EmbedSnippetOptions): string {
 	return `<!-- 1. Include the SDK (or: npm install @vctrl/embed) -->
 <script src="${EMBED_SDK_CDN_URL}"></script>
 
-<!-- 2. Your iframe -->
-<div style="width: ${width}; max-width: 100%; height: ${height};">
+<!-- 2. Your iframe, and the rule that lets it fill a flex parent -->
+${EMBED_PARENT_FIX}
+<div class="${EMBED_WRAPPER_CLASS}" style="width: ${width}; max-width: 100%; height: ${height};">
   <iframe
     id="vectreal-scene"
     src="${src}"

--- a/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/publish-embed.mdx
@@ -130,7 +130,11 @@ The hosted preview iframe can also be controlled from the parent page over `post
 **Generated snippet** (what the Embed section copies). The box is `100%` wide and `400px` tall; both are plain inline styles, so edit them in the snippet after pasting it:
 
 ```html
-<div style="width: 100%; max-width: 100%; height: 400px;">
+<style>
+	/* Lets the embed fill a bare flex parent, such as a Shopify Custom Liquid block. */
+	@layer { div:not([class]):not([style]):has(> .vctrl-embed) { flex-grow: 1; } }
+</style>
+<div class="vctrl-embed" style="width: 100%; max-width: 100%; height: 400px;">
 	<iframe
 		src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
 		style="width: 100%; height: 100%; border: 0;"
@@ -140,10 +144,59 @@ The hosted preview iframe can also be controlled from the parent page over `post
 </div>
 ```
 
-**Responsive 16:9 variant** (hand-written, if you want the box to scale with its column):
+### Why the snippet ships a stylesheet
+
+`width: 100%` only resolves against a parent with a definite width, and the snippet does not own its parent. Where a host drops it into a flex row, that parent sizes to its content instead, and the only content-derived width an iframe has is the 300px every iframe defaults to. The embed then renders 300px wide inside a full-width section, and no edit to the snippet's own box changes it, because the element that needs fixing is the one above it.
+
+A parent can only be reached from a stylesheet, which is why the rule is a `<style>` element rather than one more inline style.
+
+Two things keep a rule aimed at an element the snippet does not own from doing harm. **`@layer` puts it in an anonymous cascade layer**, which loses to every unlayered declaration on the page whatever its specificity, so a theme that sizes this element keeps its own value and the rule applies only where the theme said nothing. **`:not([class]):not([style])`** then skips any wrapper the theme marked up directly. Both fail closed, on whatever the page already did: the theme's own width where it set one, 300px where it did not. Either way the failure is visible and documented, rather than a quiet resize of part of your page. So does a theme that puts another element between the flex item and the snippet, which defeats the child combinator. The one gap is a theme rule inside its own named layer, since the snippet's layer is declared later and wins.
+
+Measured in a 900px-wide container, the embed's parent a bare `<div>`, and the sibling where there is one a fixed 100px block. Parent width, before and after:
+
+| Parent's layout context             | Without the rule | With it           |
+| ----------------------------------- | ---------------- | ----------------- |
+| Flex row, embed alone               | 300px            | 900px             |
+| Flex row, one 100px sibling         | 300px            | 800px             |
+| Flex row, parent sized by the theme | 220px            | 220px, left alone |
+| Flex column, height from content    | 900px            | 900px             |
+| Grid, `1fr 1fr`                     | 450px            | 450px             |
+| Block                               | 900px            | 900px             |
+
+A flex column is where the rule is least useful, in both directions. `flex-grow` acts on the main axis, so in a column **with a definite height** it grows the parent's height rather than its width: in a 600px-tall shell the parent went from 400px to 500px beside that 100px sibling, or to 600px alone, leaving blank space under the embed. Horizon is in scope for this, because `layout-panel-flex` sets `height: 100%` and only the row direction resets it to `auto`, so a column-direction panel keeps that height at every viewport width.
+
+And a column only escapes the width collapse through `align-items: stretch`, its default. Where a theme sets `flex-start` or `center` the parent is 300px wide exactly as in a row, and this rule does not fix it, because in a column the width is the cross axis. `align-self: stretch` is what fixes that one - see below.
+
+`flex-grow` is the whole rule on purpose. An earlier version also set `min-width: 0`, which does nothing for this bug, because a growing item never reaches its automatic minimum. It is not free either. `min-width` is not initially `0` on a grid item, and that automatic minimum is what lets a `1fr` track widen to hold its content. Setting it to `0` gives that up: widen the wrapper to `700px` in a `1fr 1fr` grid and the track holds at 450px, so the box renders at the 450px its `max-width: 100%` clamps it to rather than the width you asked for. Nothing overflows and nothing is clipped - the size you set is just silently ignored.
+
+To make the embed match the height of the row rather than its own box, change the wrapper's `height` to `100%`. That needs the parent stretched, which is the default; where a theme sets `align-items` to something else, add `align-self: stretch` to the rule you already pasted rather than to the element:
+
+```css
+@layer {
+	div:not([class]):not([style]):has(> .vctrl-embed) {
+		flex-grow: 1;
+		align-self: stretch;
+	}
+}
+```
+
+Putting it on the element directly would mean giving that element a `class` or a `style`, which is what the selector skips, so the width fix would stop applying at the same time.
+
+### Shopify: pasting into a Custom Liquid block
+
+Horizon renders a Custom Liquid **block** into a `<div>` with no attributes at all. Where the section's direction is set to Horizontal, that `<div>` is a row flex item and the collapse applies; `column` is the default, and in that direction there is nothing to fix. Paste the generated snippet unmodified either way.
+
+The Custom Liquid **section** is a different element. Horizon gives that one a class and an inline style of its own, so it is full width already and the rule correctly passes it over. Dawn wraps the same setting in ordinary block-level divs, where nothing collapses either. The block, in a horizontal section, is the case that needs the stylesheet.
+
+Two things that do not work from inside that box:
+
+- **`{{ section.id }}` is unavailable.** Shopify's [input settings reference](https://shopify.dev/docs/storefronts/themes/architecture/settings/input-settings) (accessed 2026-09-02) lists `section` among what a `liquid` setting cannot access, so you cannot scope CSS by section ID from there. That entry links to the `section` _tag_ rather than the object, so treat the exact boundary as unverified and test it before relying on it. The snippet's rule needs no ID, which is why it takes the form it does.
+- **Unclosed tags are rewritten.** Shopify closes them when the setting is saved, and warns the result may not match your intended formatting - which is worth knowing for a snippet with nested elements. The field also caps at 50kb.
+
+**Responsive 16:9 variant** (hand-written, if you want the box to scale with its column). Keep the `<style>` rule above if you paste this into a theme: in a flex row this box collapses to 0px rather than 300px, because an absolutely positioned iframe contributes no intrinsic width at all, so it disappears outright.
 
 ```html
-<div style="position:relative;padding-top:56.25%;width:100%">
+<div class="vctrl-embed" style="position:relative;padding-top:56.25%;width:100%">
 	<iframe
 		src="https://vectreal.com/embed/<projectId>/<sceneId>?token=vctrl_your_key_here"
 		style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"


### PR DESCRIPTION
## Summary

The generated embed snippet renders 300px wide when a host drops it into a flex row. Fixes it in the builders and documents the Shopify case that surfaced it.

## Root cause

The snippet sizes its wrapper with `width: 100%` but does not own that wrapper's parent, so a host that renders it into a row flex item sizes that parent to content, and the only content-derived width an iframe has is the 300px every iframe defaults to. Shopify's Horizon renders a Custom Liquid block into exactly such an attribute-less `<div>`. The fix belongs in `embed-snippet.ts` because the builders are the only place the embed's box is defined, and only a stylesheet can reach a parent - hence a `<style>` element rather than one more inline style.

## The rule

```css
@layer { div:not([class]):not([style]):has(> .vctrl-embed) { flex-grow: 1; } }
```

Two things keep a rule aimed at an element we do not own from doing harm. `@layer` puts it in an anonymous cascade layer, which loses to every unlayered declaration whatever its specificity, so a theme that sizes this element keeps its value. `:not([class]):not([style])` skips any wrapper the theme marked up directly. Both fail closed: the embed stays 300px, which is visible and documented, rather than quietly resizing part of a merchant's page.

## Measured

900px container, parent a bare `<div>`, sibling where present a fixed 100px block. Parent width:

| Parent context | Without | With |
| --- | --- | --- |
| Flex row, alone | 300px | 900px |
| Flex row, 100px sibling | 300px | 800px |
| Flex row, theme-sized | 220px | 220px, left alone |
| Flex column, content height | 900px | 900px |
| Grid `1fr 1fr` | 450px | 450px |
| Block | 900px | 900px |

Disclosed residual: `flex-grow` acts on the main axis, so a column parent with a definite height grows in height instead (400 to 500 in a 600px shell beside the sibling, 400 to 600 alone). Horizon's mobile column is in scope for this, and the guide says so.

## Safety

`<style>` is a raw-text element, so `escapeHtmlAttributeValue` is the wrong escaper inside it. Nothing caller-controlled is interpolated there; `width` and `height` stay in the `style` attribute.

## Mutation gate

| Mutation | Result |
| --- | --- |
| Selector targets a class the wrapper lacks | 3 red |
| Parent fix dropped from a builder | 8 red |
| Caller width interpolated into the stylesheet | 2 red |
| Same, with `<style type="text/css">` to dodge the guard | 2 red |
| `<style>` wrapper stripped from the docs fence | 1 red |
| `@layer` dropped from the rule | 1 red |
| `flex-grow: 1` to `0` | 1 red |
| `:not([class]):not([style])` dropped | 2 red |

## Verification

- `nx run-many --target=typecheck,lint -p vectreal-platform` green.
- `npx vitest run --root .` 1810/1810.
- Real builder output in a Horizon-shaped row: 300x400 to 800x400; a theme sizing the bare parent via `.row > div` keeps 220px; a theme-classed parent keeps 220px.

## Review

Three rounds, three reviewers on the first. Rounds 1 and 2 found real defects in this change: a test guard that stayed green with a live `<img onerror>` in the document, an unnecessary `min-width: 0` that broke grid items, a rule that overrode theme-sized parents, an `align-self` remedy that silently cancelled the fix, and four unreproducible or false measurement claims. All fixed here.

## Filed, not fixed

`prettier --write` rewrites `{/* claims ... */}` to `{/_ claims ... _/}` in the MDX docs, which stops `documented-claims.spec.ts` matching the block. Pre-existing on main and in the path of #802. This guide is therefore left prettier-unformatted, as it is on main.
