### PR TITLE
fix(publisher): restore a draft with the settings the author composed

### DIFF
--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-draft-restore-wiring.spec.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-draft-restore-wiring.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * A restored draft puts its composed settings back into the atoms.
+ *
+ * A source guard rather than a behavioural test: the hook needs a router, a
+ * model context and eight atoms to mount, and the thing worth pinning is a
+ * single call that fails silently when it is missing.
+ *
+ * The write side of the draft was fixed by spreading the settings into the
+ * persisted payload, but that only reaches IndexedDB. `useApplySceneSettings` is
+ * otherwise called from one place - the route-manifest effect in
+ * `use-scene-source.ts` - and a restored draft is an unsaved scene with no
+ * manifest. So without this call the draft round-trips through storage intact
+ * and is then dropped on the floor at the last step: the author composes
+ * hotspots, signs in, comes back, and the scene loads without them.
+ *
+ * Its limits: it pins that the restore hands the draft's own scene data to the
+ * settings applier, not that the atoms then hold any particular value - that is
+ * `useApplySceneSettings`' own contract. Renaming either local is meant to fail
+ * it; re-point the guard rather than deleting it.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+	join(import.meta.dirname, 'use-scene-draft.ts'),
+	'utf8'
+)
+
+describe('restoring a draft applies its settings', () => {
+	it('takes the settings applier', () => {
+		expect(source).toContain('useApplySceneSettings()')
+	})
+
+	it('hands it the draft scene data, which is a settings object', () => {
+		expect(source).toContain('applySceneSettings(draft.sceneData,')
+	})
+
+	it('does not adopt the restored draft as the saved baseline', () => {
+		// A restored draft has no server row. Adopting it as the last-saved state
+		// makes the unsaved-changes check report nothing to save, and the Save
+		// button goes dead on the one flow the draft feature exists for.
+		expect(source).toContain('{ isSavedBaseline: false }')
+	})
+
+	it('applies them only once the model actually loaded', () => {
+		// Applying before the `status !== 'ready'` bail would leave the atoms
+		// describing a scene the viewer never got.
+		expect(source.indexOf("result.status !== 'ready'")).toBeLessThan(
+			source.indexOf('applySceneSettings(draft.sceneData,')
+		)
+	})
+})

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-draft.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-draft.ts
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from 'react-router'
 import { toast } from 'sonner'
 
 import { usePrepareGltfDocument } from './use-scene-document-export'
+import { useApplySceneSettings } from './use-scene-settings'
 import {
 	inferOptimizationPreset,
 	persistPendingSceneDraftOrchestrator,
@@ -142,6 +143,7 @@ function useRestorePendingDraft(): boolean {
 	})
 	const [hasSettled, setHasSettled] = useState(false)
 	const restoredRef = useRef(false)
+	const applySceneSettings = useApplySceneSettings()
 
 	const { pathname, search } = location
 
@@ -194,6 +196,19 @@ function useRestorePendingDraft(): boolean {
 					return
 				}
 
+				// The draft carries the composed settings, and `ServerSceneData`
+				// extends `SceneSettings`, so this is the settings object. Applying
+				// it is what puts hotspots, interactions and normalization back into
+				// the atoms: `useApplySceneSettings` is otherwise reached only when a
+				// route manifest arrives, and a restored draft is an unsaved scene
+				// that has none - so composing, signing in and coming back silently
+				// dropped everything the author had placed.
+				//
+				// Not a saved baseline: this scene has no server row, and adopting
+				// what was just restored as the last-saved state would make the
+				// unsaved-changes check report nothing to save.
+				applySceneSettings(draft.sceneData, { isSavedBaseline: false })
+
 				setSceneMetaState(draft.sceneMeta)
 				setLastSavedSceneMeta(draft.sceneMeta)
 
@@ -210,6 +225,7 @@ function useRestorePendingDraft(): boolean {
 			}
 		})()
 	}, [
+		applySceneSettings,
 		draftId,
 		load,
 		navigate,

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-settings.spec.tsx
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-settings.spec.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+/**
+ * Applying settings and adopting them as the saved baseline are two different
+ * things, and only one caller wants both.
+ *
+ * A scene loaded from its route manifest is the saved state, so it becomes the
+ * baseline the unsaved-changes check diffs against. A draft restored from this
+ * browser has never been saved: `hasUnsavedChanges` treats a null baseline as
+ * "never saved, so everything is unsaved", and writing one makes a scene with no
+ * server row report nothing to save - the Save button goes dead on the exact
+ * flow the draft feature exists for.
+ */
+import { renderHook } from '@testing-library/react'
+import { createStore, Provider } from 'jotai'
+import { describe, expect, it } from 'vitest'
+
+import { useApplySceneSettings } from './use-scene-settings'
+import { lastSavedSettingsAtom } from '../../lib/stores/publisher-config-store'
+import { hotspotsAtom } from '../../lib/stores/scene-settings-store'
+
+import type { HotspotDefinition, SceneSettings } from '@vctrl/core'
+import type { ReactNode } from 'react'
+
+const hotspot: HotspotDefinition = {
+	id: '00000000-0000-4000-8000-000000000001',
+	name: 'Nose cone',
+	worldPosition: [1, 2, 3],
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot'
+}
+
+const settings = { hotspots: [hotspot] } as SceneSettings
+
+const arrange = () => {
+	const store = createStore()
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<Provider store={store}>{children}</Provider>
+	)
+	const { result } = renderHook(() => useApplySceneSettings(), { wrapper })
+	return { store, apply: result.current }
+}
+
+describe('useApplySceneSettings', () => {
+	it('puts the settings into the atoms either way', () => {
+		const { store, apply } = arrange()
+
+		apply(settings, { isSavedBaseline: false })
+
+		expect(store.get(hotspotsAtom)).toEqual([hotspot])
+	})
+
+	it('adopts a manifest load as the baseline', () => {
+		const { store, apply } = arrange()
+
+		apply(settings, { isSavedBaseline: true })
+
+		expect(store.get(lastSavedSettingsAtom)).not.toBeNull()
+	})
+
+	it('leaves a restored draft with no baseline, so it still reads unsaved', () => {
+		const { store, apply } = arrange()
+
+		apply(settings, { isSavedBaseline: false })
+
+		expect(store.get(lastSavedSettingsAtom)).toBeNull()
+	})
+})

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-settings.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-settings.ts
@@ -74,7 +74,10 @@ export function useApplySceneSettings() {
 	 * button goes dead on the one flow the draft feature exists for.
 	 */
 	return useCallback(
-		(settings: SceneSettings, { isSavedBaseline }: { isSavedBaseline: boolean }) => {
+		(
+			settings: SceneSettings,
+			{ isSavedBaseline }: { isSavedBaseline: boolean }
+		) => {
 			const bounds = settings.bounds ?? defaultBoundsOptions
 			const environment = settings.environment ?? defaultEnvOptions
 			const camera = settings.camera ?? defaultCameraOptions

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-settings.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-settings.ts
@@ -62,8 +62,19 @@ export function useApplySceneSettings() {
 	const setActiveHotspotId = useSetAtom(activeHotspotIdAtom)
 	const setLastSavedSettings = useSetAtom(lastSavedSettingsAtom)
 
+	/**
+	 * Puts a scene's settings into the atoms.
+	 *
+	 * `isSavedBaseline` is explicit at both call sites rather than defaulted,
+	 * because the two callers disagree and getting it wrong is invisible. A scene
+	 * loaded from its route manifest *is* the saved state, so it becomes the
+	 * baseline the unsaved-changes check diffs against. A draft restored from
+	 * this browser has never been saved at all: adopting it as a baseline makes
+	 * `hasUnsavedChanges` false for a scene with no server row, and the Save
+	 * button goes dead on the one flow the draft feature exists for.
+	 */
 	return useCallback(
-		(settings: SceneSettings) => {
+		(settings: SceneSettings, { isSavedBaseline }: { isSavedBaseline: boolean }) => {
 			const bounds = settings.bounds ?? defaultBoundsOptions
 			const environment = settings.environment ?? defaultEnvOptions
 			const camera = settings.camera ?? defaultCameraOptions
@@ -86,16 +97,20 @@ export function useApplySceneSettings() {
 					'default'
 			)
 			setActiveHotspotId(null)
-			setLastSavedSettings({
-				bounds,
-				environment,
-				interactions: settings.interactions,
-				camera,
-				controls,
-				shadows,
-				normalization,
-				hotspots: settings.hotspots
-			})
+			setLastSavedSettings(
+				isSavedBaseline
+					? {
+							bounds,
+							environment,
+							interactions: settings.interactions,
+							camera,
+							controls,
+							shadows,
+							normalization,
+							hotspots: settings.hotspots
+						}
+					: null
+			)
 		},
 		[
 			setActiveHotspotId,

--- a/apps/vectreal-platform/app/hooks/scene-loader/use-scene-source.ts
+++ b/apps/vectreal-platform/app/hooks/scene-loader/use-scene-source.ts
@@ -126,7 +126,9 @@ export function useSceneSource({
 		// Applied even when the manifest carries no settings: the save baseline is
 		// written here, and a scene left without one reads as never saved, which
 		// is what an upload is, not what an opened scene is.
-		applySceneSettings(getSettingsFromManifest(manifest) ?? {})
+		applySceneSettings(getSettingsFromManifest(manifest) ?? {}, {
+			isSavedBaseline: true
+		})
 
 		const meta = manifest.meta ?? sceneMetaInitialState
 		setSceneMeta(meta)

--- a/apps/vectreal-platform/app/lib/domain/scene/client/scene-draft-persistence.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/scene-draft-persistence.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const savePendingSceneDraft =
+	vi.fn<(args: { sceneData: Record<string, unknown> }) => Promise<string>>()
+
+vi.mock('../../../persistence/pending-scene-idb', () => ({
+	savePendingSceneDraft: (args: { sceneData: Record<string, unknown> }) =>
+		savePendingSceneDraft(args)
+}))
+
+vi.mock('./scene-draft-serialization', () => ({
+	serializeSceneAssetData: async () => ({})
+}))
+
+import { persistPendingSceneDraftOrchestrator } from './scene-draft-persistence'
+
+import type { SceneSettings } from '@vctrl/core'
+
+const hotspot = {
+	id: '11111111-1111-4111-8111-111111111111',
+	name: 'Handle',
+	worldPosition: [1, 2, 3] as [number, number, number],
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot' as const
+}
+
+const currentSettings = {
+	bounds: { margin: 1 },
+	environment: { preset: 'city' },
+	camera: { cameras: [] },
+	controls: { enabled: true },
+	shadows: { enabled: false },
+	normalization: { enabled: true, minSize: 0.5, maxSize: 5 },
+	interactions: { scrollProgress: { enabled: true } },
+	hotspots: [hotspot],
+	// Not part of `SceneSettings`, and deliberately present: the payload spreads
+	// this object wholesale, so spread order is the only thing keeping a stale
+	// settings blob from clobbering the draft's own meta and document.
+	meta: { name: 'stale', description: 'stale', thumbnailUrl: 'stale' },
+	gltfJson: 'stale',
+	assetData: 'stale'
+} as unknown as SceneSettings
+
+const persist = () =>
+	persistPendingSceneDraftOrchestrator({
+		modelAvailable: true,
+		prepareGltfDocumentForUpload: async () => ({ data: { asset: {} } }),
+		sceneMetaState: { name: 'Scene', description: '', thumbnailUrl: '' },
+		currentSettings,
+		optimizationSettings: null
+	})
+
+const persistedSettings = async () => {
+	savePendingSceneDraft.mockClear()
+	savePendingSceneDraft.mockResolvedValue('draft-1')
+	await persist()
+	const call = savePendingSceneDraft.mock.calls[0]
+	if (!call) throw new Error('savePendingSceneDraft was never called')
+	return call[0]
+}
+
+describe('persistPendingSceneDraftOrchestrator', () => {
+	it('persists the hotspots the caller composed', async () => {
+		const { sceneData } = await persistedSettings()
+
+		expect(sceneData.hotspots).toEqual([hotspot])
+	})
+
+	it('persists interactions and normalization alongside them', async () => {
+		const { sceneData } = await persistedSettings()
+
+		expect(sceneData.interactions).toEqual(currentSettings.interactions)
+		expect(sceneData.normalization).toEqual(currentSettings.normalization)
+	})
+
+	it('keeps carrying the settings the literal used to list by hand', async () => {
+		const { sceneData } = await persistedSettings()
+
+		expect(sceneData.bounds).toEqual(currentSettings.bounds)
+		expect(sceneData.environment).toEqual(currentSettings.environment)
+		expect(sceneData.camera).toEqual(currentSettings.camera)
+		expect(sceneData.controls).toEqual(currentSettings.controls)
+		expect(sceneData.shadows).toEqual(currentSettings.shadows)
+	})
+
+	it('lets the draft meta win over anything the settings carry', async () => {
+		const { sceneData } = await persistedSettings()
+
+		expect(sceneData.meta).toEqual({
+			name: 'Scene',
+			description: '',
+			thumbnailUrl: ''
+		})
+	})
+
+	it('lets the draft document win too', async () => {
+		const { sceneData } = await persistedSettings()
+
+		expect(sceneData.gltfJson).not.toBe('stale')
+		expect(sceneData.assetData).not.toBe('stale')
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/scene/client/scene-draft-persistence.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/client/scene-draft-persistence.ts
@@ -38,19 +38,20 @@ export const persistPendingSceneDraftOrchestrator = async ({
 	const gltfAssets = (gltfJsonToSend as { assets?: unknown }).assets
 	const assetData = await serializeSceneAssetData(gltfData, gltfAssets)
 
+	// Spread the settings rather than listing their fields. `ServerSceneData`
+	// extends `SceneSettings`, so enumerating them here made "dropped" the
+	// default for anything added later: `hotspots`, `interactions` and
+	// `normalization` were all passed by the caller and silently discarded, and
+	// an author who signed in mid-compose got the draft back without them.
 	const sceneData: ServerSceneData = {
+		...currentSettings,
 		meta: {
 			name: sceneMetaState.name,
 			description: sceneMetaState.description,
 			thumbnailUrl: sceneMetaState.thumbnailUrl
 		},
 		gltfJson: gltfData as ServerSceneData['gltfJson'],
-		assetData,
-		bounds: currentSettings.bounds,
-		environment: currentSettings.environment,
-		camera: currentSettings.camera,
-		controls: currentSettings.controls,
-		shadows: currentSettings.shadows
+		assetData
 	}
 
 	return savePendingSceneDraft({


### PR DESCRIPTION
## Root cause

The pending-draft payload was built from a hand-written object literal listing five settings fields, so the default for any field added later was "silently dropped" — `hotspots`, `interactions` and `normalization` were all passed by the caller and thrown away. The rule belongs in the payload builder rather than at the call site, because the caller was already correct.

## What changed

- `scene-draft-persistence.ts` spreads `...currentSettings` instead of re-listing its fields. `ServerSceneData extends SceneSettings`, and `meta` / `gltfJson` / `assetData` are written after the spread, so they still win.
- The restore applies the draft's settings. Fixing the write alone did not deliver the outcome: `useApplySceneSettings` is reached from one place, the route-manifest effect, and a restored draft is an unsaved scene with no manifest — so the draft round-tripped through IndexedDB intact and was dropped at the last step.
- `useApplySceneSettings` now takes an explicit `{ isSavedBaseline }`. It also adopts what it applies as the last-saved baseline, and `hasUnsavedChanges` reads a *null* baseline as "never saved, so everything is unsaved". Adopting one for a scene with no server row made Save report nothing to save — on the exact flow this feature exists for, and only when the draft carried hotspots, since `[]` still differs from `undefined` after canonicalization.

## Verification

- `scene-draft-persistence.spec.ts` — the fixture carries a stale `meta`/`gltfJson`, so spread order is observable rather than assumed. Mutation: restore the enumerated literal → 2 red.
- `use-scene-settings.spec.tsx` — mutation: always adopt the baseline → red.
- `use-scene-draft-restore-wiring.spec.ts` — a source guard, because the hook needs a router; it pins that the call exists and does not adopt a baseline. Mutation: delete the call → 2 red.
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — 8/8 green.
- `npx vitest run --root .` — 1929 passed.
- `build-ci` green with CI's job-level env vars.

Not verified locally: the DB integration suite. The local Supabase volume predates an OS collation bump and its storage container will not start; CI runs `test-integration` against its own Postgres service container.

## Filed, not fixed

- [`toSceneSettings` drops settings fields a flat payload carries](https://app.notion.com/p/3d0384e63e6781e58ed4f762393a6020) — same shape, but it lives in `packages/hooks` and every consumer reads it. No longer affects the publisher, which reads the atoms.
