### PR TITLE
feat(embed): tell the host page which hotspot the visitor touched

### DIFF
--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
@@ -89,6 +89,7 @@ const SceneEmbedPage = ({
 		sceneId,
 		interactions: sceneData?.interactions,
 		cameras: sceneData?.camera?.cameras,
+		hotspots: sceneData?.hotspots,
 		initialCommands
 	})
 

--- a/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-bridge.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-bridge.ts
@@ -2,13 +2,16 @@ import {
 	HOSTED_PREVIEW_VIEWER_SOURCE,
 	isHostedPreviewIncomingMessage,
 	type EmbedCameraDescriptor,
+	type EmbedHotspotDescriptor,
 	type HostedPreviewOutgoingMessage
 } from '@vctrl/embed'
+import { resolveHotspotMarkers } from '@vctrl/viewer/hotspots'
 import { useCallback, useEffect, useRef } from 'react'
 
 import type {
 	CameraConfig,
 	CameraProps,
+	HotspotDefinition,
 	SceneInteractionDefinition
 } from '@vctrl/core'
 import type {
@@ -21,6 +24,7 @@ interface UseHostedPreviewBridgeParams {
 	sceneId?: string
 	interactions?: SceneInteractionDefinition[]
 	cameras?: CameraProps['cameras']
+	hotspots?: HotspotDefinition[]
 	/** Commands to execute once on viewer_ready (e.g. from URL params). */
 	initialCommands?: import('@vctrl/viewer').ViewerCommand[]
 }
@@ -60,10 +64,37 @@ function buildCameraDescriptors(
 	}))
 }
 
+/**
+ * The hotspots a host page is allowed to hear about.
+ *
+ * Built through `resolveHotspotMarkers` with its default options, which is the
+ * same filter the renderer uses, so `internalOnly` and hidden markers cannot
+ * reach a parent page. That is not belt and braces here. `redactSettingsForEmbed`
+ * runs in exactly one place, `buildEmbedSceneManifest`, and `/preview` never
+ * reaches it - it always takes the session branch - so the settings this hook
+ * is handed there are unredacted, and this filter is the only thing standing
+ * between an internal marker's name and whichever origin pinged the frame.
+ *
+ * Names and camera ids only. A host builds navigation from these; the body and
+ * the link are what the viewer draws, and a second copy on the page would have
+ * nothing keeping it in step.
+ */
+export function buildHotspotDescriptors(
+	hotspots?: HotspotDefinition[]
+): EmbedHotspotDescriptor[] {
+	return resolveHotspotMarkers(hotspots).map((marker) => ({
+		id: marker.id,
+		name: marker.name,
+		cameraId: marker.linkedCameraId,
+		step: marker.step
+	}))
+}
+
 export function useHostedPreviewBridge({
 	sceneId,
 	interactions,
 	cameras,
+	hotspots,
 	initialCommands
 }: UseHostedPreviewBridgeParams): HostedPreviewBridgeProps {
 	const executorRef = useRef<null | ViewerCommandExecutor>(null)
@@ -74,11 +105,16 @@ export function useHostedPreviewBridge({
 	const firedViewerReadyInteractionIdsRef = useRef(new Set<string>())
 	const lastScrollProgressRef = useRef<null | number>(null)
 	const camerasRef = useRef(cameras)
+	const hotspotsRef = useRef(hotspots)
 	const initialCommandsFiredRef = useRef(false)
 
 	useEffect(() => {
 		camerasRef.current = cameras
 	}, [cameras])
+
+	useEffect(() => {
+		hotspotsRef.current = hotspots
+	}, [hotspots])
 
 	useEffect(() => {
 		sortedInteractionsRef.current = getSortedInteractions(interactions)
@@ -117,7 +153,8 @@ export function useHostedPreviewBridge({
 				source: HOSTED_PREVIEW_VIEWER_SOURCE,
 				type: 'pong',
 				sceneId,
-				cameras: buildCameraDescriptors(camerasRef.current)
+				cameras: buildCameraDescriptors(camerasRef.current),
+				hotspots: buildHotspotDescriptors(hotspotsRef.current)
 			}
 			window.parent.postMessage(pong, replyOrigin)
 		},

--- a/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-hotspot-descriptors.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-hotspot-descriptors.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * What the handshake is allowed to tell a host page about a scene's hotspots.
+ *
+ * The filter is the load-bearing part. `redactSettingsForEmbed`, which strips
+ * `internalOnly` hotspots, runs in exactly one place - `buildEmbedSceneManifest`
+ * - and `/preview` never reaches it, because it always takes the session
+ * branch. So on that route the settings this hook is handed are unredacted, and
+ * `resolveHotspotMarkers`' default options are the only thing standing between
+ * an internal marker's name and whichever origin pinged the frame.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { buildHotspotDescriptors } from './hosted-preview-bridge'
+
+import type { HotspotDefinition } from '@vctrl/core'
+
+const hotspot = (
+	overrides: Partial<HotspotDefinition> & Pick<HotspotDefinition, 'id'>
+): HotspotDefinition => ({
+	name: overrides.id,
+	worldPosition: [0, 0, 0],
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot',
+	...overrides
+})
+
+describe('buildHotspotDescriptors', () => {
+	it('describes a published hotspot by what a host can navigate with', () => {
+		expect(
+			buildHotspotDescriptors([
+				hotspot({
+					id: 'a',
+					name: 'Handle',
+					linkedCameraId: 'cam-1',
+					sequenceIndex: 0
+				})
+			])
+		).toEqual([{ id: 'a', name: 'Handle', cameraId: 'cam-1', step: 1 }])
+	})
+
+	it('reports no camera as null rather than omitting it', () => {
+		// A marker that only reveals content flies nothing, and a host has to be
+		// able to tell that apart from a field it failed to read.
+		expect(buildHotspotDescriptors([hotspot({ id: 'a' })])[0]).toMatchObject({
+			cameraId: null,
+			step: null
+		})
+	})
+
+	it('never names a hotspot the author kept backstage', () => {
+		const descriptors = buildHotspotDescriptors([
+			hotspot({ id: 'public', name: 'Handle' }),
+			hotspot({
+				id: 'internal',
+				name: 'Supplier part number',
+				internalOnly: true
+			})
+		])
+
+		expect(descriptors.map((entry) => entry.id)).toEqual(['public'])
+	})
+
+	it('never names a hotspot the author hid', () => {
+		const descriptors = buildHotspotDescriptors([
+			hotspot({ id: 'public' }),
+			hotspot({ id: 'hidden', visible: false })
+		])
+
+		expect(descriptors.map((entry) => entry.id)).toEqual(['public'])
+	})
+
+	it('numbers the steps a visitor sees, not the ones the author stored', () => {
+		// An internal marker sitting in the sequence takes no number, so the
+		// steps either side of it read the same for a host as they do on screen.
+		const descriptors = buildHotspotDescriptors([
+			hotspot({ id: 'first', sequenceIndex: 0 }),
+			hotspot({ id: 'backstage', sequenceIndex: 1, internalOnly: true }),
+			hotspot({ id: 'second', sequenceIndex: 2 })
+		])
+
+		expect(descriptors.map((entry) => entry.step)).toEqual([1, 2])
+	})
+
+	it('says nothing at all about a scene with no hotspots', () => {
+		expect(buildHotspotDescriptors(undefined)).toEqual([])
+		expect(buildHotspotDescriptors([])).toEqual([])
+	})
+
+	it('carries no body and no link', () => {
+		// The content is what the viewer draws. A second copy on the host page
+		// would have nothing keeping it in step - and on `/preview` it would be
+		// a second copy of unredacted text.
+		const [descriptor] = buildHotspotDescriptors([
+			hotspot({
+				id: 'a',
+				body: 'Cast in one piece.',
+				linkUrl: 'https://a.test'
+			})
+		])
+
+		expect(Object.keys(descriptor).sort()).toEqual([
+			'cameraId',
+			'id',
+			'name',
+			'step'
+		])
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-protocol.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-protocol.ts
@@ -7,6 +7,7 @@ export {
 
 export type {
 	EmbedCameraDescriptor,
+	EmbedHotspotDescriptor,
 	HostedPreviewCustomEventMessage,
 	HostedPreviewHostMessage,
 	HostedPreviewIncomingMessage,

--- a/packages/embed/src/embed.ts
+++ b/packages/embed/src/embed.ts
@@ -2,6 +2,7 @@ import {
 	HOSTED_PREVIEW_HOST_SOURCE,
 	HOSTED_PREVIEW_VIEWER_SOURCE,
 	type EmbedCameraDescriptor,
+	type EmbedHotspotDescriptor,
 	type HostedPreviewOutgoingMessage
 } from './protocol'
 
@@ -21,6 +22,11 @@ export interface EmbedOptions {
 export interface EmbedReadyInfo {
 	sceneId: string | undefined
 	cameras: EmbedCameraDescriptor[]
+	/**
+	 * The hotspots a visitor can see. Empty for a scene with none, and also for
+	 * an iframe older than this field - see `HostedPreviewPongMessage`.
+	 */
+	hotspots: EmbedHotspotDescriptor[]
 }
 
 export interface SetTransitionOptions {
@@ -42,6 +48,7 @@ export type EmbedEventMap = {
 		complete: boolean
 	}
 	animation_clip_finished: { clipId: string }
+	hotspot_activated: { hotspotId: string; cameraId: string | null }
 	interaction_event: {
 		interactionId?: string
 		eventName: string
@@ -130,13 +137,18 @@ export class VectrealEmbed {
 				window.clearTimeout(timer)
 				resolve({
 					sceneId: this.sceneId,
-					cameras: this.cameras
+					cameras: this.cameras,
+					hotspots: this.hotspots
 				})
 			}
 
 			if (this.isReady) {
 				window.clearTimeout(timer)
-				resolve({ sceneId: this.sceneId, cameras: this.cameras })
+				resolve({
+					sceneId: this.sceneId,
+					cameras: this.cameras,
+					hotspots: this.hotspots
+				})
 				return
 			}
 
@@ -254,6 +266,9 @@ export class VectrealEmbed {
 
 	private sceneId: string | undefined = undefined
 	private cameras: EmbedCameraDescriptor[] = []
+	// Defaulted rather than left undefined: `ready()` promises an array, and an
+	// iframe older than this field sends no `hotspots` at all.
+	private hotspots: EmbedHotspotDescriptor[] = []
 
 	// ---------------------------------------------------------------------------
 	// Private helpers
@@ -337,6 +352,7 @@ export class VectrealEmbed {
 				this.stopPingPolling()
 				this.sceneId = data.sceneId
 				this.cameras = data.cameras
+				this.hotspots = data.hotspots ?? []
 				this.isReady = true
 				this.flushPendingCommands()
 				break
@@ -367,6 +383,12 @@ export class VectrealEmbed {
 				break
 			case 'camera_changed':
 				this.emit('camera_changed', { cameraId: event.cameraId })
+				break
+			case 'hotspot_activated':
+				this.emit('hotspot_activated', {
+					hotspotId: event.hotspotId,
+					cameraId: event.cameraId
+				})
 				break
 			case 'auto_rotate_changed':
 				this.emit('auto_rotate_changed', { enabled: event.enabled })

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from './protocol'
 export type {
 	EmbedCameraDescriptor,
+	EmbedHotspotDescriptor,
 	HostedPreviewCustomEventMessage,
 	HostedPreviewHostMessage,
 	HostedPreviewIncomingMessage,

--- a/packages/embed/src/protocol.ts
+++ b/packages/embed/src/protocol.ts
@@ -47,11 +47,37 @@ export interface EmbedCameraDescriptor {
 	fov?: number
 }
 
+/**
+ * One hotspot, as a host page sees it.
+ *
+ * Carries no body, no link and no world position: a host builds navigation
+ * from these, and the content is what the viewer draws. Adding the text here
+ * would put a second copy of it on the page with nothing keeping the two in
+ * step.
+ */
+export interface EmbedHotspotDescriptor {
+	id: string
+	name: string
+	/** The camera this hotspot flies, or null when it only reveals content. */
+	cameraId: string | null
+	/** 1-based place in the navigation sequence, or null when it has none. */
+	step: number | null
+}
+
 export interface HostedPreviewPongMessage {
 	source: typeof HOSTED_PREVIEW_VIEWER_SOURCE
 	type: 'pong'
 	sceneId?: string
 	cameras: EmbedCameraDescriptor[]
+	/**
+	 * Optional, unlike `cameras`.
+	 *
+	 * An iframe and the SDK on the page around it are two separately deployed
+	 * artifacts and can be versions apart. A required field here would make an
+	 * older iframe's pong fail a newer SDK's parse, and the host would then hang
+	 * waiting for a handshake that already arrived.
+	 */
+	hotspots?: EmbedHotspotDescriptor[]
 }
 
 export interface HostedPreviewViewerEventMessage {

--- a/packages/embed/src/viewer-event-coverage.spec.ts
+++ b/packages/embed/src/viewer-event-coverage.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Every viewer event the SDK can receive has a case that re-emits it.
+ *
+ * `handleViewerEvent` is a hand-maintained switch over a union declared in a
+ * different package. A member added there and forgotten here is dropped
+ * silently: the message crosses the iframe boundary, parses, and reaches a
+ * `switch` with no matching case and no default, so nothing fails and nothing
+ * arrives. That is the same silent-drop shape `isViewerCommand`'s own comment
+ * warns about, one direction over.
+ *
+ * A name match, not a semantic one. It cannot tell a correct re-emission from
+ * a wrong one; it can tell a handled event from an unhandled one, which is the
+ * failure that has no other symptom.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const viewerTypes = readFileSync(
+	join(import.meta.dirname, '../../viewer/src/types/viewer-interactions.ts'),
+	'utf8'
+)
+const embed = readFileSync(join(import.meta.dirname, 'embed.ts'), 'utf8')
+
+const handleViewerEvent = embed
+	.split('private handleViewerEvent')[1]
+	?.split('\n\t}')[0]
+
+/** Every `type: '...'` literal declared on an interaction-event interface. */
+const eventTypes = [
+	...viewerTypes.matchAll(
+		/export interface \w+InteractionEvent \{\n\ttype: '(\w+)'/g
+	)
+].map((match) => match[1])
+
+describe('handleViewerEvent', () => {
+	it('found the union and the switch to compare', () => {
+		// Without this the two reads could yield nothing and every assertion
+		// below would pass over an empty list.
+		expect(eventTypes.length).toBeGreaterThan(5)
+		expect(handleViewerEvent).toBeTruthy()
+	})
+
+	it.each(eventTypes)('re-emits %s', (type) => {
+		expect(handleViewerEvent).toContain(`case '${type}':`)
+	})
+})

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -126,6 +126,12 @@ export interface HotspotMarkerProps {
 	onActivate?: (cameraId: string) => void
 	/** Runs when a marker is picked on a surface that selects rather than flies. */
 	onSelect?: (id: string) => void
+	/**
+	 * Runs whenever a visitor activates this marker - a reveal, a flight, or
+	 * both. Never for a selection, which is an editing surface picking the
+	 * marker up rather than a visitor doing anything with it.
+	 */
+	onActivated?: (id: string, cameraId: string | null) => void
 	/** Whether this marker's content is open. Owned by `SceneHotspots`. */
 	open?: boolean
 	/**
@@ -156,6 +162,7 @@ const HotspotMarker = ({
 	color,
 	onActivate,
 	onSelect,
+	onActivated,
 	open = false,
 	onReveal,
 	onAnchorRef
@@ -235,6 +242,12 @@ const HotspotMarker = ({
 			onSelect?.(marker.id)
 			return
 		}
+		if (interaction.action === 'none') return
+
+		// Reported once for the whole activation, before either half of it, so a
+		// host hears about a marker whether it reveals, flies, or does both.
+		onActivated?.(marker.id, marker.linkedCameraId)
+
 		if (interaction.action === 'reveal') onReveal?.(marker.id)
 		// Not an `else`. A marker that has something to say and a camera to fly
 		// does both on one click: the flight is what puts the card's subject on
@@ -248,6 +261,7 @@ const HotspotMarker = ({
 		marker.id,
 		marker.linkedCameraId,
 		onActivate,
+		onActivated,
 		onReveal,
 		onSelect
 	])

--- a/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
@@ -25,6 +25,7 @@ const read = (file: string) =>
 const marker = read('hotspot-marker.tsx')
 const layer = read('scene-hotspots.tsx')
 const popover = read('hotspot-popover.tsx')
+const viewer = read('../../vectreal-viewer.tsx')
 
 describe('the marker reaches the reveal decisions', () => {
 	it('asks the resolver what there is to reveal, rather than reading fields', () => {
@@ -120,6 +121,38 @@ describe('the hotspot layer owns which card is open', () => {
 		expect(handleReveal).toBeTruthy()
 		expect(handleReveal).toContain('setOpenId(')
 		expect(handleReveal).toContain('invalidate()')
+	})
+})
+
+describe('an activation is reported to whoever is listening', () => {
+	it('reports before either half of the activation, so both are covered', () => {
+		const click = marker
+			.split('const handleClick = useCallback')[1]
+			?.split('\t}, [')[0]
+
+		expect(click).toBeTruthy()
+		// Ordering matters: reported once for the whole activation rather than
+		// per branch, so a marker that reveals and flies is not reported twice.
+		expect(
+			(click ?? '').indexOf('onActivated?.(marker.id, marker.linkedCameraId)')
+		).toBeLessThan((click ?? '').indexOf("interaction.action === 'reveal'"))
+	})
+
+	it('reports nothing for a selection, or for an inert marker', () => {
+		const click = marker
+			.split('const handleClick = useCallback')[1]
+			?.split('\t}, [')[0]
+
+		// Selection returns before the report: an editing surface picking a
+		// marker up is not a visitor doing anything with it.
+		expect(click).toContain("if (interaction.action === 'select') {")
+		expect(click).toContain("if (interaction.action === 'none') return")
+	})
+
+	it('reaches the viewer, which turns it into an interaction event', () => {
+		expect(layer).toContain('onActivated={onHotspotActivated}')
+		expect(viewer).toContain('onHotspotActivated={handleHotspotActivated}')
+		expect(viewer).toContain("type: 'hotspot_activated'")
 	})
 })
 

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -49,6 +49,11 @@ export interface SceneHotspotsProps {
 	selectedId?: string | null
 	onActivateCamera?: (cameraId: string) => void
 	onSelect?: (id: string) => void
+	/**
+	 * Runs when a visitor activates a marker, with the camera it flies or null.
+	 * Never for a selection.
+	 */
+	onHotspotActivated?: (id: string, cameraId: string | null) => void
 	onPositionSetterReady?: (setter: null | HotspotPositionSetter) => void
 }
 
@@ -76,6 +81,7 @@ const SceneHotspots = ({
 	selectedId,
 	onActivateCamera,
 	onSelect,
+	onHotspotActivated,
 	onPositionSetterReady
 }: SceneHotspotsProps) => {
 	const camera = useThree((state) => state.camera)
@@ -394,6 +400,7 @@ const SceneHotspots = ({
 					color={color}
 					onActivate={onActivateCamera}
 					onSelect={onSelect}
+					onActivated={onHotspotActivated}
 					open={marker.id === openId}
 					onReveal={handleReveal}
 					onAnchorRef={registerAnchor}

--- a/packages/viewer/src/types/viewer-interactions.ts
+++ b/packages/viewer/src/types/viewer-interactions.ts
@@ -89,6 +89,23 @@ export interface CameraChangedInteractionEvent {
 	cameraId: string
 }
 
+/**
+ * Emitted when a visitor activates a hotspot.
+ *
+ * The host already sees `camera_changed` when a marker flies its camera, but
+ * not which marker caused it - and a marker that only reveals content moves no
+ * camera at all, so nothing reached the host for it. `cameraId` is null for
+ * exactly that case.
+ *
+ * Never emitted for a selection: that is an editing surface picking a marker
+ * up, not a visitor doing anything with it.
+ */
+export interface HotspotActivatedInteractionEvent {
+	type: 'hotspot_activated'
+	hotspotId: string
+	cameraId: null | string
+}
+
 /** Emitted when auto-rotate state changes at runtime. */
 export interface AutoRotateChangedInteractionEvent {
 	type: 'auto_rotate_changed'
@@ -117,6 +134,7 @@ export type ViewerInteractionEvent =
 	| AnimationStateChangedInteractionEvent
 	| AutoRotateChangedInteractionEvent
 	| CameraChangedInteractionEvent
+	| HotspotActivatedInteractionEvent
 	| InitialFramingCompletedInteractionEvent
 	| ModelLoadedInteractionEvent
 	| ViewerReadyInteractionEvent

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -550,6 +550,13 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		[executeViewerCommand]
 	)
 
+	const handleHotspotActivated = useCallback(
+		(hotspotId: string, cameraId: string | null) => {
+			onInteractionEvent?.({ type: 'hotspot_activated', hotspotId, cameraId })
+		},
+		[onInteractionEvent]
+	)
+
 	const handleSceneCameraExecutorReady = useCallback(
 		(executor: null | ViewerCommandExecutor) => {
 			cameraCommandExecutorRef.current = executor
@@ -698,6 +705,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									selectedId={selectedHotspotId}
 									onActivateCamera={handleActivateHotspotCamera}
 									onSelect={onHotspotSelect}
+									onHotspotActivated={handleHotspotActivated}
 									onPositionSetterReady={onHotspotPositionSetterReady}
 								/>
 								{children}


### PR DESCRIPTION
## Root cause

The embed protocol had no hotspot vocabulary at all. A host saw `camera_changed` fire and could not tell which marker caused it — and a marker that only reveals content moves no camera, so nothing reached the host for it whatsoever.

**Merge #823 → #825 → #826 → this.** Stacked because the activation carries the hotspot id, which is only available where the click is handled — a file #825 already changes.

## What this adds

- `hotspot_activated`, carrying the hotspot id and its camera id **or null**.
- An optional `hotspots` array on the pong, so a host can build navigation of its own.
- `EmbedHotspotDescriptor` exported from `@vctrl/embed`, and `hotspots` on `EmbedReadyInfo`.

**The pong field is optional where `cameras` is required.** An iframe and the SDK on the page around it are two separately deployed artifacts and can be versions apart. A required field would make an older iframe's pong fail a newer SDK's parse, and the host would then hang waiting for a handshake that had already arrived.

## The filter is the load-bearing part

Descriptors are built through `resolveHotspotMarkers` with its **default** options — the same filter the renderer uses — so `internalOnly` and hidden markers cannot reach a parent page.

That is not redundancy. `redactSettingsForEmbed` runs in exactly one place, `buildEmbedSceneManifest`, and `/preview` never reaches it because it always takes the session branch. On that route the settings this hook is handed are unredacted, and this filter is the only thing standing between an internal marker's name and whichever origin pinged the frame.

The wider `/preview` exposure — no `frame-ancestors`, no `X-Frame-Options`, and `useHostedPreviewBridge` adopting the first origin that messages it — predates hotspots, already exposes camera names, and is **filed separately** rather than fixed on a feature PR.

Descriptors carry no body and no link. A host builds navigation from these; the content is what the viewer draws, and a second copy on the page would have nothing keeping the two in step — and on `/preview`, would be a second copy of unredacted text.

## Reporting the activation once

Reported before either half of the click, so a marker that reveals *and* flies is reported once rather than twice, and an inert marker is not reported at all. A selection reports nothing.

## `viewer-event-coverage.spec.ts`

`handleViewerEvent` is a hand-maintained switch over a union declared in another package. A member added there and forgotten here is dropped silently: the message crosses the iframe, parses, and reaches a switch with no matching case and no default. Same silent-drop shape `isViewerCommand`'s own comment warns about, one direction over. The guard reads the union out of the viewer and requires a case for every member — it covers the next event added, not just this one.

## Mutations run

| Mutation | Result |
| --- | --- |
| Include `internalOnly` and hidden hotspots in the pong | 3 failed |
| Drop the `hotspot_activated` case from the SDK | 1 failed |
| Report a selection as an activation | 1 failed |
| Report after the reveal instead of before it | 1 failed |

## Verification

- `npx vitest run --root .` — 158 files, 2067 tests, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vctrl/embed,vectreal-platform` — 10/10 tasks green

## Not in this PR

The `/preview` origin-trust and framing gaps, named above and filed as their own security row.