### PR TITLE
chore(billing): show the limits that exist and drop the ones that never did

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/billing/billing-settings-section.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/billing/billing-settings-section.tsx
@@ -17,6 +17,7 @@ import { DASHBOARD_ROUTES } from '../../../constants/dashboard'
 import {
 	PLAN_DISPLAY_NAMES,
 	STORAGE_USAGE_HINT,
+	LIMIT_DISPLAY_LABELS,
 	STORAGE_USAGE_LABEL
 } from '../../../constants/product-copy'
 import {
@@ -143,8 +144,8 @@ export function BillingSettingsSection({
 	/*
 	  Same pressure reading as the dashboard band, from the same function.
 
-	  This page listed seven meters and drew attention to none of them, so the
-	  one at 96% looked exactly like the one at 4%. The nudge appears only when
+	  This page listed its meters and drew attention to none of them, so the one
+	  at 96% looked exactly like the one at 4%. The nudge appears only when
 	  something is actually close to a limit, which is what makes it worth
 	  reading when it does.
 	*/
@@ -152,10 +153,8 @@ export function BillingSettingsSection({
 		readUsage(usage.scenesTotal, usage.sceneLimit),
 		readUsage(usage.publishedScenes, usage.publishedSceneLimit),
 		readUsage(usage.projectsTotal, usage.projectsLimit),
-		readUsage(usage.storageBytesTotal, usage.storageLimit),
-		readUsage(usage.apiRequestsMonth, usage.apiRequestsMonthLimit),
-		readUsage(usage.embedBandwidthMonth, usage.embedBandwidthLimit),
-		readUsage(usage.previewLoadsMonth, usage.previewLoadsMonthLimit)
+		readUsage(usage.foldersTotal, usage.foldersLimit),
+		readUsage(usage.storageBytesTotal, usage.storageLimit)
 	])
 
 	const handleOpenPortal = () => {
@@ -270,16 +269,17 @@ export function BillingSettingsSection({
 			</section>
 
 			{/*
-			  Seven readings, each shown once.
+			  Five readings, each shown once, and each measured.
 
 			  Scenes, Projects and Published were rendered twice - as tiles at the
 			  top and again as rows below - so a third of the page repeated itself
-			  while the storage and delivery figures got a single line each.
+			  while the storage figure got a single line.
 
-			  The two groups are what you keep and what you serve. Splitting them
-			  that way also collects every per-month limit in one place, instead of
-			  scattering "/mo" across three headings, and retires the
-			  "API & processing" group that existed to head a single row.
+			  There were seven readings and two groups, "what you keep" and "what
+			  you serve". The serving side is gone: embed bandwidth, preview loads
+			  and API requests were all read from counters nothing increments, so
+			  all three showed zero against a plan number forever. With one group
+			  left, the split and its eyebrows had nothing to separate.
 			*/}
 			<section className="ds-raised space-y-5 rounded-2xl p-5">
 				<div className="flex flex-wrap items-center justify-between gap-2">
@@ -306,64 +306,57 @@ export function BillingSettingsSection({
 					) : null}
 				</div>
 
-				<div className="grid gap-x-10 gap-y-6 md:grid-cols-2">
-					<div className="space-y-3">
-						<p className="text-muted-foreground text-eyebrow">Stored</p>
-						<UsageMeter
-							variant="row"
-							label="Scenes"
-							current={usage.scenesTotal}
-							limit={usage.sceneLimit}
-						/>
-						<UsageMeter
-							variant="row"
-							label="Published scenes"
-							current={usage.publishedScenes}
-							limit={usage.publishedSceneLimit}
-						/>
-						<UsageMeter
-							variant="row"
-							label="Projects"
-							current={usage.projectsTotal}
-							limit={usage.projectsLimit}
-						/>
-						<UsageMeter
-							variant="row"
-							label={`${STORAGE_USAGE_LABEL} (MB)`}
-							hint={STORAGE_USAGE_HINT}
-							current={Math.round(usage.storageBytesTotal / (1024 * 1024))}
-							limit={
-								usage.storageLimit !== null
-									? Math.round(usage.storageLimit / (1024 * 1024))
-									: null
-							}
-						/>
-					</div>
+				{/*
+				  Every meter here is measured from rows that exist. A second column
+				  used to sit beside this one headed "Served" - embed bandwidth,
+				  preview loads and API requests - all three backed by counters
+				  nothing has ever incremented, so all three rendered `0 / limit`
+				  forever. The limits behind them are gone, so the grouping and its
+				  eyebrows went with them.
 
-					<div className="space-y-3">
-						<p className="text-muted-foreground text-eyebrow">Served</p>
-						<UsageMeter
-							variant="row"
-							label="Embed bandwidth (GB)"
-							current={usage.embedBandwidthMonth}
-							limit={usage.embedBandwidthLimit}
-							monthly
-						/>
-						<UsageMeter
-							variant="row"
-							label="Preview loads"
-							current={usage.previewLoadsMonth}
-							limit={usage.previewLoadsMonthLimit}
-							monthly
-						/>
-						<UsageMeter
-							variant="row"
-							label="API requests"
-							current={usage.apiRequestsMonth}
-							limit={usage.apiRequestsMonthLimit}
-							monthly
-						/>
-					</div>
+				  One column, not the two-column grid the pair of groups needed.
+				  Five cells across two columns leave the last meter alone beside an
+				  empty one, and the row variant drops its rail entirely on an
+				  unlimited limit (`usage-meter.tsx`), which in a grid row would show
+				  as a gap under whichever neighbour still had one. A list has
+				  neither problem.
+				*/}
+				<div className="space-y-3">
+					<UsageMeter
+						variant="row"
+						label={LIMIT_DISPLAY_LABELS.scenes_total}
+						current={usage.scenesTotal}
+						limit={usage.sceneLimit}
+					/>
+					<UsageMeter
+						variant="row"
+						label={LIMIT_DISPLAY_LABELS.scenes_published_concurrent}
+						current={usage.publishedScenes}
+						limit={usage.publishedSceneLimit}
+					/>
+					<UsageMeter
+						variant="row"
+						label={LIMIT_DISPLAY_LABELS.projects_total}
+						current={usage.projectsTotal}
+						limit={usage.projectsLimit}
+					/>
+					<UsageMeter
+						variant="row"
+						label={LIMIT_DISPLAY_LABELS.folders_total}
+						current={usage.foldersTotal}
+						limit={usage.foldersLimit}
+					/>
+					<UsageMeter
+						variant="row"
+						label={`${STORAGE_USAGE_LABEL} (MB)`}
+						hint={STORAGE_USAGE_HINT}
+						current={Math.round(usage.storageBytesTotal / (1024 * 1024))}
+						limit={
+							usage.storageLimit !== null
+								? Math.round(usage.storageLimit / (1024 * 1024))
+								: null
+						}
+					/>
 				</div>
 			</section>
 

--- a/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/dashboard-overview.tsx
@@ -14,6 +14,7 @@ import {
 import {
 	PLAN_DISPLAY_NAMES,
 	STORAGE_USAGE_HINT,
+	LIMIT_DISPLAY_LABELS,
 	STORAGE_USAGE_LABEL
 } from '../../constants/product-copy'
 import {
@@ -205,17 +206,17 @@ function AccountHealthBand({
 
 			<UsageMeterGrid>
 				<UsageMeter
-					label="Scenes"
+					label={LIMIT_DISPLAY_LABELS.scenes_total}
 					current={usage.scenesTotal}
 					limit={usage.sceneLimit}
 				/>
 				<UsageMeter
-					label="Published"
+					label={LIMIT_DISPLAY_LABELS.scenes_published_concurrent}
 					current={usage.publishedScenes}
 					limit={usage.publishedSceneLimit}
 				/>
 				<UsageMeter
-					label="Projects"
+					label={LIMIT_DISPLAY_LABELS.projects_total}
 					current={usage.projectsTotal}
 					limit={usage.projectsLimit}
 				/>

--- a/apps/vectreal-platform/app/constants/plan-config.ts
+++ b/apps/vectreal-platform/app/constants/plan-config.ts
@@ -163,11 +163,7 @@ export type LimitKey =
 	| 'projects_total'
 	| 'folders_total'
 	| 'org_seats'
-	| 'api_requests_per_minute'
-	| 'api_requests_per_month'
 	| 'api_keys_per_org'
-	| 'embed_bandwidth_gb_per_month'
-	| 'preview_loads_per_month'
 
 /**
  * Numeric quota limits per plan.
@@ -182,11 +178,7 @@ export const PLAN_LIMITS: Record<Plan, Record<LimitKey, number | null>> = {
 		projects_total: 1,
 		folders_total: 25,
 		org_seats: 1,
-		api_requests_per_minute: 30,
-		api_requests_per_month: 5_000,
-		api_keys_per_org: 2,
-		embed_bandwidth_gb_per_month: 5,
-		preview_loads_per_month: 10_000
+		api_keys_per_org: 2
 	},
 	pro: {
 		storage_bytes_total: 10_240 * 1024 * 1024, // 10 GB
@@ -196,11 +188,7 @@ export const PLAN_LIMITS: Record<Plan, Record<LimitKey, number | null>> = {
 		projects_total: 20,
 		folders_total: 500,
 		org_seats: 1,
-		api_requests_per_minute: 300,
-		api_requests_per_month: 100_000,
-		api_keys_per_org: 10,
-		embed_bandwidth_gb_per_month: 100,
-		preview_loads_per_month: 500_000
+		api_keys_per_org: 10
 	},
 	business: {
 		storage_bytes_total: 102_400 * 1024 * 1024, // 100 GB
@@ -210,11 +198,7 @@ export const PLAN_LIMITS: Record<Plan, Record<LimitKey, number | null>> = {
 		projects_total: 200,
 		folders_total: 5_000,
 		org_seats: 10,
-		api_requests_per_minute: 1_000,
-		api_requests_per_month: 1_000_000,
-		api_keys_per_org: 50,
-		embed_bandwidth_gb_per_month: 1_000,
-		preview_loads_per_month: null // Unlimited
+		api_keys_per_org: 50
 	},
 	enterprise: {
 		storage_bytes_total: null, // Custom
@@ -224,11 +208,7 @@ export const PLAN_LIMITS: Record<Plan, Record<LimitKey, number | null>> = {
 		projects_total: null, // Unlimited
 		folders_total: null, // Unlimited
 		org_seats: null, // Custom
-		api_requests_per_minute: null, // Custom
-		api_requests_per_month: null, // Custom
-		api_keys_per_org: null, // Unlimited
-		embed_bandwidth_gb_per_month: null, // Custom
-		preview_loads_per_month: null // Unlimited
+		api_keys_per_org: null // Unlimited
 	}
 }
 

--- a/apps/vectreal-platform/app/constants/product-copy.ts
+++ b/apps/vectreal-platform/app/constants/product-copy.ts
@@ -333,21 +333,37 @@ export const ENTITLEMENT_FEATURE_GROUPS: Array<{
 // Keys shown on plan cards, in display order.
 // ---------------------------------------------------------------------------
 
-export const PLAN_CARD_LIMIT_KEYS = [
+export const PLAN_CARD_LIMIT_KEYS: readonly LimitKey[] = [
 	'storage_bytes_total',
 	'scenes_total',
 	'scenes_published_concurrent',
 	'projects_total',
+	'folders_total',
 	'storage_bytes_per_scene',
+	'api_keys_per_org',
 	'org_seats'
-] as const
+]
 
-export const LIMIT_DISPLAY_LABELS: Partial<Record<LimitKey, string>> = {
+/*
+  A total record, not a partial one. Six of the twelve limits had no label, for
+  two different reasons: four were claims nothing measured, and two were real
+  limits nobody had got around to showing. The four are deleted and the two are
+  below, so every surviving limit is one a customer can be shown, and a limit
+  added without a label is now a compile error rather than a blank row.
+
+  `folders_total` and `api_keys_per_org` are new here. Both are enforced - the
+  folder limit is the oldest working one in the codebase - and neither had ever
+  appeared on a plan card, so an organization could be refused a folder or a key
+  it was never told it was near.
+*/
+export const LIMIT_DISPLAY_LABELS: Record<LimitKey, string> = {
 	storage_bytes_total: 'Storage',
 	scenes_total: 'Scenes',
 	scenes_published_concurrent: 'Published scenes',
 	projects_total: 'Projects',
+	folders_total: 'Folders',
 	storage_bytes_per_scene: 'Max scene size',
+	api_keys_per_org: 'API keys',
 	org_seats: 'Team seats'
 }
 

--- a/apps/vectreal-platform/app/db/schema/billing/usage-counters.ts
+++ b/apps/vectreal-platform/app/db/schema/billing/usage-counters.ts
@@ -22,7 +22,7 @@ import { isOrganizationAdmin, isOrganizationMember } from '../rls'
  * most recent period boundary for that counter.
  *
  * Counter keys correspond to LimitKey in app/constants/plan-config.ts,
- * e.g. "api_requests_per_month", "embed_bandwidth_gb_per_month".
+ * e.g. "scenes_total", "storage_bytes_total".
  */
 export const orgUsageCounters = pgTable(
 	'org_usage_counters',
@@ -31,7 +31,7 @@ export const orgUsageCounters = pgTable(
 		organizationId: uuid('organization_id')
 			.notNull()
 			.references(() => organizations.id, { onDelete: 'cascade' }),
-		/** Canonical counter key, e.g. "api_requests_per_month". */
+		/** Canonical counter key, e.g. "scenes_total". */
 		counterKey: text('counter_key').notNull(),
 		/**
 		 * Accumulated value for the current window.

--- a/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
@@ -1,10 +1,15 @@
-import { eq, inArray, sql } from 'drizzle-orm'
+import { count, eq, inArray, sql } from 'drizzle-orm'
 import Stripe from 'stripe'
 
 import { getOrgSubscription, getQuotaLimit } from './entitlement-service.server'
-import { getCurrentUsage } from './usage-service.server'
 import { getDbClient } from '../../../db/client'
-import { assets, folders, projects, scenePublished } from '../../../db/schema'
+import {
+	assets,
+	folders,
+	projects,
+	sceneFolders,
+	scenePublished
+} from '../../../db/schema'
 import { orgSubscriptions } from '../../../db/schema/billing/subscriptions'
 import { getStripeClient } from '../../stripe.server'
 import { loadAuthenticatedUser } from '../auth/auth-loader.server'
@@ -135,25 +140,31 @@ export async function loadOrgUsage(
 		sceneQuota,
 		projectsQuota,
 		publishedSceneQuota,
-		apiRequestsMonthQuota,
 		storageQuota,
-		embedBandwidthQuota,
-		previewLoadsQuota,
-		apiRequestsMonthUsage,
-		embedBandwidthUsage,
-		previewLoadsUsage
+		folderQuota
 	] = await Promise.all([
 		getQuotaLimit(organizationId, 'scenes_total'),
 		getQuotaLimit(organizationId, 'projects_total'),
 		getQuotaLimit(organizationId, 'scenes_published_concurrent'),
-		getQuotaLimit(organizationId, 'api_requests_per_month'),
 		getQuotaLimit(organizationId, 'storage_bytes_total'),
-		getQuotaLimit(organizationId, 'embed_bandwidth_gb_per_month'),
-		getQuotaLimit(organizationId, 'preview_loads_per_month'),
-		getCurrentUsage(organizationId, 'api_requests_per_month'),
-		getCurrentUsage(organizationId, 'embed_bandwidth_gb_per_month'),
-		getCurrentUsage(organizationId, 'preview_loads_per_month')
+		getQuotaLimit(organizationId, 'folders_total')
 	])
+
+	/*
+	  Counted from `scene_folders`, the table `assertFolderQuota` enforces
+	  against - not the `folders` table the storage sum below walks. They are two
+	  different things with one word between them: `folders` holds assets,
+	  `scene_folders` is the dashboard tree the plan limit applies to.
+
+	  This limit was enforced and never displayed, so an organization could be
+	  refused a folder it was never told it was near.
+	*/
+	const [folderRow] = await db
+		.select({ total: count() })
+		.from(sceneFolders)
+		.innerJoin(projects, eq(projects.id, sceneFolders.projectId))
+		.where(eq(projects.organizationId, organizationId))
+	const foldersTotalUsage = folderRow?.total ?? 0
 
 	const allSceneIds = allScenes.map((scene) => scene.id)
 
@@ -207,14 +218,10 @@ export async function loadOrgUsage(
 		publishedSceneLimit: publishedSceneQuota.limit,
 		projectsTotal: userProjects.length,
 		projectsLimit: projectsQuota.limit,
-		apiRequestsMonth: apiRequestsMonthUsage,
-		apiRequestsMonthLimit: apiRequestsMonthQuota.limit,
+		foldersTotal: foldersTotalUsage,
+		foldersLimit: folderQuota.limit,
 		storageBytesTotal: storageBytesTotalUsage,
-		storageLimit: storageQuota.limit,
-		embedBandwidthMonth: embedBandwidthUsage,
-		embedBandwidthLimit: embedBandwidthQuota.limit,
-		previewLoadsMonth: previewLoadsUsage,
-		previewLoadsMonthLimit: previewLoadsQuota.limit
+		storageLimit: storageQuota.limit
 	}
 }
 

--- a/apps/vectreal-platform/app/lib/domain/billing/usage-service.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/usage-service.server.ts
@@ -8,10 +8,10 @@
  * Design notes:
  *   - All mutations use database-level atomic updates to prevent double-
  *     counting under concurrent request load.
- *   - Counter windows are key-aware:
- *       - Monthly counters use calendar-month windows in UTC.
- *       - Per-minute counters use UTC minute windows.
- *       - Cumulative counters use a non-expiring window.
+ *   - Counter windows were key-aware: monthly counters used calendar-month
+ *     windows in UTC, per-minute counters used UTC minute windows, and
+ *     cumulative counters a non-expiring one. Both keyed sets are empty now, so
+ *     every key takes the non-expiring window and neither branch is reachable.
  *   - Soft-limit warnings fire at 80 % of the hard limit.
  *   - When a quota is `null` (unlimited) the action is always allowed.
  */
@@ -34,15 +34,20 @@ const SOFT_LIMIT_THRESHOLD = 0.8
 const NON_EXPIRING_WINDOW_START = new Date('1970-01-01T00:00:00.000Z')
 const NON_EXPIRING_WINDOW_END = new Date('9999-12-31T23:59:59.999Z')
 
-const MONTHLY_COUNTER_KEYS: ReadonlySet<LimitKey> = new Set([
-	'api_requests_per_month',
-	'embed_bandwidth_gb_per_month',
-	'preview_loads_per_month'
-])
+/*
+  Both key sets are empty. Every monthly and per-minute limit was removed as a
+  claim nothing measured: `incrementUsage` has never had a caller, so those
+  counters could only ever read zero, and the meters built on them rendered
+  `0 / limit` forever.
 
-const MINUTE_COUNTER_KEYS: ReadonlySet<LimitKey> = new Set([
-	'api_requests_per_minute'
-])
+  They are kept as empty sets rather than deleted because `getCounterWindow`
+  still branches on them, and this module's own collapse is a separate change -
+  `checkQuota` already has no callers, and `getCurrentUsage` loses its last
+  three here.
+*/
+const MONTHLY_COUNTER_KEYS: ReadonlySet<LimitKey> = new Set([])
+
+const MINUTE_COUNTER_KEYS: ReadonlySet<LimitKey> = new Set([])
 
 /**
  * Returns the UTC start and end of the current calendar month window.

--- a/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-types.ts
+++ b/apps/vectreal-platform/app/lib/domain/dashboard/dashboard-types.ts
@@ -167,14 +167,10 @@ export interface BillingSettingsData {
 		publishedSceneLimit: number | null
 		projectsTotal: number
 		projectsLimit: number | null
-		apiRequestsMonth: number
-		apiRequestsMonthLimit: number | null
+		foldersTotal: number
+		foldersLimit: number | null
 		storageBytesTotal: number
 		storageLimit: number | null
-		embedBandwidthMonth: number
-		embedBandwidthLimit: number | null
-		previewLoadsMonth: number
-		previewLoadsMonthLimit: number | null
 	}
 }
 


### PR DESCRIPTION
## Summary

Twelve plan limits become eight. Four were claims nothing measured; two that are
enforced but were invisible now appear. **Stacked on #810** — see below, that is
not incidental.

## Root cause

Six of the twelve limits were specified as configuration and rendered as meters
before anything measured them, so `plan-config.ts` described a usage surface no
query backed; the fix belongs at the claim, because a meter reading `0 / 5,000`
and a meter reading real usage look identical to the person looking at them.

## Changes

**Four keys deleted.** `api_requests_per_month`, `embed_bandwidth_gb_per_month`
and `preview_loads_per_month` were read through `getCurrentUsage`, which reads
counters `incrementUsage` has never written, so all three rendered zero forever
against a plan number. `api_requests_per_minute` was never enforced, never
displayed, and minute counting is not being built.

**Two limits start being shown.** `folders_total` is the oldest working limit in
the codebase and appeared on no card and no meter, so an organization could be
refused a folder it was never told it was near. `api_keys_per_org` is enforced
by #810 and was claimed only in prose, in a newsroom article.

**Why this is stacked.** Review caught that on its own branch this commit would
put `api_keys_per_org` on the pricing page while that limit still ran through
the inert `checkQuota` — publishing a number nothing enforced, in the same
commit that deletes four keys for exactly that reason. Stacking makes the claim
true within the branch and forces the merge order.

**The billing panel** loses its "Served" column, which held all three fictional
meters, and with it the two-column split and both eyebrows. What remains is one
list where every meter is measured from rows that exist.

It is a list and not a grid deliberately: five cells across two columns strand
the last meter beside an empty one, and the row variant drops its rail entirely
on an unlimited limit, which in a grid row shows as a gap under whichever
neighbour still has one. That state is reachable today through a single
`org_limit_overrides` row with a null value.

**`loadOrgUsage`** drops from seven current/limit pairs to five and counts
folders from `scene_folders` — the table `assertFolderQuota` enforces against,
not the `folders` table the storage sum walks. Two different things with one
word between them. The meter runs the guard's exact query, so display and
refusal cannot disagree.

**`LIMIT_DISPLAY_LABELS` becomes total.** It was partial while six limits had no
label, for two different reasons: four were claims nothing measured, two were
real limits nobody had shown. A limit added without a label is now a compile
error rather than a blank row.

**Three components stopped inlining their labels**, and the dashboard had been
spelling one differently from the constant — "Published" against "Published
scenes". The file header has asked for this since it was written.

## Consequence worth noting

`getCurrentUsage` loses its last caller here and `checkQuota` lost its last one
in #810. **`usage-service.server.ts` now has no live exports at all**, so Phase
1d becomes a deletion rather than a refactor. Its two counter-key sets are left
as empty sets rather than removed, because `getCounterWindow` still branches on
them and that module's collapse is its own change.

## Testing

Gates: `prettier --check .` clean, typecheck and lint green across all four
projects, 1837 unit tests, 82 integration tests.

Verified in the browser on the public pricing page: all eight limits render with
the right per-plan values, including the two new rows (folders 25 / 500 / 5,000
/ Unlimited, API keys 2 / 10 / 50 / Unlimited).

**Not verified visually:** the billing panel and the dashboard usage band are
both auth-gated, and screenshots could not be captured in this session, so the
new single-column meter list has been reviewed as code and as a DOM structure
but nobody has looked at it rendered. Worth a glance before merge.

No new tests. Every removed field was removed from the type as well, so the
compiler covers the payload change; the folders count is asserted only through
the existing `billing-storage-usage` integration spec, which exercises the same
loader.

## Filed, not fixed

- `dashboard-pieces.stories.tsx` still demos "API requests" and "Embed
  bandwidth" meters for limits that no longer exist, and is now the only
  remaining user of `UsageMeter`'s `monthly` prop.
- On the same panel, Folders and Storage are counted for one organization while
  Scenes, Published and Projects come from `getUserProjects`, which spans every
  organization the user belongs to. Pre-existing, and only visible to a
  multi-org account.
- The row variant of `UsageMeter` omits its rail on an unlimited limit while the
  tile variant deliberately draws a flat one to keep grid alignment. Harmless in
  a list; it is why this is a list.

## Type of Change

- [x] Refactor / chore (no functional change)

## Checklist

- [x] My commits follow Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
