### PR TITLE
feat(publisher): author a hotspot's body and link

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
@@ -15,6 +15,7 @@ import { getDefaultStore } from 'jotai'
 import { describe, expect, it, beforeEach } from 'vitest'
 
 import HotspotsSettingsPanel from './hotspots-settings-panel'
+import { MAX_HOTSPOT_BODY_LENGTH } from '../../../../lib/domain/scene/hotspot-urls'
 import { isClickToPlaceActiveAtom } from '../../../../lib/stores/publisher-config-store'
 import {
 	activeHotspotIdAtom,
@@ -328,6 +329,103 @@ describe('HotspotsSettingsPanel selection', () => {
 		rerender(<HotspotsSettingsPanel />)
 
 		expect(screen.getByLabelText('Asset URL')).toBeTruthy()
+	})
+})
+
+describe('HotspotsSettingsPanel content', () => {
+	const openEditor = () => {
+		store.set(hotspotsAtom, [hotspot])
+		store.set(activeHotspotIdAtom, hotspot.id)
+		render(<HotspotsSettingsPanel />)
+	}
+
+	const stored = () => store.get(hotspotsAtom)[0]
+
+	it('writes body text onto the marker being edited', () => {
+		openEditor()
+
+		fireEvent.change(screen.getByLabelText('Marker body'), {
+			target: { value: 'Cast in one piece.' }
+		})
+
+		expect(stored().body).toBe('Cast in one piece.')
+	})
+
+	/**
+	 * Clearing has to leave the field unset, not empty.
+	 *
+	 * An empty string is a different value from an absent one everywhere it
+	 * lands: the dirty-check folds absent and null together and deliberately
+	 * does not fold in the empty string, so a cleared body stored as `''`
+	 * against a null column would report the scene changed on every load and
+	 * offer a save that changes nothing.
+	 */
+	it('leaves the field unset when the author clears it', () => {
+		store.set(hotspotsAtom, [
+			{ ...hotspot, body: 'Said something.', linkUrl: 'https://a.test' }
+		])
+		store.set(activeHotspotIdAtom, hotspot.id)
+		render(<HotspotsSettingsPanel />)
+
+		fireEvent.change(screen.getByLabelText('Marker body'), {
+			target: { value: '' }
+		})
+		fireEvent.change(screen.getByLabelText('Marker link'), {
+			target: { value: '' }
+		})
+
+		expect(stored().body).toBeUndefined()
+		expect(stored().linkUrl).toBeUndefined()
+	})
+
+	it('caps the body at the length the save parser will accept', () => {
+		openEditor()
+
+		expect(screen.getByLabelText('Marker body').getAttribute('maxlength')).toBe(
+			String(MAX_HOTSPOT_BODY_LENGTH)
+		)
+	})
+
+	/**
+	 * The save answers a bad link by refusing the whole scene with a message
+	 * naming an array index, which names neither the marker nor the field. So
+	 * the panel has to say it where the field is.
+	 */
+	it('marks a link the save would refuse', () => {
+		openEditor()
+		const field = screen.getByLabelText('Marker link')
+
+		fireEvent.change(field, { target: { value: 'http://a.test' } })
+
+		expect(field.getAttribute('aria-invalid')).toBe('true')
+		expect(screen.getByText(/must start with https/i)).toBeTruthy()
+		// Named by the field, so a screen reader reaches it from the input.
+		expect(field.getAttribute('aria-describedby')).toBe(
+			screen.getByText(/must start with https/i).getAttribute('id')
+		)
+	})
+
+	it('says nothing about an https link, or about no link at all', () => {
+		openEditor()
+		const field = screen.getByLabelText('Marker link')
+
+		expect(screen.queryByText(/must start with https/i)).toBeNull()
+
+		fireEvent.change(field, { target: { value: 'https://a.test/spec' } })
+
+		expect(field.getAttribute('aria-invalid')).toBeNull()
+		expect(screen.queryByText(/must start with https/i)).toBeNull()
+	})
+
+	it('stops complaining once the link is cleared again', () => {
+		openEditor()
+		const field = screen.getByLabelText('Marker link')
+
+		fireEvent.change(field, { target: { value: 'javascript:alert(1)' } })
+		expect(screen.getByText(/must start with https/i)).toBeTruthy()
+
+		fireEvent.change(field, { target: { value: '' } })
+		expect(screen.queryByText(/must start with https/i)).toBeNull()
 	})
 })
 

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -21,6 +21,7 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@shared/components/ui/select'
+import { Textarea } from '@shared/components/ui/textarea'
 import { cn } from '@shared/utils'
 import { resolveHotspotMarkers } from '@vctrl/viewer/hotspots'
 import {
@@ -44,6 +45,10 @@ import {
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { applyHotspotPlacement } from '../../../../lib/domain/scene/client/apply-hotspot-placement'
+import {
+	isAllowedHotspotLinkUrl,
+	MAX_HOTSPOT_BODY_LENGTH
+} from '../../../../lib/domain/scene/hotspot-urls'
 import {
 	PAIRED_HOTSPOT_CAMERA_ID_PREFIX,
 	resolveDefaultSceneCameraId
@@ -786,152 +791,209 @@ const HotspotsSettingsPanel = memo(() => {
 	)
 
 	const renderEditor = useCallback(
-		(hotspot: HotspotDefinition) => (
-			<>
-				<InlineNotice tone={isClickToPlaceActive ? 'warning' : 'neutral'}>
-					{isClickToPlaceActive
-						? 'Click anywhere on the model to move this marker there.'
-						: 'Drag the marker in the scene, or place it from here.'}
-				</InlineNotice>
+		(hotspot: HotspotDefinition) => {
+			const linkErrorId = `hotspot-link-error-${hotspot.id}`
+			// An empty field is not an invalid one: clearing the link is how an
+			// author removes it.
+			const linkIsInvalid =
+				!!hotspot.linkUrl && !isAllowedHotspotLinkUrl(hotspot.linkUrl)
 
-				<Button
-					variant={isClickToPlaceActive ? 'secondary' : 'outline'}
-					size="sm"
-					aria-pressed={isClickToPlaceActive}
-					onClick={() => setIsClickToPlaceActive((active) => !active)}
-					className="publisher-shell-focus w-full gap-1.5"
-				>
-					<Crosshair
-						aria-hidden
-						className={cn(
-							'size-3.5',
-							isClickToPlaceActive && 'animate-pulse motion-reduce:animate-none'
-						)}
-					/>
-					{isClickToPlaceActive ? 'Click the model…' : 'Place on model'}
-				</Button>
+			return (
+				<>
+					<InlineNotice tone={isClickToPlaceActive ? 'warning' : 'neutral'}>
+						{isClickToPlaceActive
+							? 'Click anywhere on the model to move this marker there.'
+							: 'Drag the marker in the scene, or place it from here.'}
+					</InlineNotice>
 
-				<SettingGroup label="Position">
-					<div className="grid grid-cols-3 gap-1.5">
-						{AXES.map((axis, index) => (
-							<AxisField
-								key={axis}
-								axis={axis}
-								value={hotspot.worldPosition[index]}
-								onChange={(raw) =>
-									handlePositionChange(hotspot, index as 0 | 1 | 2, raw)
-								}
-							/>
-						))}
-					</div>
-				</SettingGroup>
-
-				<SettingGroup label="Name">
-					<Input
-						aria-label="Marker name"
-						value={hotspot.name}
-						onChange={(event) => handleRename(hotspot.id, event.target.value)}
-						placeholder="Hotspot name"
-						className="text-sm"
-					/>
-				</SettingGroup>
-
-				<SettingGroup label="Style">
-					<ToggleButtonGroup
-						options={STYLE_PRESET_OPTIONS}
-						value={hotspot.stylePreset}
-						onChange={(preset) =>
-							updateHotspot(hotspot.id, { stylePreset: preset })
-						}
-					/>
-				</SettingGroup>
-
-				<AnimatePresence initial={false}>
-					{hotspot.stylePreset !== 'dot' && (
-						<motion.div
-							key="payload-url"
-							initial={{ height: 0, opacity: 0 }}
-							animate={{ height: 'auto', opacity: 1 }}
-							exit={{ height: 0, opacity: 0 }}
-							transition={{ duration: reduceMotion ? 0 : 0.15 }}
-							className="overflow-hidden"
-						>
-							<SettingGroup label="Asset URL">
-								<Input
-									aria-label="Asset URL"
-									value={hotspot.payloadUrl ?? ''}
-									onChange={(event) =>
-										updateHotspot(hotspot.id, {
-											payloadUrl: event.target.value || undefined
-										})
-									}
-									placeholder="https://…"
-									className="text-sm"
-								/>
-							</SettingGroup>
-						</motion.div>
-					)}
-				</AnimatePresence>
-
-				<SettingGroup
-					label="Linked camera"
-					description="Viewers transition to this camera when they click the marker."
-				>
-					<Select
-						value={hotspot.linkedCameraId ?? 'none'}
-						onValueChange={(value) =>
-							handleRelink(hotspot.id, value === 'none' ? undefined : value)
-						}
+					<Button
+						variant={isClickToPlaceActive ? 'secondary' : 'outline'}
+						size="sm"
+						aria-pressed={isClickToPlaceActive}
+						onClick={() => setIsClickToPlaceActive((active) => !active)}
+						className="publisher-shell-focus w-full gap-1.5"
 					>
-						<SelectTrigger aria-label="Linked camera" className="w-full">
-							<SelectValue placeholder="None" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="none">None</SelectItem>
-							{allCameras.map((entry) => (
-								<SelectItem key={entry.cameraId} value={entry.cameraId}>
-									{entry.name || entry.cameraId}
-								</SelectItem>
+						<Crosshair
+							aria-hidden
+							className={cn(
+								'size-3.5',
+								isClickToPlaceActive &&
+									'animate-pulse motion-reduce:animate-none'
+							)}
+						/>
+						{isClickToPlaceActive ? 'Click the model…' : 'Place on model'}
+					</Button>
+
+					<SettingGroup label="Position">
+						<div className="grid grid-cols-3 gap-1.5">
+							{AXES.map((axis, index) => (
+								<AxisField
+									key={axis}
+									axis={axis}
+									value={hotspot.worldPosition[index]}
+									onChange={(raw) =>
+										handlePositionChange(hotspot, index as 0 | 1 | 2, raw)
+									}
+								/>
 							))}
-						</SelectContent>
-					</Select>
-				</SettingGroup>
+						</div>
+					</SettingGroup>
 
-				<SettingToggle
-					enabled={hotspot.sequenceIndex !== undefined}
-					onToggle={(enabled) => handleMembershipChange(hotspot.id, enabled)}
-					title="In the sequence"
-					description="Include this marker in the order viewers step through."
-				/>
+					<SettingGroup label="Name">
+						<Input
+							aria-label="Marker name"
+							value={hotspot.name}
+							onChange={(event) => handleRename(hotspot.id, event.target.value)}
+							placeholder="Hotspot name"
+							className="text-sm"
+						/>
+					</SettingGroup>
 
-				<SettingToggle
-					enabled={hotspot.visible}
-					onToggle={(enabled) =>
-						updateHotspot(hotspot.id, { visible: enabled })
-					}
-					title="Visible to viewers"
-					description="Show this marker in the published scene."
-				/>
+					<SettingGroup
+						label="Body"
+						description="Shown when a visitor opens the marker."
+					>
+						<Textarea
+							aria-label="Marker body"
+							value={hotspot.body ?? ''}
+							onChange={(event) =>
+								updateHotspot(hotspot.id, {
+									body: event.target.value || undefined
+								})
+							}
+							// The save parser refuses a longer body, and a refusal there
+							// fails the whole scene with a message naming an array index.
+							// The field is the only place an author sees the limit at the
+							// moment it applies.
+							maxLength={MAX_HOTSPOT_BODY_LENGTH}
+							placeholder="What is a visitor looking at?"
+							className="min-h-20 text-sm"
+						/>
+					</SettingGroup>
 
-				<SettingToggle
-					enabled={hotspot.internalOnly}
-					onToggle={(enabled) =>
-						updateHotspot(hotspot.id, { internalOnly: enabled })
-					}
-					title="Editor only"
-					description="Keep the marker in the publisher and leave it out of the embed."
-				/>
+					<SettingGroup label="Link">
+						<Input
+							aria-label="Marker link"
+							type="url"
+							value={hotspot.linkUrl ?? ''}
+							onChange={(event) =>
+								updateHotspot(hotspot.id, {
+									linkUrl: event.target.value || undefined
+								})
+							}
+							aria-invalid={linkIsInvalid || undefined}
+							aria-describedby={linkIsInvalid ? linkErrorId : undefined}
+							placeholder="https://…"
+							className="text-sm"
+						/>
+						{linkIsInvalid && (
+							// Said beside the field rather than left to the save, which
+							// answers a bad link by refusing the entire scene with a
+							// message naming an array index - neither the marker nor the
+							// field the author is looking at.
+							<p id={linkErrorId} className="text-destructive text-xs">
+								Links must start with https://
+							</p>
+						)}
+					</SettingGroup>
 
-				<SettingToggle
-					enabled={hotspot.occlusionEnabled ?? true}
-					onToggle={(enabled) =>
-						updateHotspot(hotspot.id, { occlusionEnabled: enabled })
-					}
-					title="Hide behind geometry"
-					description="Fade the marker when part of the model is in front of it."
-				/>
-			</>
-		),
+					<SettingGroup label="Style">
+						<ToggleButtonGroup
+							options={STYLE_PRESET_OPTIONS}
+							value={hotspot.stylePreset}
+							onChange={(preset) =>
+								updateHotspot(hotspot.id, { stylePreset: preset })
+							}
+						/>
+					</SettingGroup>
+
+					<AnimatePresence initial={false}>
+						{hotspot.stylePreset !== 'dot' && (
+							<motion.div
+								key="payload-url"
+								initial={{ height: 0, opacity: 0 }}
+								animate={{ height: 'auto', opacity: 1 }}
+								exit={{ height: 0, opacity: 0 }}
+								transition={{ duration: reduceMotion ? 0 : 0.15 }}
+								className="overflow-hidden"
+							>
+								<SettingGroup label="Asset URL">
+									<Input
+										aria-label="Asset URL"
+										value={hotspot.payloadUrl ?? ''}
+										onChange={(event) =>
+											updateHotspot(hotspot.id, {
+												payloadUrl: event.target.value || undefined
+											})
+										}
+										placeholder="https://…"
+										className="text-sm"
+									/>
+								</SettingGroup>
+							</motion.div>
+						)}
+					</AnimatePresence>
+
+					<SettingGroup
+						label="Linked camera"
+						description="Viewers transition to this camera when they click the marker."
+					>
+						<Select
+							value={hotspot.linkedCameraId ?? 'none'}
+							onValueChange={(value) =>
+								handleRelink(hotspot.id, value === 'none' ? undefined : value)
+							}
+						>
+							<SelectTrigger aria-label="Linked camera" className="w-full">
+								<SelectValue placeholder="None" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="none">None</SelectItem>
+								{allCameras.map((entry) => (
+									<SelectItem key={entry.cameraId} value={entry.cameraId}>
+										{entry.name || entry.cameraId}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</SettingGroup>
+
+					<SettingToggle
+						enabled={hotspot.sequenceIndex !== undefined}
+						onToggle={(enabled) => handleMembershipChange(hotspot.id, enabled)}
+						title="In the sequence"
+						description="Include this marker in the order viewers step through."
+					/>
+
+					<SettingToggle
+						enabled={hotspot.visible}
+						onToggle={(enabled) =>
+							updateHotspot(hotspot.id, { visible: enabled })
+						}
+						title="Visible to viewers"
+						description="Show this marker in the published scene."
+					/>
+
+					<SettingToggle
+						enabled={hotspot.internalOnly}
+						onToggle={(enabled) =>
+							updateHotspot(hotspot.id, { internalOnly: enabled })
+						}
+						title="Editor only"
+						description="Keep the marker in the publisher and leave it out of the embed."
+					/>
+
+					<SettingToggle
+						enabled={hotspot.occlusionEnabled ?? true}
+						onToggle={(enabled) =>
+							updateHotspot(hotspot.id, { occlusionEnabled: enabled })
+						}
+						title="Hide behind geometry"
+						description="Fade the marker when part of the model is in front of it."
+					/>
+				</>
+			)
+		},
 		[
 			allCameras,
 			handleMembershipChange,


### PR DESCRIPTION
## Root cause

The hotspot compose panel enumerates the fields an author can edit, and the two fields added in the base PR were simply not among them. They exist on the type and in the database with no way in.

Stacked on [#823](https://github.com/Vectreal/vectreal-platform/pull/823) because the fields it adds do not exist on `main`. **Merge #823 first.**

## What this adds

A `Textarea` for Body and an `Input` for Link, between Name and Style so the content fields sit together.

**The link is validated where the field is.** The save answers a bad link by refusing the entire scene with a message naming `hotspots[2].linkUrl` — neither the marker nor the field the author is looking at. So the panel marks it inline: `aria-invalid` on the input, and an error paragraph the input points at through `aria-describedby`.

**An empty field is not an invalid one.** Clearing the link is how an author removes it, so the error only shows for a non-empty value that fails the rule.

**Both fields write `undefined` when cleared, never `''`.** That distinction is load-bearing further down: the dirty-check folds absent and null together and deliberately does not fold in the empty string, so a cleared body stored as `''` against a null column would report the scene changed on every load and offer a save that changes nothing.

The body carries `maxLength`, because the save parser refuses a longer one and a refusal there fails the whole scene with a message naming an array index. The field is the only place an author sees the limit at the moment it applies.

## Mutations run

| Mutation | Result |
| --- | --- |
| Clearing the body writes `''` instead of unsetting it | 1 failed |
| Drop the inline link error | 2 failed |
| Treat an empty link as invalid | 2 failed |
| Drop the body's `maxLength` | 1 failed |

**The mutation the plan named for this step is not reachable.** It was: make a content handler read `activeHotspotId` instead of the hotspot it was handed, and watch the collapse-animation case go red. Radix unmounts closed collapsible content immediately when no CSS animation is running, which is always in jsdom, so the two-editors-mounted window the trap needs does not exist there. The handlers take the hotspot argument by construction, as the file's existing docblock requires, and the four mutations above stand in.

## Verification

- `npx vitest run --root .` — 154 files, 2003 tests, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — 8/8 tasks green

Browser verification of the panel runs once the viewer popover lands, so one pass covers authoring and rendering together rather than checking a field whose output has nowhere to show.

## Not in this PR

Nothing filed. The viewer does not draw the body yet — that is the next PR.