### PR TITLE
feat(viewer): draw what a hotspot has to say

### DIFF
--- a/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
@@ -151,14 +151,88 @@ describe('resolveHotspotInteraction', () => {
 					occluded: true,
 					canActivate: false,
 					canSelect: true
-				}).toggles
-			).toBe(true)
+				}).announces
+			).toBe('pressed')
 			expect(
 				resolveHotspotInteraction(linked, {
 					occluded: false,
 					canActivate: true
-				}).toggles
-			).toBe(false)
+				}).announces
+			).toBeNull()
+		})
+	})
+
+	describe('revealing content', () => {
+		const reveal = { occluded: false, canActivate: false, canReveal: true }
+
+		it('makes a marker with something to say a button', () => {
+			const interaction = resolveHotspotInteraction(unlinked, reveal)
+
+			expect(interaction.role).toBe('button')
+			expect(interaction.action).toBe('reveal')
+			expect(interaction.focusable).toBe(true)
+		})
+
+		it('announces a reveal as expanded, never as pressed', () => {
+			// The two are different claims about the same control. A reveal shows
+			// content; a press picks the marker up. Announcing one as the other
+			// tells a screen reader the wrong thing about what a click will do.
+			expect(resolveHotspotInteraction(unlinked, reveal).announces).toBe(
+				'expanded'
+			)
+		})
+
+		it('lets selection win, and announces the selection', () => {
+			// Selecting is local and reversible. An editing surface that offers
+			// both has to give a click the cheap one.
+			const interaction = resolveHotspotInteraction(linked, {
+				occluded: false,
+				canActivate: true,
+				canReveal: true,
+				canSelect: true
+			})
+
+			expect(interaction.action).toBe('select')
+			expect(interaction.announces).toBe('pressed')
+			// And never flies away from the viewpoint the author is composing in.
+			expect(interaction.fliesCamera).toBe(false)
+		})
+
+		it('reveals and flies on the same click', () => {
+			// A marker that has something to say and a camera to fly says "look
+			// here, and here is why". The flight is what puts the content's
+			// subject on screen, so they are not alternatives.
+			const interaction = resolveHotspotInteraction(linked, {
+				occluded: false,
+				canActivate: true,
+				canReveal: true
+			})
+
+			expect(interaction.action).toBe('reveal')
+			expect(interaction.fliesCamera).toBe(true)
+		})
+
+		it('flies alone when there is nothing to reveal', () => {
+			const interaction = resolveHotspotInteraction(linked, {
+				occluded: false,
+				canActivate: true
+			})
+
+			expect(interaction.action).toBe('activate')
+			expect(interaction.fliesCamera).toBe(true)
+		})
+
+		it('does neither while occluded, and still announces expanded', () => {
+			const interaction = resolveHotspotInteraction(linked, {
+				occluded: true,
+				canActivate: true,
+				canReveal: true
+			})
+
+			expect(interaction.action).toBe('none')
+			expect(interaction.fliesCamera).toBe(false)
+			expect(interaction.announces).toBe('expanded')
+			expect(interaction.pointerEvents).toBe('none')
 		})
 	})
 })

--- a/packages/viewer/src/components/scene/hotspot-interaction.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.ts
@@ -15,18 +15,36 @@ export interface HotspotInteraction {
 	 * What a click does. `none` while occluded, and for a marker that offers
 	 * nothing.
 	 *
-	 * Selecting beats activating wherever a surface offers both. Selecting is
-	 * local and reversible; activating throws away the viewpoint the author was
-	 * working from, so the cheap one has to be what a click gets. A surface that
-	 * wants the camera instead says so by not passing a select handler.
+	 * Precedence is select, then reveal, then activate. Selecting beats
+	 * everything wherever a surface offers it: it is local and reversible, while
+	 * the others throw away the viewpoint the author was working from, so the
+	 * cheap one has to be what a click gets. A surface that wants the content or
+	 * the camera instead says so by not passing a select handler.
+	 *
+	 * Revealing beats activating only in the sense of naming what the button
+	 * announces itself as. A marker that has something to say *and* a camera to
+	 * fly does both on one click - see `fliesCamera`.
 	 */
-	action: 'select' | 'activate' | 'none'
+	action: 'select' | 'reveal' | 'activate' | 'none'
 	/**
-	 * True when this button is a selection toggle, so it can carry
-	 * `aria-pressed`. Independent of occlusion for the same reason `role` is: a
-	 * marker must not change what it announces itself to be mid-orbit.
+	 * Whether a click should also move the camera.
+	 *
+	 * Separate from `action` because the two are not alternatives. A marker
+	 * carrying content and a linked camera says "look here, and here is why";
+	 * making the author choose which of those a click gets would be a false
+	 * choice, and the flight is what puts the popover's subject on screen.
 	 */
-	toggles: boolean
+	fliesCamera: boolean
+	/**
+	 * Which state this button announces, or null when it announces none.
+	 *
+	 * A discriminant rather than two booleans: a selection is `aria-pressed` and
+	 * a reveal is `aria-expanded`, they cannot both be true of one control, and
+	 * a marker carrying both would otherwise announce itself wrongly. Independent
+	 * of occlusion for the same reason `role` is: a marker must not change what
+	 * it announces itself to be mid-orbit.
+	 */
+	announces: 'pressed' | 'expanded' | null
 	/**
 	 * False while occluded, so an invisible marker is not a tab stop. Focus that
 	 * is already on it survives, which `disabled` would not allow.
@@ -45,11 +63,19 @@ export function resolveHotspotInteraction(
 	{
 		occluded,
 		canActivate,
-		canSelect = false
+		canSelect = false,
+		canReveal = false
 	}: {
 		occluded: boolean
 		/** Whether the viewer was given somewhere to send an activation. */
 		canActivate: boolean
+		/**
+		 * Whether this marker has anything to reveal. Content the renderer would
+		 * refuse to draw is not content: `resolveHotspotPopoverContent` decides,
+		 * so a marker whose only body is an unsafe link stays inert rather than
+		 * becoming a button that opens an empty card.
+		 */
+		canReveal?: boolean
 		/**
 		 * Whether the viewer was given somewhere to send a selection. An editing
 		 * surface passes a select handler only while its own tool is armed, so
@@ -62,7 +88,7 @@ export function resolveHotspotInteraction(
 	const canFly = marker.linkedCameraId !== null && canActivate
 	// Selection needs no camera: an editing surface has to be able to pick a
 	// marker that names none, which is the whole point of drawing it.
-	const isButton = canSelect || canFly
+	const isButton = canSelect || canReveal || canFly
 
 	return {
 		role: isButton ? 'button' : 'image',
@@ -70,10 +96,16 @@ export function resolveHotspotInteraction(
 			? 'none'
 			: canSelect
 				? 'select'
-				: canFly
-					? 'activate'
-					: 'none',
-		toggles: canSelect,
+				: canReveal
+					? 'reveal'
+					: canFly
+						? 'activate'
+						: 'none',
+		// Not on an editing surface: there a click picks the marker up, and
+		// flying away from the viewpoint the author is composing in is the one
+		// thing selection exists to avoid.
+		fliesCamera: !occluded && !canSelect && canFly,
+		announces: canSelect ? 'pressed' : canReveal ? 'expanded' : null,
 		focusable: isButton && !occluded,
 		pointerEvents: occluded ? 'none' : 'auto'
 	}

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -3,6 +3,8 @@ import { cn } from '@shared/utils'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { resolveHotspotInteraction } from './hotspot-interaction'
+import HotspotPopover from './hotspot-popover'
+import { resolveHotspotPopoverContent } from './resolve-hotspot-popover'
 
 import type { HotspotMarker as HotspotMarkerModel } from './resolve-hotspot-markers'
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react'
@@ -15,6 +17,17 @@ import type { Group } from 'three'
  * frame, which is also what decides how two overlapping markers stack.
  */
 const HOTSPOT_Z_INDEX_RANGE = [40, 0]
+
+/**
+ * The band an open marker moves into, above every closed one and still under
+ * the viewer's own chrome at 100.
+ *
+ * The whole marker moves, not just the card. drei writes its depth-derived
+ * value as a z-index on the wrapper div, which makes that div a stacking
+ * context - so a card inside it cannot paint over a marker that happens to sit
+ * nearer the camera, however high its own z-index is.
+ */
+const HOTSPOT_OPEN_Z_INDEX_RANGE = [99, 41]
 
 /**
  * How long the name stays up after a tap.
@@ -113,6 +126,14 @@ export interface HotspotMarkerProps {
 	onActivate?: (cameraId: string) => void
 	/** Runs when a marker is picked on a surface that selects rather than flies. */
 	onSelect?: (id: string) => void
+	/** Whether this marker's content is open. Owned by `SceneHotspots`. */
+	open?: boolean
+	/**
+	 * Toggles this marker's content open or closed. A marker with nothing to
+	 * say never calls it, and a surface that does not pass it gets no reveal
+	 * behaviour at all - which is how a host page takes the content for itself.
+	 */
+	onReveal?: (id: string) => void
 	/**
 	 * Hands `SceneHotspots` the anchor group it moves during a drag, and `null`
 	 * on unmount. See the group below.
@@ -135,15 +156,23 @@ const HotspotMarker = ({
 	color,
 	onActivate,
 	onSelect,
+	open = false,
+	onReveal,
 	onAnchorRef
 }: HotspotMarkerProps) => {
 	const [labelVisible, setLabelVisible] = useState(false)
 	const touchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const rootRef = useRef<HTMLDivElement>(null)
+	const buttonRef = useRef<HTMLButtonElement>(null)
+
+	const content = resolveHotspotPopoverContent(marker)
+	const popoverId = `vctrl-hotspot-popover-${marker.id}`
 
 	const interaction = resolveHotspotInteraction(marker, {
 		occluded,
 		canActivate: !!onActivate,
-		canSelect: !!onSelect
+		canSelect: !!onSelect,
+		canReveal: !!content && !!onReveal
 	})
 
 	// A block body, not a concise one. React 19 treats a *function* returned from
@@ -204,16 +233,42 @@ const HotspotMarker = ({
 	const handleClick = useCallback(() => {
 		if (interaction.action === 'select') {
 			onSelect?.(marker.id)
-		} else if (interaction.action === 'activate' && marker.linkedCameraId) {
+			return
+		}
+		if (interaction.action === 'reveal') onReveal?.(marker.id)
+		// Not an `else`. A marker that has something to say and a camera to fly
+		// does both on one click: the flight is what puts the card's subject on
+		// screen, so making them alternatives would be a false choice.
+		if (interaction.fliesCamera && marker.linkedCameraId) {
 			onActivate?.(marker.linkedCameraId)
 		}
 	}, [
 		interaction.action,
+		interaction.fliesCamera,
 		marker.id,
 		marker.linkedCameraId,
 		onActivate,
+		onReveal,
 		onSelect
 	])
+
+	/**
+	 * Escape closes the card and puts focus back on the marker.
+	 *
+	 * On the root rather than the card, because focus can be on either: the
+	 * marker's own button opens it and stays focused, and this is the only
+	 * ancestor both share. Nothing is trapped - a visitor has to be able to tab
+	 * straight out to the next marker while this is open.
+	 */
+	const handleKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLDivElement>) => {
+			if (event.key !== 'Escape' || !open) return
+			event.stopPropagation()
+			onReveal?.(marker.id)
+			buttonRef.current?.focus()
+		},
+		[marker.id, onReveal, open]
+	)
 
 	// Set on the marker root rather than the viewer container: drei portals every
 	// Html separately, so there is no shared ancestor inside the marker layer.
@@ -286,21 +341,24 @@ const HotspotMarker = ({
 			*/}
 			<Html
 				center
-				zIndexRange={HOTSPOT_Z_INDEX_RANGE}
+				zIndexRange={open ? HOTSPOT_OPEN_Z_INDEX_RANGE : HOTSPOT_Z_INDEX_RANGE}
 				style={HTML_WRAPPER_STYLE}
 			>
 				<div
+					ref={rootRef}
 					className={cn(markerClasses.root, occluded && markerClasses.occluded)}
 					style={colorStyle}
 					data-selected={selected || undefined}
 					data-hidden={marker.hidden || undefined}
 					onPointerEnter={handlePointerEnter}
 					onPointerLeave={handlePointerLeave}
+					onKeyDown={handleKeyDown}
 				>
 					<span aria-hidden="true" className={markerClasses.pulse} />
 
 					{interaction.role === 'button' ? (
 						<button
+							ref={buttonRef}
 							type="button"
 							className={cn(
 								bodyClasses,
@@ -308,7 +366,17 @@ const HotspotMarker = ({
 								interaction.action !== 'none' && markerClasses.interactive
 							)}
 							aria-label={marker.accessibleName}
-							aria-pressed={interaction.toggles ? selected : undefined}
+							aria-pressed={
+								interaction.announces === 'pressed' ? selected : undefined
+							}
+							aria-expanded={
+								interaction.announces === 'expanded' ? open : undefined
+							}
+							aria-controls={
+								interaction.announces === 'expanded' && open
+									? popoverId
+									: undefined
+							}
 							aria-disabled={interaction.action === 'none' ? true : undefined}
 							tabIndex={interaction.focusable ? undefined : -1}
 							onClick={handleClick}
@@ -327,8 +395,21 @@ const HotspotMarker = ({
 						</div>
 					)}
 
-					{labelVisible && (
+					{/*
+					  The name is already the card's heading, so showing the label over
+					  an open card would print it twice, one above the other.
+					*/}
+					{labelVisible && !open && (
 						<span className={markerClasses.label}>{marker.name}</span>
+					)}
+
+					{open && content && (
+						<HotspotPopover
+							id={popoverId}
+							title={marker.name}
+							content={content}
+							anchorRef={rootRef}
+						/>
 					)}
 				</div>
 			</Html>

--- a/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * The `.tsx` half of the reveal, pinned by reading the source.
+ *
+ * This package's test runner loads only spec files ending in `.ts`, under
+ * `environment: 'node'`, deliberately, so a component cannot be rendered here at all. Every
+ * decision the reveal makes therefore lives in `resolve-hotspot-popover.ts` and
+ * `hotspot-interaction.ts`, which have their own specs. What is left in the
+ * components is wiring - and wiring is exactly what type-checks cleanly while
+ * doing nothing, which is how a complete renderer once shipped with no surface
+ * calling it.
+ *
+ * So this asserts the calls, not the behaviour. It cannot tell a correct
+ * popover from a broken one; it can tell one that is mounted from one that is
+ * not. Renaming a local here is meant to fail it - re-point the guard rather
+ * than deleting it.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const read = (file: string) =>
+	readFileSync(join(import.meta.dirname, file), 'utf8')
+
+const marker = read('hotspot-marker.tsx')
+const layer = read('scene-hotspots.tsx')
+const popover = read('hotspot-popover.tsx')
+
+describe('the marker reaches the reveal decisions', () => {
+	it('asks the resolver what there is to reveal, rather than reading fields', () => {
+		expect(marker).toContain('resolveHotspotPopoverContent(marker)')
+		// The link rule lives behind that resolver. A marker reading `linkUrl`
+		// straight would be rendering an unchecked href.
+		expect(marker).not.toContain('marker.linkUrl')
+	})
+
+	it('tells the interaction resolver whether there is anything to reveal', () => {
+		expect(marker).toContain('canReveal: !!content && !!onReveal')
+	})
+
+	it('mounts the card only when it is open and has content', () => {
+		expect(marker).toContain('{open && content && (')
+		expect(marker).toContain('<HotspotPopover')
+	})
+})
+
+describe('the marker announces the card it opens', () => {
+	it('carries aria-expanded from the interaction, not from the content', () => {
+		// Occlusion changes what a click does but must not change what the
+		// control claims to be, which is why this reads `announces`.
+		expect(marker).toContain("interaction.announces === 'expanded' ? open")
+	})
+
+	it('names the open card from the button', () => {
+		expect(marker).toContain('aria-controls')
+		expect(marker).toContain('popoverId')
+		expect(popover).toContain('id={id}')
+	})
+
+	it('closes on Escape and puts focus back on the marker', () => {
+		expect(marker).toContain("event.key !== 'Escape'")
+		expect(marker).toContain('buttonRef.current?.focus()')
+		// Non-modal: a visitor has to be able to tab out to the next marker
+		// while this is open, so nothing may trap focus.
+		expect(marker).not.toContain('focusTrap')
+	})
+
+	it('lifts the whole marker out of the closed markers band while open', () => {
+		// The card cannot escape the wrapper drei writes a z-index onto, so the
+		// wrapper is what has to move.
+		expect(marker).toContain('open ? HOTSPOT_OPEN_Z_INDEX_RANGE')
+		expect(marker).toContain('const HOTSPOT_OPEN_Z_INDEX_RANGE = [99, 41]')
+		expect(marker).toContain('const HOTSPOT_Z_INDEX_RANGE = [40, 0]')
+	})
+})
+
+describe('the hotspot layer owns which card is open', () => {
+	it('opens at most one, toggling the one already open shut', () => {
+		expect(layer).toContain('previous === id ? null : id')
+	})
+
+	it('hands each marker its own open state and the toggle', () => {
+		expect(layer).toContain('open={marker.id === openId}')
+		expect(layer).toContain('onReveal={handleReveal}')
+	})
+
+	it('closes a card whose marker went behind the model or left the list', () => {
+		// An occluded marker takes no pointer events and offers no action, so a
+		// card left open over it is the one state with no way to dismiss.
+		expect(layer).toContain('occludedIds.has(openId)')
+		expect(layer).toContain('!markers.some((marker) => marker.id === openId)')
+	})
+
+	it('asks for a frame when a card opens', () => {
+		// The card measures its own placement from a frame, and under
+		// `frameloop="demand"` nothing else would request one.
+		const handleReveal = layer
+			.split('const handleReveal =')[1]
+			?.split('\n\t/**')[0]
+
+		expect(handleReveal).toBeTruthy()
+		expect(handleReveal).toContain('setOpenId(')
+		expect(handleReveal).toContain('invalidate()')
+	})
+})
+
+describe('the card is safe to put inside a third-party page', () => {
+	it('opens a link in a new context that cannot reach back', () => {
+		expect(popover).toContain('rel="noopener noreferrer"')
+		expect(popover).toContain('target="_blank"')
+	})
+
+	it('takes the pointer back from the wrapper that refuses it', () => {
+		// The marker's `Html` wrapper is `pointerEvents: 'none'`, so anything
+		// inside it that has to be clickable says so itself.
+		expect(popover).toContain('pointer-events-auto')
+	})
+})

--- a/packages/viewer/src/components/scene/hotspot-popover.tsx
+++ b/packages/viewer/src/components/scene/hotspot-popover.tsx
@@ -1,0 +1,161 @@
+import { useFrame, useThree } from '@react-three/fiber'
+import { cn } from '@shared/utils'
+import { useRef, useState } from 'react'
+
+import { resolveHotspotPopoverPlacement } from './resolve-hotspot-popover'
+
+import type {
+	HotspotPopoverContent,
+	HotspotPopoverPlacement
+} from './resolve-hotspot-popover'
+import type { CSSProperties } from 'react'
+
+/**
+ * Clearance between the marker's centre and the popover's near edge, and
+ * between the popover and the edge of the canvas.
+ *
+ * The gap clears the 24px marker box plus a little air; the margin is what
+ * stops a card from sitting flush against the canvas edge, where it reads as
+ * clipped whether or not it is.
+ */
+const ANCHOR_GAP_PX = 20
+const CANVAS_MARGIN_PX = 8
+
+/**
+ * How often the placement is re-decided while the popover is open, in seconds.
+ *
+ * The card follows its marker for free - it is inside the same portal - so this
+ * only has to catch the marker crossing an edge as the camera moves. Two
+ * `getBoundingClientRect` calls at 10Hz, for at most one open popover.
+ */
+const PLACEMENT_INTERVAL_SECONDS = 0.1
+
+const DEFAULT_PLACEMENT: HotspotPopoverPlacement = {
+	side: 'above',
+	offsetX: 0
+}
+
+const popoverClasses = {
+	// `rounded-[0.5rem]`, never a named radius: this package clears Tailwind's
+	// radius namespace, so every named token but `full` compiles to nothing once
+	// the package is consumed from npm.
+	root: 'vctrl-hotspot-popover pointer-events-auto absolute left-1/2 w-max max-w-[240px] rounded-[0.5rem] bg-[var(--vctrl-bg)] px-3 py-2 text-left text-[var(--vctrl-text)] shadow-[0_2px_12px_rgba(0,0,0,0.35)]',
+	above: 'bottom-[calc(100%+var(--vctrl-hotspot-popover-gap))]',
+	below: 'top-[calc(100%+var(--vctrl-hotspot-popover-gap))]',
+	// `font-[600]` rather than the named scale: a named weight registers its
+	// theme variable in the published stylesheet's `:root, :host` block, which
+	// lands in a host application after hydration. See styles.css.
+	title: 'text-[12px] leading-[1.35] font-[600]',
+	// `whitespace-pre-wrap` so the line breaks an author typed survive. The body
+	// is plain text, never markup, so this is the only formatting it carries.
+	body: 'mt-1 text-[11px] leading-[1.5] whitespace-pre-wrap opacity-90',
+	link: 'mt-2 inline-block max-w-full truncate text-[11px] leading-[1.5] underline underline-offset-2 opacity-90 hover:opacity-100'
+} as const
+
+export interface HotspotPopoverProps {
+	/** Heads the card. The marker's own name, so the two cannot drift apart. */
+	title: string
+	content: HotspotPopoverContent
+	/** Names the card from the marker's `aria-controls`. */
+	id: string
+	/** The marker root, which the card is placed against. */
+	anchorRef: React.RefObject<HTMLDivElement | null>
+}
+
+/**
+ * What a marker says when a visitor opens it.
+ *
+ * Non-modal by design: no focus trap and no scroll lock, because the visitor
+ * has to be able to keep orbiting the model and reach the other markers while
+ * this is open. `info-popover.tsx`'s document-global trap is the right shape
+ * for a chrome panel and the wrong one here.
+ *
+ * Placement is re-decided from the canvas box rather than fixed, so a marker
+ * near the top of the frame flips its card below instead of drawing it off the
+ * viewport - which is also what the hover label does not do yet.
+ */
+const HotspotPopover = ({
+	title,
+	content,
+	id,
+	anchorRef
+}: HotspotPopoverProps) => {
+	const canvas = useThree((state) => state.gl.domElement)
+	const cardRef = useRef<HTMLDivElement>(null)
+	// Seeded at the interval so the very first frame measures rather than
+	// waiting one out. Under `frameloop="demand"` that first frame is the only
+	// one the card is guaranteed, and until it runs the placement is the default
+	// rather than the measured answer.
+	const elapsed = useRef(PLACEMENT_INTERVAL_SECONDS)
+	const [placement, setPlacement] =
+		useState<HotspotPopoverPlacement>(DEFAULT_PLACEMENT)
+
+	useFrame((_state, delta) => {
+		elapsed.current += delta
+		if (elapsed.current < PLACEMENT_INTERVAL_SECONDS) return
+		elapsed.current = 0
+
+		const anchor = anchorRef.current
+		const card = cardRef.current
+		if (!anchor || !card) return
+
+		const anchorBox = anchor.getBoundingClientRect()
+		const canvasBox = canvas.getBoundingClientRect()
+
+		const next = resolveHotspotPopoverPlacement({
+			anchor: {
+				x: anchorBox.left + anchorBox.width / 2 - canvasBox.left,
+				y: anchorBox.top + anchorBox.height / 2 - canvasBox.top
+			},
+			size: { width: card.offsetWidth, height: card.offsetHeight },
+			bounds: { width: canvasBox.width, height: canvasBox.height },
+			gap: ANCHOR_GAP_PX,
+			margin: CANVAS_MARGIN_PX
+		})
+
+		// One state write only when the answer moved: this runs in the frame
+		// loop, where an unconditional write would re-render the marker's portal
+		// ten times a second for as long as the card is open.
+		setPlacement((previous) =>
+			previous.side === next.side && previous.offsetX === next.offsetX
+				? previous
+				: next
+		)
+	})
+
+	return (
+		<div
+			ref={cardRef}
+			id={id}
+			className={cn(popoverClasses.root, popoverClasses[placement.side])}
+			// Read by the stylesheet, which owns the transform so the entry
+			// animation can reuse the same X and move nothing but opacity and Y.
+			data-side={placement.side}
+			style={
+				{
+					'--vctrl-hotspot-popover-gap': `${ANCHOR_GAP_PX}px`,
+					'--vctrl-hotspot-popover-shift': `calc(-50% + ${placement.offsetX}px)`
+				} as CSSProperties
+			}
+		>
+			<p className={popoverClasses.title}>{title}</p>
+			{content.body && <p className={popoverClasses.body}>{content.body}</p>}
+			{content.link && (
+				<a
+					className={popoverClasses.link}
+					href={content.link.href}
+					target="_blank"
+					// `noopener` is the one that matters - it denies the opened page a
+					// handle on this one, which for an embedded viewer is somebody
+					// else's page. `noreferrer` follows it because a target of `_blank`
+					// implies opener in older engines that do not honour the first.
+					rel="noopener noreferrer"
+				>
+					{content.link.label}
+				</a>
+			)}
+		</div>
+	)
+}
+
+export default HotspotPopover

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
@@ -437,6 +437,63 @@ describe('resolveHotspotMarkers', () => {
 		})
 	})
 
+	describe('content', () => {
+		it('carries body text and a link through, trimmed', () => {
+			const [drawn] = resolveHotspotMarkers([
+				hotspot({
+					id: 'a',
+					body: '  Cast in one piece.  ',
+					linkUrl: '  https://a.test/spec  '
+				})
+			])
+
+			expect(drawn.body).toBe('Cast in one piece.')
+			expect(drawn.linkUrl).toBe('https://a.test/spec')
+		})
+
+		it('reads a missing or whitespace-only field as no content at all', () => {
+			const [absent] = resolveHotspotMarkers([hotspot({ id: 'a' })])
+			const [blank] = resolveHotspotMarkers([
+				hotspot({ id: 'b', body: '   ', linkUrl: '' })
+			])
+
+			expect(absent.body).toBeNull()
+			expect(absent.linkUrl).toBeNull()
+			expect(blank.body).toBeNull()
+			expect(blank.linkUrl).toBeNull()
+		})
+
+		it('survives a non-string body, which would throw on trim mid-render', () => {
+			// A direct consumer of this package goes through no parser at all.
+			const [drawn] = resolveHotspotMarkers([
+				malformed({
+					id: 'a',
+					name: 'Handle',
+					worldPosition: [0, 0, 0],
+					visible: true,
+					internalOnly: false,
+					stylePreset: 'dot',
+					body: 42,
+					linkUrl: { href: 'https://a.test' }
+				})
+			])
+
+			expect(drawn.body).toBeNull()
+			expect(drawn.linkUrl).toBeNull()
+		})
+
+		it('leaves the scheme to the renderer rather than filtering here', () => {
+			// `resolveHotspotLink` owns that rule, and it is what decides whether
+			// the marker has anything to reveal. Dropping the value here would
+			// hide the field from any consumer drawing its own card.
+			const [drawn] = resolveHotspotMarkers([
+				hotspot({ id: 'a', linkUrl: 'javascript:alert(1)' })
+			])
+
+			expect(drawn.linkUrl).toBe('javascript:alert(1)')
+		})
+	})
+
 	it('does not mutate the settings it was given', () => {
 		const stored = [
 			hotspot({ id: 'b', sequenceIndex: 1 }),

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
@@ -11,6 +11,14 @@ export interface HotspotMarker {
 	id: string
 	/** Trimmed, and never empty. */
 	name: string
+	/** Trimmed, or null when the hotspot carries no body text. */
+	body: string | null
+	/**
+	 * Trimmed, or null when the hotspot names no link. Not yet checked for a
+	 * scheme the renderer will accept - `resolveHotspotLink` owns that, and it
+	 * is what decides whether the marker has anything to reveal.
+	 */
+	linkUrl: string | null
 	/** What a screen reader announces, including the step and how many there are. */
 	accessibleName: string
 	position: [number, number, number]
@@ -124,10 +132,10 @@ interface DrawableEntry {
  * mount and never reorders, so document order - and with it tab order - follows
  * whichever order the markers first mounted in.)
  *
- * Everything else here is hardening. The platform's own parser validates most of
- * these fields on save, but it never sees `payloadUrl`, and a direct consumer of
- * `@vctrl/viewer` goes through no parser at all: a non-string `name` would throw
- * on `.trim()` mid-render, and a `NaN` sequence index would make the comparator
+ * Everything else here is hardening. The platform's own parser validates every
+ * one of these fields on save, but a direct consumer of `@vctrl/viewer` goes
+ * through no parser at all: a non-string `name` or `body` would throw on
+ * `.trim()` mid-render, and a `NaN` sequence index would make the comparator
  * return `NaN` and leave the order to the sort implementation.
  */
 export function resolveHotspotMarkers(
@@ -231,6 +239,8 @@ function toMarker(
 		id,
 		name,
 		accessibleName: accessibleName(name, step, stepCount, hidden),
+		body: text(hotspot.body),
+		linkUrl: text(hotspot.linkUrl),
 		position,
 		step,
 		stepCount,

--- a/packages/viewer/src/components/scene/resolve-hotspot-popover.spec.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-popover.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	resolveHotspotLink,
+	resolveHotspotPopoverContent,
+	resolveHotspotPopoverPlacement
+} from './resolve-hotspot-popover'
+
+describe('resolveHotspotLink', () => {
+	it('takes an https URL and names it by its host', () => {
+		expect(resolveHotspotLink('https://docs.vectreal.com/specs?a=1')).toEqual({
+			href: 'https://docs.vectreal.com/specs?a=1',
+			label: 'docs.vectreal.com'
+		})
+	})
+
+	it('keeps a non-default port in the label, which is part of the host', () => {
+		expect(resolveHotspotLink('https://staging.test:8443/a')?.label).toBe(
+			'staging.test:8443'
+		)
+	})
+
+	it.each([
+		['a script URL', 'javascript:alert(1)'],
+		['a script URL in mixed case', 'JavaScript:alert(1)'],
+		['an inline document', 'data:text/html;base64,AAAA'],
+		['plain http', 'http://vectreal.com'],
+		['a protocol-relative URL', '//vectreal.com'],
+		['a relative path', '/docs'],
+		['a bare scheme', 'https://'],
+		['an unparseable value behind the right prefix', 'https:// spaced'],
+		['nothing at all', null]
+	])('refuses %s', (_label, value) => {
+		expect(resolveHotspotLink(value)).toBeNull()
+	})
+
+	/**
+	 * The prefix is the gate, not the parsed protocol.
+	 *
+	 * `new URL('https:evil')` yields protocol `https:` with no host at all, so a
+	 * rule written as "parse it and check `url.protocol`" accepts a value that
+	 * is not an absolute https URL.
+	 */
+	it('refuses a scheme-only form that parses as https', () => {
+		expect(resolveHotspotLink('https:evil')).toBeNull()
+	})
+})
+
+describe('resolveHotspotPopoverContent', () => {
+	it('carries a body on its own', () => {
+		expect(
+			resolveHotspotPopoverContent({
+				body: 'Cast in one piece.',
+				linkUrl: null
+			})
+		).toEqual({ body: 'Cast in one piece.', link: null })
+	})
+
+	it('carries a link on its own', () => {
+		expect(
+			resolveHotspotPopoverContent({ body: null, linkUrl: 'https://a.test/x' })
+		).toEqual({
+			body: null,
+			link: { href: 'https://a.test/x', label: 'a.test' }
+		})
+	})
+
+	it('has nothing to reveal when it carries neither', () => {
+		expect(
+			resolveHotspotPopoverContent({ body: null, linkUrl: null })
+		).toBeNull()
+	})
+
+	/**
+	 * A marker whose only content is a link the renderer refuses has nothing to
+	 * reveal. Without this it would become a button that opens an empty card,
+	 * which is worse than the inert marker it was.
+	 */
+	it('has nothing to reveal when its only link is one the renderer refuses', () => {
+		expect(
+			resolveHotspotPopoverContent({
+				body: null,
+				linkUrl: 'javascript:alert(1)'
+			})
+		).toBeNull()
+	})
+})
+
+describe('resolveHotspotPopoverPlacement', () => {
+	const bounds = { width: 800, height: 600 }
+	const size = { width: 200, height: 100 }
+	const place = (anchor: { x: number; y: number }, overrides = {}) =>
+		resolveHotspotPopoverPlacement({
+			anchor,
+			size,
+			bounds,
+			gap: 20,
+			margin: 8,
+			...overrides
+		})
+
+	it('sits above a marker with room above it', () => {
+		expect(place({ x: 400, y: 300 })).toEqual({ side: 'above', offsetX: 0 })
+	})
+
+	// The clipped-label defect, in the shape the popover would have inherited.
+	it('flips below a marker near the top edge', () => {
+		expect(place({ x: 400, y: 40 }).side).toBe('below')
+	})
+
+	it('goes back above once there is room for it again', () => {
+		// 100 tall, 20 of gap and 8 of margin: 128 is the first y that fits.
+		expect(place({ x: 400, y: 127 }).side).toBe('below')
+		expect(place({ x: 400, y: 128 }).side).toBe('above')
+	})
+
+	it('shifts right off the left edge, by exactly what it takes', () => {
+		// Centred would put the left edge at 20 - 100 = -80; the margin wants 8.
+		expect(place({ x: 20, y: 300 }).offsetX).toBe(88)
+	})
+
+	it('shifts left off the right edge, by exactly what it takes', () => {
+		// Centred would put the right edge at 780 + 100 = 880; the margin wants
+		// it at 792.
+		expect(place({ x: 780, y: 300 }).offsetX).toBe(-88)
+	})
+
+	it('leaves a marker that already fits alone', () => {
+		expect(place({ x: 108, y: 300 }).offsetX).toBe(0)
+		expect(place({ x: 692, y: 300 }).offsetX).toBe(0)
+	})
+
+	it('pins a card wider than the canvas to the left margin', () => {
+		// The clamp that keeps the right edge on screen would otherwise push the
+		// left edge off it, which is the worse of the two.
+		const wide = resolveHotspotPopoverPlacement({
+			anchor: { x: 400, y: 300 },
+			size: { width: 900, height: 100 },
+			bounds,
+			gap: 20,
+			margin: 8
+		})
+
+		expect(400 - 900 / 2 + wide.offsetX).toBe(8)
+	})
+
+	it('picks the roomier side when the card fits on neither', () => {
+		const tall = { width: 200, height: 560 }
+		const near = (y: number) =>
+			resolveHotspotPopoverPlacement({
+				anchor: { x: 400, y },
+				size: tall,
+				bounds,
+				gap: 20,
+				margin: 8
+			}).side
+
+		expect(near(500)).toBe('above')
+		expect(near(100)).toBe('below')
+	})
+})

--- a/packages/viewer/src/components/scene/resolve-hotspot-popover.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-popover.ts
@@ -1,0 +1,135 @@
+import type { HotspotMarker } from './resolve-hotspot-markers'
+
+/** A link a marker's popover can offer, once it is safe to render. */
+export interface HotspotLink {
+	href: string
+	/**
+	 * What the anchor says. The URL's host, never an author-supplied label:
+	 * there is no second field to keep in step with the destination, so the
+	 * visible text cannot go stale against where the link points.
+	 */
+	label: string
+}
+
+/** What a marker has to say, or null when it has nothing. */
+export interface HotspotPopoverContent {
+	body: string | null
+	link: HotspotLink | null
+}
+
+/** Which side of the marker the popover sits on. */
+export type HotspotPopoverSide = 'above' | 'below'
+
+export interface HotspotPopoverPlacement {
+	side: HotspotPopoverSide
+	/**
+	 * Horizontal shift from centred on the marker, in pixels. Non-zero only
+	 * where a centred popover would leave the canvas.
+	 */
+	offsetX: number
+}
+
+export interface HotspotPopoverPlacementInput {
+	/** The marker's centre, in canvas coordinates. */
+	anchor: { x: number; y: number }
+	/** The popover's measured size. */
+	size: { width: number; height: number }
+	/** The canvas the popover has to stay inside. */
+	bounds: { width: number; height: number }
+	/** Clearance between the marker's centre and the popover's near edge. */
+	gap: number
+	/** Clearance kept between the popover and the edge of the canvas. */
+	margin: number
+}
+
+/**
+ * A marker's link, or null.
+ *
+ * `https:` only, and the check is the prefix rather than the parsed protocol,
+ * because this is a security gate and a prefix cannot be talked out of its
+ * answer. The parse that follows only reads the host for the label.
+ *
+ * The platform's save parser applies the same rule, so this is the second of
+ * two independent gates rather than the only one - the same arrangement
+ * `internalOnly` has. It is load-bearing here for the same reason: this package
+ * ships to npm, a consumer can hand it any settings object at all, and this
+ * value lands in an `<a href>` where `javascript:` executes.
+ */
+export function resolveHotspotLink(value: string | null): HotspotLink | null {
+	if (!value) return null
+	if (!value.toLowerCase().startsWith('https://')) return null
+
+	try {
+		// Behind that prefix, `new URL` either throws or yields a non-empty host -
+		// `https://`, `https://?a=1` and `https://:443` all throw - so there is no
+		// empty-host case left to branch on here.
+		return { href: value, label: new URL(value).host }
+	} catch {
+		// It does still throw on values the prefix check alone does not rule out:
+		// `https://` followed by a bare space is one.
+		return null
+	}
+}
+
+/**
+ * What a marker reveals when it is opened, or null when it reveals nothing.
+ *
+ * A marker whose only content is a link the rule above refuses has nothing to
+ * reveal, which is what keeps an unsafe link from turning an otherwise inert
+ * marker into a button that opens an empty card.
+ */
+export function resolveHotspotPopoverContent(
+	marker: Pick<HotspotMarker, 'body' | 'linkUrl'>
+): HotspotPopoverContent | null {
+	const body = marker.body
+	const link = resolveHotspotLink(marker.linkUrl)
+
+	if (!body && !link) return null
+	return { body, link }
+}
+
+/**
+ * Where to draw an open popover so it stays on the canvas.
+ *
+ * Above the marker by default, because that is where the hover label already
+ * appears and a card below a marker covers the geometry the marker is pointing
+ * at. It flips below only when it does not fit above, and shifts sideways only
+ * as far as it takes to stay inside the canvas.
+ *
+ * Total by construction: when neither side fits, the roomier one wins rather
+ * than a default that guarantees a clipped card.
+ *
+ * Pure, and measured in canvas coordinates rather than page coordinates, so
+ * an embedded viewer inside a scrolled host page places the same as a
+ * full-page one.
+ */
+export function resolveHotspotPopoverPlacement({
+	anchor,
+	size,
+	bounds,
+	gap,
+	margin
+}: HotspotPopoverPlacementInput): HotspotPopoverPlacement {
+	const roomAbove = anchor.y - gap - margin
+	const roomBelow = bounds.height - anchor.y - gap - margin
+
+	const side: HotspotPopoverSide =
+		size.height <= roomAbove
+			? 'above'
+			: size.height <= roomBelow
+				? 'below'
+				: roomBelow > roomAbove
+					? 'below'
+					: 'above'
+
+	const centredLeft = anchor.x - size.width / 2
+	// `max` last, so a popover wider than the canvas pins to the left margin
+	// rather than being pushed off the other side by the clamp meant to keep it
+	// on screen.
+	const clampedLeft = Math.max(
+		margin,
+		Math.min(centredLeft, bounds.width - size.width - margin)
+	)
+
+	return { side, offsetX: clampedLeft - centredLeft }
+}

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -82,6 +82,15 @@ const SceneHotspots = ({
 	const invalidate = useThree((state) => state.invalidate)
 	const [occludedIds, setOccludedIds] =
 		useState<ReadonlySet<string>>(NO_OCCLUSIONS)
+	/**
+	 * Which marker has its content open, at most one.
+	 *
+	 * Owned here rather than by each marker so opening one closes the last: the
+	 * cards are non-modal and anchored to points that can overlap on screen, and
+	 * several open at once is unreadable. It also puts the open marker in reach
+	 * of the occlusion pass below.
+	 */
+	const [openId, setOpenId] = useState<string | null>(null)
 
 	const markers = useMemo(
 		() => resolveHotspotMarkers(hotspots, { includeInternal, includeHidden }),
@@ -132,6 +141,34 @@ const SceneHotspots = ({
 	 * nothing - which is the correct thing for it to find.
 	 */
 	const anchors = useRef(new Map<string, Group>())
+
+	const handleReveal = useCallback(
+		(id: string) => {
+			setOpenId((previous) => (previous === id ? null : id))
+			// Under `frameloop="demand"` nothing else asks for a frame here, and
+			// the card measures its own placement from one.
+			invalidate()
+		},
+		[invalidate]
+	)
+
+	/**
+	 * An open card closes when its marker goes behind the model or leaves the
+	 * list.
+	 *
+	 * An occluded marker takes no pointer events and offers no action, so a card
+	 * left open over hidden geometry would be the one state with no way to
+	 * dismiss it - and it would be describing something the visitor cannot see.
+	 */
+	useEffect(() => {
+		if (!openId) return
+		if (
+			occludedIds.has(openId) ||
+			!markers.some((marker) => marker.id === openId)
+		) {
+			setOpenId(null)
+		}
+	}, [markers, occludedIds, openId])
 
 	const registerAnchor = useCallback((id: string, node: Group | null) => {
 		if (node) anchors.current.set(id, node)
@@ -357,6 +394,8 @@ const SceneHotspots = ({
 					color={color}
 					onActivate={onActivateCamera}
 					onSelect={onSelect}
+					open={marker.id === openId}
+					onReveal={handleReveal}
 					onAnchorRef={registerAnchor}
 				/>
 			))}

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -236,6 +236,52 @@
 	animation: none;
 }
 
+/*
+  The card a marker opens.
+
+  It rises from the marker it belongs to rather than fading in place, so the
+  connection between the two is carried by the motion and the card needs no
+  caret of its own - which it could not have had cheaply anyway: the placement
+  resolver shifts the card sideways to keep it on the canvas, and a caret would
+  have to counter that shift and then stay clear of the corner radius.
+
+  8px of travel, not more. The card is anchored 20px from a marker that stays
+  drawn the whole time, so this only has to read as "from here"; a longer throw
+  turns a 150ms reveal into something the visitor waits out.
+*/
+@keyframes vctrl-hotspot-popover-in {
+	from {
+		opacity: 0;
+		transform: translateX(var(--vctrl-hotspot-popover-shift, -50%))
+			translateY(var(--vctrl-hotspot-popover-rise));
+	}
+}
+
+.vctrl-hotspot-popover {
+	--vctrl-hotspot-popover-rise: 8px;
+	/*
+	  The centring and the resolver's shift, in one place. The component supplies
+	  only the shift, as a custom property, so the animation's `from` can reuse
+	  the same X and move nothing but opacity and Y.
+	*/
+	transform: translateX(var(--vctrl-hotspot-popover-shift, -50%));
+	animation: vctrl-hotspot-popover-in 150ms ease-out;
+}
+
+/*
+  Below the marker, the card rises from the other direction, so both sides read
+  as coming out of the marker rather than one of them sliding past it.
+*/
+.vctrl-hotspot-popover[data-side='below'] {
+	--vctrl-hotspot-popover-rise: -8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.vctrl-hotspot-popover {
+		animation: none;
+	}
+}
+
 @media (prefers-color-scheme: dark) {
 	.viewer[data-theme='system'] {
 		--vctrl-bg: #141414;

--- a/packages/viewer/src/vectreal-viewer.stories.tsx
+++ b/packages/viewer/src/vectreal-viewer.stories.tsx
@@ -253,6 +253,42 @@ const occlusionHotspots: StoryHotspot[] = [
 	}
 ]
 
+/**
+ * Content, and the three shapes it comes in. Click a marker to open its card.
+ *
+ * The last two are the rules worth looking at rather than decoration: a marker
+ * near the top of the frame flips its card below instead of drawing it off the
+ * canvas, and a marker whose only content is a link the renderer refuses stays
+ * inert rather than becoming a button that opens an empty card.
+ */
+const contentHotspots: StoryHotspot[] = [
+	{
+		...base('body-only', 'Body only', [-0.75, 0.15, 0.7]),
+		body: 'Cast in one piece, then machined flat so the two halves meet without a shim.'
+	},
+	{
+		...base('link-only', 'Link only', [-0.2, 0.15, 0.7]),
+		linkUrl: 'https://docs.vectreal.com/packages/viewer'
+	},
+	{
+		...base('both', 'Body and link', [0.35, 0.15, 0.7]),
+		sequenceIndex: 0,
+		body: 'The same joint, seen from the other side.',
+		linkUrl: 'https://docs.vectreal.com/packages/viewer'
+	},
+	{
+		// High enough that the card cannot fit above it.
+		...base('near-top', 'Near the top edge', [0.9, 0.95, 0.7]),
+		body: 'Its card flips below, because there is no room for it above.'
+	},
+	{
+		// Refused by `resolveHotspotLink`, so this marker reveals nothing and
+		// stays a plain label.
+		...base('unsafe-link', 'Link the renderer refuses', [-1.2, 0.15, 0.7]),
+		linkUrl: 'javascript:alert(1)'
+	}
+]
+
 const hotspotRender: Story['render'] = (args) => (
 	<VectrealViewer {...args}>
 		<ambientLight intensity={0.8} />
@@ -333,6 +369,24 @@ export const HotspotSelection: Story = {
 		showHiddenHotspots: true,
 		selectedHotspotId: 'step-2',
 		onHotspotSelect: () => {}
+	},
+	render: hotspotRender
+}
+
+/**
+ * A marker with something to say opens a card anchored to it.
+ *
+ * Non-modal on purpose: the card does not trap focus and does not stop the
+ * orbit, so a visitor can keep turning the model while reading it and tab
+ * straight on to the next marker. Escape closes it and puts focus back on the
+ * marker it came from.
+ *
+ * A marker carrying content *and* a linked camera does both on one click. None
+ * of these names a camera, so what is on show here is the card alone.
+ */
+export const HotspotContent: Story = {
+	args: {
+		hotspots: contentHotspots
 	},
 	render: hotspotRender
 }


### PR DESCRIPTION
## Root cause

The viewer had no renderer for hotspot content, so the fields existed end to end and reached a runtime that drew nothing with them.

Stacked on [#823](https://github.com/Vectreal/vectreal-platform/pull/823) for the type. A sibling of [#824](https://github.com/Vectreal/vectreal-platform/pull/824), not a child — the two do not touch the same files. **Merge #823 first.**

## Where the decisions live

All of them in `resolve-hotspot-popover.ts`, a pure module with its own spec: whether a marker has anything to reveal, whether its link is one the renderer will draw, and which side of the marker the card sits on. This package's runner loads only `.ts` under `environment: 'node'`, so a decision left inside the component could not be covered at all. `hotspot-popover-wiring.spec.ts` pins the calls the components make, and says plainly that it can tell a mounted popover from an unmounted one and nothing more.

## The link rule is the viewer's own

The platform parser applies the same rule on save, but this package ships to npm and a consumer can hand it any settings object at all — so this is the second of two independent gates, the arrangement `internalOnly` already has.

The gate is the `https://` prefix, **not** the parsed protocol: `new URL('https:evil')` reads as protocol `https:` with no authority at all, so a rule written as "parse it and check `url.protocol`" accepts something that is not an absolute https URL.

A marker whose only content is a link the rule refuses reveals nothing, rather than becoming a button that opens an empty card.

## Placement

Above by default — where the hover label already appears, and a card below covers the geometry the marker points at. It flips below near the top edge and shifts sideways only as far as it takes to stay on the canvas. Measured in canvas coordinates rather than page coordinates, so an embedded viewer inside a scrolled host page places the same as a full-page one. When the card fits on neither side the roomier one wins, rather than a default that guarantees a clipped card.

**The hover label has the same defect and is deliberately left for its own change.** It would alter what every published scene looks like on hover, which is the same reasoning the plan used to keep the you-are-here cue separate — and it can now reuse this function rather than take a second one-off.

## Interaction

`resolveHotspotInteraction` gained a `reveal` action, precedence `select > reveal > activate`.

`toggles` split into an `announces` discriminant. A reveal is `aria-expanded` and a selection is `aria-pressed`; they cannot both be true of one control, and a marker carrying both would otherwise announce itself wrongly.

`fliesCamera` is separate from the action, because the two are not alternatives: a marker with content *and* a camera says "look here, and here is why", and the flight is what puts the card's subject on screen.

Non-modal — no focus trap, no scroll lock — so a visitor can keep orbiting and tab straight on to the next marker. `info-popover.tsx`'s document-global trap is the right shape for a chrome panel and the wrong one here. Escape closes and returns focus to the marker. `prefers-reduced-motion` kills the entry animation.

An open card closes when its marker goes behind the model. An occluded marker takes no pointer events and offers no action, so that is otherwise the one state with no way to dismiss it.

**The whole marker moves into the free 41–99 band while open, not just the card.** drei writes a depth-derived z-index onto the wrapper div, which makes it a stacking context, so a card inside it cannot paint over a nearer marker however high its own z-index is.

## Mutations run

| Mutation | Result |
| --- | --- |
| Force the placement resolver to always return "above" | 3 failed |
| Accept any link scheme | 6 failed |
| Count a refused link as content | 1 failed |
| Let reveal beat select | 2 failed |
| Announce a reveal as `pressed` | 2 failed |
| Stop a reveal from flying its camera | 1 failed |
| Never mount the card | 1 failed |
| Leave an open card in the closed-marker z-index band | 1 failed |
| Leave a card open behind the model | 1 failed |

## Verification

- `npx vitest run --root .` — 156 files, 2044 tests, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — 8/8 tasks green
- New Storybook story `HotspotContent`, covering body-only, link-only, both, the near-top-edge flip and a marker whose link the renderer refuses

Browser verification runs across the whole stack once the remaining PRs land, so one pass covers authoring and rendering together.

## Also in this diff

`resolve-hotspot-markers.ts` claimed the platform parser "never sees `payloadUrl`". That stopped being true when the parser was hardened, and a stale claim in a file that explains its own hardening reads as authoritative.

## Not in this PR

Nothing new filed. The hover label's placement is named above as deliberately deferred.