### PR TITLE
test(claims): pin the plan numbers to the code that serves them

### DIFF
--- a/.agents/skills/vectreal-extension-architecture/SKILL.md
+++ b/.agents/skills/vectreal-extension-architecture/SKILL.md
@@ -132,11 +132,57 @@ including `catalog:`. Trust it over hand-editing. A package that deliberately
 bundles a dependency declares that as an `ignoredDependencies` entry in
 `eslint.config.mts` with a reason.
 
+## Plan limits: count rows, never `checkQuota`
+
+`checkQuota` reads `org_usage_counters`. Nothing in the app has ever called
+`incrementUsage`, so every counter sits at zero and `hard_limit_exceeded` cannot
+be returned for any organization. Four guards were written against it and none
+of them refused anything: a free organization created its second project by
+submitting the ordinary form again.
+
+Enforce with `assertWithinQuota` (`app/lib/domain/billing/quota-enforcement.server.ts`),
+which takes a `measure` callback and counts the rows the limit describes:
+
+```ts
+await assertWithinQuota({
+	organizationId,
+	limitKey: 'projects_total',
+	measure: async () => {
+		const [row] = await db
+			.select({ total: count() })
+			.from(projects)
+			.where(eq(projects.organizationId, organizationId))
+		return row?.total ?? 0
+	},
+	message: ({ limit }) => `Project limit reached for your plan (${limit}).`
+})
+```
+
+`getQuotaLimit` is the half that always worked: it reads plan config and merges
+`org_limit_overrides`, and a `null` result means unlimited. Only the usage side
+was inert.
+
+Three things the guards get wrong when written from memory:
+
+1. **Measure the organization that will own the row**, not the caller's own.
+   `targetProjectId` can name a project in an organization the caller was
+   invited into.
+2. **Filter what the limit means.** `api_keys_per_org` counts keys where
+   `revoked_at is null`, or an organization stays at its ceiling forever after a
+   rotation.
+3. **The guard and the meter must run the same query.** `folders_total` counts
+   `scene_folders`; the storage sum walks `folders`. Two tables, one word apart.
+
+None of these guards shares a transaction with the insert it protects, so a test
+that only asserts the thrown message passes just as happily when the row was
+written anyway. Assert the count too.
+
 ## Anti-patterns
 
 | Anti-pattern | Replacement |
 | --- | --- |
 | Access check that relies on RLS, `auth.uid()`, or a hand-written role comparison | `assertDashboardPermission` against the operation table |
+| Quota guard routed through `checkQuota` | `assertWithinQuota`, counting the rows the limit describes |
 | 403 for a resource the actor cannot see | 404, so ids cannot be enumerated |
 | Drizzle query inside a route module | Repository function, called through a service when it spans repositories |
 | Shared abstraction created for one current caller | Explicit local code until a second caller exists |
@@ -183,4 +229,12 @@ present  shared/utils/src/lib/api.utils.ts                                      
 exists   apps/vectreal-platform/app/lib/domain/scene/scene-route-params.ts
 present  apps/vectreal-platform/app/routes.tsx                                              api/dashboard/mutations
 present  eslint.config.mts                                                                  dependency-checks
+present  apps/vectreal-platform/app/lib/domain/billing/quota-enforcement.server.ts        export async function assertWithinQuota
+present  apps/vectreal-platform/app/lib/domain/scene/server/scene-folder-repository.server.ts  assertFolderQuota
+present  apps/vectreal-platform/app/lib/domain/project/project-repository.server.ts       limitKey: 'projects_total'
+present  apps/vectreal-platform/app/lib/domain/organization/organization-repository.server.ts  limitKey: 'org_seats'
+present  apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts  limitKey: 'scenes_total'
+absent   apps/vectreal-platform/app/lib/domain/project/project-repository.server.ts       await checkQuota(
+absent   apps/vectreal-platform/app/lib/domain/organization/organization-repository.server.ts  await checkQuota(
+absent   apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts  await checkQuota(
 ```

--- a/apps/vectreal-platform/app/routes/docs/guides/upload.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/upload.mdx
@@ -41,6 +41,19 @@ The parser identifies the `.gltf` root and resolves all referenced `.bin` and te
 
 The Publisher enforces your plan's maximum scene size: 50 MB on Free, 200 MB on Pro, 500 MB on Business, and a custom limit on Enterprise. While a scene is over the limit the Save button becomes **Optimize to Save**, the optimizer opens automatically, and the server rejects the save until the scene fits. Run optimization first for production-grade assets (see [Optimizing & Configuring](/docs/guides/optimize)).
 
+{/* claims
+  # The three sizes above, tied to the config, and to the gate that applies it.
+  # This page is prerendered, so a plan change would leave it stating numbers
+  # nobody serves.
+  present  apps/vectreal-platform/app/constants/plan-config.ts   storage_bytes_per_scene: 50 * 1024 * 1024
+  present  apps/vectreal-platform/app/constants/plan-config.ts   storage_bytes_per_scene: 200 * 1024 * 1024
+  present  apps/vectreal-platform/app/constants/plan-config.ts   storage_bytes_per_scene: 500 * 1024 * 1024
+
+  # "the server rejects the save" is the load-bearing half of the sentence.
+  present  apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts   limitKey: 'storage_bytes_per_scene'
+  present  apps/vectreal-platform/app/lib/domain/scene/scene-size-limit.ts   isSceneOverSizeLimit
+*/}
+
 ---
 
 ## Error handling

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx
@@ -214,6 +214,27 @@ You are building a SaaS product where each of your customers gets their own Vect
 
 This is the layout most likely to grow past plan limits. The current per-org limits are **2 keys (Free), 10 (Pro), 50 (Business), unlimited (Enterprise)**. If you are crossing those thresholds at customer growth scale, the conversation is about tier rather than security model.
 
+{/* claims
+  # The four numbers in the paragraph above, tied to the config they came from.
+  # They were correct when written and nothing would have noticed if a plan
+  # changed underneath them - this article is prerendered and public.
+  #
+  # A literal is matched as a substring, so `api_keys_per_org: 2` would also
+  # match a future `: 25`. It still catches a rename, a deletion, and any new
+  # value that does not share the old one's prefix.
+  present  apps/vectreal-platform/app/constants/plan-config.ts   api_keys_per_org: 2
+  present  apps/vectreal-platform/app/constants/plan-config.ts   api_keys_per_org: 10
+  present  apps/vectreal-platform/app/constants/plan-config.ts   api_keys_per_org: 50
+  present  apps/vectreal-platform/app/constants/plan-config.ts   api_keys_per_org: null
+
+  # And that the limit is enforced by counting rows, which is what makes the
+  # sentence "most likely to grow past plan limits" mean anything. It ran
+  # through `checkQuota` until 2026-09-03, and that helper reads a counter
+  # nothing increments, so the ceiling did not exist.
+  present  apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts   limitKey: 'api_keys_per_org'
+  absent   apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts   await checkQuota(
+*/}
+
 ---
 
 ### The Three Mistakes We See Most Often

--- a/apps/vectreal-platform/tests/documented-claims.spec.ts
+++ b/apps/vectreal-platform/tests/documented-claims.spec.ts
@@ -104,7 +104,16 @@ const CLAIM_CARRYING_DOCS = [
 	  editor payload is refused to a key. Each of those is a sentence a reader
 	  acts on, and each has a line of code that decides it.
 	*/
-	'apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx'
+	'apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx',
+	/*
+	  Both of these state plan numbers in prose, hardcoded, with no link to
+	  `plan-config.ts`. Both are prerendered and public. They were accurate when
+	  written, which is the whole problem: nothing would have gone red if a plan
+	  changed underneath them, and nothing did go red through the audit that
+	  found four limits nobody measured and twelve entitlements nobody shipped.
+	*/
+	'apps/vectreal-platform/app/routes/docs/guides/upload.mdx',
+	'apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx'
 ]
 
 const documentFiles = [...skillFiles, ...CLAIM_CARRYING_DOCS]


### PR DESCRIPTION
## Summary

Nothing in the repo asserted anything about `plan-config.ts` or
`product-copy.ts`. This adds 21 claims that tie the published plan numbers to
the code that serves them, and each limit to the call site that refuses on it.

**Stacked on #811.** Merge order: #810 → #811 → this.

## Root cause

Nothing asserted anything about the plan config, so a 12-key deletion, four
value flips and a rewrite of every public pricing string passed 1837 tests
without one going red; the guard belongs on the claim rather than on the config,
because the failure mode is a sentence and a value drifting apart, not either
one being wrong alone.

## Changes

Two public documents state plan numbers in prose, hardcoded, with no link to the
config. Both are prerendered, so a plan change leaves them serving figures
nobody honors:

| Document | Claim |
| --- | --- |
| `articles/04_api-keys-101.mdx` | "2 keys (Free), 10 (Pro), 50 (Business), unlimited (Enterprise)" |
| `docs/guides/upload.mdx` | "50 MB on Free, 200 MB on Pro, 500 MB on Business" |

Both now carry a claims block tying those figures to `PLAN_LIMITS`, and both are
added to `CLAIM_CARRYING_DOCS`. The blocks are MDX expression comments, so they
compile away — verified in the browser that neither page renders any of it, and
that both paragraphs read exactly as before.

**The claims pin enforcement, not declaration**, and that distinction is the
whole point. The mechanism proves a literal appears in a file, never that a
value is enforced, so a claim aimed at `plan-config.ts` alone would re-create
the failure being fixed. Each limit is therefore also pinned to the call site
that refuses on it, and to the **absence** of `await checkQuota(` there — the
helper that reads a counter nothing increments, and that four guards used while
refusing nothing.

`vectreal-extension-architecture` gains a section on the rule, an anti-pattern
row, and claims for the enforcement sites the two documents do not cover. It
records the three things these guards get wrong when written from memory:
measuring the caller's own organization instead of the one that will own the
row, counting revoked API keys, and letting the meter and the guard run
different queries.

## Testing

**Mutation gate:**

| Mutation | Result |
| --- | --- |
| free API key allowance changed | 1 claim red |
| pro per-scene size changed | 1 claim red |
| API keys routed back through `checkQuota` | 1 claim red |
| a guard routed back through `checkQuota` | 1 claim red |
| the shared helper renamed | 1 claim red |
| the seat guard deleted outright | 1 claim red |

96 claims total, up from 75. Gates: `prettier --check .` clean, typecheck and
lint green across all four projects, 1858 unit tests.

## Known limitation, stated in the claim blocks

A literal is matched as a verbatim substring, so `api_keys_per_org: 2` would
also match a future `: 25`. It still catches a rename, a deletion, and any new
value that does not share the old one's prefix. Worth knowing before trusting a
numeric claim to catch every edit.

## Type of Change

- [x] Refactor / chore (no functional change)

## Checklist

- [x] My commits follow Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
