### PR TITLE
chore(domain): delete domain functions nothing calls

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/consent/consent-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/consent/consent-repository.server.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto'
 
-import { eq } from 'drizzle-orm'
 
 import { getDbClient } from '../../../db/client'
 import { consentRecords } from '../../../db/schema/consent/consent-records'
@@ -105,35 +104,3 @@ export async function upsertConsent(
 	}
 }
 
-/**
- * Read the most recent consent record for a user or anonymous visitor.
- * Returns null if no record exists (banner not yet shown / answered).
- */
-export async function getConsent(
-	userId: string | null,
-	anonymousId: string | null
-): Promise<ConsentState | null> {
-	const db = getDbClient()
-
-	if (userId) {
-		const rows = await db
-			.select()
-			.from(consentRecords)
-			.where(eq(consentRecords.userId, userId))
-			.limit(1)
-
-		return (rows[0] as ConsentState | undefined) ?? null
-	}
-
-	if (anonymousId) {
-		const rows = await db
-			.select()
-			.from(consentRecords)
-			.where(eq(consentRecords.anonymousId, anonymousId))
-			.limit(1)
-
-		return (rows[0] as ConsentState | undefined) ?? null
-	}
-
-	return null
-}

--- a/apps/vectreal-platform/app/lib/domain/consent/consent-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/consent/consent-repository.server.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto'
 
-
 import { getDbClient } from '../../../db/client'
 import { consentRecords } from '../../../db/schema/consent/consent-records'
 import {
@@ -103,4 +102,3 @@ export async function upsertConsent(
 		return { ...row, anonymousId: resolvedAnonymousId } as ConsentState
 	}
 }
-

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.spec.ts
@@ -1,6 +1,4 @@
-import {
-	buildDashboardCapabilities
-} from './dashboard-capabilities'
+import { buildDashboardCapabilities } from './dashboard-capabilities'
 
 const OWNED_ORG = 'org-owned'
 const MEMBER_ORG = 'org-member'
@@ -76,5 +74,4 @@ describe('dashboard capabilities', () => {
 			expect(capabilities[MEMBER_ORG].quotaExceeded).toBe(false)
 		})
 	})
-
 })

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.spec.ts
@@ -1,6 +1,5 @@
 import {
-	buildDashboardCapabilities,
-	capabilitiesFor
+	buildDashboardCapabilities
 } from './dashboard-capabilities'
 
 const OWNED_ORG = 'org-owned'
@@ -78,18 +77,4 @@ describe('dashboard capabilities', () => {
 		})
 	})
 
-	describe('capabilitiesFor', () => {
-		it('returns null for an organization the user is not in', () => {
-			const capabilities = buildDashboardCapabilities(MEMBERSHIPS)
-
-			expect(capabilitiesFor(capabilities, 'org-stranger')).toBeNull()
-		})
-
-		it('returns null for a missing organization id', () => {
-			const capabilities = buildDashboardCapabilities(MEMBERSHIPS)
-
-			expect(capabilitiesFor(capabilities, null)).toBeNull()
-			expect(capabilitiesFor(capabilities, undefined)).toBeNull()
-		})
-	})
 })

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.ts
@@ -92,14 +92,3 @@ export function buildDashboardCapabilities(
 	return capabilities
 }
 
-/** Absent organization means no membership, which means no. */
-export function capabilitiesFor(
-	capabilities: DashboardCapabilityMap,
-	organizationId: string | null | undefined
-): DashboardOrganizationCapabilities | null {
-	if (!organizationId) {
-		return null
-	}
-
-	return capabilities[organizationId] ?? null
-}

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-capabilities.ts
@@ -91,4 +91,3 @@ export function buildDashboardCapabilities(
 
 	return capabilities
 }
-

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-permissions.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-permissions.server.ts
@@ -144,24 +144,6 @@ export async function resolveSceneFolderMembership(
 	}
 }
 
-export async function resolveOrganizationMembership(
-	organizationId: string,
-	userId: string
-): Promise<MembershipRole | null> {
-	const [row] = await db
-		.select({ role: organizationMemberships.role })
-		.from(organizationMemberships)
-		.where(
-			and(
-				eq(organizationMemberships.organizationId, organizationId),
-				eq(organizationMemberships.userId, userId)
-			)
-		)
-		.limit(1)
-
-	return row?.role ?? null
-}
-
 /**
  * Throws unless the actor may perform the operation.
  *

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-stats.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-stats.server.ts
@@ -111,7 +111,6 @@ export function computeOrganizationStats(
 	}
 }
 
-
 /**
  * Gets the most recent scenes (by updatedAt).
  */

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-stats.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-stats.server.ts
@@ -111,22 +111,6 @@ export function computeOrganizationStats(
 	}
 }
 
-/**
- * Gets the most recent projects.
- * Note: Projects table doesn't have updatedAt, so we return projects as-is (in DB order)
- */
-export function getRecentProjects(
-	userProjects: Array<{
-		project: typeof projects.$inferSelect
-		organizationId: string
-	}>,
-	limit = 5
-): Array<{
-	project: typeof projects.$inferSelect
-	organizationId: string
-}> {
-	return userProjects.slice(0, limit)
-}
 
 /**
  * Gets the most recent scenes (by updatedAt).

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-domain-policy.ts
@@ -100,16 +100,6 @@ export function parseAllowedDomainPatterns(
 	return Array.from(new Set(normalized))
 }
 
-export function serializeAllowedDomainPatterns(
-	patterns: string[]
-): string | null {
-	if (patterns.length === 0) {
-		return null
-	}
-
-	return patterns.join('\n')
-}
-
 export function validateAllowedDomainInput(
 	rawValue: string | null | undefined
 ):

--- a/apps/vectreal-platform/app/lib/domain/project/project-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/project/project-repository.server.ts
@@ -107,18 +107,6 @@ export async function getSidebarProjects(
 		.limit(limit)
 }
 
-export async function getOrganizationProjects(
-	organizationId: string,
-	userId: string
-): Promise<Array<typeof projects.$inferSelect>> {
-	await verifyOrganizationAccess(db, organizationId, userId)
-
-	return await db
-		.select()
-		.from(projects)
-		.where(eq(projects.organizationId, organizationId))
-}
-
 export async function getProject(
 	projectId: string,
 	userId: string

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-folder-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-folder-repository.server.ts
@@ -79,19 +79,6 @@ async function verifyProjectAccess(
 	}
 }
 
-export async function getProjectScenes(
-	projectId: string,
-	userId: string
-): Promise<Array<typeof scenes.$inferSelect>> {
-	await verifyProjectAccess(db, projectId, userId)
-
-	return await db
-		.select()
-		.from(scenes)
-		.where(eq(scenes.projectId, projectId))
-		.orderBy(desc(scenes.updatedAt))
-}
-
 export async function getProjectsScenes(
 	projectIds: string[],
 	userId: string
@@ -419,23 +406,6 @@ export async function getChildFolders(
 		.from(sceneFolders)
 		.where(eq(sceneFolders.parentFolderId, parentFolderId))
 		.orderBy(desc(sceneFolders.updatedAt))
-}
-
-export async function getAccessibleSceneFolders(
-	userId: string
-): Promise<Array<typeof sceneFolders.$inferSelect>> {
-	const rows = await db
-		.select({ folder: sceneFolders })
-		.from(sceneFolders)
-		.innerJoin(projects, eq(projects.id, sceneFolders.projectId))
-		.innerJoin(
-			organizationMemberships,
-			eq(organizationMemberships.organizationId, projects.organizationId)
-		)
-		.where(eq(organizationMemberships.userId, userId))
-		.orderBy(desc(sceneFolders.updatedAt))
-
-	return rows.map(({ folder }) => folder)
 }
 
 /**

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
@@ -548,7 +548,6 @@ class SceneSettingsService {
 		}
 	}
 
-
 	/**
 	 * Retrieves scene stats for a specific scene.
 	 * @param sceneId - The scene ID

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-service.server.ts
@@ -18,9 +18,6 @@ import { getDbClient } from '../../../../db/client'
 import {
 	assets,
 	folders,
-	organizations,
-	permissions,
-	projects,
 	sceneAssets,
 	sceneFolders,
 	scenePublished,
@@ -551,50 +548,6 @@ class SceneSettingsService {
 		}
 	}
 
-	/**
-	 * Checks if user has permission for a scene.
-	 * @param sceneId - The scene ID
-	 * @param userId - The user ID
-	 * @param permission - Required permission level
-	 * @returns Whether user has the permission
-	 */
-	async hasScenePermission(
-		sceneId: string,
-		userId: string,
-		permission: 'read' | 'write' | 'admin' | 'delete'
-	): Promise<boolean> {
-		// Get the scene and its project
-		const scene = await this.db
-			.select({
-				scene: scenes,
-				project: projects,
-				organization: organizations
-			})
-			.from(scenes)
-			.leftJoin(projects, eq(scenes.projectId, projects.id))
-			.leftJoin(organizations, eq(projects.organizationId, organizations.id))
-			.where(eq(scenes.id, sceneId))
-			.limit(1)
-
-		if (scene.length === 0) return false
-
-		// Check explicit permissions
-		const userPermission = await this.db
-			.select()
-			.from(permissions)
-			.where(
-				and(
-					eq(permissions.resourceType, 'scene'),
-					eq(permissions.resourceId, sceneId),
-					eq(permissions.entityType, 'user'),
-					eq(permissions.entityId, userId),
-					eq(permissions.permission, permission)
-				)
-			)
-			.limit(1)
-
-		return userPermission.length > 0
-	}
 
 	/**
 	 * Retrieves scene stats for a specific scene.

--- a/apps/vectreal-platform/app/lib/domain/user/user-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/user/user-repository.server.ts
@@ -253,26 +253,6 @@ async function getOrCreateDefaultProjectDb(
 	return project
 }
 
-export async function ensureUserExists(
-	supabaseUser: User
-): Promise<typeof users.$inferSelect> {
-	try {
-		const { user } = await ensureUserExistsDb(db, supabaseUser)
-		return user
-	} catch (error) {
-		throw error
-	}
-}
-
-export async function createOrganization(
-	userId: string,
-	name: string
-): Promise<typeof organizations.$inferSelect> {
-	return db.transaction(async (tx) => {
-		return await createOrganizationDb(tx as DbClient, userId, name)
-	})
-}
-
 export async function getOrCreateDefaultOrganization(
 	userId: string
 ): Promise<typeof organizations.$inferSelect> {
@@ -299,41 +279,6 @@ export async function getUserOrganizations(userId: string): Promise<
 		)
 		.where(eq(organizationMemberships.userId, userId))
 		.orderBy(organizationMemberships.joinedAt)
-}
-
-export async function getUserOrganizationMembership(
-	userId: string,
-	organizationId: string
-): Promise<typeof organizationMemberships.$inferSelect | null> {
-	return await getUserOrganizationMembershipDb(db, userId, organizationId)
-}
-
-export async function addUserToOrganization(
-	userId: string,
-	organizationId: string,
-	role: 'owner' | 'admin' | 'member' = 'member',
-	invitedBy?: string
-): Promise<typeof organizationMemberships.$inferSelect> {
-	const existingMembership = await getUserOrganizationMembership(
-		userId,
-		organizationId
-	)
-
-	if (existingMembership) {
-		throw new Error('User is already a member of this organization')
-	}
-
-	const [membership] = await db
-		.insert(organizationMemberships)
-		.values({
-			userId,
-			organizationId,
-			role,
-			invitedBy
-		})
-		.returning()
-
-	return membership
 }
 
 export async function getOrCreateDefaultProject(
@@ -381,26 +326,6 @@ export async function initializeUserDefaults(
 			isNewUser
 		}
 	})
-}
-
-export async function getUserWithDefaultProject(
-	userId: string
-): Promise<{ user: typeof users.$inferSelect; projectId: string } | null> {
-	const user = await db
-		.select()
-		.from(users)
-		.where(eq(users.id, userId))
-		.limit(1)
-		.then((rows) => rows[0])
-
-	if (!user) return null
-
-	const project = await getOrCreateDefaultProject(userId)
-
-	return {
-		user,
-		projectId: project.id
-	}
 }
 
 export async function userExists(userId: string): Promise<boolean> {

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
@@ -530,7 +530,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 	const authHeaders = authResult.headers
 
-
 	if (action === 'update-scene-metadata') {
 		/*
 		  Token CSRF, not just the route's origin check.

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
@@ -530,28 +530,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 	const authHeaders = authResult.headers
 
-	/*
-	  Create, rename, delete and move moved to POST /api/dashboard/mutations,
-	  which speaks one contract for projects, folders and scenes and validates a
-	  CSRF token rather than only an origin header.
-
-	  This stub exists for the deploy window: a tab opened before the release
-	  still posts here, and without it the request would fall through to the
-	  scene settings parser and fail in a way nobody can act on.
-	*/
-	if (
-		routeSceneId === 'bulk' ||
-		action === 'create-folder' ||
-		action === 'delete' ||
-		action === 'rename'
-	) {
-		return withAdditionalHeaders(
-			ApiResponse.badRequest(
-				'This action moved to /api/dashboard/mutations. Reload the page and try again.'
-			),
-			authHeaders
-		)
-	}
 
 	if (action === 'update-scene-metadata') {
 		/*


### PR DESCRIPTION
## Summary

Fourteen exported domain functions with no consumer anywhere in app code, plus a
route stub that outlived its deploy window. 290 lines out, 1 in.

Phase 1c of the limits/claims cleanup plan.

## Root cause

n/a — pure deletion, no behaviour change.

## Changes

Each deleted symbol was verified to have exactly its own definition and nothing
else: no direct import, barrel re-export, dynamic `import()`, string reference,
spec, MDX page or route registration.

`resolveOrganizationMembership`, `getRecentProjects`, `getOrganizationProjects`,
`getProjectScenes`, `getAccessibleSceneFolders`, `serializeAllowedDomainPatterns`,
`SceneSettingsService.hasScenePermission`, `getConsent`, `capabilitiesFor`, and
five from `user-repository.server.ts`.

**Why the five came out together.** `addUserToOrganization` was the only caller
of `getUserOrganizationMembership`, so counted alone that one looked alive. The
private `*Db` helpers are the ones with real callers and all three survive:
`getUserOrganizationMembershipDb`, `ensureUserExistsDb` and `createOrganizationDb`
are still called from `getOrCreateDefaultProjectDb`, `initializeUserDefaults` and
line 191 respectively. Only the exported wrappers had no caller outside the file.

### Two deletions with consequences worth stating

**`getConsent` was the only reader of `consent_records`.** That table is now
write-only: the banner inserts on every consent decision and nothing reads it
back. It holds **121 rows in production**. Whether consent proof is needed for an
audit is a product question, so the table stays and the question is filed rather
than answered inside a cleanup PR.

**`hasScenePermission` was the only reader of the `permissions` table.** After
this change that table has no application code touching it at all — schema
definition and barrel export only. It would have returned `false` for every input
regardless, since nothing has ever written a row. This is the abandoned row-level
ACL design; the authorization that actually runs is the in-code role table in
`dashboard-operations.ts`. Phase 1e drops the table.

**`capabilitiesFor` had a spec and no consumer.** A spec is not a consumer, so
the function and its `describe` block go together. That is the entire 1803 → 1801
test-count change.

### The route stub

`app/routes/api/scenes.$sceneId.ts` loses the branch handling
`routeSceneId === 'bulk'` and the `create-folder` / `delete` / `rename` actions.
Its comment said it existed "for the deploy window: a tab opened before the
release still posts here." It landed 2026-08-03; the window closed a month ago.

Verified no live caller: `useDashboardMutations` posts to
`/api/dashboard/mutations` and keys its payloads on `verb`, not `action`, and
every client still posting to `/api/scenes/…` sends one of the nine surviving
scene actions. A stale tab now gets `Unknown action: …` from the switch default
instead of a sentence telling it to reload — a worse message, not a worse
outcome, and no destructive branch is reachable under those four names.

## Type of Change

- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (existing functionality changes)
- [ ] Documentation update
- [x] Refactor / chore (no functional change)

## Testing

- [ ] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [ ] Storybook story added/updated (for `@vctrl/viewer` changes)
- [x] No tests required (explain why)

A deletion's test is that nothing else changes. `typecheck` + `lint` across the
four TS projects with `--skip-nx-cache`, and 1801 tests across 144 files — down
exactly the two `capabilitiesFor` specs removed alongside their function, and
otherwise identical to `main`.

Lint is what caught the imports left behind: `eq` in the consent repository, and
`organizations`, `permissions` and `projects` in the scene settings service.

## Review

The deletions were made by a script that cuts from `export function NAME` back
over its doc comment and forward to the next `}` at column 0, so the review was
pointed at that heuristic first — a brace-matching cut is the one thing here that
could silently swallow an adjacent declaration. It came back clean on all eleven
files: no neighbour lost a doc comment, no fragment survived, and
`SceneSettingsService` is syntactically intact.

The one artifact it did find — a stray blank line at each cut site — is fixed in
the second commit. There is no format gate in CI, so nothing else would have.
