### PR TITLE
fix(viewer): measure the hotspot occlusion slack against the model

### DIFF
--- a/packages/viewer/src/components/scene/hotspot-occlusion.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-occlusion.spec.ts
@@ -2,32 +2,76 @@ import { describe, expect, it } from 'vitest'
 
 import { occlusionRayFar } from './hotspot-occlusion'
 
+/** A model whose bounding-box diagonal is 4 units, the middle of the range. */
+const DIAGONAL = 4
+
 describe('occlusionRayFar', () => {
 	it('stops the ray short of the hotspot itself', () => {
 		// The whole reason this function exists: a hotspot is authored by
 		// raycasting the model and storing the hit verbatim, so it sits exactly on
 		// a triangle. A ray cast the full distance hits that triangle and reports
 		// the hotspot as occluded by the surface it is pinned to.
-		expect(occlusionRayFar(4)).toBeLessThan(4)
+		expect(occlusionRayFar(4, DIAGONAL)).toBeLessThan(4)
 	})
 
-	it('scales the gap with distance so it holds at any model size', () => {
-		const near = 4 - occlusionRayFar(4)
-		const far = 40 - occlusionRayFar(40)
+	it('scales the gap with the model, so it holds at any model size', () => {
+		const small = 4 - occlusionRayFar(4, 0.5)
+		const large = 4 - occlusionRayFar(4, 5)
 
 		// Proportional, not merely larger: a flat epsilon also grows by a float
-		// ulp here, so `far > near` would pass without the gap scaling at all.
-		expect(far).toBeGreaterThan(near * 5)
+		// ulp here, so `large > small` would pass without the gap scaling at all.
+		expect(large).toBeGreaterThan(small * 5)
+	})
+
+	it('stops the gap growing once the camera is beyond the model', () => {
+		// The defect this replaced. Taking the tolerance from camera distance alone
+		// made the slack unbounded: nothing bounds the dolly, so zooming out grew
+		// it until a marker behind real geometry stopped dimming. Past the model's
+		// own size the model is the smaller reference, so the slack stops moving.
+		const atModelSize = 200 - occlusionRayFar(200, DIAGONAL)
+		const farBeyond = 20000 - occlusionRayFar(20000, DIAGONAL)
+
+		expect(farBeyond).toBeCloseTo(atModelSize, 10)
+		// And it is the model that set it, not the distance.
+		expect(farBeyond).toBeCloseTo(DIAGONAL * 0.005, 10)
 	})
 
 	it('keeps the gap small enough to still detect a real occluder', () => {
 		// A wall 2% of the way in front of the hotspot must still register.
-		expect(occlusionRayFar(4)).toBeGreaterThan(4 * 0.98)
+		expect(occlusionRayFar(4, DIAGONAL)).toBeGreaterThan(4 * 0.98)
+	})
+
+	it('keeps a large model from swallowing a close occluder', () => {
+		// Normalization is off by default, so a 200-unit model is the ordinary
+		// case. Orbiting in to 3 units, 0.5% of the model would be a whole world
+		// unit of slack and a railing in front of the marker would stop occluding
+		// it. The distance is the smaller reference here, so it wins.
+		const slack = 3 - occlusionRayFar(3, 200)
+
+		expect(slack).toBeCloseTo(3 * 0.005, 10)
+	})
+
+	it('lets the model bound the slack once the camera is further than it', () => {
+		const slack = 500 - occlusionRayFar(500, 4)
+
+		expect(slack).toBeCloseTo(4 * 0.005, 10)
 	})
 
 	it('keeps a gap even as the distance approaches zero', () => {
-		expect(occlusionRayFar(1e-6)).toBe(0)
-		expect(occlusionRayFar(1e-3)).toBeLessThan(1e-3)
+		expect(occlusionRayFar(1e-6, DIAGONAL)).toBe(0)
+		expect(occlusionRayFar(1e-3, DIAGONAL)).toBeLessThan(1e-3)
+	})
+
+	it('falls back to the camera distance when the model has no size yet', () => {
+		// The first pass can run before the bounding box has been measured. A zero
+		// diagonal must behave exactly as the camera-distance reference, not fall
+		// through to the 1e-4 floor - that would be 200x too small at this
+		// distance and report every marker as occluded by its own triangle.
+		const withoutModel = 4 - occlusionRayFar(4, 0)
+		const cameraReference = 4 - occlusionRayFar(4, 4)
+
+		expect(withoutModel).toBeCloseTo(cameraReference, 10)
+		expect(4 - occlusionRayFar(4, Number.NaN)).toBeCloseTo(cameraReference, 10)
 	})
 
 	it.each([
@@ -36,6 +80,6 @@ describe('occlusionRayFar', () => {
 		['NaN', Number.NaN],
 		['Infinity', Number.POSITIVE_INFINITY]
 	])('reports nothing to cast against for %s', (_label, distance) => {
-		expect(occlusionRayFar(distance)).toBe(0)
+		expect(occlusionRayFar(distance, DIAGONAL)).toBe(0)
 	})
 })

--- a/packages/viewer/src/components/scene/hotspot-occlusion.ts
+++ b/packages/viewer/src/components/scene/hotspot-occlusion.ts
@@ -12,11 +12,12 @@
 export const OCCLUSION_INTERVAL_SECONDS = 1 / 15
 
 /**
- * Fraction of the camera-to-hotspot distance ignored at the far end of the ray.
+ * Fraction of the model's bounding-box diagonal ignored at the far end of the
+ * ray.
  */
 const OCCLUSION_TOLERANCE_RATIO = 0.005
 
-/** Floor for the tolerance, for a hotspot almost touching the camera. */
+/** Floor for the tolerance, for a degenerately small model. */
 const MIN_OCCLUSION_TOLERANCE = 1e-4
 
 /**
@@ -29,20 +30,46 @@ const MIN_OCCLUSION_TOLERANCE = 1e-4
  * a marker sitting in plain view flickers between drawn and faded, and while it
  * reads as faded its linked camera cannot be reached at all.
  *
- * Relative rather than absolute so it holds across model scales. The viewer
- * normalizes a model's diagonal into [0.5, 5], and a fixed epsilon that suits
- * the top of that range swallows thin geometry at the bottom of it.
+ * Relative rather than absolute so it holds across model scales: a fixed epsilon
+ * that suits a 5-unit model swallows thin geometry on a 0.5-unit one.
  *
- * Returns 0 when nothing can occlude - the hotspot is at or inside the
- * tolerance - which callers read as "do not bother casting". The final clamp is
- * what produces that for a zero or negative distance, so there is no separate
- * guard for it.
+ * Relative to the *smaller* of the model's diagonal and the camera distance,
+ * because the two references fail at opposite ends. Camera distance alone is
+ * unbounded above - nothing bounds the dolly, so zooming out widened the slack
+ * until markers behind real geometry stopped dimming. The model's diagonal alone
+ * is unbounded relative to the view: normalization is off by default, so a
+ * 200-unit model is ordinary, and 0.5% of it is a whole world unit that would
+ * swallow a railing standing in front of the marker the moment the author
+ * orbits in to look at it. Taking the smaller keeps each one honest where the
+ * other is not.
+ *
+ * Returns 0 when nothing can occlude - the hotspot is at or behind the camera,
+ * or so close to it that nothing could fit in between - which callers read as
+ * "do not bother casting".
  */
-export function occlusionRayFar(distance: number): number {
+export function occlusionRayFar(
+	distance: number,
+	modelDiagonal: number
+): number {
 	if (!Number.isFinite(distance)) return 0
+	// Nothing fits between the camera and a marker this close, so skip the cast
+	// rather than let the distance cap below hand back a ray of a few hundred
+	// nanometres for every such marker on every pass.
+	if (distance <= MIN_OCCLUSION_TOLERANCE) return 0
+
+	// Whichever reference is smaller. The model bounds the far dolly, where a
+	// camera-relative slack grew without limit until markers behind real geometry
+	// stopped dimming. The distance bounds the near case, where a large model's
+	// slack would otherwise swallow a genuine occluder a few units in front of
+	// the marker - and normalization is off by default, so a 200-unit model is
+	// the ordinary case rather than an extreme one.
+	const reference =
+		Number.isFinite(modelDiagonal) && modelDiagonal > 0
+			? Math.min(modelDiagonal, distance)
+			: distance
 
 	const tolerance = Math.max(
-		distance * OCCLUSION_TOLERANCE_RATIO,
+		reference * OCCLUSION_TOLERANCE_RATIO,
 		MIN_OCCLUSION_TOLERANCE
 	)
 

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -1,6 +1,6 @@
 import { useFrame, useThree } from '@react-three/fiber'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Raycaster, Vector3 } from 'three'
+import { Box3, Raycaster, Vector3 } from 'three'
 
 import HotspotMarker from './hotspot-marker'
 import {
@@ -98,6 +98,12 @@ const SceneHotspots = ({
 	 */
 	const overrideId = useRef<string | null>(null)
 	const overridePosition = useRef(new Vector3())
+
+	/**
+	 * Scratch objects for the per-pass bounding-box measurement, allocated once.
+	 */
+	const measureBox = useRef(new Box3())
+	const measureSize = useRef(new Vector3())
 	/**
 	 * A released hotspot whose anchor still has to be put back where stored state
 	 * says, handled on the next frame rather than inside the release itself.
@@ -276,6 +282,24 @@ const SceneHotspots = ({
 			// model swap would otherwise test against the previous placement.
 			if (forced) model.updateWorldMatrix(true, true)
 
+			/*
+			  The occlusion tolerance is a fraction of the model's own size, so the
+			  diagonal is measured here, once per pass, rather than cached against the
+			  model's identity. Normalization rescales the model through an ancestor
+			  group without replacing the object, so an effect keyed on `model` would
+			  hold a stale diagonal for exactly the edit this tolerance has to survive.
+			  One `Box3` walk at 15Hz is the same order as one of the raycasts below,
+			  and there are as many of those as there are markers - but skipped
+			  entirely when every marker has occlusion off, which is a scene that
+			  casts no rays at all.
+			*/
+			const diagonal = markers.some((marker) => marker.occlusionEnabled)
+				? measureBox.current
+						.setFromObject(model)
+						.getSize(measureSize.current)
+						.length()
+				: 0
+
 			for (const marker of markers) {
 				if (!marker.occlusionEnabled) continue
 				/*
@@ -293,7 +317,7 @@ const SceneHotspots = ({
 
 				target.current.set(...marker.position)
 				direction.current.subVectors(target.current, camera.position)
-				const far = occlusionRayFar(direction.current.length())
+				const far = occlusionRayFar(direction.current.length(), diagonal)
 				if (far === 0) continue
 
 				raycaster.set(camera.position, direction.current.normalize())


### PR DESCRIPTION
## Root cause

`occlusionRayFar` derived its tolerance from the camera-to-hotspot distance. The error it exists to absorb is in the *stored intersection point* — a hotspot is authored by raycasting the model and storing the hit verbatim, so it lies exactly on a triangle — and that error scales with the geometry's coordinates, not with the camera. The rule belongs on the model's own size.

## Why `min(modelDiagonal, distance)` rather than the model alone

The two references fail at opposite ends, and a first pass at this got it half right:

- **Camera distance alone is unbounded above.** Nothing bounds the dolly, so zooming out widened the slack until a marker genuinely behind geometry stopped dimming. This is the reported defect.
- **The model's diagonal alone is unbounded relative to the view.** `defaultNormalizationOptions.enabled` is `false`, so a 200-unit model is the ordinary case, not an edge case. At 3 units away the tolerance would be a full world unit — a door or railing in front of the marker stops registering. The band that fixes is narrow; the band it degrades is wide.

Taking the smaller keeps each honest where the other is not, and it subsumes the explicit distance cap the first version needed.

## Verification

- `hotspot-occlusion.spec.ts` — mutation: revert the reference to camera distance → 2 red.
- `stops the gap growing once the camera is beyond the model` pins the reported defect from both sides: the slack stops moving past the model's size, *and* it is the model that set it.
- `keeps a large model from swallowing a close occluder` pins the regression that a model-only reference would have introduced.
- `falls back to the camera distance when the model has no size yet` asserts the magnitude, not just an inequality — an earlier version of this test passed with a tolerance 200× too small.
- 8/8 gate tasks, 1929 tests, `build-ci` green with CI's env.

## Note

The per-pass `Box3` walk is deliberate and the comment says why: normalization rescales the model through an ancestor group without replacing the object, so an effect keyed on `model` would hold a stale diagonal for exactly the edit the tolerance has to survive. It is one tree walk at 15Hz against as many raycasts as there are markers, and it is skipped when no marker has occlusion enabled.
