### PR TITLE
fix(billing): count usage for one organization, the way the guards do

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/billing-dashboard-loader.server.ts
@@ -1,4 +1,4 @@
-import { count, eq, inArray, sql } from 'drizzle-orm'
+import { count, eq, sql } from 'drizzle-orm'
 import Stripe from 'stripe'
 
 import { getOrgSubscription, getQuotaLimit } from './entitlement-service.server'
@@ -8,13 +8,12 @@ import {
 	folders,
 	projects,
 	sceneFolders,
-	scenePublished
+	scenePublished,
+	scenes
 } from '../../../db/schema'
 import { orgSubscriptions } from '../../../db/schema/billing/subscriptions'
 import { getStripeClient } from '../../stripe.server'
 import { loadAuthenticatedUser } from '../auth/auth-loader.server'
-import { getUserProjects } from '../project/project-repository.server'
-import { getProjectsScenes } from '../scene/server/scene-folder-repository.server'
 
 import type {
 	BillingCheckoutOption,
@@ -123,16 +122,24 @@ export async function getCheckoutOptions(): Promise<BillingCheckoutOptions> {
 }
 
 /**
- * Usage and limits for one organization, given its projects and scenes.
+ * Usage and limits for one organization.
  *
- * Takes them as arguments rather than fetching them so callers that already
- * have them - the dashboard index loads every scene row to compute its own
- * stats - do not pay for the same two queries twice.
+ * Every figure is counted for `organizationId` and nothing else. It used to
+ * take the caller's projects and scenes as arguments, to save two queries the
+ * dashboard index had already run - but those come from `getUserProjects`,
+ * which joins `organization_memberships` on the user alone and so spans every
+ * organization they belong to. The limits beside them, and all four guards that
+ * enforce them, are per-organization.
+ *
+ * The result was a usage panel where scenes, published scenes and projects were
+ * counted across every organization the viewer belonged to while their limits,
+ * folders and storage were counted for one: a free user who also sat in a
+ * colleague's Business organization read "Projects 21 / 1" in red while project
+ * creation worked fine. Two saved queries were not worth a meter that disagrees
+ * with the guard beside it.
  */
 export async function loadOrgUsage(
-	organizationId: string,
-	userProjects: Array<unknown>,
-	allScenes: Array<{ id: string }>
+	organizationId: string
 ): Promise<BillingSettingsData['usage']> {
 	const db = getDbClient()
 
@@ -166,7 +173,22 @@ export async function loadOrgUsage(
 		.where(eq(projects.organizationId, organizationId))
 	const foldersTotalUsage = folderRow?.total ?? 0
 
-	const allSceneIds = allScenes.map((scene) => scene.id)
+	/*
+	  Counted here rather than taken from the caller, and joined through
+	  `projects` the way `createProject` and the `scenes_total` guard count.
+	*/
+	const [projectRow] = await db
+		.select({ total: count() })
+		.from(projects)
+		.where(eq(projects.organizationId, organizationId))
+	const projectsTotalUsage = projectRow?.total ?? 0
+
+	const [sceneRow] = await db
+		.select({ total: count() })
+		.from(scenes)
+		.innerJoin(projects, eq(projects.id, scenes.projectId))
+		.where(eq(projects.organizationId, organizationId))
+	const scenesTotalUsage = sceneRow?.total ?? 0
 
 	/*
 	  Storage is measured, not counted.
@@ -200,23 +222,30 @@ export async function loadOrgUsage(
 		.where(eq(projects.organizationId, organizationId))
 	const storageBytesTotalUsage = Number(storageRow?.total ?? 0)
 
-	// Published is counted from `scene_published`, not `scenes.status`. The two
-	// can disagree, and the quota is enforced against this table.
-	let publishedCount = 0
-	if (allSceneIds.length > 0) {
-		const publishedRows = await db
-			.select({ sceneId: scenePublished.sceneId })
-			.from(scenePublished)
-			.where(inArray(scenePublished.sceneId, allSceneIds))
-		publishedCount = publishedRows.length
-	}
+	/*
+	  Published is counted from `scene_published`, not `scenes.status`. The two
+	  can disagree, and the quota is enforced against this table.
+
+	  Counted in the database rather than by shipping every scene id into an `IN`
+	  list, which is what this did while the caller handed the ids over. That
+	  list was as long as the organization's scene count - two thousand on
+	  business, unbounded on enterprise - and neither figure needed the ids
+	  themselves.
+	*/
+	const [publishedRow] = await db
+		.select({ total: count() })
+		.from(scenePublished)
+		.innerJoin(scenes, eq(scenes.id, scenePublished.sceneId))
+		.innerJoin(projects, eq(projects.id, scenes.projectId))
+		.where(eq(projects.organizationId, organizationId))
+	const publishedCount = publishedRow?.total ?? 0
 
 	return {
-		scenesTotal: allScenes.length,
+		scenesTotal: scenesTotalUsage,
 		sceneLimit: sceneQuota.limit,
 		publishedScenes: publishedCount,
 		publishedSceneLimit: publishedSceneQuota.limit,
-		projectsTotal: userProjects.length,
+		projectsTotal: projectsTotalUsage,
 		projectsLimit: projectsQuota.limit,
 		foldersTotal: foldersTotalUsage,
 		foldersLimit: folderQuota.limit,
@@ -247,13 +276,10 @@ export async function loadBillingDashboardData(
 
 	const { plan, billingState } = await getOrgSubscription(organizationId)
 
-	const userProjects = await getUserProjects(user.id)
-	const projectIds = userProjects.map(({ project }) => project.id)
-	const scenesByProject = await getProjectsScenes(projectIds, user.id)
-	const allScenes = Array.from(scenesByProject.values()).flat()
-
+	// `loadOrgUsage` fetches what it counts now, so the two queries that used to
+	// feed it from the caller's whole membership set are gone with it.
 	const [usage, checkoutOptions] = await Promise.all([
-		loadOrgUsage(organizationId, userProjects, allScenes),
+		loadOrgUsage(organizationId),
 		includeCheckoutOptions ? getCheckoutOptions() : Promise.resolve(undefined)
 	])
 

--- a/apps/vectreal-platform/app/routes/dashboard-page/dashboard-page.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/dashboard-page.tsx
@@ -48,12 +48,16 @@ export async function loader({ request }: Route.LoaderArgs) {
 	const sceneStats = computeSceneStats(scenes)
 	const mostRecentScene = recentScenes[0]
 
-	// `loadOrgUsage` takes the projects and scenes already in hand rather than
-	// re-fetching them, which is why it is a separate function from
-	// `loadBillingDashboardData`.
+	/*
+	  `loadOrgUsage` counts for itself. It used to take the projects and scenes
+	  above, which come from `getUserProjects` and span every organization the
+	  viewer belongs to, so three of its five figures were measured across all of
+	  them against one organization's limits. The two extra reads here are the
+	  price of the meter matching the guard beside it.
+	*/
 	const organizationId = userWithDefaults.organization.id
 	const [usage, { plan }] = await Promise.all([
-		loadOrgUsage(organizationId, userProjects, scenes),
+		loadOrgUsage(organizationId),
 		getOrgSubscription(organizationId)
 	])
 

--- a/apps/vectreal-platform/tests/integration/billing-storage-usage.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/billing-storage-usage.integration.spec.ts
@@ -150,6 +150,29 @@ describe('organization storage usage', () => {
 			name: 'Scene Assets'
 		})
 		await addAsset('elsewhere.bin', OTHER_ORG_BYTES, otherFolderId)
+
+		/*
+		  And a scene, so the scene count has something to leak. Without this the
+		  other organization holds only assets, and dropping the organization
+		  filter from the scene count changes no number - the test would pass
+		  against the defect it exists to catch.
+		*/
+		const otherSceneId = randomUUID()
+		await db.insert(schema.scenes).values({
+			id: otherSceneId,
+			projectId: otherProjectId,
+			folderId: null,
+			name: 'other org scene'
+		})
+		/*
+		  Published too, so the published count is pinned directly rather than
+		  only through the scene count it used to be derived from.
+		*/
+		await db.insert(schema.scenePublished).values({
+			sceneId: otherSceneId,
+			assetId: await addAsset('other-published.glb', 1, otherFolderId),
+			publishedBy: ownerId
+		})
 	})
 
 	afterAll(async () => {
@@ -163,16 +186,31 @@ describe('organization storage usage', () => {
 	})
 
 	it('counts every stored byte once', async () => {
-		const usage = await loadOrgUsage(
-			organizationId,
-			[{}],
-			sceneIds.map((id) => ({ id }))
-		)
+		const usage = await loadOrgUsage(organizationId)
 
 		// The other organization's asset is deliberately far larger than the
 		// total, so leaking it in cannot be mistaken for a rounding difference.
 		expect(usage.storageBytesTotal).toBe(
 			SHARED_BYTES + PUBLISHED_BYTES + ORPHAN_BYTES
 		)
+	})
+
+	it('counts scenes and projects for this organization alone', async () => {
+		/*
+		  These two used to be handed in by the caller, from `getUserProjects`,
+		  which joins memberships on the user and so spans every organization they
+		  belong to - while the limits beside them, and the guards enforcing those
+		  limits, count one. A member of two organizations saw the sum of both
+		  measured against one organization's allowance, in red, while creation
+		  went on working.
+
+		  The fixture's owner is a member of both organizations, so a regression
+		  to the caller-supplied counts shows up here as inflated numbers.
+		*/
+		const usage = await loadOrgUsage(organizationId)
+
+		expect(usage.scenesTotal).toBe(sceneIds.length)
+		expect(usage.projectsTotal).toBe(1)
+		expect(usage.publishedScenes).toBe(1)
 	})
 })


### PR DESCRIPTION
Root cause: `loadOrgUsage` took the caller's projects and scenes as arguments to
save two queries, and both callers supply them from `getUserProjects`, which
joins `organization_memberships` on the user alone and so spans every
organization they belong to - while the limits beside those figures, and all
four guards that enforce them, count one organization.

Three of the five meters were cross-organization and two were not. A free user
who also sits in a colleague's Business organization read "Projects 21 / 1" and
"Scenes 340 / 10" on their own billing page and dashboard band, in red, while
`createProject` granted them their first project without complaint. Folders and
storage, added later, were correct - so the panel disagreed with itself as well
as with the guards.

Both PRs that produced this were reviewed and neither could see it: one wrote
the guards, the other rewrote the meters, and the mismatch only exists between
them. The rule it breaks is the one those PRs added to
`vectreal-extension-architecture`: the guard and the meter must run the same
query.

`loadOrgUsage` now fetches what it counts, joined through `projects` on the
organization exactly as `createProject` and the `scenes_total` guard do. The two
parameters are gone, and with them the three queries in
`loadBillingDashboardData` that existed only to feed them.

Mutation-gated: dropping the organization filter from either the project count
or the scene count reds the new test. The fixture's second organization gains a
scene, because it previously held only assets - so the scene-filter mutation
passed against the very defect the test exists to catch until it had something
to leak.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

Gates: prettier clean, typecheck and lint green across four projects, 1858 unit tests, 83 integration tests.

## Checklist

- [x] Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes