### PR TITLE
fix(publisher): let a hotspot coordinate hold an entry that is not yet a number

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
@@ -118,6 +118,95 @@ describe('HotspotsSettingsPanel arming', () => {
 		expect(store.get(cameraAtom).cameras?.[0].target).toEqual([9, 2, 3])
 	})
 
+	/**
+	 * Clearing the well and retyping is the only way to enter a negative
+	 * coordinate, and it used to be impossible: the handler bailed on `NaN`
+	 * without setting state, and React restored the previous number over the
+	 * input on that same keystroke. The field now keeps the string it is being
+	 * given, so an entry that is not yet a number can sit there until it is one.
+	 */
+	it('lets an axis be cleared and retyped as a negative', () => {
+		arrange()
+		render(<HotspotsSettingsPanel />)
+
+		const field = screen.getByLabelText('X position') as HTMLInputElement
+
+		act(() => {
+			fireEvent.change(field, { target: { value: '' } })
+		})
+
+		// The old value must not have been written back over the empty field.
+		expect(field.value).toBe('')
+
+		act(() => {
+			fireEvent.change(field, { target: { value: '-5' } })
+		})
+
+		expect(store.get(hotspotsAtom)[0].worldPosition).toEqual([-5, 2, 3])
+	})
+
+	it.each([
+		['a lone minus', '-'],
+		['a trailing decimal point', '1.'],
+		['an empty well', '']
+	])('does not write the old number back over %s', (_label, entry) => {
+		// A `type="number"` input reports `""` for any entry that is not yet a
+		// number, these three included - which is exactly why the old handler,
+		// bailing on `NaN`, let React restore the previous digits on that
+		// keystroke. What matters is that the well does not refill itself.
+		arrange()
+		render(<HotspotsSettingsPanel />)
+
+		const field = screen.getByLabelText('X position') as HTMLInputElement
+
+		act(() => {
+			fireEvent.change(field, { target: { value: entry } })
+		})
+
+		expect(field.value).not.toBe('1')
+	})
+
+	it('commits a decimal typed through a trailing point', () => {
+		arrange()
+		render(<HotspotsSettingsPanel />)
+
+		const field = screen.getByLabelText('X position') as HTMLInputElement
+
+		act(() => {
+			fireEvent.change(field, { target: { value: '1.' } })
+			fireEvent.change(field, { target: { value: '1.5' } })
+		})
+
+		expect(store.get(hotspotsAtom)[0].worldPosition).toEqual([1.5, 2, 3])
+	})
+
+	it('leaves the committed position alone while the entry is incomplete', () => {
+		arrange()
+		render(<HotspotsSettingsPanel />)
+
+		act(() => {
+			fireEvent.change(screen.getByLabelText('X position'), {
+				target: { value: '' }
+			})
+		})
+
+		expect(store.get(hotspotsAtom)[0].worldPosition).toEqual([1, 2, 3])
+	})
+
+	it('shows the committed position again after an abandoned entry', () => {
+		arrange()
+		render(<HotspotsSettingsPanel />)
+
+		const field = screen.getByLabelText('X position') as HTMLInputElement
+
+		act(() => {
+			fireEvent.change(field, { target: { value: '' } })
+			fireEvent.blur(field)
+		})
+
+		expect(field.value).toBe('1')
+	})
+
 	it('disarms click-to-place when the panel unmounts', () => {
 		arrange()
 		const { unmount } = render(<HotspotsSettingsPanel />)

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -144,6 +144,15 @@ const sequencedFirst = (hotspots: readonly HotspotDefinition[]) => {
  * `SettingRow`'s label is a sibling with no `htmlFor`, so it names nothing to a
  * screen reader. Until that is fixed in its owner, every field here carries its
  * own `aria-label`.
+ *
+ * The field keeps its own string while it is being typed in, and that is the
+ * whole point of it. Committed state holds a number, and a controlled
+ * `type="number"` input reports `""` for any entry that is not yet one - `""`
+ * itself, a lone `-`, a trailing `.`. React re-runs its input restore after
+ * every change event whether or not the handler set state, so a handler that
+ * bails on `NaN` hands the old digits straight back on that keystroke. Clearing
+ * the well was therefore impossible, and with it the only natural way to enter
+ * a negative coordinate - in a scene centred on the origin, half the space.
  */
 const AxisField = memo(
 	({
@@ -154,24 +163,37 @@ const AxisField = memo(
 		axis: (typeof AXES)[number]
 		value: number
 		onChange: (raw: string) => void
-	}) => (
-		<div className="publisher-shell-nested focus-within:ring-ring flex items-center rounded-lg pl-2 focus-within:ring-2">
-			<span
-				aria-hidden
-				className="text-muted-foreground w-3 shrink-0 text-xs font-medium"
-			>
-				{axis}
-			</span>
-			<Input
-				type="number"
-				step="0.1"
-				aria-label={`${axis} position`}
-				value={value}
-				onChange={(event) => onChange(event.target.value)}
-				className="h-8 border-0 bg-transparent px-2 font-mono text-xs shadow-none focus-visible:ring-0"
-			/>
-		</div>
-	)
+	}) => {
+		const [draft, setDraft] = useState<string | null>(null)
+
+		// Committed state wins whenever the field is not mid-edit, so a drag on the
+		// canvas still moves the numbers under the author's cursor.
+		const shown = draft ?? String(value)
+
+		return (
+			<div className="publisher-shell-nested focus-within:ring-ring flex items-center rounded-lg pl-2 focus-within:ring-2">
+				<span
+					aria-hidden
+					className="text-muted-foreground w-3 shrink-0 text-xs font-medium"
+				>
+					{axis}
+				</span>
+				<Input
+					type="number"
+					step="0.1"
+					aria-label={`${axis} position`}
+					value={shown}
+					onChange={(event) => {
+						const raw = event.target.value
+						setDraft(raw)
+						onChange(raw)
+					}}
+					onBlur={() => setDraft(null)}
+					className="h-8 border-0 bg-transparent px-2 font-mono text-xs shadow-none focus-visible:ring-0"
+				/>
+			</div>
+		)
+	}
 )
 
 AxisField.displayName = 'AxisField'


### PR DESCRIPTION
## Root cause

`handlePositionChange` bails on `NaN` without setting state, and `AxisField` is a fully controlled `type="number"` input reading committed state. React re-runs its input restore after **every** change event, whether or not the handler set state, so the old value is written straight back on that keystroke.

A `type="number"` input reports `""` for any incomplete entry — `""` itself, a lone `-`, a trailing `.`. So clearing the well was impossible, and with it the natural way to enter a negative coordinate. In a scene centred on the origin, negative coordinates are half the space.

Prepending a minus to an existing number still worked, because `-2` is valid at every keystroke. The break was specifically clear-then-retype.

## Fix

A local string draft in `AxisField`, committed on blur. Contained to that one component; the `NaN` bail stays, and is now correct — an uncommittable string should not reach the store, and the draft is what keeps it on screen meanwhile.

## Verification

- Mutation: remove the draft and restore `value={value}` → the negative case goes red.
- `lets an axis be cleared and retyped as a negative` — asserts the well does not refill *and* that `-5` commits.
- `commits a decimal typed through a trailing point`.
- `shows the committed position again after an abandoned entry`.
- The existing camera-follow test still passes: typing a coordinate is placing the marker, so it still goes through the same paired edit.
- 8/8 gate tasks, 1929 tests, `build-ci` green with CI's env.

One thing the tests deliberately do *not* assert: that the field displays `-` while typing it. jsdom is right that a number input reports `""` there — that is the premise of the bug, not a regression. What matters is that the well does not refill itself, which is what they check.

## Note

The panel's `crypto.randomUUID()` throws outside a secure context, so "Add marker" fails on a dev server reached over `http://192.168.x.x` from a phone. `localhost` qualifies as secure, so dev and prod are unaffected, and a fallback is not worth it — the id has to be a real uuid or Postgres rejects the insert and fails the whole save. Left alone.
