### PR TITLE
fix(scene): check everything the hotspot save parser accepts

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.spec.ts
@@ -10,7 +10,10 @@ describe('isAllowedHotspotPayloadUrl', () => {
 		['an https URL', 'https://cdn.example.com/pin.png'],
 		['an inline png', 'data:image/png;base64,AAAA'],
 		['an inline svg', 'data:image/svg+xml;base64,AAAA'],
-		['an inline svg with no parameter', 'data:image/svg+xml,%3Csvg%3E%3C/svg%3E'],
+		[
+			'an inline svg with no parameter',
+			'data:image/svg+xml,%3Csvg%3E%3C/svg%3E'
+		],
 		['an uppercase scheme', 'HTTPS://cdn.example.com/pin.png'],
 		['a mixed-case data media type', 'data:IMAGE/PNG;base64,AAAA']
 	])('accepts %s', (_label, value) => {
@@ -19,7 +22,10 @@ describe('isAllowedHotspotPayloadUrl', () => {
 
 	it.each([
 		['a script URL', 'javascript:alert(1)'],
-		['plain http, which fails silently as mixed content', 'http://x.test/a.png'],
+		[
+			'plain http, which fails silently as mixed content',
+			'http://x.test/a.png'
+		],
 		['an inline document', 'data:text/html;base64,AAAA'],
 		['a bare data prefix', 'data:'],
 		['a scheme with no host', 'https://'],

--- a/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	isAllowedHotspotPayloadUrl,
+	MAX_HOTSPOT_URL_LENGTH
+} from './hotspot-urls'
+
+describe('isAllowedHotspotPayloadUrl', () => {
+	it.each([
+		['an https URL', 'https://cdn.example.com/pin.png'],
+		['an inline png', 'data:image/png;base64,AAAA'],
+		['an inline svg', 'data:image/svg+xml;base64,AAAA'],
+		['an inline svg with no parameter', 'data:image/svg+xml,%3Csvg%3E%3C/svg%3E'],
+		['an uppercase scheme', 'HTTPS://cdn.example.com/pin.png'],
+		['a mixed-case data media type', 'data:IMAGE/PNG;base64,AAAA']
+	])('accepts %s', (_label, value) => {
+		expect(isAllowedHotspotPayloadUrl(value)).toBe(true)
+	})
+
+	it.each([
+		['a script URL', 'javascript:alert(1)'],
+		['plain http, which fails silently as mixed content', 'http://x.test/a.png'],
+		['an inline document', 'data:text/html;base64,AAAA'],
+		['a bare data prefix', 'data:'],
+		['a scheme with no host', 'https://'],
+		['a relative path', '/assets/pin.png'],
+		['empty', '']
+	])('rejects %s', (_label, value) => {
+		expect(isAllowedHotspotPayloadUrl(value)).toBe(false)
+	})
+
+	it('rejects a data URI past the length ceiling', () => {
+		const oversized = `data:image/png;base64,${'A'.repeat(MAX_HOTSPOT_URL_LENGTH)}`
+
+		expect(isAllowedHotspotPayloadUrl(oversized)).toBe(false)
+	})
+
+	it('applies the same ceiling to an https URL', () => {
+		// `payload_url` is an unbounded text column either way, so a ceiling that
+		// only covered data URIs would leave the column unbounded again.
+		const oversized = `https://x.test/${'a'.repeat(MAX_HOTSPOT_URL_LENGTH)}`
+
+		expect(isAllowedHotspotPayloadUrl(oversized)).toBe(false)
+	})
+
+	it('accepts a value at exactly the ceiling', () => {
+		const prefix = 'https://x.test/'
+		const exact = prefix + 'a'.repeat(MAX_HOTSPOT_URL_LENGTH - prefix.length)
+
+		expect(exact).toHaveLength(MAX_HOTSPOT_URL_LENGTH)
+		expect(isAllowedHotspotPayloadUrl(exact)).toBe(true)
+	})
+
+	it('rejects a media type that merely starts with an allowed one', () => {
+		expect(isAllowedHotspotPayloadUrl('data:image/pngx,AAAA')).toBe(false)
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.ts
@@ -54,7 +54,5 @@ export function isAllowedHotspotPayloadUrl(value: string): boolean {
 		return ALLOWED_IMAGE_MEDIA_TYPES.includes(dataMediaType(normalized))
 	}
 
-	return (
-		normalized.startsWith('https://') && value.length > 'https://'.length
-	)
+	return normalized.startsWith('https://') && value.length > 'https://'.length
 }

--- a/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.ts
@@ -1,0 +1,60 @@
+/**
+ * What a hotspot is allowed to point at.
+ *
+ * `payloadUrl` was added to the type and to the `payload_url` column without
+ * ever being added to the save parser, so it was the one hotspot field that
+ * reached Postgres unexamined. That is not currently exploitable - the value
+ * only ever lands in an `<img src>`, where `javascript:` is inert and
+ * `data:text/html` fails image decode - but it is the one field with no rule,
+ * and the rule is what the next URL-shaped field inherits rather than
+ * reinventing.
+ */
+
+/**
+ * Ceiling on a stored URL, in characters.
+ *
+ * `payload_url` is an unbounded `text` column and an inline `data:` URI has no
+ * natural size, so a handful of hotspots carrying full-resolution artwork can
+ * make a scene's settings row larger than the model it describes.
+ */
+export const MAX_HOTSPOT_URL_LENGTH = 8192
+
+const ALLOWED_IMAGE_MEDIA_TYPES = [
+	'image/png',
+	'image/jpeg',
+	'image/webp',
+	'image/gif',
+	'image/svg+xml'
+]
+
+/**
+ * A `data:` URI's media type ends at either a parameter or the payload.
+ *
+ * RFC 2397 is `data:<mediatype>[;base64],<data>`, so the separator is a comma
+ * when there is no parameter. Matching only on `;` rejected
+ * `data:image/svg+xml,%3Csvg...` - the canonical inline SVG, and the form the
+ * style preset exists to carry.
+ */
+const dataMediaType = (value: string): string =>
+	value.slice('data:'.length).split(/[;,]/, 1)[0]
+
+/**
+ * A marker's artwork: an `https:` URL, or an inline image.
+ *
+ * `http:` is rejected because the embed runs inside somebody else's page, and a
+ * mixed-content request there fails silently rather than visibly.
+ */
+export function isAllowedHotspotPayloadUrl(value: string): boolean {
+	if (value.length > MAX_HOTSPOT_URL_LENGTH) return false
+
+	// Schemes and media types are case-insensitive per RFC 3986 and RFC 2045.
+	const normalized = value.toLowerCase()
+
+	if (normalized.startsWith('data:')) {
+		return ALLOWED_IMAGE_MEDIA_TYPES.includes(dataMediaType(normalized))
+	}
+
+	return (
+		normalized.startsWith('https://') && value.length > 'https://'.length
+	)
+}

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
@@ -206,9 +206,9 @@ describe('hotspot ceilings and payload URLs', () => {
 	})
 
 	it('still rejects a non-string payloadUrl on a dot marker', () => {
-		expect(rejected(parse([hotspot({ stylePreset: 'dot', payloadUrl: 42 })]))).toBe(
-			true
-		)
+		expect(
+			rejected(parse([hotspot({ stylePreset: 'dot', payloadUrl: 42 })]))
+		).toBe(true)
 	})
 
 	it('rejects that same legacy value once the marker shows an image', () => {

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
@@ -120,3 +120,102 @@ describe('hotspot validation', () => {
 		expect(rejected(parse([hotspot({ name: '  ' })]))).toBe(true)
 	})
 })
+
+describe('hotspot ceilings and payload URLs', () => {
+	/** Distinct, valid uuids so the count is the only thing under test. */
+	const manyHotspots = (count: number) =>
+		Array.from({ length: count }, (_, i) =>
+			hotspot({
+				id: `${(i + 1).toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`
+			})
+		)
+
+	it('accepts a scene at the ceiling', () => {
+		expect(rejected(parse(manyHotspots(200)))).toBe(false)
+	})
+
+	it('rejects a scene past the ceiling', async () => {
+		const result = parse(manyHotspots(201))
+		expect(rejected(result)).toBe(true)
+		expect((await bodyOf(result)).error).toMatch(/at most 200/)
+	})
+
+	it('rejects a script URL in payloadUrl', async () => {
+		const result = parse([
+			hotspot({ stylePreset: 'image', payloadUrl: 'javascript:alert(1)' })
+		])
+
+		expect(rejected(result)).toBe(true)
+		expect((await bodyOf(result)).error).toMatch(/payloadUrl/)
+	})
+
+	it('rejects a non-string payloadUrl', async () => {
+		const result = parse([hotspot({ stylePreset: 'image', payloadUrl: 42 })])
+
+		expect(rejected(result)).toBe(true)
+		expect((await bodyOf(result)).error).toMatch(/payloadUrl must be a string/)
+	})
+
+	it('accepts an https payloadUrl', () => {
+		const result = parse([
+			hotspot({ stylePreset: 'image', payloadUrl: 'https://cdn.test/p.png' })
+		])
+
+		expect(rejected(result)).toBe(false)
+	})
+
+	it('accepts an inline svg written without a parameter', () => {
+		// RFC 2397's comma form, and the canonical inline SVG. Rejecting it would
+		// 400 the whole scene save for the preset that exists to carry it.
+		const result = parse([
+			hotspot({
+				stylePreset: 'svg',
+				payloadUrl: 'data:image/svg+xml,%3Csvg%3E%3C/svg%3E'
+			})
+		])
+
+		expect(rejected(result)).toBe(false)
+	})
+
+	it('accepts an explicit null payloadUrl', () => {
+		// The repository writes `payloadUrl ?? null` and the comparison module
+		// types it `string | null`, so an explicit null round-trips through the
+		// client. Treating it as a non-string would 400 an ordinary save.
+		expect(rejected(parse([hotspot({ payloadUrl: null })]))).toBe(false)
+	})
+
+	it('leaves a legacy payloadUrl alone while the marker is a dot', () => {
+		// A scene saved before this rule can hold an http:// value. The dot preset
+		// never renders it and the panel never shows the field, so rejecting it
+		// would make that scene permanently unsaveable with nothing to correct.
+		const result = parse([
+			hotspot({ stylePreset: 'dot', payloadUrl: 'http://legacy.test/p.png' })
+		])
+
+		expect(rejected(result)).toBe(false)
+	})
+
+	it('still bounds the size of a dot marker\u2019s payloadUrl', () => {
+		// The column is unbounded text and every manifest reads it back whatever
+		// the preset says, so the size cap cannot be preset-gated.
+		const result = parse([
+			hotspot({ stylePreset: 'dot', payloadUrl: 'a'.repeat(9000) })
+		])
+
+		expect(rejected(result)).toBe(true)
+	})
+
+	it('still rejects a non-string payloadUrl on a dot marker', () => {
+		expect(rejected(parse([hotspot({ stylePreset: 'dot', payloadUrl: 42 })]))).toBe(
+			true
+		)
+	})
+
+	it('rejects that same legacy value once the marker shows an image', () => {
+		const result = parse([
+			hotspot({ stylePreset: 'image', payloadUrl: 'http://legacy.test/p.png' })
+		])
+
+		expect(rejected(result)).toBe(true)
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
@@ -9,6 +9,10 @@ import {
 
 import { UUID_REGEX } from '../../../../constants/utility-constants'
 import { parseActionRequest } from '../../../http/requests.server'
+import {
+	isAllowedHotspotPayloadUrl,
+	MAX_HOTSPOT_URL_LENGTH
+} from '../hotspot-urls'
 import { parseOptimizationReport } from '../optimization-report-guard'
 import {
 	applyDefaultCameraFlag,
@@ -33,6 +37,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Request parser for scene settings API operations.
  * Handles validation and normalization of incoming requests.
  */
+/**
+ * Ceiling on how many hotspots one scene can persist.
+ *
+ * Sized well above any authored walkthrough and well below a payload that would
+ * degrade an embed: a sequenced tour runs to tens of markers, and the occlusion
+ * pass is throttled to 15Hz, so the cost only becomes visible in the hundreds.
+ */
+const MAX_HOTSPOTS_PER_SCENE = 200
+
 export class SceneSettingsParser {
 	/**
 	 * Parses and validates scene settings request data.
@@ -421,6 +434,16 @@ export class SceneSettingsParser {
 		if (!Array.isArray(hotspots)) {
 			return ApiResponse.badRequest('hotspots must be an array')
 		}
+		// Every hotspot mounts its own portal and takes part in the viewer's
+		// occlusion raycast, which every embed visitor then pays for. A structural
+		// ceiling, not a plan limit: entitlements are resolved asynchronously
+		// against an organization this static parser has no handle on, and a
+		// ceiling that cannot be enforced where the write happens is not a ceiling.
+		if (hotspots.length > MAX_HOTSPOTS_PER_SCENE) {
+			return ApiResponse.badRequest(
+				`hotspots must contain at most ${MAX_HOTSPOTS_PER_SCENE} entries`
+			)
+		}
 
 		// Must stay in step with HotspotStylePreset in @vctrl/core and with the
 		// publisher's STYLE_PRESET_OPTIONS. This set omitted 'svg' while both of
@@ -476,6 +499,34 @@ export class SceneSettingsParser {
 				return ApiResponse.badRequest(
 					`hotspots[${i}].stylePreset must be 'dot', 'image' or 'svg'`
 				)
+			}
+			if (hotspot.payloadUrl !== undefined && hotspot.payloadUrl !== null) {
+				// Shape and size hold for every preset. The column is unbounded
+				// `text` and is read back into every manifest whatever the preset
+				// says, so a 'dot' marker carrying megabytes of dead string is the
+				// same row bloat the hotspot ceiling above exists to stop.
+				if (typeof hotspot.payloadUrl !== 'string') {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].payloadUrl must be a string`
+					)
+				}
+				if (hotspot.payloadUrl.length > MAX_HOTSPOT_URL_LENGTH) {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].payloadUrl must be at most ${MAX_HOTSPOT_URL_LENGTH} characters`
+					)
+				}
+				// The scheme is checked only for the presets that render it. A 'dot'
+				// marker never reaches an `<img src>`, so rejecting a legacy value
+				// there would make an existing scene unsaveable with no field on
+				// screen to correct.
+				if (
+					hotspot.stylePreset !== 'dot' &&
+					!isAllowedHotspotPayloadUrl(hotspot.payloadUrl)
+				) {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].payloadUrl must be an https URL or an inline image`
+					)
+				}
 			}
 			if (
 				hotspot.occlusionEnabled !== undefined &&


### PR DESCRIPTION
## Root cause

`normalizeHotspots` validates nine fields of every entry and never looks at `hotspots.length`, and `payloadUrl` was added to `HotspotDefinition` and to the `payload_url` column without ever being added to the parser — the one hotspot field that reached Postgres unexamined. One function, one gap: it does not check everything it accepts.

## What changed

- A 200-hotspot ceiling, placed beside the `Array.isArray` guard and before the per-entry loop.
- `payloadUrl` validated through a new pure `hotspot-urls.ts`.

## Two decisions worth the review

**The ceiling is a structural constant, not a plan limit.** `getQuotaLimit` is async and needs an organization id; `SceneSettingsParser` is a static class with none in scope. Plumbing entitlements into the settings parser to bound an array is a product decision wearing a defect's clothes — a ceiling that cannot be enforced where the write happens is not a ceiling. If per-plan hotspot counts are wanted, that is its own change against the entitlement layer.

**The URL rule is split by what actually reads the field.** Shape and size hold for *every* preset, because the column is unbounded `text` and is read back into every manifest regardless of preset — 200 `dot` markers carrying megabytes of dead string is the same row bloat the ceiling exists to prevent. The *scheme* is checked only for presets that render it: a `dot` marker never reaches an `<img src>`, so rejecting a legacy `http://` value there would make an existing scene permanently unsaveable with no field on screen to correct.

The render bypass this opens is closed downstream: `resolve-hotspot-markers.ts` only resolves to `image`/`svg` when `payloadUrl` is truthy, and persisting a preset flip re-runs validation on the value that comes with it.

## Verification

- Mutations: raise the ceiling past the fixture → red; disable the scheme check → red.
- `200` and `201` pin the boundary from both sides, with ids generated from the index so the count is the only variable.
- `data:image/svg+xml,…` — RFC 2397's comma form, and the canonical inline SVG. An earlier version of the rule rejected it and would have 400'd the whole scene save for the preset that exists to carry it.
- `payloadUrl: null` accepted — the repository writes `?? null` and `scene-hotspot-comparison.ts` types it `string | null`, so an explicit null round-trips through the client.
- Length ceiling proven for `https://` as well as `data:`, plus the exact-boundary case.
- 8/8 gate tasks, 1929 tests, `build-ci` green with CI's env.

Not verified locally: the DB integration suite — the local Supabase volume predates an OS collation bump. CI runs it against its own Postgres service container.

## Filed, not fixed

- [The publisher accepts a hotspot asset URL the server will reject](https://app.notion.com/p/3d0384e63e678199b234e6d041bcaf9f) — the Asset URL field has no client-side validation, so an author pasting `http://` sees the raw parser message at save time. `isAllowedHotspotPayloadUrl` is pure and client-safe, so the two cannot drift when that lands.
- [Restrict payloadUrl to assets the platform serves](https://app.notion.com/p/3d0384e63e67816e885ae29b33e839bf) — a remote URL means every embed visitor's browser hits a third party from inside the customer's page. A product decision, not a validation one.
