### PR TITLE
fix(billing): count rows so the plan limits actually refuse

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { and, count, eq, inArray, isNull } from 'drizzle-orm'
 
 import { generateApiKey } from './api-key-generator.server'
 import { resolveApiKeyState } from './api-key-lifecycle'
@@ -10,12 +10,7 @@ import { organizations } from '../../../db/schema/core/organizations'
 import { users } from '../../../db/schema/core/users'
 import { projects } from '../../../db/schema/project/projects'
 import { encryptEmbedToken } from '../../security/embed-token-cipher.server'
-import {
-	getOrgSubscription,
-	getRecommendedUpgrade
-} from '../billing/entitlement-service.server'
-import { QuotaExceededError } from '../billing/quota-exceeded-error'
-import { checkQuota } from '../billing/usage-service.server'
+import { assertWithinQuota } from '../billing/quota-enforcement.server'
 import { type DashboardOperation } from '../dashboard/dashboard-operations'
 import { assertDashboardPermission } from '../dashboard/dashboard-permissions.server'
 
@@ -270,20 +265,24 @@ export async function createApiKey(
 		'api-key:create'
 	)
 
-	const quotaCheck = await checkQuota(organizationId, 'api_keys_per_org')
-	if (quotaCheck.outcome === 'hard_limit_exceeded') {
-		const { plan } = await getOrgSubscription(organizationId)
-		const upgradeTo = getRecommendedUpgrade(plan)
-		throw new QuotaExceededError({
-			limitKey: 'api_keys_per_org',
-			currentValue: quotaCheck.currentValue,
-			limit: quotaCheck.limit,
-			plan,
-			upgradeTo,
-			message:
-				'API key limit reached for your plan. Upgrade to create more API keys.'
-		})
-	}
+	await assertWithinQuota({
+		organizationId,
+		limitKey: 'api_keys_per_org',
+		measure: async () => {
+			const [row] = await db
+				.select({ total: count() })
+				.from(apiKeys)
+				.where(
+					and(
+						eq(apiKeys.organizationId, organizationId),
+						isNull(apiKeys.revokedAt)
+					)
+				)
+			return row?.total ?? 0
+		},
+		message: ({ limit }) =>
+			`API key limit reached for your plan (${limit}). Revoke a key or upgrade to create more.`
+	})
 
 	// Verify all projects belong to organization
 	await verifyProjectsInOrganization(db, projectIds, organizationId)

--- a/apps/vectreal-platform/app/lib/domain/billing/quota-enforcement.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/quota-enforcement.server.ts
@@ -1,0 +1,58 @@
+/**
+ * Refuses an operation that would take an organization past a plan limit.
+ *
+ * Counts real rows rather than going through `checkQuota`. That helper reads
+ * `org_usage_counters`, and nothing in the app calls `incrementUsage` or
+ * `decrementUsage`, so every counter sits at zero and `checkQuota` can never
+ * report an exceeded limit. Four call sites routed their guard through it and
+ * enforced nothing for the life of the product: a free organization could
+ * create its second project by resubmitting the ordinary form.
+ *
+ * `getQuotaLimit` is used as-is. The limit side reads plan config and per-org
+ * overrides and works; only the usage side was inert.
+ *
+ * `measure` is a callback so the query stays next to the rows it counts and
+ * runs only when a limit actually applies. `getQuotaLimit` has already merged
+ * any per-org override by the time it returns, so a `null` here means unlimited
+ * rather than "look somewhere else", and no count is issued.
+ */
+
+import {
+	getQuotaLimit,
+	getRecommendedUpgrade
+} from './entitlement-service.server'
+import { QuotaExceededError } from './quota-exceeded-error'
+
+import type { LimitKey } from '../../../constants/plan-config'
+
+export async function assertWithinQuota(params: {
+	organizationId: string
+	limitKey: LimitKey
+	/** Current usage, measured from rows that exist. */
+	measure: () => Promise<number>
+	/** What this operation would add. Defaults to one row. */
+	adds?: number
+	/** Built only on refusal, so it can name the limit it hit. */
+	message: (context: { limit: number; current: number }) => string
+}): Promise<void> {
+	const { organizationId, limitKey, measure, adds = 1, message } = params
+
+	const { limit, effectivePlan } = await getQuotaLimit(organizationId, limitKey)
+	if (limit === null) {
+		return
+	}
+
+	const current = await measure()
+	if (current + adds <= limit) {
+		return
+	}
+
+	throw new QuotaExceededError({
+		limitKey,
+		currentValue: current,
+		limit,
+		plan: effectivePlan,
+		upgradeTo: getRecommendedUpgrade(effectivePlan),
+		message: message({ limit, current })
+	})
+}

--- a/apps/vectreal-platform/app/lib/domain/organization/organization-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/organization/organization-repository.server.ts
@@ -1,10 +1,11 @@
-import { and, asc, eq, sql } from 'drizzle-orm'
+import { and, asc, count, eq, sql } from 'drizzle-orm'
 
 import { getDbClient } from '../../../db/client'
 import { organizationMemberships } from '../../../db/schema/core/organization-memberships'
 import { organizations } from '../../../db/schema/core/organizations'
 import { users } from '../../../db/schema/core/users'
 import { projects } from '../../../db/schema/project/projects'
+import { assertWithinQuota } from '../billing/quota-enforcement.server'
 import { assertDashboardPermission } from '../dashboard/dashboard-permissions.server'
 
 const db = getDbClient()
@@ -172,6 +173,20 @@ export async function inviteOrganizationMember(
 	if (existing.length > 0) {
 		throw new Error('User is already a member of this organization')
 	}
+
+	await assertWithinQuota({
+		organizationId,
+		limitKey: 'org_seats',
+		measure: async () => {
+			const [row] = await db
+				.select({ total: count() })
+				.from(organizationMemberships)
+				.where(eq(organizationMemberships.organizationId, organizationId))
+			return row?.total ?? 0
+		},
+		message: ({ limit }) =>
+			`Seat limit reached for your plan (${limit}). Remove a member or upgrade to invite more.`
+	})
 
 	const [membership] = await db
 		.insert(organizationMemberships)

--- a/apps/vectreal-platform/app/lib/domain/project/project-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/project/project-repository.server.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from 'drizzle-orm'
+import { and, asc, count, eq } from 'drizzle-orm'
 
 import { getDbClient } from '../../../db/client'
 import { organizationMemberships } from '../../../db/schema/core/organization-memberships'
@@ -6,13 +6,7 @@ import { assets } from '../../../db/schema/project/assets'
 import { folders } from '../../../db/schema/project/folders'
 import { projects } from '../../../db/schema/project/projects'
 import { deleteStorageObjects } from '../asset/asset-storage.server'
-import {
-	getOrgSubscription,
-	getQuotaLimit,
-	getRecommendedUpgrade
-} from '../billing/entitlement-service.server'
-import { QuotaExceededError } from '../billing/quota-exceeded-error'
-import { checkQuota } from '../billing/usage-service.server'
+import { assertWithinQuota } from '../billing/quota-enforcement.server'
 import { assertDashboardPermission } from '../dashboard/dashboard-permissions.server'
 
 const db = getDbClient()
@@ -123,28 +117,21 @@ export async function createProject(
 ): Promise<typeof projects.$inferSelect> {
 	await verifyOrganizationAccess(db, organizationId, userId)
 
-	const quotaCheck = await checkQuota(organizationId, 'projects_total')
-	if (quotaCheck.outcome === 'hard_limit_exceeded') {
-		const [{ plan: subscriptionPlan }, { effectivePlan }] = await Promise.all([
-			getOrgSubscription(organizationId),
-			getQuotaLimit(organizationId, 'projects_total')
-		])
-		const upgradeTo = getRecommendedUpgrade(effectivePlan)
-		const message =
-			effectivePlan === 'free'
-				? subscriptionPlan === 'free'
-					? 'Free plan limit reached: you can have one project. Delete an existing project or upgrade to create another.'
-					: 'Project creation is currently limited to free-tier quotas. Delete an existing project or restore full access to create another.'
-				: 'Project limit reached for your plan. Upgrade to create more projects.'
-		throw new QuotaExceededError({
-			limitKey: 'projects_total',
-			currentValue: quotaCheck.currentValue,
-			limit: quotaCheck.limit,
-			plan: effectivePlan,
-			upgradeTo,
-			message
-		})
-	}
+	await assertWithinQuota({
+		organizationId,
+		limitKey: 'projects_total',
+		measure: async () => {
+			const [row] = await db
+				.select({ total: count() })
+				.from(projects)
+				.where(eq(projects.organizationId, organizationId))
+			return row?.total ?? 0
+		},
+		message: ({ limit }) =>
+			limit === 1
+				? 'Free plan limit reached: you can have one project. Delete an existing project or upgrade to create another.'
+				: `Project limit reached for your plan (${limit}). Delete a project or upgrade to create more.`
+	})
 
 	const [newProject] = await db
 		.insert(projects)

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
@@ -23,8 +23,8 @@ import {
 	getOrgSubscription,
 	getQuotaLimit
 } from '../../billing/entitlement-service.server'
+import { assertWithinQuota } from '../../billing/quota-enforcement.server'
 import { QuotaExceededError } from '../../billing/quota-exceeded-error'
-import { checkQuota } from '../../billing/usage-service.server'
 import { getProject } from '../../project/project-repository.server'
 import {
 	getOrCreateDefaultOrganization,
@@ -178,6 +178,29 @@ async function validateSaveLocationTarget(
 	*/
 }
 
+/**
+ * The organization whose plan governs a scene save.
+ *
+ * `targetProjectId` wins when the client names one, because that project may
+ * belong to an organization the caller was invited into rather than their own.
+ * Falls back to the caller's default organization, which is what an ordinary
+ * save from the publisher uses.
+ */
+async function resolveOwningOrganizationId(
+	request: SceneSettingsRequest,
+	userId: string
+): Promise<string> {
+	if (!request.targetProjectId) {
+		return (await getOrCreateDefaultOrganization(userId)).id
+	}
+
+	const project = await getProject(request.targetProjectId, userId)
+	if (!project) {
+		throw new Error('Target project not found or access denied')
+	}
+	return project.organizationId
+}
+
 export async function prepareSceneUpload(
 	request: SceneSettingsRequest,
 	userId: string
@@ -189,45 +212,63 @@ export async function prepareSceneUpload(
 		)
 	}
 
-	// Enforce scenes_total quota when a new scene is being created (no existing sceneId)
 	const isNewScene = !request.sceneId?.trim()
+
+	/*
+	  The organization whose limits apply is the one that will own the scene, not
+	  necessarily the caller's own: `targetProjectId` can name a project in an org
+	  they were invited into. Counting their personal org would enforce the wrong
+	  tenant in both directions - theirs refusing a scene it will never hold, the
+	  target's never enforced at all.
+
+	  Resolved only when a guard below actually needs it. It was briefly hoisted,
+	  which put `getOrCreateDefaultOrganization` - a transaction that *creates* an
+	  organization when its name lookup misses - on the per-asset upload calls,
+	  which need no guard at all.
+	*/
 	if (isNewScene) {
-		const organization = await getOrCreateDefaultOrganization(userId)
-		const quotaCheck = await checkQuota(organization.id, 'scenes_total')
-		if (quotaCheck.outcome === 'hard_limit_exceeded') {
-			const { plan } = await getOrgSubscription(organization.id)
-			const upgradeTo = getRecommendedUpgrade(plan)
-			throw new QuotaExceededError({
-				limitKey: 'scenes_total',
-				currentValue: quotaCheck.currentValue,
-				limit: quotaCheck.limit,
-				plan,
-				upgradeTo,
-				message:
-					'Scene limit reached for your plan. Upgrade to create more scenes.'
-			})
-		}
+		const organizationId = await resolveOwningOrganizationId(request, userId)
+		await assertWithinQuota({
+			organizationId,
+			limitKey: 'scenes_total',
+			measure: async () => {
+				const [row] = await getDbClient()
+					.select({ total: count() })
+					.from(scenes)
+					.innerJoin(projects, eq(projects.id, scenes.projectId))
+					.where(eq(projects.organizationId, organizationId))
+				return row?.total ?? 0
+			},
+			message: ({ limit }) =>
+				`Scene limit reached for your plan (${limit}). Delete a scene or upgrade to create more.`
+		})
 	}
 
-	// Enforce per-scene size limit against the reported final (post-optimization)
-	// scene size. currentSceneBytes is client-reported (same value used for scene
-	// stats); this is a plan gate, not a security boundary. storage_bytes_total
-	// and the storage bucket file-size limit remain hard backstops.
+	/*
+	  Enforced against the reported final (post-optimization) scene size.
+	  `currentSceneBytes` is client-reported - the same value that feeds scene
+	  stats - so this is a plan gate, not a security boundary. The storage
+	  bucket's own per-file limit is the boundary.
+
+	  This comment used to name `storage_bytes_total` as a second hard backstop.
+	  It was not one, and it still is not: nothing enforces it. Enforcing it here
+	  was tried and reverted, because the figure arrives from the same client
+	  value and is absent from every path that actually writes bytes.
+	*/
 	if (typeof request.currentSceneBytes === 'number') {
-		const organization = await getOrCreateDefaultOrganization(userId)
+		const organizationId = await resolveOwningOrganizationId(request, userId)
 		const { limit } = await getQuotaLimit(
-			organization.id,
+			organizationId,
 			'storage_bytes_per_scene'
 		)
 		if (isSceneOverSizeLimit(request.currentSceneBytes, limit)) {
-			const { plan } = await getOrgSubscription(organization.id)
-			const upgradeTo = getRecommendedUpgrade(plan)
+			const { plan } = await getOrgSubscription(organizationId)
 			throw new QuotaExceededError({
 				limitKey: 'storage_bytes_per_scene',
 				currentValue: request.currentSceneBytes,
 				limit,
 				plan,
-				upgradeTo,
+				upgradeTo: getRecommendedUpgrade(plan),
 				message:
 					'Scene exceeds the maximum size for your plan. Optimize further or upgrade.'
 			})
@@ -650,20 +691,23 @@ export async function publishScene(
 						.innerJoin(projects, eq(projects.id, scenes.projectId))
 						.where(eq(projects.organizationId, project.organizationId))
 
-			const quotaCheck = await checkQuota(
+			/*
+			  `getQuotaLimit`, not `checkQuota`. The count above already is the
+			  usage, and checkQuota's usage side reads counters nothing writes, so
+			  the `hard_limit_exceeded` branch that used to be OR'd in here could
+			  never fire. This gate worked only because of the row count.
+			*/
+			const { limit } = await getQuotaLimit(
 				project.organizationId,
-				'scenes_published_concurrent',
-				1
+				'scenes_published_concurrent'
 			)
-			const wouldExceedLimit =
-				quotaCheck.limit !== null && totalPublished >= quotaCheck.limit
 
-			if (quotaCheck.outcome === 'hard_limit_exceeded' || wouldExceedLimit) {
+			if (limit !== null && totalPublished >= limit) {
 				const upgradeTo = getRecommendedUpgrade(effectivePlan)
 				throw new QuotaExceededError({
 					limitKey: 'scenes_published_concurrent',
 					currentValue: totalPublished,
-					limit: quotaCheck.limit,
+					limit,
 					plan: effectivePlan,
 					upgradeTo,
 					message: useProjectScopedLimit

--- a/apps/vectreal-platform/tests/integration/api-key-lifecycle.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/api-key-lifecycle.integration.spec.ts
@@ -235,6 +235,29 @@ describe('api key rotation', () => {
 		  updates match and both return success, leaving one admin holding a
 		  plaintext that authorizes nothing - presented as the new live key.
 		*/
+		/*
+		  Establish two pooled connections before racing. postgres.js opens them
+		  lazily, so the second caller spends its first moments on a connect-and-
+		  auth handshake while the first completes all four of its round trips on
+		  the already-warm socket. The second then reads the secret the first just
+		  wrote, its compare-and-swap matches, and both report success - which is
+		  not the guard failing, it is the race never happening.
+
+		  This test passed for a while on nothing but luck: enough earlier queries
+		  happened to leave two sockets warm. Removing a couple of queries
+		  elsewhere in the suite was enough to undo that and turn the assertion
+		  red, which is how the dependency surfaced.
+
+		  `reserve()` waits for an established connection rather than inferring one
+		  from a query that happens to need it, so this states the precondition
+		  instead of relying on a side effect.
+		*/
+		const pool = (
+			db as unknown as { $client: { reserve(): Promise<{ release(): void }> } }
+		).$client
+		const reserved = await Promise.all([pool.reserve(), pool.reserve()])
+		reserved.forEach((connection) => connection.release())
+
 		const results = await Promise.allSettled([
 			rotateApiKey({ apiKeyId, userId: ownerId }),
 			rotateApiKey({ apiKeyId, userId: ownerId })
@@ -249,6 +272,17 @@ describe('api key rotation', () => {
 		)
 
 		expect(winners).toHaveLength(1)
+
+		/*
+		  And the loser lost for the stated reason. Filtering on `status` alone
+		  accepts any failure - a dropped connection, a permission throw, a raw
+		  serialization error - so a compare-and-swap replaced by something that
+		  fails less usefully would still pass.
+		*/
+		const loser = results.find((result) => result.status === 'rejected')
+		expect(String((loser as PromiseRejectedResult).reason)).toMatch(
+			/changed while it was being rotated/
+		)
 
 		rotatedPlaintext = winners[0].value.plaintext
 		const decision = await validatePreviewApiKeyForProject({

--- a/apps/vectreal-platform/tests/integration/plan-quota-enforcement.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/plan-quota-enforcement.integration.spec.ts
@@ -1,0 +1,412 @@
+/**
+ * Proves the plan limits refuse at the boundary, against a real Postgres.
+ *
+ * These guards all used to call `checkQuota`, which reads `org_usage_counters`.
+ * Nothing in the app ever called `incrementUsage`, so every counter sat at zero
+ * and none of them could fire: a free organization created its second project
+ * by resubmitting the ordinary form. A unit test cannot catch that, because the
+ * defect is the query the guard runs, not the arithmetic it does afterwards.
+ *
+ * So every assertion here goes through the real repository function and lets it
+ * hit the database. Each limit is squeezed with an `org_limit_overrides` row
+ * rather than by creating hundreds of rows, which is the technique
+ * `dashboard-folder-sql.integration.spec.ts` already uses for `folders_total`.
+ *
+ * Opt-in, because it writes to whatever `DATABASE_URL` points at:
+ *
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ *
+ * Every row it creates is namespaced by a run id and dropped in `afterAll`.
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { and, count, eq, inArray, isNull } from 'drizzle-orm'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+type Schema = typeof import('../../app/db/schema')
+type ProjectRepo =
+	typeof import('../../app/lib/domain/project/project-repository.server')
+type ApiKeyRepo =
+	typeof import('../../app/lib/domain/auth/api-key-repository.server')
+type OrgRepo =
+	typeof import('../../app/lib/domain/organization/organization-repository.server')
+type SceneOps =
+	typeof import('../../app/lib/domain/scene/server/scene-settings.operations.server')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+
+describe('plan limits refuse at the boundary', () => {
+	// Imported in `beforeAll`: each of these calls `getDbClient()` at module
+	// scope, which throws without a `DATABASE_URL`.
+	let schema: Schema
+	let projectRepo: ProjectRepo
+	let apiKeyRepo: ApiKeyRepo
+	let orgRepo: OrgRepo
+	let sceneOps: SceneOps
+	let db: Db
+
+	const ownerId = randomUUID()
+	const inviteeId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+	const folderId = randomUUID()
+
+	/*
+	  A second tenant that no test touches. Every count in the guards filters by
+	  organization, and with only one organization in the fixture an unfiltered
+	  count returns the same number - so dropping the filter would enforce one
+	  tenant's usage against another's limit and no assertion would notice. These
+	  rows exist so that mistake changes a number.
+	*/
+	const decoyOwnerId = randomUUID()
+	const decoyOrganizationId = randomUUID()
+	const decoyProjectId = randomUUID()
+
+	/** Squeezes one limit for this org. Enterprise-style `null` means no cap. */
+	const setLimit = async (limitKey: string, value: number) => {
+		await db
+			.delete(schema.orgLimitOverrides)
+			.where(eq(schema.orgLimitOverrides.organizationId, organizationId))
+		await db.insert(schema.orgLimitOverrides).values({
+			organizationId,
+			limitKey,
+			limitValue: BigInt(value)
+		})
+	}
+
+	beforeAll(async () => {
+		schema = await import('../../app/db/schema')
+		projectRepo =
+			await import('../../app/lib/domain/project/project-repository.server')
+		apiKeyRepo =
+			await import('../../app/lib/domain/auth/api-key-repository.server')
+		orgRepo =
+			await import('../../app/lib/domain/organization/organization-repository.server')
+		sceneOps =
+			await import('../../app/lib/domain/scene/server/scene-settings.operations.server')
+		db = (await import('../../app/db/client')).getDbClient()
+
+		await db.insert(schema.users).values([
+			{ id: ownerId, email: `owner-${ownerId}@quota.test`, name: 'Owner' },
+			{
+				id: inviteeId,
+				email: `invitee-${inviteeId}@quota.test`,
+				name: 'Guest'
+			},
+			{
+				id: decoyOwnerId,
+				email: `decoy-${decoyOwnerId}@quota.test`,
+				name: 'Decoy'
+			}
+		])
+
+		/*
+		  Named exactly 'My Organization' because `prepareSceneUpload` resolves the
+		  acting org through `getOrCreateDefaultOrganization`, which matches on that
+		  literal name plus an owner membership. Any other name and the scene tests
+		  would create a second org and measure the wrong one - which fails loudly
+		  rather than quietly, since the new org holds no scenes and the refusal
+		  assertions would stop seeing a refusal.
+		*/
+		await db.insert(schema.organizations).values({
+			id: organizationId,
+			name: 'My Organization',
+			ownerId
+		})
+		await db
+			.insert(schema.organizationMemberships)
+			.values({ userId: ownerId, organizationId, role: 'owner' })
+
+		// The decoy tenant, described above. Nothing in any test touches it.
+		await db.insert(schema.organizations).values({
+			id: decoyOrganizationId,
+			name: `decoy-${decoyOrganizationId}`,
+			ownerId: decoyOwnerId
+		})
+		await db.insert(schema.organizationMemberships).values([
+			{
+				userId: decoyOwnerId,
+				organizationId: decoyOrganizationId,
+				role: 'owner'
+			},
+			{
+				userId: inviteeId,
+				organizationId: decoyOrganizationId,
+				role: 'member'
+			}
+		])
+		await db.insert(schema.projects).values({
+			id: decoyProjectId,
+			organizationId: decoyOrganizationId,
+			name: 'Decoy project',
+			slug: `decoy-${decoyProjectId}`
+		})
+		await db.insert(schema.scenes).values({
+			id: randomUUID(),
+			projectId: decoyProjectId,
+			folderId: null,
+			name: 'decoy scene'
+		})
+		await apiKeyRepo.createApiKey({
+			userId: decoyOwnerId,
+			organizationId: decoyOrganizationId,
+			name: 'decoy key',
+			projectIds: [decoyProjectId]
+		})
+	})
+
+	/*
+	  Each test starts from the same baseline: one project, no scenes, no assets,
+	  no keys, no overrides. Without this the API key tests inherited the live key
+	  the previous one minted and started already at their limit, which reads as
+	  the guard misfiring rather than as leaked state.
+	*/
+	beforeEach(async () => {
+		await db
+			.delete(schema.orgLimitOverrides)
+			.where(eq(schema.orgLimitOverrides.organizationId, organizationId))
+		await db
+			.delete(schema.apiKeys)
+			.where(eq(schema.apiKeys.organizationId, organizationId))
+		await db.delete(schema.assets).where(eq(schema.assets.folderId, folderId))
+		await db.delete(schema.scenes).where(eq(schema.scenes.projectId, projectId))
+		await db
+			.delete(schema.organizationMemberships)
+			.where(
+				and(
+					eq(schema.organizationMemberships.organizationId, organizationId),
+					eq(schema.organizationMemberships.userId, inviteeId)
+				)
+			)
+		await db
+			.delete(schema.projects)
+			.where(eq(schema.projects.organizationId, organizationId))
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Quota project',
+			slug: `quota-${projectId}`
+		})
+		await db
+			.insert(schema.folders)
+			.values({ id: folderId, projectId, name: 'Quota folder' })
+	})
+
+	afterAll(async () => {
+		if (!db) return
+
+		await db
+			.delete(schema.orgLimitOverrides)
+			.where(eq(schema.orgLimitOverrides.organizationId, organizationId))
+		await db
+			.delete(schema.apiKeys)
+			.where(eq(schema.apiKeys.organizationId, organizationId))
+		await db.delete(schema.assets).where(eq(schema.assets.folderId, folderId))
+		await db
+			.delete(schema.folders)
+			.where(eq(schema.folders.projectId, projectId))
+		await db.delete(schema.scenes).where(eq(schema.scenes.projectId, projectId))
+		await db
+			.delete(schema.projects)
+			.where(eq(schema.projects.organizationId, organizationId))
+		await db
+			.delete(schema.organizationMemberships)
+			.where(eq(schema.organizationMemberships.organizationId, organizationId))
+		await db
+			.delete(schema.organizations)
+			.where(
+				inArray(schema.organizations.id, [organizationId, decoyOrganizationId])
+			)
+		await db
+			.delete(schema.users)
+			.where(inArray(schema.users.id, [ownerId, inviteeId, decoyOwnerId]))
+	})
+
+	/*
+	  Counts used by the "and nothing was written" half of each refusal. None of
+	  these guards shares a transaction with the insert it protects, so moving a
+	  guard below its insert would commit the row *and* throw - and an assertion
+	  that only checks the message stays green through it. For API keys that is
+	  live damage: the row is written active, with a decryptable value, so the
+	  embed panel would later hand out a key the caller was told it could not
+	  have.
+	*/
+	const countProjects = async () => {
+		const [row] = await db
+			.select({ total: count() })
+			.from(schema.projects)
+			.where(eq(schema.projects.organizationId, organizationId))
+		return row?.total ?? 0
+	}
+	const countLiveKeys = async () => {
+		const [row] = await db
+			.select({ total: count() })
+			.from(schema.apiKeys)
+			.where(
+				and(
+					eq(schema.apiKeys.organizationId, organizationId),
+					isNull(schema.apiKeys.revokedAt)
+				)
+			)
+		return row?.total ?? 0
+	}
+	const countMembers = async () => {
+		const [row] = await db
+			.select({ total: count() })
+			.from(schema.organizationMemberships)
+			.where(eq(schema.organizationMemberships.organizationId, organizationId))
+		return row?.total ?? 0
+	}
+	const countScenes = async () => {
+		const [row] = await db
+			.select({ total: count() })
+			.from(schema.scenes)
+			.where(eq(schema.scenes.projectId, projectId))
+		return row?.total ?? 0
+	}
+
+	/*
+	  The free baseline is already 1 project, so this refusal needs no override -
+	  and deliberately uses none. An override of 1 here would be decorative: it
+	  matches the default, so the test would pass even if override resolution
+	  were broken entirely. The allow test below is where the override earns its
+	  keep, by raising the limit above the default.
+	*/
+	it('refuses a project at the free plan default, and writes nothing', async () => {
+		await expect(
+			projectRepo.createProject(
+				organizationId,
+				'over quota',
+				`over-${randomUUID()}`,
+				ownerId
+			)
+		).rejects.toThrow(/you can have one project/)
+
+		expect(await countProjects()).toBe(1)
+	})
+
+	it('allows a project when an override raises the limit', async () => {
+		await setLimit('projects_total', 2)
+
+		const created = await projectRepo.createProject(
+			organizationId,
+			'within quota',
+			`within-${randomUUID()}`,
+			ownerId
+		)
+		expect(created.id).toBeTruthy()
+		expect(await countProjects()).toBe(2)
+	})
+
+	it('refuses an API key once api_keys_per_org is used up, and writes nothing', async () => {
+		await setLimit('api_keys_per_org', 1)
+
+		const first = await apiKeyRepo.createApiKey({
+			userId: ownerId,
+			organizationId,
+			name: 'first',
+			projectIds: [projectId]
+		})
+		expect(first.plaintext).toBeTruthy()
+
+		await expect(
+			apiKeyRepo.createApiKey({
+				userId: ownerId,
+				organizationId,
+				name: 'second',
+				projectIds: [projectId]
+			})
+		).rejects.toThrow(/API key limit reached/)
+
+		expect(await countLiveKeys()).toBe(1)
+	})
+
+	it('counts only live keys, so revoking one frees a slot', async () => {
+		/*
+		  The count filters on `revoked_at is null`. Counting every row would leave
+		  an organization permanently stuck at its limit after a rotation, which is
+		  the opposite of what revoking is for.
+		*/
+		await setLimit('api_keys_per_org', 1)
+
+		const first = await apiKeyRepo.createApiKey({
+			userId: ownerId,
+			organizationId,
+			name: 'to be revoked',
+			projectIds: [projectId]
+		})
+		await apiKeyRepo.revokeApiKey(first.apiKey.id, ownerId)
+
+		const second = await apiKeyRepo.createApiKey({
+			userId: ownerId,
+			organizationId,
+			name: 'replacement',
+			projectIds: [projectId]
+		})
+		expect(second.plaintext).toBeTruthy()
+		expect(await countLiveKeys()).toBe(1)
+	})
+
+	// Free is one seat and the owner holds it, so no override is needed here
+	// either. See the note on the project refusal above.
+	it('refuses an invite at the free plan default, and writes nothing', async () => {
+		await expect(
+			orgRepo.inviteOrganizationMember(
+				organizationId,
+				ownerId,
+				inviteeId,
+				'member'
+			)
+		).rejects.toThrow(/Seat limit reached/)
+
+		expect(await countMembers()).toBe(1)
+	})
+
+	it('allows an invite when an override raises the seat limit', async () => {
+		/*
+		  Without this, dropping the organization filter from the seat count would
+		  over-count, still refuse, and stay green - while locking every
+		  business-plan organization out of inviting anyone.
+		*/
+		await setLimit('org_seats', 2)
+
+		const membership = await orgRepo.inviteOrganizationMember(
+			organizationId,
+			ownerId,
+			inviteeId,
+			'member'
+		)
+		expect(membership.userId).toBe(inviteeId)
+		expect(await countMembers()).toBe(2)
+	})
+
+	it('refuses a new scene once scenes_total is used up, and writes nothing', async () => {
+		await db
+			.insert(schema.scenes)
+			.values({ id: randomUUID(), projectId, folderId: null, name: 'existing' })
+		await setLimit('scenes_total', 1)
+
+		await expect(
+			sceneOps.prepareSceneUpload(
+				{ action: 'prepare-scene-upload', requestId: randomUUID() },
+				ownerId
+			)
+		).rejects.toThrow(/Scene limit reached/)
+
+		expect(await countScenes()).toBe(1)
+	})
+
+	it('allows a new scene when an override raises the limit', async () => {
+		await db
+			.insert(schema.scenes)
+			.values({ id: randomUUID(), projectId, folderId: null, name: 'existing' })
+		await setLimit('scenes_total', 2)
+
+		const prepared = await sceneOps.prepareSceneUpload(
+			{ action: 'prepare-scene-upload', requestId: randomUUID() },
+			ownerId
+		)
+		expect(prepared.sceneId).toBeTruthy()
+	})
+})


### PR DESCRIPTION
## Summary

Four quota guards asked `checkQuota`, which reads counters nothing writes, so
none of them had ever refused anything. They count real rows now, and each one
is covered by an integration test that goes red when the guard is neutered.

Stacked on #809 (base retargets to `main` when that merges). It is stacked only
for the format gate: `main` currently fails `prettier --check .` on a file
neither PR authored, and #809 carries the fix. The two touch disjoint files.

## Root cause

`incrementUsage` has zero callers, so every `org_usage_counters` row sits at
zero and `checkQuota` cannot return `hard_limit_exceeded` for any organization;
the fix belongs in the guards rather than in the counter, because `folders_total`
already showed the working shape by counting rows and saying why.

## Changes

**A free organization created its second project by resubmitting the form.**
`createProject` has exactly one caller, the ordinary route action, and its
refusal branch was unreachable, so the twenty-odd lines of plan-aware refusal
messaging under it had never executed. No crafted request was needed. This is a
quota gap, not an authorization gap: org membership and the `project:create`
role were always enforced.

`assertWithinQuota` (new, `app/lib/domain/billing/quota-enforcement.server.ts`)
takes a `measure` callback so the count sits next to the rows it counts and runs
only when a limit applies.

| Limit | Measured by |
| --- | --- |
| `projects_total` | `count(projects)` for the org |
| `scenes_total` | `count(scenes)` joined through `projects` |
| `api_keys_per_org` | `count(api_keys)` where `revoked_at is null` |
| `org_seats` | `count(organization_memberships)`, previously read nowhere |

`api_keys_per_org` filters revoked rows deliberately: counting every row would
leave an organization permanently at its limit after a rotation, which is the
opposite of what revoking is for. There is a test for exactly that.

**The scene guard resolves the organization from `targetProjectId`** when the
client names one. That project can belong to an org the caller was invited into,
and counting their personal org would enforce the wrong tenant in both
directions: theirs refusing a scene it will never hold, the target's never
enforced at all.

**The published-scenes gate stops routing through `checkQuota`.** It already
worked, because it counted rows itself, but it OR'd in a `hard_limit_exceeded`
branch that could never be true. **`checkQuota` now has zero callers repo-wide**,
which unblocks collapsing `usage-service.server.ts` as a separate change.

**One comment corrected rather than deleted.** `storage_bytes_per_scene`
described itself as a soft plan gate leaning on `storage_bytes_total` and the
storage bucket's file-size limit as "hard backstops". Only the bucket limit was
ever real.

## What was attempted and dropped

`storage_bytes_total` was enforced here in an earlier revision of this branch and
removed, because review showed it cannot be correct at `prepareSceneUpload`:

- **It double-counts on an update.** The org sum already includes the assets of
  the scene being saved, and the whole scene size is then added again. The client
  sends `sceneId` and `currentSceneBytes` together on every save, so an org near
  its limit would be refused a save that adds zero bytes.
- **It never runs where bytes are written.** It is gated on `currentSceneBytes`,
  which `upload-scene-asset`, `upload-scene-gltf` and `upload-published-glb` all
  omit, including the published GLB.

It belongs at the asset write site with real file sizes. Filed.

## Testing

- [x] Unit / integration tests added or updated

`tests/integration/plan-quota-enforcement.integration.spec.ts` exercises every
guard through the real repository function against Postgres. Each refusal test
also asserts **no row was written**, because none of these guards shares a
transaction with the insert it protects: a guard moved below its insert would
commit the row and throw, and a message-only assertion stays green through it.
For API keys that is live damage, since the row is written active with a
decryptable value.

The fixture carries a **second tenant that no test touches**, so a count that
forgets to filter by organization changes a number instead of returning the same
one.

Every refusal has a matching allow test on the exact boundary, so an
unconditionally-refusing guard cannot pass. The project and seat refusals use the
free-plan default rather than an override, because an override equal to the
default proves nothing about override resolution; the allow tests raise the limit
instead, which is where the override earns its keep.

**Mutation gate:**

| Mutation | Result |
| --- | --- |
| helper never refuses | 4 red, allow-side tests stay green |
| projects guard neutered | 1 red |
| seats guard neutered | 1 red |
| scenes guard neutered | 1 red |
| api key count ignores `revoked_at` | 1 red |
| seat count drops the organization filter | 1 red (green before the decoy tenant) |
| projects guard moved below its insert | 2 red, caught by the no-row assertions |
| rotation loser fails less usefully | 1 red |

Gates: `prettier --check .` clean, typecheck and lint green across all four
projects, 1837 unit tests, 82 integration tests.

Integration tests were run locally against `supabase/postgres:17.4.1.075` with
the migrations applied by hand, mirroring what CI does, because `supabase start`
will not come up on this machine (see below).

## A test that was passing on luck

`api-key-lifecycle`'s rotation race asserts that one of two concurrent rotations
loses the compare-and-swap. postgres.js opens pooled connections lazily, so the
second caller is still completing a connect-and-auth handshake while the first
finishes all four of its round trips; the second then reads what the first wrote,
its CAS matches, and both legitimately succeed. The race never happened.

Removing a couple of queries elsewhere in the suite was enough to undo the
incidental warm-up and turn the assertion red, which is how the dependency
surfaced. It now reserves two connections before racing, and asserts the loser
failed for the stated reason rather than only that it failed. The rotation guard
itself is unchanged and was never at fault.

## Filed, not fixed

- `storage_bytes_total`, per above: enforce at the asset write site, against real
  file sizes.
- `getOrCreateDefaultOrganization` matches on the literal name `'My
  Organization'`, so renaming an organization makes the lookup miss and creates a
  fresh empty one. Harmless while nothing enforced; now it resets the scene quota.
- `scenes_total` is keyed on the client not supplying a scene id. A caller that
  generates its own UUID and goes straight to `commit-scene-save` never passes
  the guard. Closing that means guarding at the scene insert.
- A `QuotaExceededError` thrown inside `publishScene` is caught by that
  function's own handler and returned as `ApiResponse.serverError`, so a quota
  refusal on publish reaches the client as a 500.
- `assertFolderQuota` is now a duplicate of `assertWithinQuota` and will drift.
- `supabase start` fails locally: the storage container dies on a template
  database collation mismatch in a cached volume.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Checklist

- [x] My commits follow Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
