### PR TITLE
fix(viewer): let a keyboard reach a marker that only names a point

### DIFF
--- a/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
@@ -63,6 +63,25 @@ describe('resolveHotspotInteraction', () => {
 		).toBe('activate')
 	})
 
+	/**
+	 * A marker with nothing to activate still carries a name, and hover was the
+	 * only way to read it. So a keyboard-only visitor, or anyone on a device
+	 * with no hover at all, could not read a published marker that names no
+	 * camera - which is every marker in a scene that carries no cameras.
+	 */
+	it('keeps a marker with nothing to do in the tab order', () => {
+		const inert = resolveHotspotInteraction(unlinked, {
+			occluded: false,
+			canActivate: false
+		})
+
+		expect(inert.focusable).toBe(true)
+		// A focus stop, not a button: the role is what says whether a press does
+		// anything, and here it does not.
+		expect(inert.role).toBe('image')
+		expect(inert.action).toBe('none')
+	})
+
 	it('drops an occluded marker out of the tab order', () => {
 		expect(
 			resolveHotspotInteraction(linked, { occluded: true, canActivate: true })
@@ -72,6 +91,14 @@ describe('resolveHotspotInteraction', () => {
 			resolveHotspotInteraction(linked, { occluded: false, canActivate: true })
 				.focusable
 		).toBe(true)
+		// Including one that offers nothing: it is invisible, so its name is not
+		// worth a stop either.
+		expect(
+			resolveHotspotInteraction(unlinked, {
+				occluded: true,
+				canActivate: false
+			}).focusable
+		).toBe(false)
 	})
 
 	describe('an editing surface that can select', () => {

--- a/packages/viewer/src/components/scene/hotspot-interaction.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.ts
@@ -48,6 +48,11 @@ export interface HotspotInteraction {
 	/**
 	 * False while occluded, so an invisible marker is not a tab stop. Focus that
 	 * is already on it survives, which `disabled` would not allow.
+	 *
+	 * True for a marker that offers nothing to do, which is not a contradiction:
+	 * such a marker still carries a name, and hover is the only other way to
+	 * read it. Someone on a keyboard, or on a device with no hover at all, had
+	 * no way to reach that name while this tracked `role`.
 	 */
 	focusable: boolean
 	/**
@@ -106,7 +111,10 @@ export function resolveHotspotInteraction(
 		// thing selection exists to avoid.
 		fliesCamera: !occluded && !canSelect && canFly,
 		announces: canSelect ? 'pressed' : canReveal ? 'expanded' : null,
-		focusable: isButton && !occluded,
+		// Not `isButton && !occluded`. A marker with nothing to activate is still
+		// a marker with a name, and focus is what reveals that name where hover
+		// cannot - which is every keyboard, and every touch device.
+		focusable: !occluded,
 		pointerEvents: occluded ? 'none' : 'auto'
 	}
 }

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -387,9 +387,17 @@ const HotspotMarker = ({
 						</button>
 					) : (
 						<div
-							className={bodyClasses}
+							className={cn(bodyClasses, FOCUS_RING)}
 							role="img"
 							aria-label={marker.accessibleName}
+							// A focus stop, not a button. Promoting it would announce
+							// something a press does not do; leaving it out left the
+							// marker's name reachable by hover alone, so a keyboard-only
+							// visitor, or anyone on a device with no hover, could not read
+							// it at all.
+							tabIndex={interaction.focusable ? 0 : -1}
+							onFocus={showLabel}
+							onBlur={hideLabel}
 						>
 							{body}
 						</div>

--- a/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
@@ -74,6 +74,25 @@ describe('the marker announces the card it opens', () => {
 	})
 })
 
+describe('a marker with nothing to do is still reachable', () => {
+	it('takes a focus stop on the non-button branch', () => {
+		const imageBranch = marker.split('role="img"')[1]?.split('>')[0]
+
+		expect(imageBranch).toContain('tabIndex={interaction.focusable ? 0 : -1}')
+	})
+
+	it('shows its name on focus, which is the only reason the stop exists', () => {
+		const imageBranch = marker.split('role="img"')[1]?.split('>')[0]
+
+		expect(imageBranch).toContain('onFocus={showLabel}')
+		expect(imageBranch).toContain('onBlur={hideLabel}')
+	})
+
+	it('draws a focus ring, so the stop is visible as well as reachable', () => {
+		expect(marker).toContain('cn(bodyClasses, FOCUS_RING)')
+	})
+})
+
 describe('the hotspot layer owns which card is open', () => {
 	it('opens at most one, toggling the one already open shut', () => {
 		expect(layer).toContain('previous === id ? null : id')


### PR DESCRIPTION
## Root cause

`focusable` was derived from whether the marker was a button, so a marker with nothing to activate got no tab stop — and its name was then reachable by hover alone.

Stacked on [#825](https://github.com/Vectreal/vectreal-platform/pull/825), which changes which markers are inert: a marker carrying content is now activatable, so the button branch already covers it. What remains is the genuinely inert one. **Merge #823 → #825 → this.**

## What was actually broken

The name reaches a screen reader through `aria-label` either way. What it did not reach was a sighted keyboard-only visitor, or anyone on a device with no hover at all — which is every phone. A published scene carrying no cameras is made entirely of these markers, so on a phone it was a row of dots with no way to find out what any of them meant.

## Why a focus stop and not a button

Promoting it to `role="button"` would announce that pressing it does something, and pressing it does nothing. `tabIndex={0}` on the `role="img"` branch gives it the stop without the false promise. Focus shows the name the same way hover does, and the focus ring the button branch already carried now draws on both.

Occlusion still drops the stop, including for these: an invisible marker's name is not worth stopping on either.

## Mutations run

| Mutation | Result |
| --- | --- |
| Restore `focusable: isButton && !occluded` | 1 failed |
| Drop the `tabIndex` from the non-button branch | 1 failed |
| Drop the focus handlers that reveal the name | 1 failed |

## Verification

- `npx vitest run --root .` — 156 files, 2048 tests, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform` — 8/8 tasks green

Keyboard verification in a real browser runs across the whole stack once the remaining PRs land.

## Not in this PR

Nothing filed.