### PR TITLE
feat(scene): give a hotspot something to say

### DIFF
--- a/apps/vectreal-platform/app/db/schema/project/scene-hotspots.ts
+++ b/apps/vectreal-platform/app/db/schema/project/scene-hotspots.ts
@@ -33,6 +33,12 @@ export const sceneHotspots = pgTable(
 
 		name: text('name').notNull(),
 
+		// What the hotspot says when revealed, and where it points. Both
+		// nullable: a marker that only flies its linked camera carries neither,
+		// and every row written before these columns existed is exactly that.
+		body: text('body'),
+		linkUrl: text('link_url'),
+
 		// World-space position stored as three real columns for direct querying.
 		worldPositionX: real('world_position_x').notNull().default(0),
 		worldPositionY: real('world_position_y').notNull().default(0),

--- a/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	isAllowedHotspotLinkUrl,
 	isAllowedHotspotPayloadUrl,
 	MAX_HOTSPOT_URL_LENGTH
 } from './hotspot-urls'
@@ -59,5 +60,41 @@ describe('isAllowedHotspotPayloadUrl', () => {
 
 	it('rejects a media type that merely starts with an allowed one', () => {
 		expect(isAllowedHotspotPayloadUrl('data:image/pngx,AAAA')).toBe(false)
+	})
+})
+
+describe('isAllowedHotspotLinkUrl', () => {
+	it.each([
+		['an https URL', 'https://vectreal.com/docs'],
+		['an uppercase scheme', 'HTTPS://vectreal.com/docs']
+	])('accepts %s', (_label, value) => {
+		expect(isAllowedHotspotLinkUrl(value)).toBe(true)
+	})
+
+	it.each([
+		['a script URL', 'javascript:alert(1)'],
+		['a script URL with mixed case', 'JavaScript:alert(1)'],
+		['plain http', 'http://vectreal.com/docs'],
+		['a bare scheme with no host', 'https://'],
+		['a relative path', '/docs'],
+		['an empty string', '']
+	])('rejects %s', (_label, value) => {
+		expect(isAllowedHotspotLinkUrl(value)).toBe(false)
+	})
+
+	it('rejects an inline document that the payload rule would allow the shape of', () => {
+		// The two rules diverge here on purpose. A payload URL reaches an
+		// `<img src>`, where a `data:` image is the point; a link URL reaches an
+		// `<a href>`, where `data:text/html` navigates to attacker markup.
+		expect(isAllowedHotspotPayloadUrl('data:image/png;base64,AAAA')).toBe(true)
+		expect(isAllowedHotspotLinkUrl('data:image/png;base64,AAAA')).toBe(false)
+		expect(isAllowedHotspotLinkUrl('data:text/html;base64,AAAA')).toBe(false)
+	})
+
+	it('shares the payload rule\u2019s length ceiling', () => {
+		const long = `https://vectreal.com/${'a'.repeat(MAX_HOTSPOT_URL_LENGTH)}`
+
+		expect(long.length).toBeGreaterThan(MAX_HOTSPOT_URL_LENGTH)
+		expect(isAllowedHotspotLinkUrl(long)).toBe(false)
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.ts
@@ -1,5 +1,6 @@
 /**
- * What a hotspot is allowed to point at.
+ * What a hotspot is allowed to carry: the URLs it may point at, and how much
+ * text it may hold.
  *
  * `payloadUrl` was added to the type and to the `payload_url` column without
  * ever being added to the save parser, so it was the one hotspot field that
@@ -18,6 +19,16 @@
  * make a scene's settings row larger than the model it describes.
  */
 export const MAX_HOTSPOT_URL_LENGTH = 8192
+
+/**
+ * Ceiling on a hotspot's body text, in characters.
+ *
+ * `body` is an unbounded `text` column that is read back into every embed
+ * manifest, so the ceiling is what keeps a scene at the hotspot limit from
+ * shipping megabytes of prose to every visitor. Sized for a paragraph or two,
+ * which is all a marker-anchored popover can show without scrolling.
+ */
+export const MAX_HOTSPOT_BODY_LENGTH = 2000
 
 const ALLOWED_IMAGE_MEDIA_TYPES = [
 	'image/png',
@@ -53,6 +64,25 @@ export function isAllowedHotspotPayloadUrl(value: string): boolean {
 	if (normalized.startsWith('data:')) {
 		return ALLOWED_IMAGE_MEDIA_TYPES.includes(dataMediaType(normalized))
 	}
+
+	return normalized.startsWith('https://') && value.length > 'https://'.length
+}
+
+/**
+ * A marker's link destination: `https:` only.
+ *
+ * Deliberately stricter than `isAllowedHotspotPayloadUrl`, which shares its
+ * length cap but accepts inline images. This value lands in an `<a href>`,
+ * where `javascript:` executes and `data:text/html` navigates to attacker
+ * markup - both inert in the `<img src>` a payload URL reaches. So the rule
+ * here is an allowlist of one scheme rather than a denylist of the schemes
+ * that are known to be dangerous today.
+ */
+export function isAllowedHotspotLinkUrl(value: string): boolean {
+	if (value.length > MAX_HOTSPOT_URL_LENGTH) return false
+
+	// Schemes are case-insensitive per RFC 3986.
+	const normalized = value.toLowerCase()
 
 	return normalized.startsWith('https://') && value.length > 'https://'.length
 }

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-comparison.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-comparison.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { haveHotspotsChanged } from './scene-hotspot-comparison'
 
 const hotspot = (overrides: Record<string, unknown> = {}) => ({
@@ -141,5 +144,110 @@ describe('haveHotspotsChanged', () => {
 				[hotspot({ worldPosition: [1.0005, 2, 3] })]
 			)
 		).toBe(true)
+	})
+})
+
+describe('hotspot content', () => {
+	// Save availability is driven by this comparison, so a field the comparator
+	// does not read is a field an author can edit with the button staying
+	// disabled - the edit looks refused rather than unsaved.
+	it('detects body text being added, changed and cleared', () => {
+		expect(
+			haveHotspotsChanged(
+				[hotspot({ body: 'Cast in one piece.' })],
+				[hotspot()]
+			)
+		).toBe(true)
+		expect(
+			haveHotspotsChanged(
+				[hotspot({ body: 'Machined.' })],
+				[hotspot({ body: 'Cast.' })]
+			)
+		).toBe(true)
+		expect(haveHotspotsChanged([hotspot()], [hotspot({ body: 'Cast.' })])).toBe(
+			true
+		)
+	})
+
+	it('detects a link being added, changed and cleared', () => {
+		expect(
+			haveHotspotsChanged([hotspot({ linkUrl: 'https://a.test' })], [hotspot()])
+		).toBe(true)
+		expect(
+			haveHotspotsChanged(
+				[hotspot({ linkUrl: 'https://b.test' })],
+				[hotspot({ linkUrl: 'https://a.test' })]
+			)
+		).toBe(true)
+		expect(
+			haveHotspotsChanged([hotspot()], [hotspot({ linkUrl: 'https://a.test' })])
+		).toBe(true)
+	})
+
+	it('reads absent and null as the same unset value on both fields', () => {
+		// The client omits a cleared field; a row read back carries null. If
+		// these differed, every scene with a text-free hotspot would report
+		// itself dirty on load and offer a save that changes nothing.
+		expect(
+			haveHotspotsChanged(
+				[hotspot({ body: undefined, linkUrl: undefined })],
+				[hotspot({ body: null, linkUrl: null })]
+			)
+		).toBe(false)
+	})
+})
+
+/**
+ * `sameHotspot` enumerates every field by hand, and this is the third
+ * hand-maintained enumeration of the hotspot shape after the draft payload and
+ * `toSceneSettings`. Both of the others dropped a field silently before anyone
+ * noticed, so rather than patch this one a third time and hope, the guard reads
+ * `HotspotDefinition` out of the core type and requires every field to appear
+ * in the comparison.
+ *
+ * A name match, not a semantic one: it cannot tell a correct comparison from a
+ * wrong one, only a present field from a missing one. That is the failure it is
+ * for - the next field added to the type and forgotten here.
+ */
+describe('sameHotspot covers HotspotDefinition', () => {
+	const coreTypes = readFileSync(
+		join(
+			import.meta.dirname,
+			'../../../../../../packages/core/src/types/scene-types.ts'
+		),
+		'utf8'
+	)
+	const comparison = readFileSync(
+		join(import.meta.dirname, 'scene-hotspot-comparison.ts'),
+		'utf8'
+	)
+
+	const interfaceBody = coreTypes
+		.split('export interface HotspotDefinition {')[1]
+		?.split('\n}')[0]
+
+	const fields = [...(interfaceBody ?? '').matchAll(/^\t(\w+)\??:/gm)].map(
+		(match) => match[1]
+	)
+
+	const sameHotspotBody = comparison
+		.split('const sameHotspot =')[1]
+		?.split('export const haveHotspotsChanged')[0]
+
+	it('found the type and the comparison to read', () => {
+		// Without this the two splits above could yield nothing and every
+		// assertion below would pass over an empty list.
+		expect(fields.length).toBeGreaterThan(5)
+		expect(sameHotspotBody).toBeTruthy()
+	})
+
+	it.each(
+		// `id` identifies which stored hotspot to compare against and is matched
+		// by `haveHotspotsChanged`; comparing it inside `sameHotspot` could only
+		// ever be true.
+		fields.filter((field) => field !== 'id')
+	)('compares %s', (field) => {
+		expect(sameHotspotBody).toContain(`a.${field}`)
+		expect(sameHotspotBody).toContain(`b.${field}`)
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-comparison.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-comparison.ts
@@ -22,6 +22,8 @@
 interface HotspotLike {
 	id?: string
 	name?: string
+	body?: string | null
+	linkUrl?: string | null
 	worldPosition?: readonly number[]
 	linkedCameraId?: string | null
 	visible?: boolean
@@ -65,6 +67,15 @@ const sameOptional = (
 	b: string | null | undefined
 ): boolean => (a ?? null) === (b ?? null)
 
+/**
+ * Every field is enumerated by hand, which is why a field added to
+ * `HotspotDefinition` and forgotten here leaves Save disabled after an author
+ * edits it - the save button is driven by this comparison. This is the third
+ * hand-maintained enumeration of the hotspot shape, after the draft payload and
+ * `toSceneSettings`, so `scene-hotspot-comparison.spec.ts` reads
+ * `HotspotDefinition` out of the core type and asserts every field name appears
+ * below. Adding a field to the type and not to this function fails that test.
+ */
 const sameHotspot = (a: HotspotLike, b: HotspotLike): boolean =>
 	a.name === b.name &&
 	a.visible === b.visible &&
@@ -74,6 +85,8 @@ const sameHotspot = (a: HotspotLike, b: HotspotLike): boolean =>
 	// authoring panel falls back to.
 	(a.occlusionEnabled ?? true) === (b.occlusionEnabled ?? true) &&
 	(a.sequenceIndex ?? null) === (b.sequenceIndex ?? null) &&
+	sameOptional(a.body, b.body) &&
+	sameOptional(a.linkUrl, b.linkUrl) &&
 	sameOptional(a.linkedCameraId, b.linkedCameraId) &&
 	sameOptional(a.payloadUrl, b.payloadUrl) &&
 	samePosition(a.worldPosition, b.worldPosition)

--- a/apps/vectreal-platform/app/lib/domain/scene/server/hotspot-upsert-wiring.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/hotspot-upsert-wiring.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * A hotspot column has to be named twice in `replaceHotspots`: once in the
+ * `values` list that writes it, and again in `onConflictDoUpdate.set` so a
+ * surviving row takes the new value. Rows that survive a save are updated in
+ * place rather than deleted and reinserted, to keep `createdAt` recording when
+ * the hotspot was authored, so the second list is not optional.
+ *
+ * A column present in the first list and absent from the second writes
+ * correctly on the save that creates the hotspot and silently no-ops on every
+ * save after it. Nothing fails: no type error, no Postgres error, no failing
+ * insert-only test. To the author it looks like an edit that will not stick.
+ *
+ * `tests/integration/scene-hotspots.integration.spec.ts` proves the behaviour
+ * against a real Postgres, but that suite is opt-in and needs a database. This
+ * guard is the half that runs on every unit run, and it reads the source rather
+ * than the module because importing the repository pulls in `getDbClient`,
+ * which throws at module scope without `DATABASE_URL`.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+	join(import.meta.dirname, 'scene-settings-repository.server.ts'),
+	'utf8'
+)
+
+const replaceHotspots = source
+	.split('export async function replaceHotspots')[1]
+	?.split('\nexport ')[0]
+
+const columnsIn = (block: string | undefined): string[] =>
+	[...(block ?? '').matchAll(/^\t+(\w+):/gm)].map((match) => match[1])
+
+const written = columnsIn(
+	replaceHotspots?.split('.values(')[1]?.split('.onConflictDoUpdate(')[0]
+)
+const updated = columnsIn(
+	replaceHotspots?.split('set: {')[1]?.split('.returning(')[0]
+)
+
+describe('the hotspot upsert updates every column it inserts', () => {
+	it('found both column lists to compare', () => {
+		// Without this the splits above could yield nothing and the assertion
+		// below would pass over two empty lists.
+		expect(written.length).toBeGreaterThan(5)
+		expect(updated.length).toBeGreaterThan(5)
+	})
+
+	it.each(
+		written.filter(
+			// `id` is the conflict target and `sceneSettingsId` is the scope the
+			// conflict is resolved within. Writing either from `excluded` would
+			// let one scene's save move another scene's hotspot.
+			(column) => column !== 'id' && column !== 'sceneSettingsId'
+		)
+	)('updates %s on a conflict, not only on insert', (column) => {
+		expect(updated).toContain(column)
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
@@ -1,3 +1,4 @@
+import { MAX_HOTSPOT_BODY_LENGTH } from '../hotspot-urls'
 import { SceneSettingsParser } from './scene-settings.parser.server'
 
 /**
@@ -217,5 +218,76 @@ describe('hotspot ceilings and payload URLs', () => {
 		])
 
 		expect(rejected(result)).toBe(true)
+	})
+
+	// --- body and link -----------------------------------------------------
+
+	it('accepts a hotspot carrying body text and a link', () => {
+		expect(
+			rejected(
+				parse([
+					hotspot({ body: 'Cast in one piece.', linkUrl: 'https://x.test/a' })
+				])
+			)
+		).toBe(false)
+	})
+
+	it('accepts both absent, and both explicitly null', () => {
+		// The panel clears a field to `undefined`; a value mapped off a database
+		// row arrives as null. Treating either as a value would 400 an ordinary
+		// save of a marker that only flies its camera.
+		expect(rejected(parse([hotspot()]))).toBe(false)
+		expect(rejected(parse([hotspot({ body: null, linkUrl: null })]))).toBe(
+			false
+		)
+	})
+
+	it('rejects a non-string body', () => {
+		expect(rejected(parse([hotspot({ body: 42 })]))).toBe(true)
+	})
+
+	it('bounds the body at the shared ceiling', async () => {
+		const withinCap = parse([
+			hotspot({ body: 'a'.repeat(MAX_HOTSPOT_BODY_LENGTH) })
+		])
+		const overCap = parse([
+			hotspot({ body: 'a'.repeat(MAX_HOTSPOT_BODY_LENGTH + 1) })
+		])
+
+		expect(rejected(withinCap)).toBe(false)
+		expect(rejected(overCap)).toBe(true)
+		expect(JSON.stringify(await bodyOf(overCap))).toContain('body')
+	})
+
+	it('rejects a javascript: link', async () => {
+		// This is the field that reaches an `<a href>`, so the scheme rule is the
+		// whole reason it is validated separately from payloadUrl.
+		const result = parse([hotspot({ linkUrl: 'javascript:alert(1)' })])
+
+		expect(rejected(result)).toBe(true)
+		expect(JSON.stringify(await bodyOf(result))).toContain('linkUrl')
+	})
+
+	it('rejects a non-string link', () => {
+		expect(rejected(parse([hotspot({ linkUrl: 42 })]))).toBe(true)
+	})
+
+	it('checks the link on every preset, unlike payloadUrl', () => {
+		// payloadUrl is preset-gated so that rows predating its rule stay
+		// saveable. `link_url` is a new column, so nothing stored can fail this
+		// and there is nothing to grandfather.
+		for (const preset of ['dot', 'image', 'svg']) {
+			expect(
+				rejected(
+					parse([
+						hotspot({
+							stylePreset: preset,
+							payloadUrl: preset === 'dot' ? undefined : 'https://x.test/p.png',
+							linkUrl: 'http://x.test/a'
+						})
+					])
+				)
+			).toBe(true)
+		}
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-repository.server.ts
@@ -174,6 +174,8 @@ export async function getHotspotsBySceneSettingsId(
 	return rows.map((r) => ({
 		id: r.id,
 		name: r.name,
+		body: r.body ?? undefined,
+		linkUrl: r.linkUrl ?? undefined,
 		worldPosition: [r.worldPositionX, r.worldPositionY, r.worldPositionZ] as [
 			number,
 			number,
@@ -218,6 +220,8 @@ export async function replaceHotspots(
 				id: h.id,
 				sceneSettingsId,
 				name: h.name,
+				body: h.body ?? null,
+				linkUrl: h.linkUrl ?? null,
 				worldPositionX: h.worldPosition[0],
 				worldPositionY: h.worldPosition[1],
 				worldPositionZ: h.worldPosition[2],
@@ -240,6 +244,8 @@ export async function replaceHotspots(
 			setWhere: scopedToScene,
 			set: {
 				name: sql`excluded.name`,
+				body: sql`excluded.body`,
+				linkUrl: sql`excluded.link_url`,
 				worldPositionX: sql`excluded.world_position_x`,
 				worldPositionY: sql`excluded.world_position_y`,
 				worldPositionZ: sql`excluded.world_position_z`,

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
@@ -10,7 +10,9 @@ import {
 import { UUID_REGEX } from '../../../../constants/utility-constants'
 import { parseActionRequest } from '../../../http/requests.server'
 import {
+	isAllowedHotspotLinkUrl,
 	isAllowedHotspotPayloadUrl,
+	MAX_HOTSPOT_BODY_LENGTH,
 	MAX_HOTSPOT_URL_LENGTH
 } from '../hotspot-urls'
 import { parseOptimizationReport } from '../optimization-report-guard'
@@ -473,6 +475,32 @@ export class SceneSettingsParser {
 			seenIds.add(hotspot.id)
 			if (typeof hotspot.name !== 'string' || !hotspot.name.trim()) {
 				return ApiResponse.badRequest(`hotspots[${i}].name is required`)
+			}
+			if (hotspot.body !== undefined && hotspot.body !== null) {
+				if (typeof hotspot.body !== 'string') {
+					return ApiResponse.badRequest(`hotspots[${i}].body must be a string`)
+				}
+				if (hotspot.body.length > MAX_HOTSPOT_BODY_LENGTH) {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].body must be at most ${MAX_HOTSPOT_BODY_LENGTH} characters`
+					)
+				}
+			}
+			if (hotspot.linkUrl !== undefined && hotspot.linkUrl !== null) {
+				if (typeof hotspot.linkUrl !== 'string') {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].linkUrl must be a string`
+					)
+				}
+				// Checked for every preset, unlike `payloadUrl`. That field is
+				// gated on the preset because rows predating its rule would
+				// otherwise become unsaveable; `link_url` is a new column, so no
+				// stored value can fail this and there is nothing to grandfather.
+				if (!isAllowedHotspotLinkUrl(hotspot.linkUrl)) {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].linkUrl must be an https URL of at most ${MAX_HOTSPOT_URL_LENGTH} characters`
+					)
+				}
 			}
 			if (
 				!Array.isArray(hotspot.worldPosition) ||

--- a/apps/vectreal-platform/supabase/migrations/0022_polite_harpoon.sql
+++ b/apps/vectreal-platform/supabase/migrations/0022_polite_harpoon.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "scene_hotspots" ADD COLUMN "body" text;--> statement-breakpoint
+ALTER TABLE "scene_hotspots" ADD COLUMN "link_url" text;

--- a/apps/vectreal-platform/supabase/migrations/meta/0022_snapshot.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/0022_snapshot.json
@@ -1,0 +1,4075 @@
+{
+  "id": "1909e182-f73b-46e4-b13a-0f5ab6011164",
+  "prevId": "90fa1a55-bf38-4d3a-92cd-2bbf0f714368",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "users_select_self": {
+          "name": "users_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_insert_self": {
+          "name": "users_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_update_self": {
+          "name": "users_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())",
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference_code": {
+          "name": "reference_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "is_authenticated": {
+          "name": "is_authenticated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inquiry_type": {
+          "name": "inquiry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "failure_stage": {
+          "name": "failure_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "internal_message_id": {
+          "name": "internal_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_message_id": {
+          "name": "confirmation_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_users_id_fk": {
+          "name": "contact_submissions_user_id_users_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_submissions_reference_code_unique": {
+          "name": "contact_submissions_reference_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_owner_id_idx": {
+          "name": "organizations_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_id_users_id_fk": {
+          "name": "organizations_owner_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "organizations_select_member": {
+          "name": "organizations_select_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_insert_owner": {
+          "name": "organizations_insert_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"organizations\".\"owner_id\" = (select auth.uid())"
+        },
+        "organizations_update_owner": {
+          "name": "organizations_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_delete_owner": {
+          "name": "organizations_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_memberships_user_id_idx": {
+          "name": "organization_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_organization_id_idx": {
+          "name": "organization_memberships_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_invited_by_idx": {
+          "name": "organization_memberships_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_memberships_select_org_member": {
+          "name": "org_memberships_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_insert_org_admin": {
+          "name": "org_memberships_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_update_org_admin": {
+          "name": "org_memberships_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_delete_org_admin_or_self": {
+          "name": "org_memberships_delete_org_admin_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\n\t\t\t\t\texists (\n\t\t\t\t\t\tselect 1\n\t\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t\t)\n\t\t\t\t\tor \"organization_memberships\".\"user_id\" = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_embed_domains": {
+          "name": "allowed_embed_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "projects_select_org_member": {
+          "name": "projects_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "projects_insert_org_admin": {
+          "name": "projects_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"projects\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_update_org_admin": {
+          "name": "projects_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_delete_org_admin": {
+          "name": "projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_folders": {
+      "name": "scene_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_folders_project_id_idx": {
+          "name": "scene_folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_owner_id_idx": {
+          "name": "scene_folders_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_parent_folder_id_idx": {
+          "name": "scene_folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_folders_project_id_projects_id_fk": {
+          "name": "scene_folders_project_id_projects_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_owner_id_users_id_fk": {
+          "name": "scene_folders_owner_id_users_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_parent_folder_id_scene_folders_id_fk": {
+          "name": "scene_folders_parent_folder_id_scene_folders_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_folders_select_project_member": {
+          "name": "scene_folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_folders_insert_project_member_self_owner": {
+          "name": "scene_folders_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scene_folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_update_owner_or_admin": {
+          "name": "scene_folders_update_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_delete_owner_or_admin": {
+          "name": "scene_folders_delete_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {
+        "scene_folders_parent_not_self": {
+          "name": "scene_folders_parent_not_self",
+          "value": "\"scene_folders\".\"parent_folder_id\" is null or \"scene_folders\".\"parent_folder_id\" <> \"scene_folders\".\"id\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "folders_project_id_idx": {
+          "name": "folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "folders_parent_folder_id_idx": {
+          "name": "folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_project_id_projects_id_fk": {
+          "name": "folders_project_id_projects_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folders_parent_folder_id_folders_id_fk": {
+          "name": "folders_parent_folder_id_folders_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "folders_select_project_member": {
+          "name": "folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "folders_insert_project_admin": {
+          "name": "folders_insert_project_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_update_project_admin": {
+          "name": "folders_update_project_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_delete_project_admin": {
+          "name": "folders_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_folder_id_idx": {
+          "name": "assets_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_owner_id_idx": {
+          "name": "assets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_folder_id_folders_id_fk": {
+          "name": "assets_folder_id_folders_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_owner_id_users_id_fk": {
+          "name": "assets_owner_id_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "assets_select_project_member": {
+          "name": "assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "assets_insert_project_member_self_owner": {
+          "name": "assets_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"assets\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_update_project_member_owner": {
+          "name": "assets_update_project_member_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_delete_project_admin": {
+          "name": "assets_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scenes": {
+      "name": "scenes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scenes_project_id_idx": {
+          "name": "scenes_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_folder_id_idx": {
+          "name": "scenes_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scenes_project_id_projects_id_fk": {
+          "name": "scenes_project_id_projects_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scenes_folder_id_scene_folders_id_fk": {
+          "name": "scenes_folder_id_scene_folders_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scenes_select_project_member": {
+          "name": "scenes_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scenes_insert_project_member": {
+          "name": "scenes_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scenes\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_update_project_member": {
+          "name": "scenes_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_delete_project_admin": {
+          "name": "scenes_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_settings": {
+      "name": "scene_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera": {
+          "name": "camera",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controls": {
+          "name": "controls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactions": {
+          "name": "interactions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shadows": {
+          "name": "shadows",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalization": {
+          "name": "normalization",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_settings_created_by_idx": {
+          "name": "scene_settings_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_settings_scene_id_scenes_id_fk": {
+          "name": "scene_settings_scene_id_scenes_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_settings_created_by_users_id_fk": {
+          "name": "scene_settings_created_by_users_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_settings_scene_id_unique": {
+          "name": "scene_settings_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_settings_select_project_member": {
+          "name": "scene_settings_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_insert_project_member_self_creator": {
+          "name": "scene_settings_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_settings\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_settings_update_project_member": {
+          "name": "scene_settings_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_delete_project_admin": {
+          "name": "scene_settings_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_hotspots": {
+      "name": "scene_hotspots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "world_position_x": {
+          "name": "world_position_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_y": {
+          "name": "world_position_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_z": {
+          "name": "world_position_z",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_camera_id": {
+          "name": "linked_camera_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "internal_only": {
+          "name": "internal_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occlusion_enabled": {
+          "name": "occlusion_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_preset": {
+          "name": "style_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dot'"
+        },
+        "payload_url": {
+          "name": "payload_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_hotspots_scene_settings_id_idx": {
+          "name": "scene_hotspots_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_hotspots_sequence_index_idx": {
+          "name": "scene_hotspots_sequence_index_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_hotspots_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_hotspots_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_hotspots",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_hotspots_select_project_member": {
+          "name": "scene_hotspots_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_insert_project_member": {
+          "name": "scene_hotspots_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_update_project_member": {
+          "name": "scene_hotspots_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_delete_project_admin": {
+          "name": "scene_hotspots_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_stats": {
+      "name": "scene_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized": {
+          "name": "optimized",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_scene_bytes": {
+          "name": "initial_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_scene_bytes": {
+          "name": "current_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_optimizations": {
+          "name": "applied_optimizations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimization_settings": {
+          "name": "optimization_settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_metrics": {
+          "name": "additional_metrics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_stats_created_by_idx": {
+          "name": "scene_stats_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_stats_scene_id_scenes_id_fk": {
+          "name": "scene_stats_scene_id_scenes_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_stats_created_by_users_id_fk": {
+          "name": "scene_stats_created_by_users_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_stats_scene_id_unique": {
+          "name": "scene_stats_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_stats_select_project_member": {
+          "name": "scene_stats_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_insert_project_member_self_creator": {
+          "name": "scene_stats_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_stats\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_stats_update_project_member": {
+          "name": "scene_stats_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_delete_project_admin": {
+          "name": "scene_stats_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_assets": {
+      "name": "scene_assets",
+      "schema": "",
+      "columns": {
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_assets_scene_settings_id_idx": {
+          "name": "scene_assets_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_assets_asset_id_idx": {
+          "name": "scene_assets_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_assets_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_assets_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_assets_asset_id_assets_id_fk": {
+          "name": "scene_assets_asset_id_assets_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scene_assets_scene_settings_id_asset_id_pk": {
+          "name": "scene_assets_scene_settings_id_asset_id_pk",
+          "columns": [
+            "scene_settings_id",
+            "asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_assets_select_project_member": {
+          "name": "scene_assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_insert_project_member": {
+          "name": "scene_assets_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"scene_assets\".\"asset_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_delete_project_member": {
+          "name": "scene_assets_delete_project_member",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_published": {
+      "name": "scene_published",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_published_asset_id_idx": {
+          "name": "scene_published_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_scene_settings_id_idx": {
+          "name": "scene_published_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_published_by_idx": {
+          "name": "scene_published_published_by_idx",
+          "columns": [
+            {
+              "expression": "published_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_published_scene_id_scenes_id_fk": {
+          "name": "scene_published_scene_id_scenes_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_asset_id_assets_id_fk": {
+          "name": "scene_published_asset_id_assets_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_published_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scene_published_published_by_users_id_fk": {
+          "name": "scene_published_published_by_users_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_published_select_project_member": {
+          "name": "scene_published_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_insert_project_member_self_publisher": {
+          "name": "scene_published_insert_project_member_self_publisher",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand \"scene_published\".\"published_by\" = (select auth.uid())\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom assets a\n\t\t\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\t\t\tjoin projects p on p.id = f.project_id\n\t\t\t\t\tjoin scenes s on s.project_id = p.id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\t\t\tand a.id = \"scene_published\".\"asset_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_published_update_project_member": {
+          "name": "scene_published_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_delete_project_admin": {
+          "name": "scene_published_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_requests": {
+      "name": "scene_action_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_action_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_requests_status_idx": {
+          "name": "scene_action_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_scene_id_idx": {
+          "name": "scene_action_requests_scene_id_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_expires_at_idx": {
+          "name": "scene_action_requests_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_action_requests_request_key_unique": {
+          "name": "scene_action_requests_request_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_locks": {
+      "name": "scene_action_locks",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_key": {
+          "name": "holder_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_locks_expires_at_idx": {
+          "name": "scene_action_locks_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_runtime_limits": {
+      "name": "scene_runtime_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "in_flight": {
+          "name": "in_flight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_id_idx": {
+          "name": "group_memberships_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "group_memberships_select_owner_or_member": {
+          "name": "group_memberships_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"group_memberships\".\"group_id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_insert_owner_or_self_join": {
+          "name": "group_memberships_insert_owner_or_self_join",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        },
+        "group_memberships_update_owner": {
+          "name": "group_memberships_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_delete_owner_or_self": {
+          "name": "group_memberships_delete_owner_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_id_idx": {
+          "name": "groups_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "groups_select_owner_or_member": {
+          "name": "groups_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid()) or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"groups\".\"id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "groups_insert_self_owner": {
+          "name": "groups_insert_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_update_owner": {
+          "name": "groups_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_delete_owner": {
+          "name": "groups_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "api_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'embed'"
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_preview": {
+          "name": "key_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_organization_id_idx": {
+          "name": "api_keys_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_organization_id_organizations_id_fk": {
+          "name": "api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "api_keys_select_org_admin": {
+          "name": "api_keys_select_org_admin",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_insert_org_admin": {
+          "name": "api_keys_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_update_org_admin": {
+          "name": "api_keys_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_delete_org_admin": {
+          "name": "api_keys_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_key_projects": {
+      "name": "api_key_projects",
+      "schema": "",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_projects_api_key_id_idx": {
+          "name": "api_key_projects_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_projects_project_id_idx": {
+          "name": "api_key_projects_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_projects_api_key_id_api_keys_id_fk": {
+          "name": "api_key_projects_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_projects_project_id_projects_id_fk": {
+          "name": "api_key_projects_project_id_projects_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_key_projects_api_key_id_project_id_pk": {
+          "name": "api_key_projects_api_key_id_project_id_pk",
+          "columns": [
+            "api_key_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "api_key_projects_select_org_admin_and_project_member": {
+          "name": "api_key_projects_select_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_insert_org_admin_and_project_member": {
+          "name": "api_key_projects_insert_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_delete_org_admin": {
+          "name": "api_key_projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "billing_state": {
+          "name": "billing_state",
+          "type": "billing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_stripe_subscription_id_idx": {
+          "name": "org_subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_customer_id_idx": {
+          "name": "org_subscriptions_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_billing_state_idx": {
+          "name": "org_subscriptions_billing_state_idx",
+          "columns": [
+            {
+              "expression": "billing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_subscriptions_organization_id_unique": {
+          "name": "org_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {
+        "org_subscriptions_select_org_member": {
+          "name": "org_subscriptions_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_subscriptions_insert_org_admin": {
+          "name": "org_subscriptions_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_update_org_admin": {
+          "name": "org_subscriptions_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_delete_org_admin": {
+          "name": "org_subscriptions_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_limit_overrides": {
+      "name": "org_limit_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_key": {
+          "name": "limit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_limit_overrides_org_key_uidx": {
+          "name": "org_limit_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "limit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_limit_overrides_organization_id_organizations_id_fk": {
+          "name": "org_limit_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_limit_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_limit_overrides_select_org_member": {
+          "name": "org_limit_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_limit_overrides_insert_org_admin": {
+          "name": "org_limit_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_update_org_admin": {
+          "name": "org_limit_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_delete_org_admin": {
+          "name": "org_limit_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_entitlement_overrides": {
+      "name": "org_entitlement_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_key": {
+          "name": "entitlement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_entitlement_overrides_org_key_uidx": {
+          "name": "org_entitlement_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_entitlement_overrides_organization_id_organizations_id_fk": {
+          "name": "org_entitlement_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_entitlement_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_entitlement_overrides_select_org_member": {
+          "name": "org_entitlement_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_insert_org_admin": {
+          "name": "org_entitlement_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_update_org_admin": {
+          "name": "org_entitlement_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_delete_org_admin": {
+          "name": "org_entitlement_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_usage_counters": {
+      "name": "org_usage_counters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter_key": {
+          "name": "counter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_usage_counters_org_key_window_uidx": {
+          "name": "org_usage_counters_org_key_window_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_usage_counters_window_end_idx": {
+          "name": "org_usage_counters_window_end_idx",
+          "columns": [
+            {
+              "expression": "window_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_usage_counters_organization_id_organizations_id_fk": {
+          "name": "org_usage_counters_organization_id_organizations_id_fk",
+          "tableFrom": "org_usage_counters",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_usage_counters_select_org_member": {
+          "name": "org_usage_counters_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_usage_counters_insert_org_admin": {
+          "name": "org_usage_counters_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_update_org_admin": {
+          "name": "org_usage_counters_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_delete_org_admin": {
+          "name": "org_usage_counters_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.billing_webhook_events": {
+      "name": "billing_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_webhook_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_webhook_events_provider_event_id_uidx": {
+          "name": "billing_webhook_events_provider_event_id_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_status_idx": {
+          "name": "billing_webhook_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_created_at_idx": {
+          "name": "billing_webhook_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.consent_records": {
+      "name": "consent_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "necessary": {
+          "name": "necessary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "functional": {
+          "name": "functional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_country": {
+          "name": "ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "consent_records_user_id_users_id_fk": {
+          "name": "consent_records_user_id_users_id_fk",
+          "tableFrom": "consent_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_records_user_id_unique": {
+          "name": "consent_records_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "consent_records_anonymous_id_unique": {
+          "name": "consent_records_anonymous_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anonymous_id"
+          ]
+        }
+      },
+      "policies": {
+        "consent_records_select_self": {
+          "name": "consent_records_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_insert_self": {
+          "name": "consent_records_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_update_self": {
+          "name": "consent_records_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())",
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.contact_submission_status": {
+      "name": "contact_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.membership_role": {
+      "name": "membership_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "texture",
+        "material",
+        "model",
+        "environment",
+        "other"
+      ]
+    },
+    "public.scene_status": {
+      "name": "scene_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.scene_action_request_status": {
+      "name": "scene_action_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.api_key_kind": {
+      "name": "api_key_kind",
+      "schema": "public",
+      "values": [
+        "embed"
+      ]
+    },
+    "public.billing_state": {
+      "name": "billing_state",
+      "schema": "public",
+      "values": [
+        "none",
+        "trialing",
+        "active",
+        "past_due",
+        "unpaid",
+        "canceled",
+        "paused",
+        "incomplete",
+        "incomplete_expired"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "business",
+        "enterprise"
+      ]
+    },
+    "public.billing_webhook_event_status": {
+      "name": "billing_webhook_event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/vectreal-platform/supabase/migrations/meta/_journal.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1788368674707,
       "tag": "0021_youthful_rawhide_kid",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1788523065966,
+      "tag": "0022_polite_harpoon",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/vectreal-platform/tests/integration/scene-hotspots.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/scene-hotspots.integration.spec.ts
@@ -153,6 +153,8 @@ describe('hotspot persistence', () => {
 			sequenceIndex: 0,
 			stylePreset: 'svg',
 			payloadUrl: 'https://example.test/marker.svg',
+			body: 'Cast in one piece, then machined flat.',
+			linkUrl: 'https://example.test/spec',
 			occlusionEnabled: false,
 			internalOnly: true,
 			visible: false
@@ -167,6 +169,57 @@ describe('hotspot persistence', () => {
 		)
 
 		expect(read).toEqual(written)
+	})
+
+	/**
+	 * The update half of the upsert, which the insert-only test above cannot
+	 * reach. A surviving hotspot is updated in place rather than deleted and
+	 * reinserted, so every column has to be named twice: once in `values` and
+	 * again in `onConflictDoUpdate.set`. A column missing from the second list
+	 * writes correctly on the save that creates the hotspot and silently
+	 * no-ops on every save after it, which reads to an author as an edit that
+	 * will not stick.
+	 */
+	it('updates a hotspot\u2019s content in place on a second save', async () => {
+		const id = randomUUID()
+
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [
+				hotspot({ id, body: 'First draft.', linkUrl: 'https://a.test/one' })
+			])
+		)
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [
+				hotspot({ id, body: 'Second draft.', linkUrl: 'https://a.test/two' })
+			])
+		)
+
+		const [read] = await db.transaction((tx) =>
+			getHotspotsBySceneSettingsId(tx, sceneSettingsId)
+		)
+
+		expect(read.body).toBe('Second draft.')
+		expect(read.linkUrl).toBe('https://a.test/two')
+	})
+
+	it('clears a hotspot\u2019s content when the author empties both fields', async () => {
+		const id = randomUUID()
+
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [
+				hotspot({ id, body: 'Said something.', linkUrl: 'https://a.test/one' })
+			])
+		)
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [hotspot({ id })])
+		)
+
+		const [read] = await db.transaction((tx) =>
+			getHotspotsBySceneSettingsId(tx, sceneSettingsId)
+		)
+
+		expect(read.body).toBeUndefined()
+		expect(read.linkUrl).toBeUndefined()
 	})
 
 	// The whole reason this file exists.

--- a/packages/core/src/types/scene-types.ts
+++ b/packages/core/src/types/scene-types.ts
@@ -341,6 +341,18 @@ export type HotspotStylePreset = 'dot' | 'image' | 'svg'
 export interface HotspotDefinition {
 	id: string
 	name: string
+	/**
+	 * Plain text shown when the hotspot is revealed. Plain, not markup: it is
+	 * rendered by a package that runs inside third-party pages, so there is
+	 * nothing here to sanitize on the render side.
+	 */
+	body?: string
+	/**
+	 * Optional destination for the revealed hotspot. `https:` only, and shown
+	 * with its own host as the visible text so a label cannot go stale against
+	 * where it points.
+	 */
+	linkUrl?: string
 	/** World-space 3D position [x, y, z]. */
 	worldPosition: [number, number, number]
 	/**


### PR DESCRIPTION
## Root cause

`HotspotDefinition` had nowhere to hold content — a `name` and rendering metadata and nothing else — so the only thing a hotspot could do was fly a linked camera. The gap belongs in the type and the persistence chain that defines what a hotspot *is* (schema, parser, repository, dirty-check), not in the viewer where the absence merely shows.

## What this adds

`body?: string` and `linkUrl?: string` on `HotspotDefinition`, `body text` and `link_url text` on `scene_hotspots` (migration `0022_polite_harpoon.sql`, generated).

**Two columns, not three.** The popover heads with the existing `name`, so the hover label, the accessible name and the popover heading cannot drift apart, and there is no second field to validate.

**`linkUrl` gets its own rule** rather than reusing `isAllowedHotspotPayloadUrl`. A payload URL reaches an `<img src>`, where `javascript:` is inert and an inline `data:` image is the point. A link URL reaches an `<a href>`, where `javascript:` executes and `data:text/html` navigates to attacker markup. So `isAllowedHotspotLinkUrl` is an allowlist of one scheme, sharing the existing length cap.

It is also checked on **every** style preset, unlike `payloadUrl`. That field is preset-gated so rows written before its rule stay saveable; `link_url` is a new column, so nothing stored can fail this and there is nothing to grandfather.

**The comparator had to learn both fields** or Save would stay disabled after a body edit — `haveHotspotsChanged` is what drives the save button.

## Two guards against the same class of defect

`sameHotspot` is the third hand-maintained enumeration of the hotspot shape, after the draft payload and `toSceneSettings`. Both of the others dropped a field silently before anyone noticed, so rather than patch this one a third time, `scene-hotspot-comparison.spec.ts` now reads `HotspotDefinition` out of the core type and requires every field to appear in the comparison.

`hotspot-upsert-wiring.spec.ts` covers the same shape one layer down. A column is named twice in `replaceHotspots` — once to insert it, once in `onConflictDoUpdate.set` — and a column missing from the second list writes on the save that creates the hotspot and silently no-ops on every save after it. To an author that reads as an edit that will not stick. The integration suite proves it against a real Postgres, but it is opt-in, so the source guard is the half that runs on every unit run.

## Mutations run

| Mutation | Result |
| --- | --- |
| Drop `linkUrl: sql\`excluded.link_url\`` from the upsert's `set` block | `hotspot-upsert-wiring` 1 failed |
| Drop `sameOptional(a.body, b.body)` from `sameHotspot` | `scene-hotspot-comparison` 2 failed |
| Replace the parser's `isAllowedHotspotLinkUrl` check with `false` | parser spec 2 failed |
| Widen the link rule to accept whatever the payload rule accepts | `hotspot-urls` 1 failed |

## Verification

- `npx vitest run --root .` — 154 files, 1997 tests, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — 8/8 tasks green

**Not verified locally:** the integration suite. The local Supabase data volume predates an OS collation bump, so the storage container never becomes healthy and `supabase-start` exits 0 without a database. The two new update-in-place cases run in CI against its own Postgres, and `hotspot-upsert-wiring.spec.ts` is the unit-runnable stand-in for the same defect.

## Not in this PR

Nothing new filed. The publisher fields, the viewer popover, the embed protocol and the docs follow in their own PRs; the fields are unreachable from any UI until then.