### PR TITLE
fix(billing): enforce the storage allowance where the bytes land

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
@@ -287,12 +287,13 @@ export async function uploadSceneAssets(
 	requestId?: string
 ): Promise<AssetUploadResult[]> {
 	/*
-	  The folder first, the bucket last. Reuse resolution and the quota check
-	  below need the folder; neither needs storage, and a request that is about
-	  to be refused should not create a bucket or open a client on the way to
-	  being told no.
+	  Reads first, writes last. Reuse resolution and the quota check below only
+	  need to know which folder to look in, not that one exists, so a request
+	  that is about to be refused writes nothing on the way to being told no:
+	  no folder row, no bucket, no client. A null id is a project with no folder
+	  yet, so there is nothing to reuse and every entry counts as new bytes.
 	*/
-	const folder = await ensureAssetFolder(projectId)
+	const existingFolderId = await findAssetFolderId(projectId)
 	const results: AssetUploadResult[] = []
 
 	/*
@@ -317,11 +318,13 @@ export async function uploadSceneAssets(
 			return {
 				asset,
 				contentHash,
-				existingAsset: await findExistingAsset(
-					contentHash,
-					asset.fileName,
-					folder.id
-				)
+				existingAsset: existingFolderId
+					? await findExistingAsset(
+							contentHash,
+							asset.fileName,
+							existingFolderId
+						)
+					: null
 			}
 		})
 	)
@@ -354,6 +357,7 @@ export async function uploadSceneAssets(
 
 	await ensureStorageBucketOnce()
 	const storage = getStorageClient()
+	const folder = await ensureAssetFolder(projectId)
 
 	for (const { asset, contentHash, existingAsset } of resolved) {
 		const fileName = asset.fileName

--- a/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/asset/asset-storage.server.ts
@@ -18,11 +18,13 @@ import { getDbClient } from '../../../db/client'
 import {
 	assets,
 	folders,
+	projects,
 	sceneAssets,
 	scenePublished,
 	scenes
 } from '../../../db/schema'
 import { reportServerError } from '../../observability/report-server-error.server'
+import { assertWithinQuota } from '../billing/quota-enforcement.server'
 
 import type { SceneAssetBinaryDataMap } from '../../../types/api'
 
@@ -257,6 +259,26 @@ function getErrorMessage(error: unknown): string {
  * Existing assets are reused when filename + content hash match, so repeated
  * saves avoid unnecessary uploads.
  */
+/**
+ * The organization whose storage allowance these bytes count against.
+ *
+ * Resolved from the project the assets are being written into, not from the
+ * uploading user: a member can upload into a project owned by an organization
+ * they were invited to, and it is that organization's allowance being spent.
+ */
+async function getProjectOrganizationId(projectId: string): Promise<string> {
+	const [row] = await db
+		.select({ organizationId: projects.organizationId })
+		.from(projects)
+		.where(eq(projects.id, projectId))
+		.limit(1)
+
+	if (!row) {
+		throw new Error(`Project not found: ${projectId}`)
+	}
+	return row.organizationId
+}
+
 export async function uploadSceneAssets(
 	sceneId: string,
 	userId: string,
@@ -264,22 +286,77 @@ export async function uploadSceneAssets(
 	gltfAssets: GLTFAssetData[],
 	requestId?: string
 ): Promise<AssetUploadResult[]> {
-	await ensureStorageBucketOnce()
-
-	const storage = getStorageClient()
+	/*
+	  The folder first, the bucket last. Reuse resolution and the quota check
+	  below need the folder; neither needs storage, and a request that is about
+	  to be refused should not create a bucket or open a client on the way to
+	  being told no.
+	*/
 	const folder = await ensureAssetFolder(projectId)
 	const results: AssetUploadResult[] = []
 
-	for (const asset of gltfAssets) {
-		const contentHash = computeAssetHash(asset.data)
-		const fileName = asset.fileName
+	/*
+	  Resolve reuse before uploading anything.
 
-		// Reuse already uploaded project asset when bytes are unchanged.
-		const existingAsset = await findExistingAsset(
-			contentHash,
-			fileName,
-			folder.id
-		)
+	  Two reasons the quota check has to happen here and not at the caller. The
+	  bytes are the server's own `byteLength`, not a figure the client reported;
+	  and the content hash already says which of them are new, so a re-save that
+	  changes nothing adds nothing. `storage_bytes_total` was briefly enforced in
+	  `prepareSceneUpload` against the client's scene size, which double-counted
+	  on every update - the organization sum already included the scene being
+	  saved - and never ran for `upload-scene-asset`, `upload-scene-gltf` or
+	  `upload-published-glb`, which are the three actions that write bytes.
+
+	  Refusing before the first upload also matters: a refusal partway through
+	  the loop below would leave objects in the bucket with no row pointing at
+	  them, and nothing reclaims those.
+	*/
+	const resolved = await Promise.all(
+		gltfAssets.map(async (asset) => {
+			const contentHash = computeAssetHash(asset.data)
+			return {
+				asset,
+				contentHash,
+				existingAsset: await findExistingAsset(
+					contentHash,
+					asset.fileName,
+					folder.id
+				)
+			}
+		})
+	)
+
+	const incomingBytes = resolved.reduce(
+		(total, entry) =>
+			entry.existingAsset ? total : total + entry.asset.data.byteLength,
+		0
+	)
+
+	if (incomingBytes > 0) {
+		const organizationId = await getProjectOrganizationId(projectId)
+		await assertWithinQuota({
+			organizationId,
+			limitKey: 'storage_bytes_total',
+			adds: incomingBytes,
+			measure: async () => {
+				const [row] = await db
+					.select({ total: sql<null | string>`sum(${assets.fileSize})` })
+					.from(assets)
+					.innerJoin(folders, eq(folders.id, assets.folderId))
+					.innerJoin(projects, eq(projects.id, folders.projectId))
+					.where(eq(projects.organizationId, organizationId))
+				return Number(row?.total ?? 0)
+			},
+			message: ({ limit }) =>
+				`Storage limit reached for your plan (${Math.round(limit / (1024 * 1024))} MB). Delete a scene or upgrade for more room.`
+		})
+	}
+
+	await ensureStorageBucketOnce()
+	const storage = getStorageClient()
+
+	for (const { asset, contentHash, existingAsset } of resolved) {
+		const fileName = asset.fileName
 
 		if (existingAsset) {
 			// No metadata rewrite here. This row is referenced by something, so it

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
@@ -341,6 +341,16 @@ export async function uploadSceneAsset(
 			mimeType: uploadResult.mimeType
 		})
 	} catch (error) {
+		/*
+		  A quota refusal is not a server error. These three actions are the only
+		  ones that write bytes, so they are the only ones that can raise the
+		  storage limit, and flattening it here would reach the client as a 500
+		  carrying a quota message - no upgrade prompt, no limit, no plan. The
+		  route's own handler maps it to `ApiResponse.quotaExceeded`.
+		*/
+		if (error instanceof QuotaExceededError) {
+			throw error
+		}
 		return ApiResponse.serverError(
 			error instanceof Error ? error.message : 'Failed to upload scene asset'
 		)
@@ -379,6 +389,16 @@ export async function uploadSceneGltf(
 			mimeType: uploadResult.mimeType
 		})
 	} catch (error) {
+		/*
+		  A quota refusal is not a server error. These three actions are the only
+		  ones that write bytes, so they are the only ones that can raise the
+		  storage limit, and flattening it here would reach the client as a 500
+		  carrying a quota message - no upgrade prompt, no limit, no plan. The
+		  route's own handler maps it to `ApiResponse.quotaExceeded`.
+		*/
+		if (error instanceof QuotaExceededError) {
+			throw error
+		}
 		return ApiResponse.serverError(
 			error instanceof Error ? error.message : 'Failed to upload scene glTF'
 		)
@@ -417,6 +437,16 @@ export async function uploadPublishedGlb(
 			mimeType: uploadResult.mimeType
 		})
 	} catch (error) {
+		/*
+		  A quota refusal is not a server error. These three actions are the only
+		  ones that write bytes, so they are the only ones that can raise the
+		  storage limit, and flattening it here would reach the client as a 500
+		  carrying a quota message - no upgrade prompt, no limit, no plan. The
+		  route's own handler maps it to `ApiResponse.quotaExceeded`.
+		*/
+		if (error instanceof QuotaExceededError) {
+			throw error
+		}
 		return ApiResponse.serverError(
 			error instanceof Error ? error.message : 'Failed to upload published GLB'
 		)

--- a/apps/vectreal-platform/tests/integration/storage-quota.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/storage-quota.integration.spec.ts
@@ -1,0 +1,247 @@
+/**
+ * Asks a real Postgres whether the storage allowance refuses the bytes it
+ * should and lets through the bytes it should.
+ *
+ * `storage_bytes_total` was enforced once before, in `prepareSceneUpload`,
+ * against the scene size the client reported. That figure already included the
+ * scene being saved, and the organization sum it was compared to included it
+ * too, so every update charged the same bytes twice and an organization near
+ * its limit was refused a save that added nothing. It also never ran for the
+ * three actions that write bytes.
+ *
+ * The guard lives at the single insert site now, where the lengths are the
+ * server's own and the content hash already says which bytes are new. That is
+ * what the second test below is for: a re-save of unchanged assets has to pass
+ * with the organization sitting exactly on its limit.
+ *
+ * Storage is faked at the `createClient` boundary; nothing here depends on
+ * bytes actually moving.
+ *
+ * Opt-in:
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { eq, inArray } from 'drizzle-orm'
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi
+} from 'vitest'
+
+vi.mock('@supabase/supabase-js', () => ({
+	createClient: () => ({
+		storage: {
+			getBucket: async () => ({ data: { name: 'assets' }, error: null }),
+			createBucket: async () => ({ data: null, error: null }),
+			from: () => ({
+				upload: async (path: string) => ({ data: { path }, error: null }),
+				remove: async () => ({ data: null, error: null })
+			})
+		}
+	})
+}))
+
+type Schema = typeof import('../../app/db/schema')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+type Storage = typeof import('../../app/lib/domain/asset/asset-storage.server')
+
+describe('the storage allowance, at the place bytes become rows', () => {
+	let schema: Schema
+	let db: Db
+	let uploadSceneAssets: Storage['uploadSceneAssets']
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+
+	const bytes = (size: number, seed: number) =>
+		Uint8Array.from({ length: size }, (_, i) => (i + seed) % 251)
+
+	const upload = (fileName: string, data: Uint8Array) =>
+		uploadSceneAssets(
+			randomUUID(),
+			ownerId,
+			projectId,
+			[
+				{ fileName, data, mimeType: 'application/octet-stream', type: 'buffer' }
+			],
+			randomUUID()
+		)
+
+	/**
+	 * Links an asset to a throwaway scene. Reuse is only offered for rows
+	 * something already references, so without this a second upload of the same
+	 * bytes would write a new row and the reuse tests would prove nothing.
+	 */
+	const reference = async (assetId: string) => {
+		const sceneId = randomUUID()
+		await db
+			.insert(schema.scenes)
+			.values({ id: sceneId, projectId, folderId: null, name: `s-${sceneId}` })
+		const settingsId = randomUUID()
+		await db
+			.insert(schema.sceneSettings)
+			.values({ id: settingsId, sceneId, createdBy: ownerId })
+		await db
+			.insert(schema.sceneAssets)
+			.values({ sceneSettingsId: settingsId, assetId })
+	}
+
+	const storedBytes = async () => {
+		const rows = await db
+			.select({ fileSize: schema.assets.fileSize })
+			.from(schema.assets)
+			.innerJoin(schema.folders, eq(schema.folders.id, schema.assets.folderId))
+			.where(eq(schema.folders.projectId, projectId))
+		return rows.reduce((total, row) => total + (row.fileSize ?? 0), 0)
+	}
+
+	const assetCount = async () => (await storedRows()).length
+	const storedRows = async () =>
+		db
+			.select({ id: schema.assets.id })
+			.from(schema.assets)
+			.innerJoin(schema.folders, eq(schema.folders.id, schema.assets.folderId))
+			.where(eq(schema.folders.projectId, projectId))
+
+	const setStorageLimit = async (value: number) => {
+		await db
+			.delete(schema.orgLimitOverrides)
+			.where(eq(schema.orgLimitOverrides.organizationId, organizationId))
+		await db.insert(schema.orgLimitOverrides).values({
+			organizationId,
+			limitKey: 'storage_bytes_total',
+			limitValue: BigInt(value)
+		})
+	}
+
+	beforeAll(async () => {
+		process.env.SUPABASE_URL ??= 'http://127.0.0.1:54321'
+		process.env.SUPABASE_SECRET_KEY ??= 'integration-test-key'
+
+		schema = await import('../../app/db/schema')
+		db = (await import('../../app/db/client')).getDbClient()
+		;({ uploadSceneAssets } =
+			await import('../../app/lib/domain/asset/asset-storage.server'))
+
+		await db.insert(schema.users).values({
+			id: ownerId,
+			email: `owner-${ownerId}@quota.test`,
+			name: 'Owner'
+		})
+		await db
+			.insert(schema.organizations)
+			.values({ id: organizationId, name: `quota-${organizationId}`, ownerId })
+		await db
+			.insert(schema.organizationMemberships)
+			.values({ userId: ownerId, organizationId, role: 'owner' })
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Quota project',
+			slug: `quota-${projectId}`
+		})
+	})
+
+	beforeEach(async () => {
+		await db
+			.delete(schema.orgLimitOverrides)
+			.where(eq(schema.orgLimitOverrides.organizationId, organizationId))
+	})
+
+	afterAll(async () => {
+		if (!db) return
+		await db
+			.delete(schema.orgLimitOverrides)
+			.where(eq(schema.orgLimitOverrides.organizationId, organizationId))
+		await db
+			.delete(schema.projects)
+			.where(eq(schema.projects.organizationId, organizationId))
+		await db
+			.delete(schema.organizationMemberships)
+			.where(eq(schema.organizationMemberships.organizationId, organizationId))
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.id, organizationId))
+		await db.delete(schema.users).where(inArray(schema.users.id, [ownerId]))
+	})
+
+	it('refuses bytes that would take the organization past its allowance, and writes nothing', async () => {
+		const before = await assetCount()
+		await setStorageLimit(500)
+
+		await expect(upload('too-big.bin', bytes(900, 1))).rejects.toThrow(
+			/Storage limit reached/
+		)
+
+		expect(await assetCount()).toBe(before)
+	})
+
+	it('lets bytes through while the allowance has room', async () => {
+		await setStorageLimit(10_000)
+
+		const [result] = await upload('within.bin', bytes(400, 2))
+		expect(result.assetId).toBeTruthy()
+		await reference(result.assetId)
+	})
+
+	it('charges nothing for a re-save of unchanged assets, at exactly the limit', async () => {
+		/*
+		  The regression this whole change exists for. The organization sum already
+		  contains these bytes, so charging them again refuses a save that adds
+		  none - and the client sends the scene id and its size together on every
+		  save, so it fires on ordinary edits, not edge cases.
+		*/
+		await setStorageLimit(10_000)
+		const sameBytes = bytes(700, 3)
+		const [first] = await upload('unchanged.bin', sameBytes)
+		await reference(first.assetId)
+
+		const total = await storedBytes()
+		await setStorageLimit(total)
+
+		const [again] = await upload('unchanged.bin', sameBytes)
+		expect(again.assetId).toBe(first.assetId)
+	})
+
+	it('charges only the new bytes in a batch that also reuses', async () => {
+		await setStorageLimit(10_000)
+		const reused = bytes(600, 4)
+		const [existing] = await upload('reused.bin', reused)
+		await reference(existing.assetId)
+
+		// Room for the new file alone, not for the new file plus the reused one.
+		await setStorageLimit((await storedBytes()) + 300)
+
+		const results = await uploadSceneAssets(
+			randomUUID(),
+			ownerId,
+			projectId,
+			[
+				{
+					fileName: 'reused.bin',
+					data: reused,
+					mimeType: 'application/octet-stream',
+					type: 'buffer'
+				},
+				{
+					fileName: 'fresh.bin',
+					data: bytes(250, 5),
+					mimeType: 'application/octet-stream',
+					type: 'buffer'
+				}
+			],
+			randomUUID()
+		)
+
+		expect(results).toHaveLength(2)
+		expect(results[0].assetId).toBe(existing.assetId)
+	})
+})

--- a/apps/vectreal-platform/tests/integration/storage-quota.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/storage-quota.integration.spec.ts
@@ -11,7 +11,7 @@
  *
  * The guard lives at the single insert site now, where the lengths are the
  * server's own and the content hash already says which bytes are new. That is
- * what the second test below is for: a re-save of unchanged assets has to pass
+ * what the third test below is for: a re-save of unchanged assets has to pass
  * with the organization sitting exactly on its limit.
  *
  * Storage is faked at the `createClient` boundary; nothing here depends on
@@ -110,6 +110,13 @@ describe('the storage allowance, at the place bytes become rows', () => {
 			.from(schema.assets)
 			.innerJoin(schema.folders, eq(schema.folders.id, schema.assets.folderId))
 			.where(eq(schema.folders.projectId, projectId))
+	const folderCount = async () =>
+		(
+			await db
+				.select({ id: schema.folders.id })
+				.from(schema.folders)
+				.where(eq(schema.folders.projectId, projectId))
+		).length
 
 	const setStorageLimit = async (value: number) => {
 		await db
@@ -182,6 +189,12 @@ describe('the storage allowance, at the place bytes become rows', () => {
 		)
 
 		expect(await assetCount()).toBe(before)
+		/*
+		  The folder counts as a write too. Reuse resolution used to create it
+		  ahead of the guard, so a refused request left a row behind and "writes
+		  nothing" held only for the assets.
+		*/
+		expect(await folderCount()).toBe(0)
 	})
 
 	it('lets bytes through while the allowance has room', async () => {
@@ -217,8 +230,9 @@ describe('the storage allowance, at the place bytes become rows', () => {
 		const [existing] = await upload('reused.bin', reused)
 		await reference(existing.assetId)
 
+		const before = await storedBytes()
 		// Room for the new file alone, not for the new file plus the reused one.
-		await setStorageLimit((await storedBytes()) + 300)
+		await setStorageLimit(before + 300)
 
 		const results = await uploadSceneAssets(
 			randomUUID(),
@@ -243,5 +257,11 @@ describe('the storage allowance, at the place bytes become rows', () => {
 
 		expect(results).toHaveLength(2)
 		expect(results[0].assetId).toBe(existing.assetId)
+		/*
+		  Both halves, or a regression that reused the second entry as well would
+		  return two results, skip the quota block entirely and still pass.
+		*/
+		expect(results[1].assetId).not.toBe(existing.assetId)
+		expect(await storedBytes()).toBe(before + 250)
 	})
 })


### PR DESCRIPTION
## Summary

`storage_bytes_total` is enforced for the first time, at the single place bytes
become rows. It is the one limit Phase 2 promised and did not deliver.

## Root cause

It was enforced once before, in `prepareSceneUpload`, against the scene size the
client reported — a figure the organization sum it was compared to already
contained, so every update charged the same bytes twice and an organization near
its limit was refused a save that added nothing; the guard belongs in
`uploadSceneAssets`, the single insert site, where the lengths are the server's
own `byteLength` and the content hash already says which bytes are new.

## Changes

That earlier attempt was written and removed inside its own branch, after review
caught the double-count. It was also gated on a field none of the three
byte-writing actions sends, so `upload-scene-asset`, `upload-scene-gltf` and
`upload-published-glb` were never checked — including the published GLB, the
largest artifact the product stores. All three funnel through
`uploadSceneAssets`, so one guard covers them.

**Reuse is resolved before anything uploads.** Two reasons: the quota must see
only the bytes this call will actually add, and a refusal partway through the
loop would leave objects in the bucket with no row pointing at them, which
nothing reclaims. The bucket and storage client move below the guard for the
same reason — a request about to be refused should not provision a bucket on the
way to being told no.

**The organization comes from the project**, not the uploading user: a member
can upload into a project owned by an organization they were invited to, and it
is that allowance being spent.

**The three write paths stop flattening `QuotaExceededError` into
`ApiResponse.serverError`.** A refusal reaching the client as a 500 carrying a
quota message has no limit, no plan and no upgrade prompt. The route's handler
already maps the typed error. `publishScene` still flattens
`scenes_published_concurrent` the same way and is left alone: different limit,
pre-existing, filed.

## Testing

Four integration tests against real Postgres, storage faked at the `createClient`
boundary as the dedup spec already does.

| Mutation | Result |
| --- | --- |
| reuses charged again (the old double-count) | 2 red |
| the delta zeroed | 1 red |
| the sum left as a string | 2 red |
| the guard skipped entirely | 1 red |
| the guard moved below the uploads | 2 red, via the no-row assertions |

Gates: prettier clean, typecheck and lint green across four projects, 1858 unit
tests, 86 integration tests.

## Filed, not fixed

- `publishScene` flattens its own quota refusal into a 500 the same way.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Checklist

- [x] Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
