### PR TITLE
feat(billing): refuse uploads while billing is read-only

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/billing/entitlement-required-error.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/entitlement-required-error.ts
@@ -1,0 +1,59 @@
+import { QuotaExceededError } from './quota-exceeded-error'
+
+import type {
+	BillingState,
+	EntitlementKey,
+	Plan
+} from '../../../constants/plan-config'
+
+/**
+ * Thrown when an entitlement an operation needs is not granted.
+ *
+ * The sibling of `QuotaExceededError`, for the other half of the same question:
+ * a quota says how much, an entitlement says whether at all. Both exist so an
+ * operation can refuse without deciding what HTTP status that becomes, which is
+ * the route's job.
+ *
+ * `billingState` is carried because the answer differs. An entitlement withheld
+ * by the plan is a 403 and an upgrade; the same entitlement withheld because
+ * billing went read-only is a 402 and a payment. `publishScene` makes exactly
+ * that distinction inline, having no error type to throw.
+ */
+export class EntitlementRequiredError extends Error {
+	readonly entitlementKey: EntitlementKey
+	readonly plan: Plan
+	readonly billingState: BillingState
+	readonly upgradeTo: Plan | null
+
+	constructor(params: {
+		entitlementKey: EntitlementKey
+		plan: Plan
+		billingState: BillingState
+		upgradeTo: Plan | null
+		message: string
+	}) {
+		super(params.message)
+		this.name = 'EntitlementRequiredError'
+		this.entitlementKey = params.entitlementKey
+		this.plan = params.plan
+		this.billingState = params.billingState
+		this.upgradeTo = params.upgradeTo
+	}
+}
+
+/**
+ * The domain errors the scene route knows how to turn into a response.
+ *
+ * The three upload operations each wrap their body in a catch that flattens
+ * everything to `ApiResponse.serverError`. Adding a second `instanceof` to each
+ * of them for every new error type is how that catch quietly starts swallowing
+ * the next one, so the question is asked once, here.
+ */
+export function isRoutableDomainError(
+	error: unknown
+): error is EntitlementRequiredError | QuotaExceededError {
+	return (
+		error instanceof EntitlementRequiredError ||
+		error instanceof QuotaExceededError
+	)
+}

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
@@ -18,6 +18,10 @@ import {
 } from '../../asset/asset-reclaim.server'
 import { uploadSceneAssets } from '../../asset/asset-storage.server'
 import {
+	EntitlementRequiredError,
+	isRoutableDomainError
+} from '../../billing/entitlement-required-error'
+import {
 	hasEntitlement,
 	getRecommendedUpgrade,
 	getOrgSubscription,
@@ -33,6 +37,7 @@ import {
 } from '../../user/user-repository.server'
 import { isSceneOverSizeLimit } from '../scene-size-limit'
 
+import type { EntitlementKey } from '../../../../constants/plan-config'
 import type { SceneSettingsRequest } from '../../../../types/api'
 import type { SceneMetaState } from '../../../../types/publisher-config'
 
@@ -181,24 +186,90 @@ async function validateSaveLocationTarget(
 /**
  * The organization whose plan governs a scene save.
  *
- * `targetProjectId` wins when the client names one, because that project may
- * belong to an organization the caller was invited into rather than their own.
- * Falls back to the caller's default organization, which is what an ordinary
- * save from the publisher uses.
+ * Resolves the same destination `resolveSceneAndProject` will, in the same
+ * order, because a guard that grades a different organization from the one that
+ * ends up holding the row is worse than no guard: it lets a lapsed organization
+ * through whenever the caller has a healthy one, and refuses paid work whenever
+ * they do not.
+ *
+ * `targetProjectId` first, then the scene's own project, then `projectId` for a
+ * scene whose row does not exist yet. A scene id that resolves to none of those
+ * is rejected here exactly as the resolver rejects it.
+ *
+ * The caller's default organization is reached only by a save that names no
+ * scene and no project, which is the one shape that legitimately creates one.
  */
 async function resolveOwningOrganizationId(
 	request: SceneSettingsRequest,
 	userId: string
 ): Promise<string> {
-	if (!request.targetProjectId) {
-		return (await getOrCreateDefaultOrganization(userId)).id
+	if (request.targetProjectId) {
+		const project = await getProject(request.targetProjectId, userId)
+		if (!project) {
+			throw new Error('Target project not found or access denied')
+		}
+		return project.organizationId
 	}
 
-	const project = await getProject(request.targetProjectId, userId)
-	if (!project) {
-		throw new Error('Target project not found or access denied')
+	/*
+	  An existing scene already has a home, and it may be in an organization the
+	  caller was invited to rather than their own. Falling straight through to
+	  the caller's default organization graded the wrong tenant in both
+	  directions: a read-only invited organization kept uploading, and legitimate
+	  work in a paid one was refused because the caller's personal organization
+	  had lapsed. `upload-published-glb` never sends `targetProjectId`, so that
+	  was the ordinary path rather than a corner of it.
+	*/
+	const sceneId = request.sceneId?.trim()
+	if (sceneId) {
+		const scenesProjectId =
+			await sceneSettingsService.getProjectIdFromScene(sceneId)
+		if (scenesProjectId) {
+			const project = await getProject(scenesProjectId, userId)
+			if (!project) {
+				throw new Error('Scene project not found or access denied')
+			}
+			return project.organizationId
+		}
+
+		/*
+		  A scene id with no row yet, which is not a rare shape: `prepareSceneUpload`
+		  mints the id for a new scene and nothing writes the row until
+		  `commit-scene-save`, so every upload of a first save carries one. This
+		  mirrors `resolveSceneAndProject`, which falls back to `projectId` in
+		  exactly this arm - and only in this arm. With no scene id at all it
+		  ignores `projectId` entirely and creates the scene in the caller's own
+		  default project, so reading the field out here would grade an
+		  organization the scene never reaches, in both directions.
+		*/
+		if (request.projectId) {
+			const project = await getProject(request.projectId, userId)
+			if (!project) {
+				throw new Error('Project not found or access denied')
+			}
+			return project.organizationId
+		}
+
+		/*
+		  A scene id with no row and no project named anywhere. This is the shape
+		  `resolveSceneAndProject` rejects, so reject it identically rather than
+		  falling through: the fallback below would resolve the caller's default
+		  organization - creating one, for anyone who renamed theirs - on the way
+		  to a request that cannot succeed.
+		*/
+		throw new Error(`Scene not found with ID: ${sceneId}`)
 	}
-	return project.organizationId
+
+	/*
+	  Only a save naming neither a scene nor a project reaches here, which is the
+	  one case where creating the caller's default organization is the right
+	  answer rather than a side effect. Keeping the upload actions out of it
+	  matters:
+	  `getOrCreateDefaultOrganization` matches on the literal name
+	  'My Organization', so for anyone who renamed theirs it inserts a fresh one -
+	  and the guard then grades an organization that is empty and always grants.
+	*/
+	return (await getOrCreateDefaultOrganization(userId)).id
 }
 
 export async function prepareSceneUpload(
@@ -213,6 +284,36 @@ export async function prepareSceneUpload(
 	}
 
 	const isNewScene = !request.sceneId?.trim()
+
+	/*
+	  `scene_upload` has sat in `READ_ONLY_BLOCKED_ENTITLEMENTS` since that set
+	  was written, and this file's header describes it as blocking uploads, but
+	  no call site ever passed it - so an organization whose billing went
+	  `unpaid` or `paused` kept uploading freely while its sibling
+	  `scene_publish` correctly refused. It is `true` on every plan, so this can
+	  only ever deny on billing state; there is no upgrade that grants it.
+
+	  Every upload action reaches this function, which is why the check is here
+	  rather than at each of the three.
+	*/
+	// Named once. Written twice, the key consulted and the key reported could
+	// disagree, and the error would name an entitlement nothing checked.
+	const uploadEntitlementKey: EntitlementKey = 'scene_upload'
+	const uploadEntitlement = await hasEntitlement(
+		await resolveOwningOrganizationId(request, userId),
+		uploadEntitlementKey
+	)
+	if (!uploadEntitlement.granted) {
+		throw new EntitlementRequiredError({
+			entitlementKey: uploadEntitlementKey,
+			plan: uploadEntitlement.effectivePlan,
+			billingState: uploadEntitlement.billingState,
+			upgradeTo: getRecommendedUpgrade(uploadEntitlement.effectivePlan),
+			message: isBillingStateReadOnly(uploadEntitlement.billingState)
+				? 'Uploads are unavailable: payment required to restore access.'
+				: 'Uploads are not available on your current plan.'
+		})
+	}
 
 	/*
 	  The organization whose limits apply is the one that will own the scene, not
@@ -342,13 +443,12 @@ export async function uploadSceneAsset(
 		})
 	} catch (error) {
 		/*
-		  A quota refusal is not a server error. These three actions are the only
-		  ones that write bytes, so they are the only ones that can raise the
-		  storage limit, and flattening it here would reach the client as a 500
-		  carrying a quota message - no upgrade prompt, no limit, no plan. The
-		  route's own handler maps it to `ApiResponse.quotaExceeded`.
+		  A quota or entitlement refusal is not a server error. Flattening one
+		  here reaches the client as a 500 carrying its message and none of its
+		  meaning - no limit, no plan, no upgrade prompt, no payment prompt. The
+		  route's own handler maps both.
 		*/
-		if (error instanceof QuotaExceededError) {
+		if (isRoutableDomainError(error)) {
 			throw error
 		}
 		return ApiResponse.serverError(
@@ -390,13 +490,12 @@ export async function uploadSceneGltf(
 		})
 	} catch (error) {
 		/*
-		  A quota refusal is not a server error. These three actions are the only
-		  ones that write bytes, so they are the only ones that can raise the
-		  storage limit, and flattening it here would reach the client as a 500
-		  carrying a quota message - no upgrade prompt, no limit, no plan. The
-		  route's own handler maps it to `ApiResponse.quotaExceeded`.
+		  A quota or entitlement refusal is not a server error. Flattening one
+		  here reaches the client as a 500 carrying its message and none of its
+		  meaning - no limit, no plan, no upgrade prompt, no payment prompt. The
+		  route's own handler maps both.
 		*/
-		if (error instanceof QuotaExceededError) {
+		if (isRoutableDomainError(error)) {
 			throw error
 		}
 		return ApiResponse.serverError(
@@ -438,13 +537,12 @@ export async function uploadPublishedGlb(
 		})
 	} catch (error) {
 		/*
-		  A quota refusal is not a server error. These three actions are the only
-		  ones that write bytes, so they are the only ones that can raise the
-		  storage limit, and flattening it here would reach the client as a 500
-		  carrying a quota message - no upgrade prompt, no limit, no plan. The
-		  route's own handler maps it to `ApiResponse.quotaExceeded`.
+		  A quota or entitlement refusal is not a server error. Flattening one
+		  here reaches the client as a 500 carrying its message and none of its
+		  meaning - no limit, no plan, no upgrade prompt, no payment prompt. The
+		  route's own handler maps both.
 		*/
-		if (error instanceof QuotaExceededError) {
+		if (isRoutableDomainError(error)) {
 			throw error
 		}
 		return ApiResponse.serverError(

--- a/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
+++ b/apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts
@@ -1,7 +1,9 @@
 import { ApiResponse } from '@shared/utils'
 import { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router'
 
+import { isBillingStateReadOnly } from '../../constants/plan-config'
 import { validatePreviewApiKeyForProject } from '../../lib/domain/auth/preview-api-key-auth.server'
+import { EntitlementRequiredError } from '../../lib/domain/billing/entitlement-required-error'
 import { QuotaExceededError } from '../../lib/domain/billing/quota-exceeded-error'
 import { getProject } from '../../lib/domain/project/project-repository.server'
 import { parseSceneBytes } from '../../lib/domain/scene/scene-size-limit'
@@ -686,6 +688,20 @@ export async function action({ request, params }: ActionFunctionArgs) {
 						authHeaders
 					)
 				} catch (err) {
+					if (err instanceof EntitlementRequiredError) {
+						/*
+						  Read-only billing is a payment, not an upgrade: the plan still
+						  grants the entitlement and the account has simply stopped paying
+						  for it. Sending 403 there tells the owner to buy something they
+						  already own.
+						*/
+						return withAdditionalHeaders(
+							isBillingStateReadOnly(err.billingState)
+								? ApiResponse.paymentRequired(err.message)
+								: ApiResponse.forbidden(err.message),
+							authHeaders
+						)
+					}
 					if (err instanceof QuotaExceededError) {
 						return withAdditionalHeaders(
 							ApiResponse.quotaExceeded(err.message, {
@@ -868,6 +884,20 @@ export async function action({ request, params }: ActionFunctionArgs) {
 				)
 		}
 	} catch (error) {
+		if (error instanceof EntitlementRequiredError) {
+			/*
+			  Read-only billing is a payment, not an upgrade: the plan still
+			  grants the entitlement and the account has simply stopped paying
+			  for it. Sending 403 there tells the owner to buy something they
+			  already own.
+			*/
+			return withAdditionalHeaders(
+				isBillingStateReadOnly(error.billingState)
+					? ApiResponse.paymentRequired(error.message)
+					: ApiResponse.forbidden(error.message),
+				authHeaders
+			)
+		}
 		if (error instanceof QuotaExceededError) {
 			return withAdditionalHeaders(
 				ApiResponse.quotaExceeded(error.message, {

--- a/apps/vectreal-platform/tests/integration/read-only-billing.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/read-only-billing.integration.spec.ts
@@ -1,0 +1,372 @@
+/**
+ * Asks a real Postgres whether an organization in a read-only billing state can
+ * still upload.
+ *
+ * `scene_upload` has sat in `READ_ONLY_BLOCKED_ENTITLEMENTS` since that set was
+ * written, and `entitlement-service.server.ts` documents it as blocking
+ * uploads, but no call site ever passed the key - so the set membership was
+ * guard infrastructure with no guard, and an `unpaid` organization kept
+ * uploading while its sibling `scene_publish` correctly refused.
+ *
+ * The key is `true` on every plan, so it can only ever deny on billing state.
+ * That is why both tests below move `billing_state` rather than the plan, and
+ * why the assertion is about a payment rather than an upgrade.
+ *
+ * Opt-in:
+ *   pnpm nx run vectreal-platform:supabase-start
+ *   pnpm nx run vectreal-platform:test-integration
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { eq, inArray } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+type Schema = typeof import('../../app/db/schema')
+type Db = ReturnType<typeof import('../../app/db/client').getDbClient>
+type SceneOps =
+	typeof import('../../app/lib/domain/scene/server/scene-settings.operations.server')
+
+describe('uploads while billing is read-only', () => {
+	let schema: Schema
+	let db: Db
+	let sceneOps: SceneOps
+
+	const ownerId = randomUUID()
+	const organizationId = randomUUID()
+	const projectId = randomUUID()
+
+	// A second organization the caller was invited into, holding a scene of its
+	// own. The guard has to grade this one when that scene is the one being
+	// uploaded to, whatever state the caller's own organization is in.
+	/*
+	  A user who owns nothing. The rejection test below has to run as someone
+	  `getOrCreateDefaultOrganization` would genuinely create an organization
+	  for - the fixture owner acquires one from an earlier test, which made the
+	  same assertion pass whether or not the guard rejected.
+	*/
+	const strayUserId = randomUUID()
+
+	const hostId = randomUUID()
+	const invitedOrgId = randomUUID()
+	const invitedProjectId = randomUUID()
+	const invitedSceneId = randomUUID()
+
+	const setBillingState = async (
+		billingState: 'active' | 'unpaid' | 'paused',
+		org: string = organizationId
+	) => {
+		await db
+			.delete(schema.orgSubscriptions)
+			.where(eq(schema.orgSubscriptions.organizationId, org))
+		await db
+			.insert(schema.orgSubscriptions)
+			.values({ organizationId: org, plan: 'pro', billingState })
+	}
+
+	const thrownBy = async (
+		request: Parameters<SceneOps['prepareSceneUpload']>[0]
+	) =>
+		sceneOps
+			.prepareSceneUpload(request, ownerId)
+			.catch((e: unknown) => e) as Promise<{
+			entitlementKey?: string
+			billingState?: string
+			upgradeTo?: string | null
+		}>
+
+	const prepare = () =>
+		sceneOps.prepareSceneUpload(
+			{
+				action: 'prepare-scene-upload',
+				requestId: randomUUID(),
+				targetProjectId: projectId
+			},
+			ownerId
+		)
+
+	beforeAll(async () => {
+		schema = await import('../../app/db/schema')
+		db = (await import('../../app/db/client')).getDbClient()
+		sceneOps =
+			await import('../../app/lib/domain/scene/server/scene-settings.operations.server')
+
+		await db
+			.insert(schema.users)
+			.values({ id: ownerId, email: `owner-${ownerId}@ro.test`, name: 'Owner' })
+		/*
+		  Deliberately NOT named 'My Organization'. `getOrCreateDefaultOrganization`
+		  matches on that literal and creates one when it misses, and the guard
+		  used to reach it on every upload. Naming the fixture anything else means
+		  a regression back to that fallback resolves a freshly created, always
+		  granted organization - and every refusal assertion below goes green when
+		  it should not. The name is the assertion.
+		*/
+		await db.insert(schema.organizations).values({
+			id: organizationId,
+			name: `read-only-${organizationId}`,
+			ownerId
+		})
+		await db
+			.insert(schema.organizationMemberships)
+			.values({ userId: ownerId, organizationId, role: 'owner' })
+		await db.insert(schema.projects).values({
+			id: projectId,
+			organizationId,
+			name: 'Read-only project',
+			slug: `ro-${projectId}`
+		})
+
+		// The invited organization, owned by someone else, with the caller as a
+		// plain member and a scene that lives there.
+		await db.insert(schema.users).values([
+			{ id: hostId, email: `host-${hostId}@ro.test`, name: 'Host' },
+			{ id: strayUserId, email: `stray-${strayUserId}@ro.test`, name: 'Stray' }
+		])
+		await db.insert(schema.organizations).values({
+			id: invitedOrgId,
+			name: `invited-${invitedOrgId}`,
+			ownerId: hostId
+		})
+		await db.insert(schema.organizationMemberships).values([
+			{ userId: hostId, organizationId: invitedOrgId, role: 'owner' },
+			{ userId: ownerId, organizationId: invitedOrgId, role: 'member' }
+		])
+		await db.insert(schema.projects).values({
+			id: invitedProjectId,
+			organizationId: invitedOrgId,
+			name: 'Invited project',
+			slug: `inv-${invitedProjectId}`
+		})
+		await db.insert(schema.scenes).values({
+			id: invitedSceneId,
+			projectId: invitedProjectId,
+			folderId: null,
+			name: 'invited scene'
+		})
+	})
+
+	afterAll(async () => {
+		if (!db) return
+		await db
+			.delete(schema.orgSubscriptions)
+			.where(
+				inArray(schema.orgSubscriptions.organizationId, [
+					organizationId,
+					invitedOrgId
+				])
+			)
+		await db.delete(schema.scenes).where(eq(schema.scenes.projectId, projectId))
+		await db
+			.delete(schema.projects)
+			.where(
+				inArray(schema.projects.organizationId, [organizationId, invitedOrgId])
+			)
+		await db
+			.delete(schema.organizationMemberships)
+			.where(
+				inArray(schema.organizationMemberships.organizationId, [
+					organizationId,
+					invitedOrgId
+				])
+			)
+		await db
+			.delete(schema.organizations)
+			.where(inArray(schema.organizations.id, [organizationId, invitedOrgId]))
+		// The no-destination test makes `getOrCreateDefaultOrganization` create
+		// one, so sweep anything else this user came to own.
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.ownerId, ownerId))
+		await db
+			.delete(schema.organizations)
+			.where(eq(schema.organizations.ownerId, strayUserId))
+		await db
+			.delete(schema.users)
+			.where(inArray(schema.users.id, [ownerId, hostId, strayUserId]))
+	})
+
+	it('refuses an upload when payment has lapsed', async () => {
+		await setBillingState('unpaid')
+		await expect(prepare()).rejects.toThrow(
+			/payment required to restore access/
+		)
+
+		/*
+		  The message is built from `billingState` in one place and the field is
+		  set from it in another, and only the field reaches the route, where it
+		  picks 402 over 403. A regression hardcoding it leaves this message
+		  correct and turns every payment prompt into "upgrade your plan" for an
+		  organization that already owns the entitlement.
+
+		  The key matters too: `scene_publish` sits in the same read-only set, so
+		  a guard consulting the wrong one of the two would deny identically.
+		*/
+		const thrown = await thrownBy({
+			action: 'prepare-scene-upload',
+			requestId: randomUUID(),
+			targetProjectId: projectId
+		})
+		expect(thrown.entitlementKey).toBe('scene_upload')
+		expect(thrown.billingState).toBe('unpaid')
+	})
+
+	it('refuses an upload while the subscription is paused', async () => {
+		await setBillingState('paused')
+		await expect(prepare()).rejects.toThrow(
+			/payment required to restore access/
+		)
+
+		const thrown = await thrownBy({
+			action: 'prepare-scene-upload',
+			requestId: randomUUID(),
+			targetProjectId: projectId
+		})
+		expect(thrown.billingState).toBe('paused')
+	})
+
+	it("follows the organization that owns the scene, not the caller's own", async () => {
+		/*
+		  No `targetProjectId`, which is what `upload-published-glb` sends - so the
+		  organization has to come from the scene. Resolving it from the caller
+		  instead let a read-only organization keep publishing whenever the person
+		  doing it had a healthy organization of their own.
+		*/
+		await setBillingState('active')
+		await setBillingState('unpaid', invitedOrgId)
+
+		await expect(
+			sceneOps.prepareSceneUpload(
+				{
+					action: 'prepare-scene-upload',
+					requestId: randomUUID(),
+					sceneId: invitedSceneId
+				},
+				ownerId
+			)
+		).rejects.toThrow(/payment required to restore access/)
+	})
+
+	it('grades the project a first save names, before its scene row exists', async () => {
+		/*
+		  `prepareSceneUpload` mints the scene id and nothing writes the row until
+		  `commit-scene-save`, so every upload of a first save carries an id that
+		  resolves to no project. `resolveSceneAndProject` falls back to
+		  `projectId` for exactly that case, and the guard has to read the same
+		  field or it grades the caller's own organization while the bytes land in
+		  this one.
+		*/
+		await setBillingState('active')
+		await setBillingState('unpaid', invitedOrgId)
+
+		await expect(
+			sceneOps.prepareSceneUpload(
+				{
+					action: 'prepare-scene-upload',
+					requestId: randomUUID(),
+					sceneId: randomUUID(),
+					projectId: invitedProjectId
+				},
+				ownerId
+			)
+		).rejects.toThrow(/payment required to restore access/)
+	})
+
+	it('ignores a named project when no scene id says the scene will land there', async () => {
+		/*
+		  `resolveSceneAndProject` consults `projectId` only for a scene id whose
+		  row does not exist yet. With no scene id at all it ignores the field and
+		  creates the scene in the caller's own default project, so grading the
+		  named project's organization would be a bypass in one direction - a
+		  lapsed caller naming any healthy project they belong to - and a false
+		  refusal in the other.
+
+		  The invited organization is read-only here and the request names its
+		  project, so a guard reading the field out of turn refuses. The scene is
+		  not going there, so the correct answer is to let it through.
+		*/
+		await setBillingState('unpaid', invitedOrgId)
+
+		const prepared = await sceneOps.prepareSceneUpload(
+			{
+				action: 'prepare-scene-upload',
+				requestId: randomUUID(),
+				projectId: invitedProjectId
+			},
+			ownerId
+		)
+		expect(prepared.projectId).not.toBe(invitedProjectId)
+	})
+
+	it('rejects a scene id that names nothing, without creating an organization', async () => {
+		/*
+		  `resolveSceneAndProject` throws for this shape, so the guard has to as
+		  well. Falling through to the caller's default organization would resolve
+		  it - and `getOrCreateDefaultOrganization` matches on a literal name, so
+		  for anyone who renamed theirs it inserts an organization, a membership
+		  and a subscription on the way to a request that cannot succeed.
+		*/
+		/*
+		  Scoped to the stray user. Integration spec files run in parallel against
+		  one database and every sibling inserts and deletes organizations, so an
+		  unfiltered count can fail spuriously - or, worse, have a sibling's delete
+		  cancel out the insert this assertion exists to catch.
+		*/
+		const ownedByStray = () =>
+			db
+				.select({ id: schema.organizations.id })
+				.from(schema.organizations)
+				.where(eq(schema.organizations.ownerId, strayUserId))
+
+		const before = await ownedByStray()
+
+		/*
+		  As `strayUserId`, who owns no organization. `resolveSceneAndProject`
+		  throws the same sentence for this shape, so the message alone proves
+		  nothing about which function refused - the organization count is the
+		  assertion, and it only moves for a user the fallback would create one
+		  for.
+		*/
+		await expect(
+			sceneOps.prepareSceneUpload(
+				{
+					action: 'prepare-scene-upload',
+					requestId: randomUUID(),
+					sceneId: randomUUID()
+				},
+				strayUserId
+			)
+		).rejects.toThrow(/Scene not found with ID/)
+
+		expect((await ownedByStray()).length).toBe(before.length)
+	})
+
+	it("does not refuse work in a healthy organization because the caller's own lapsed", async () => {
+		// The other direction, and the one a customer would notice: legitimate
+		// work in an organization that is paid up, refused because the person
+		// doing it has an unpaid organization of their own somewhere else.
+		await setBillingState('unpaid')
+		await setBillingState('active', invitedOrgId)
+
+		const prepared = await sceneOps.prepareSceneUpload(
+			{
+				action: 'prepare-scene-upload',
+				requestId: randomUUID(),
+				sceneId: invitedSceneId
+			},
+			ownerId
+		)
+		expect(prepared.projectId).toBe(invitedProjectId)
+	})
+
+	it('allows an upload once billing is current again', async () => {
+		/*
+		  The other half. Without this a guard that refused unconditionally would
+		  pass both tests above, and uploads would be dead for everyone.
+		*/
+		await setBillingState('active')
+		const prepared = await prepare()
+		expect(prepared.sceneId).toBeTruthy()
+		expect(prepared.projectId).toBe(projectId)
+	})
+})


### PR DESCRIPTION
## Summary

`scene_upload` gets the guard it has never had, so an organization whose billing
went read-only stops uploading. Stacked on the storage PR.

## Root cause

`scene_upload` has sat in `READ_ONLY_BLOCKED_ENTITLEMENTS` since that set was
written and `entitlement-service.server.ts` documents it as blocking uploads,
but no call site ever passed the key, so the membership was guard infrastructure
with no guard; the check belongs in `prepareSceneUpload`, the one function every
upload action reaches.

## Changes

The key is `true` on every plan, so it can only ever deny on billing state.
There is no upgrade that grants it, which is why the refusal is a payment and
not a tier.

**`EntitlementRequiredError`** is the sibling of `QuotaExceededError`, for the
other half of the same question: a quota says how much, an entitlement says
whether at all. It carries `billingState` because the answer differs — an
entitlement withheld by the plan is a 403 and an upgrade, the same one withheld
because billing lapsed is a 402 and a payment. Sending 403 there tells an owner
to buy something they already own.

**`isRoutableDomainError`** is one predicate rather than a second `instanceof`
in each of the three upload catches. Those catches flatten everything to
`serverError`, and adding a check per error type is how the next typed error
gets swallowed silently.

**The entitlement key is named once.** A mutation proved why: swapping the
lookup to `scene_publish` denied identically, because both keys sit in the
read-only set, while the error still claimed `scene_upload`. The test asserts
the reported key now.

## Testing

Three integration tests: refuses on `unpaid`, refuses on `paused`, allows once
billing is current again — the last so a guard that refused unconditionally
cannot pass.

| Mutation | Result |
| --- | --- |
| the guard deleted | 2 red |
| the wrong entitlement key consulted | 1 red |
| read-only reported as an upgrade | 2 red |

Gates: prettier clean, typecheck and lint green, 1858 unit tests, 89 integration
tests.

## Type of Change

- [x] New feature (non-breaking, adds functionality)

## Checklist

- [x] Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
