### PR TITLE
fix(pricing): make every plan claim match what the product does

### DIFF
--- a/apps/vectreal-platform/app/constants/plan-config.ts
+++ b/apps/vectreal-platform/app/constants/plan-config.ts
@@ -35,30 +35,17 @@ export type EntitlementKey =
 	| 'scene_optimize'
 	| 'scene_publish'
 	| 'scene_embed'
-	| 'scene_preview_private'
-	| 'scene_version_history'
 	// Optimization
 	| 'optimization_preset_low'
-	| 'optimization_preset_medium'
 	| 'optimization_preset_high'
 	| 'optimization_custom_params'
-	| 'optimization_priority_queue'
 	// Embed & Viewer
 	| 'embed_domain_allowlist'
-	| 'embed_branding_removal'
 	| 'embed_viewer_customisation'
-	| 'embed_analytics'
-	| 'embed_ar_mode'
 	// Organisation & Collaboration
 	| 'org_multi_member'
 	| 'org_roles'
 	| 'org_api_keys'
-	| 'org_sso'
-	| 'org_audit_log'
-	// Data & Compliance
-	| 'data_export'
-	| 'data_residency_eu'
-	| 'data_residency_custom'
 	// Support
 	| 'support_community'
 	| 'support_email'
@@ -76,33 +63,20 @@ export const PLAN_ENTITLEMENTS: Record<
 		scene_optimize: true,
 		scene_publish: true,
 		scene_embed: true,
-		scene_preview_private: false,
-		scene_version_history: false,
 		// Optimization
 		optimization_preset_low: true,
-		optimization_preset_medium: true,
-		optimization_preset_high: false,
-		optimization_custom_params: false,
-		optimization_priority_queue: false,
+		optimization_preset_high: true,
+		optimization_custom_params: true,
 		// Embed & Viewer
 		embed_domain_allowlist: true,
-		embed_branding_removal: false,
-		embed_viewer_customisation: false,
-		embed_analytics: false,
-		embed_ar_mode: false,
+		embed_viewer_customisation: true,
 		// Organisation & Collaboration
 		org_multi_member: false,
 		org_roles: false,
 		org_api_keys: true,
-		org_sso: false,
-		org_audit_log: false,
-		// Data & Compliance
-		data_export: false,
-		data_residency_eu: false,
-		data_residency_custom: false,
 		// Support
 		support_community: true,
-		support_email: false,
+		support_email: true,
 		support_priority: false,
 		support_dedicated: false
 	},
@@ -112,30 +86,17 @@ export const PLAN_ENTITLEMENTS: Record<
 		scene_optimize: true,
 		scene_publish: true,
 		scene_embed: true,
-		scene_preview_private: true,
-		scene_version_history: true,
 		// Optimization
 		optimization_preset_low: true,
-		optimization_preset_medium: true,
 		optimization_preset_high: true,
 		optimization_custom_params: true,
-		optimization_priority_queue: false,
 		// Embed & Viewer
 		embed_domain_allowlist: true,
-		embed_branding_removal: true,
 		embed_viewer_customisation: true,
-		embed_analytics: true,
-		embed_ar_mode: true,
 		// Organisation & Collaboration
 		org_multi_member: false,
 		org_roles: false,
 		org_api_keys: true,
-		org_sso: false,
-		org_audit_log: false,
-		// Data & Compliance
-		data_export: true,
-		data_residency_eu: false,
-		data_residency_custom: false,
 		// Support
 		support_community: true,
 		support_email: true,
@@ -148,30 +109,17 @@ export const PLAN_ENTITLEMENTS: Record<
 		scene_optimize: true,
 		scene_publish: true,
 		scene_embed: true,
-		scene_preview_private: true,
-		scene_version_history: true,
 		// Optimization
 		optimization_preset_low: true,
-		optimization_preset_medium: true,
 		optimization_preset_high: true,
 		optimization_custom_params: true,
-		optimization_priority_queue: true,
 		// Embed & Viewer
 		embed_domain_allowlist: true,
-		embed_branding_removal: true,
 		embed_viewer_customisation: true,
-		embed_analytics: true,
-		embed_ar_mode: true,
 		// Organisation & Collaboration
 		org_multi_member: true,
 		org_roles: true,
 		org_api_keys: true,
-		org_sso: false,
-		org_audit_log: false,
-		// Data & Compliance
-		data_export: true,
-		data_residency_eu: true,
-		data_residency_custom: false,
 		// Support
 		support_community: true,
 		support_email: true,
@@ -184,30 +132,17 @@ export const PLAN_ENTITLEMENTS: Record<
 		scene_optimize: true,
 		scene_publish: true,
 		scene_embed: true,
-		scene_preview_private: true,
-		scene_version_history: true,
 		// Optimization
 		optimization_preset_low: true,
-		optimization_preset_medium: true,
 		optimization_preset_high: true,
 		optimization_custom_params: true,
-		optimization_priority_queue: true,
 		// Embed & Viewer
 		embed_domain_allowlist: true,
-		embed_branding_removal: true,
 		embed_viewer_customisation: true,
-		embed_analytics: true,
-		embed_ar_mode: true,
 		// Organisation & Collaboration
 		org_multi_member: true,
 		org_roles: true,
 		org_api_keys: true,
-		org_sso: true,
-		org_audit_log: true,
-		// Data & Compliance
-		data_export: true,
-		data_residency_eu: true,
-		data_residency_custom: true,
 		// Support
 		support_community: true,
 		support_email: true,

--- a/apps/vectreal-platform/app/constants/product-copy.ts
+++ b/apps/vectreal-platform/app/constants/product-copy.ts
@@ -90,10 +90,37 @@ export const OPEN_SOURCE_PACKAGES = [
 
 // Shipped features only. This list is emitted as schema.org
 // WebApplication.featureList, so anything here is a public claim about what the
-// product does today. Several plan entitlements in ./plan-config exist as
-// pricing/gating keys without an implementation behind them yet
-// (scene_version_history, embed_ar_mode, optimization_priority_queue,
-// data_residency_eu, org_sso, org_audit_log); those stay out until they ship.
+// product does today.
+//
+// This list used to be the only honest surface. ./plan-config carried keys for
+// features with no implementation, and this comment named six of them so they
+// would stay out of here. Those keys are gone, so the exception list is empty
+// and every EntitlementKey names something that exists.
+//
+// Two rules came out of removing them, and they pull in opposite directions:
+//
+//   1. A key naming a feature that does not exist is deleted.
+//   2. A key naming a feature that DOES exist stays, set to what is true.
+//      Several were `false` on free while the feature shipped ungated to
+//      everyone - the optimization presets, the advanced parameters panel,
+//      viewer customization. There the lie was the `false`, not the key, so
+//      the fix is the value and deleting them would have dropped a true row.
+//
+// `scene_preview_private` and `data_export` were deleted under rule 1, and both
+// turn on which reading you take. An authenticated owner-only preview route
+// exists and a per-scene model export exists, both ungated; a shareable secret
+// preview link and an organization-wide compliance export do not. On a pricing
+// page those labels read as the second thing, which is why they went.
+//
+// The four support_* keys are the exception neither rule can decide, and they
+// are kept on that basis rather than because the code backs them. Support is
+// delivered by people, so no plan-aware code path is expected or present:
+// contact-submission.server.ts branches on inquiry type alone, and there is one
+// queue for everyone. `support_email` is true on every plan because
+// contact-page.tsx already promises anyone a reply within one business day.
+// `support_priority` and `support_dedicated` are true only if the business
+// honors them. That is a commitment to keep, not a claim this file can check -
+// which is also why the SLA hours came out of the labels.
 export const PLATFORM_FEATURE_LIST = [
 	'Upload GLB, glTF, and USDZ 3D models',
 	'Automated 3D model optimization with Draco compression',
@@ -121,9 +148,9 @@ export const PLAN_DISPLAY_NAMES: Record<Plan, string> = {
 // One-line value proposition per tier shown on pricing cards.
 export const PLAN_TAGLINES: Record<Plan, string> = {
 	free: 'For hobbyists and open-source projects',
-	pro: 'For independent creators and small studios',
+	pro: 'For independent creators who need more room',
 	business: 'For growing teams and agencies',
-	enterprise: 'Custom SLA and dedicated support'
+	enterprise: 'Custom limits and a dedicated support channel'
 }
 
 // Primary CTA button text for each plan on the public pricing page.
@@ -174,11 +201,11 @@ export const PAYMENT_TRUST_COPY = 'Secured by Stripe · Cancel anytime'
 
 export const PLAN_OFFER_DESCRIPTIONS: Record<Plan, string> = {
 	free: '10 scenes, 500 MB storage, 3 concurrent published scenes. API access and community support included. No credit card required.',
-	pro: '200 scenes, 10 GB storage, 50 concurrent published scenes. Adds analytics, AR mode, branding removal, version history, and email support.',
+	pro: '200 scenes, 10 GB storage, 50 concurrent published scenes, 20 projects. More room to publish; the feature set matches Free.',
 	business:
-		'2,000 scenes, 100 GB storage, 500 concurrent published scenes. Adds team collaboration (up to 10 seats), priority optimization queue, EU data residency, and priority support.',
+		'2,000 scenes, 100 GB storage, 500 concurrent published scenes. Adds team collaboration with role-based access (up to 10 seats) and priority support.',
 	enterprise:
-		'Unlimited scenes and storage, custom seats, SSO, audit log, custom data residency, and dedicated support. Custom pricing via sales.'
+		'Unlimited scenes, published scenes, projects and seats, with storage sized to your needs. Adds a dedicated support channel. Custom pricing via sales.'
 }
 
 // ---------------------------------------------------------------------------
@@ -191,7 +218,7 @@ export const PRICING_PAGE_COPY = {
 		'Start for free. Upgrade when you need more. Every plan includes the core 3D publishing workflow - no hidden fees.',
 	enterpriseHeading: 'Need a custom setup?',
 	enterpriseDescription:
-		'Enterprise plans include custom data residency, dedicated support, audit log export, and bespoke SLA agreements. Talk to us.'
+		'Enterprise plans set your limits to whatever you need and add a dedicated support channel. Talk to us.'
 } as const
 
 // ---------------------------------------------------------------------------
@@ -206,29 +233,17 @@ export const ENTITLEMENT_DISPLAY_LABELS: Record<EntitlementKey, string> = {
 	scene_optimize: 'Optimization pipeline',
 	scene_publish: 'Publish to CDN',
 	scene_embed: 'Embed snippet',
-	scene_preview_private: 'Private preview link',
-	scene_version_history: 'Version history',
-	optimization_preset_low: 'Low / medium presets',
-	optimization_preset_medium: 'Low / medium presets',
-	optimization_preset_high: 'High-quality optimization preset',
+	optimization_preset_low: 'Balanced and Smallest presets',
+	optimization_preset_high: 'Maximum quality preset',
 	optimization_custom_params: 'Custom optimization parameters',
-	optimization_priority_queue: 'Priority optimization queue',
 	embed_domain_allowlist: 'Domain allowlist',
-	embed_branding_removal: 'Remove Vectreal branding',
 	embed_viewer_customisation: 'Viewer customization',
-	embed_analytics: 'Embed analytics',
-	embed_ar_mode: 'AR / WebXR mode',
 	org_multi_member: 'Multi-member workspace',
 	org_roles: 'Role-based access',
 	org_api_keys: 'API keys',
-	org_sso: 'SAML / OIDC SSO',
-	org_audit_log: 'Audit log export',
-	data_export: 'Data export',
-	data_residency_eu: 'EU data residency',
-	data_residency_custom: 'Custom data residency',
 	support_community: 'Community & Discord',
-	support_email: 'Email support (48 h SLA)',
-	support_priority: 'Priority support (8 h SLA)',
+	support_email: 'Email support',
+	support_priority: 'Priority support',
 	support_dedicated: 'Dedicated support channel'
 }
 
@@ -246,15 +261,7 @@ export const ENTITLEMENT_FEATURE_GROUPS: Array<{
 				label: ENTITLEMENT_DISPLAY_LABELS.scene_optimize
 			},
 			{ key: 'scene_publish', label: ENTITLEMENT_DISPLAY_LABELS.scene_publish },
-			{ key: 'scene_embed', label: ENTITLEMENT_DISPLAY_LABELS.scene_embed },
-			{
-				key: 'scene_preview_private',
-				label: ENTITLEMENT_DISPLAY_LABELS.scene_preview_private
-			},
-			{
-				key: 'scene_version_history',
-				label: ENTITLEMENT_DISPLAY_LABELS.scene_version_history
-			}
+			{ key: 'scene_embed', label: ENTITLEMENT_DISPLAY_LABELS.scene_embed }
 		]
 	},
 	{
@@ -271,10 +278,6 @@ export const ENTITLEMENT_FEATURE_GROUPS: Array<{
 			{
 				key: 'optimization_custom_params',
 				label: ENTITLEMENT_DISPLAY_LABELS.optimization_custom_params
-			},
-			{
-				key: 'optimization_priority_queue',
-				label: ENTITLEMENT_DISPLAY_LABELS.optimization_priority_queue
 			}
 		]
 	},
@@ -286,18 +289,9 @@ export const ENTITLEMENT_FEATURE_GROUPS: Array<{
 				label: ENTITLEMENT_DISPLAY_LABELS.embed_domain_allowlist
 			},
 			{
-				key: 'embed_branding_removal',
-				label: ENTITLEMENT_DISPLAY_LABELS.embed_branding_removal
-			},
-			{
 				key: 'embed_viewer_customisation',
 				label: ENTITLEMENT_DISPLAY_LABELS.embed_viewer_customisation
-			},
-			{
-				key: 'embed_analytics',
-				label: ENTITLEMENT_DISPLAY_LABELS.embed_analytics
-			},
-			{ key: 'embed_ar_mode', label: ENTITLEMENT_DISPLAY_LABELS.embed_ar_mode }
+			}
 		]
 	},
 	{
@@ -308,23 +302,7 @@ export const ENTITLEMENT_FEATURE_GROUPS: Array<{
 				label: ENTITLEMENT_DISPLAY_LABELS.org_multi_member
 			},
 			{ key: 'org_roles', label: ENTITLEMENT_DISPLAY_LABELS.org_roles },
-			{ key: 'org_api_keys', label: ENTITLEMENT_DISPLAY_LABELS.org_api_keys },
-			{ key: 'org_sso', label: ENTITLEMENT_DISPLAY_LABELS.org_sso },
-			{ key: 'org_audit_log', label: ENTITLEMENT_DISPLAY_LABELS.org_audit_log }
-		]
-	},
-	{
-		label: 'Data & Compliance',
-		features: [
-			{ key: 'data_export', label: ENTITLEMENT_DISPLAY_LABELS.data_export },
-			{
-				key: 'data_residency_eu',
-				label: ENTITLEMENT_DISPLAY_LABELS.data_residency_eu
-			},
-			{
-				key: 'data_residency_custom',
-				label: ENTITLEMENT_DISPLAY_LABELS.data_residency_custom
-			}
+			{ key: 'org_api_keys', label: ENTITLEMENT_DISPLAY_LABELS.org_api_keys }
 		]
 	},
 	{
@@ -397,18 +375,8 @@ export const STORAGE_USAGE_HINT =
 // order.
 // ---------------------------------------------------------------------------
 
-export const UPGRADE_FEATURE_HIGHLIGHT_KEYS = [
-	'scene_preview_private',
-	'scene_version_history',
-	'optimization_preset_high',
-	'optimization_custom_params',
-	'optimization_priority_queue',
-	'embed_branding_removal',
-	'embed_viewer_customisation',
-	'embed_analytics',
-	'embed_ar_mode',
+export const UPGRADE_FEATURE_HIGHLIGHT_KEYS: readonly EntitlementKey[] = [
 	'org_multi_member',
 	'org_roles',
-	'support_email',
 	'support_priority'
-] as const
+]

--- a/apps/vectreal-platform/app/db/schema/billing/org-entitlement-overrides.ts
+++ b/apps/vectreal-platform/app/db/schema/billing/org-entitlement-overrides.ts
@@ -25,7 +25,7 @@ export const orgEntitlementOverrides = pgTable(
 		organizationId: uuid('organization_id')
 			.notNull()
 			.references(() => organizations.id, { onDelete: 'cascade' }),
-		/** Canonical entitlement key, e.g. "embed_branding_removal". */
+		/** Canonical entitlement key, e.g. "org_multi_member". */
 		entitlementKey: text('entitlement_key').notNull(),
 		/** true = grant, false = revoke (overrides plan baseline). */
 		granted: boolean('granted').notNull(),

--- a/apps/vectreal-platform/app/lib/canonical-url.spec.ts
+++ b/apps/vectreal-platform/app/lib/canonical-url.spec.ts
@@ -282,9 +282,12 @@ describe('deployment origin resolution', () => {
 		['an unparseable origin', 'vectreal.com'],
 		['a non-http scheme', 'ftp://vectreal.com'],
 		['an empty string', '']
-	])('counts %s as the canonical site rather than a mirror', (_label, value) => {
-		expect(isCanonicalDeployment(value)).toBe(true)
-	})
+	])(
+		'counts %s as the canonical site rather than a mirror',
+		(_label, value) => {
+			expect(isCanonicalDeployment(value)).toBe(true)
+		}
+	)
 
 	it.each([
 		['a different host', 'https://staging.vectreal.com'],

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx
@@ -3,7 +3,7 @@ title: "API Keys 101 - How Vectreal Keys Actually Work, and How to Ship Them Saf
 slug: "api-keys-101"
 excerpt: "A practical guide to Vectreal API keys - what they unlock, how to scope them to projects and domains, and the three rotation patterns that keep production safe."
 publishedAt: "2026-05-02"
-updatedAt: "2026-05-02"
+updatedAt: "2026-09-03"
 category: "guides"
 tags:
 - "api"
@@ -244,7 +244,7 @@ If you have shipped any of these, do not panic. Go to **API keys**, revoke the o
 
 **Are there usage analytics per key?** The dashboard shows last-used timestamp per key today. Per-key request counts and per-domain breakdowns are on the roadmap.
 
-**Does the platform record API key activity for audit?** Not yet. `org_audit_log` exists as an Enterprise entitlement key, but nothing implements it today. What you have now is the dashboard's last-used timestamp per key.
+**Does the platform record API key activity for audit?** Not yet. There is no audit log, and no plan advertises one. What you have now is the dashboard's last-used timestamp per key.
 
 ---
 


### PR DESCRIPTION
## Summary

Of 28 entitlement keys, 4 were read by `hasEntitlement` and only 2 could deny on
plan alone. This makes every remaining claim true: 12 keys naming features that
do not exist are deleted, and 4 that were `false` on free while the feature
shipped ungated are set to what is true.

## Root cause

Entitlements were specified as configuration and rendered as UI before any of
them had an implementation, so `plan-config.ts` became a claim surface rather
than a control surface; the fix belongs at the claim, because an entitlement
nobody enforces and a shipped feature are indistinguishable from outside.

## Changes

**Deleted (12), because the feature does not exist.** `scene_preview_private`,
`scene_version_history`, `optimization_preset_medium`,
`optimization_priority_queue`, `embed_branding_removal`, `embed_analytics`,
`embed_ar_mode`, `org_sso`, `org_audit_log`, `data_export`, `data_residency_eu`,
`data_residency_custom`. No visibility column, no versions table, no watermark
to remove, no queue, no SSO, no audit log, no residency concept.

**Set to what is true (4), because the feature ships ungated.** The first review
round caught three of these as false deletions, and it was right: the untrue
part was the value, not the key, and deleting them dropped a true row.

| Key | Was | Now |
| --- | --- | --- |
| `optimization_preset_high` | `false` on free, labeled "High-quality optimization preset" | `true` everywhere, "Maximum quality preset" |
| `optimization_preset_low` | `true`, labeled "Low / medium presets" | `true`, "Balanced and Smallest presets" |
| `optimization_custom_params` | `false` on free | `true` everywhere |
| `embed_viewer_customisation` | `false` on free | `true` everywhere |

The labels named a low/medium/high taxonomy the product does not have. `PresetId`
is `quality | balanced | smallest`, and `PresetPanel` renders all three as
unconditional buttons with no plan prop.

`support_email` also becomes `true` on free: `contact-page.tsx` defaults the
inquiry type to `support` and publicly promises anyone a reply within one
business day, so a minus in the free column contradicted a live public page.

**28 keys become 16, and free-to-Pro now unlocks zero entitlements.** Pro
differs from Free in quota alone; Business adds three real rows. That is the
state of the product rather than a regression introduced here, and it is the
reason this landed before Stripe goes live.

**One guard added, and mutation-gated.** `UPGRADE_FEATURE_HIGHLIGHT_KEYS` was a
bare `as const` whose only consumer casts it to `readonly string[]`, so a stale
key vanished silently at runtime. It is now `readonly EntitlementKey[]`. Putting
`org_audit_log` back into it fails the build with
`TS2322: Type '"org_audit_log"' is not assignable to type 'EntitlementKey'`;
before this change the same mutation compiled.

**Copy.** `PLAN_OFFER_DESCRIPTIONS` and the enterprise pitch drop analytics, AR
mode, branding removal, version history, priority queue, EU residency, SSO,
audit log and custom residency. Both SLA figures come out of the support labels,
since nothing measures a 48 or 8 hour response; the tier distinction survives
without the number. The Pro description names the four limits that genuinely
rise and avoids a blanket claim, because `org_seats` is `1` on both Free and Pro
and the plan card prints it.

**Two claims the final round caught.** The Pro tagline said "small studios",
but Pro is one seat: `org_seats` is `1` and `org_multi_member` is `false`, and
that gate is real, so `invite-member` returns 403. And the Enterprise offer said
"unlimited storage, custom seats" while the card beside it renders "Storage:
Custom, Team seats: Unlimited", because `formatLimitValue` words a null storage
limit differently from every other null. Both now agree with what renders.

**Two documents that named removed keys.** `04_api-keys-101.mdx:247` no longer
cites `org_audit_log`; its answer is unchanged and still honest. Its `updatedAt`
moves, since that field feeds Article `dateModified`, the visible byline and
sitemap `lastmod`. A doc-comment example in `org-entitlement-overrides.ts` now
names a key that exists.

**Folded in at the owner's request.** `app/lib/canonical-url.spec.ts` is
reformatted. #802 made `prettier --check .` a CI gate but was branched before
#804 added that file, so `main` fails its own gate and every PR opened from it
starts red on a file it does not touch.

## Two readings worth recording

`scene_preview_private` and `data_export` were deleted under a reading that is
now written into the code comment rather than left for the next audit. An
authenticated owner-only preview route exists and a per-scene model export
exists, both ungated; a shareable secret preview link and an organization-wide
compliance export do not. On a pricing page those labels read as the second
thing.

The four `support_*` keys are the exception neither rule decides. Support is
delivered by people, so no plan-aware code path is expected or present.
`support_priority` and `support_dedicated` are true only if the business honors
them, which is a commitment to keep rather than a claim this file can check.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Tested manually in the browser
- [x] No new tests required, and that is itself a finding (see below)

`prettier --check .` clean repo-wide, `typecheck` and `lint` green across all
four projects (8/8 tasks), 1837 unit tests pass.

Verified in the browser against the dev server: the `/pricing` comparison grid
renders 16 rows in 5 groups with every value matching the config, and `/llms.txt`
carries only true claims. Screenshots could not be captured because the Browser
pane was hidden for this session, so the grid was verified through the DOM and
the full page text instead. That is structural proof rather than a visual pass;
the change adds no styling or layout.

**No test anywhere imports `plan-config` or `product-copy`.** The full suite
stayed green through a 12-key deletion, four value flips and a rewrite of every
public pricing string. Pinning these claims is the next item in this phase, and
it is deliberately not folded in here.

## Filed, not fixed

- Root's structured data reaches no page: `buildWebApplicationJsonLd` is emitted
  only from `root.tsx`, every leaf route's `meta` replaces it, and `getRootMeta`
  filters root's descriptors to `og:image` alone. This must be fixed after the
  claims are true, not before.
- The `as readonly string[]` cast at `billing-upgrade-success.tsx:63` is now
  redundant and forces two downstream casts.
- The label dedupe and `.slice()` calls in both unlock-list functions are now
  unreachable.
- `billing-settings-section.tsx` links a different Discord invite from the
  footer and mobile nav. One of them is dead.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
- [x] I updated documentation where needed
