### PR TITLE
feat(embed): let a host focus a hotspot

### DIFF
--- a/packages/embed/src/embed.ts
+++ b/packages/embed/src/embed.ts
@@ -173,6 +173,18 @@ export class VectrealEmbed {
 		this.sendCommand({ type: 'activate_camera', cameraId })
 	}
 
+	/**
+	 * Focus a hotspot: reveal what it says and fly its camera, as clicking the
+	 * marker would.
+	 *
+	 * Ids come from `ready()`, which reports only the hotspots a visitor can
+	 * see. A hotspot the author hid or kept internal is not drawn, and naming
+	 * one here does nothing.
+	 */
+	focusHotspot(hotspotId: string): void {
+		this.sendCommand({ type: 'focus_hotspot', hotspotId })
+	}
+
 	/** Override the transition behaviour for subsequent camera switches. */
 	setTransition(options: SetTransitionOptions): void {
 		this.sendCommand({

--- a/packages/embed/src/protocol.spec.ts
+++ b/packages/embed/src/protocol.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { isViewerCommand } from './protocol'
@@ -11,6 +14,7 @@ import { isViewerCommand } from './protocol'
 describe('isViewerCommand', () => {
 	it.each([
 		{ type: 'activate_camera', cameraId: 'front' },
+		{ type: 'focus_hotspot', hotspotId: 'handle' },
 		{ type: 'set_controls_enabled', enabled: false },
 		{ type: 'set_auto_rotate', enabled: true },
 		{ type: 'set_auto_rotate', enabled: true, speed: 0.5 },
@@ -47,5 +51,54 @@ describe('isViewerCommand', () => {
 		{ type: 'seek_animation_clip', clipId: 'spin', time: '1' }
 	])('rejects %j', (command) => {
 		expect(isViewerCommand(command)).toBe(false)
+	})
+})
+
+describe('focus_hotspot', () => {
+	it.each([
+		['no id at all', { type: 'focus_hotspot' }],
+		['a blank id', { type: 'focus_hotspot', hotspotId: '   ' }],
+		['a non-string id', { type: 'focus_hotspot', hotspotId: 42 }]
+	])('refuses %s', (_label, command) => {
+		expect(isViewerCommand(command)).toBe(false)
+	})
+})
+
+/**
+ * Every command in the union has a case in the guard.
+ *
+ * `isViewerCommand`'s `default: return false` drops an unregistered command
+ * silently, with no error on either side of the iframe - so a command added to
+ * the union and forgotten here type-checks, sends, and simply never arrives.
+ * The guard reads the union out of the viewer package rather than repeating it,
+ * so it covers the next command added, not just this one.
+ */
+describe('the guard covers the command union', () => {
+	const viewerTypes = readFileSync(
+		join(import.meta.dirname, '../../viewer/src/types/viewer-interactions.ts'),
+		'utf8'
+	)
+	const protocol = readFileSync(
+		join(import.meta.dirname, 'protocol.ts'),
+		'utf8'
+	)
+
+	const commandTypes = [
+		...viewerTypes.matchAll(
+			/export interface \w+ViewerCommand \{\n\ttype: '(\w+)'/g
+		)
+	].map((match) => match[1])
+
+	const guard = protocol
+		.split('export function isViewerCommand')[1]
+		?.split('\nexport ')[0]
+
+	it('found the union and the guard to compare', () => {
+		expect(commandTypes.length).toBeGreaterThan(5)
+		expect(guard).toBeTruthy()
+	})
+
+	it.each(commandTypes)('registers %s', (type) => {
+		expect(guard).toContain(`case '${type}':`)
 	})
 })

--- a/packages/embed/src/protocol.ts
+++ b/packages/embed/src/protocol.ts
@@ -119,6 +119,10 @@ export function isViewerCommand(value: unknown): value is ViewerCommand {
 			return (
 				typeof value.cameraId === 'string' && value.cameraId.trim().length > 0
 			)
+		case 'focus_hotspot':
+			return (
+				typeof value.hotspotId === 'string' && value.hotspotId.trim().length > 0
+			)
 		case 'set_controls_enabled':
 			return typeof value.enabled === 'boolean'
 		case 'set_auto_rotate':

--- a/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
@@ -156,6 +156,49 @@ describe('an activation is reported to whoever is listening', () => {
 	})
 })
 
+describe('a host can focus a hotspot the way a click would', () => {
+	const focusHotspot = layer
+		.split('const focusHotspot = useCallback')[1]
+		?.split('\t\t[invalidate')[0]
+
+	it('found the executor to read', () => {
+		expect(focusHotspot).toBeTruthy()
+	})
+
+	it('resolves the id against the drawn markers, never the stored settings', () => {
+		// A hotspot the author hid or kept internal is not in that list on a
+		// public surface, so a stale host list cannot reach one by id.
+		expect(focusHotspot).toContain('markersRef.current.find(')
+		expect(focusHotspot).toContain('if (!marker) return')
+	})
+
+	it('does what a click does: reveal, and fly if there is a camera', () => {
+		expect(focusHotspot).toContain('resolveHotspotPopoverContent(marker)')
+		expect(focusHotspot).toContain('setOpenId(marker.id)')
+		expect(focusHotspot).toContain('onActivateCamera?.(marker.linkedCameraId)')
+	})
+
+	it('reports no activation, which would echo the host back to itself', () => {
+		expect(focusHotspot).not.toContain('onHotspotActivated')
+	})
+
+	it('reads the list from a ref, so registering it is not re-run per edit', () => {
+		// A dependency that changed with the list would unregister and
+		// re-register the executor on every edit, which is the shape that has
+		// left this viewer with no executor at all before.
+		expect(layer).toContain('const markersRef = useRef(markers)')
+		expect(focusHotspot).not.toContain('markers.find(')
+	})
+
+	it('is registered with the viewer, which routes the command to it', () => {
+		expect(layer).toContain("command.type === 'focus_hotspot'")
+		expect(viewer).toContain(
+			'onCommandExecutorReady={handleSceneHotspotsExecutorReady}'
+		)
+		expect(viewer).toContain("case 'focus_hotspot':")
+	})
+})
+
 describe('the card is safe to put inside a third-party page', () => {
 	it('opens a link in a new context that cannot reach back', () => {
 		expect(popover).toContain('rel="noopener noreferrer"')

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -8,7 +8,9 @@ import {
 	occlusionRayFar
 } from './hotspot-occlusion'
 import { resolveHotspotMarkers } from './resolve-hotspot-markers'
+import { resolveHotspotPopoverContent } from './resolve-hotspot-popover'
 
+import type { ViewerCommandExecutor } from '../../types/viewer-interactions'
 import type { HotspotDefinition } from '@vctrl/core'
 import type { Group, Object3D } from 'three'
 
@@ -54,6 +56,13 @@ export interface SceneHotspotsProps {
 	 * Never for a selection.
 	 */
 	onHotspotActivated?: (id: string, cameraId: string | null) => void
+	/**
+	 * Registers the executor that handles `focus_hotspot`, and `null` on
+	 * unmount. The same shape `SceneCamera` and `SceneAnimation` use: the
+	 * command needs the drawn marker list and the open-card state, both of
+	 * which live here.
+	 */
+	onCommandExecutorReady?: (executor: null | ViewerCommandExecutor) => void
 	onPositionSetterReady?: (setter: null | HotspotPositionSetter) => void
 }
 
@@ -82,6 +91,7 @@ const SceneHotspots = ({
 	onActivateCamera,
 	onSelect,
 	onHotspotActivated,
+	onCommandExecutorReady,
 	onPositionSetterReady
 }: SceneHotspotsProps) => {
 	const camera = useThree((state) => state.camera)
@@ -102,6 +112,17 @@ const SceneHotspots = ({
 		() => resolveHotspotMarkers(hotspots, { includeInternal, includeHidden }),
 		[hotspots, includeInternal, includeHidden]
 	)
+
+	/**
+	 * The drawn list, for the command executor to resolve an id against.
+	 *
+	 * A ref rather than a closure over `markers`: the executor is registered by
+	 * an effect, and a dependency that changes whenever the list does would
+	 * unregister and re-register it on every edit. That is the shape that has
+	 * silently left this viewer with no executor before.
+	 */
+	const markersRef = useRef(markers)
+	markersRef.current = markers
 
 	/**
 	 * Where the gizmo is while a drag is in flight, and whose drag it is.
@@ -175,6 +196,38 @@ const SceneHotspots = ({
 			setOpenId(null)
 		}
 	}, [markers, occludedIds, openId])
+
+	/**
+	 * A host focusing a hotspot does what clicking the marker does.
+	 *
+	 * Resolved against `markers` rather than the stored settings, so a hotspot
+	 * the author hid or kept internal cannot be reached by id: it is not in that
+	 * list on a public surface, and the command falls through doing nothing.
+	 *
+	 * No `hotspot_activated` event follows. That event says a visitor touched
+	 * the marker, and echoing a host's own command back to it as a visitor
+	 * action would be a lie the host cannot tell apart from the real thing.
+	 */
+	const focusHotspot = useCallback(
+		(hotspotId: string) => {
+			const marker = markersRef.current.find((entry) => entry.id === hotspotId)
+			if (!marker) return
+
+			if (resolveHotspotPopoverContent(marker)) setOpenId(marker.id)
+			if (marker.linkedCameraId) onActivateCamera?.(marker.linkedCameraId)
+			invalidate()
+		},
+		[invalidate, onActivateCamera]
+	)
+
+	useEffect(() => {
+		onCommandExecutorReady?.({
+			execute: (command) => {
+				if (command.type === 'focus_hotspot') focusHotspot(command.hotspotId)
+			}
+		})
+		return () => onCommandExecutorReady?.(null)
+	}, [focusHotspot, onCommandExecutorReady])
 
 	const registerAnchor = useCallback((id: string, node: Group | null) => {
 		if (node) anchors.current.set(id, node)

--- a/packages/viewer/src/types/viewer-interactions.ts
+++ b/packages/viewer/src/types/viewer-interactions.ts
@@ -32,6 +32,20 @@ export interface SetControlsOptionsViewerCommand {
 	pan?: boolean
 }
 
+/**
+ * Command that focuses a single hotspot: reveals whatever it has to say and
+ * flies its linked camera, exactly as clicking the marker would.
+ *
+ * For a host driving its own navigation from the hotspot descriptors in the
+ * handshake. Naming a hotspot that is not drawn - one the author hid or kept
+ * internal - does nothing, so a stale host list cannot reach a marker a
+ * visitor is not allowed to see.
+ */
+export interface FocusHotspotViewerCommand {
+	type: 'focus_hotspot'
+	hotspotId: string
+}
+
 /** Command that plays the animation program from the beginning. */
 export interface RestartAnimationViewerCommand {
 	type: 'restart_animation'
@@ -59,6 +73,7 @@ export interface SetAnimationPlayingViewerCommand {
 /** Minimal imperative command surface currently supported by the viewer runtime. */
 export type ViewerCommand =
 	| ActivateCameraViewerCommand
+	| FocusHotspotViewerCommand
 	| RestartAnimationViewerCommand
 	| SeekAnimationClipViewerCommand
 	| SetAnimationPlayingViewerCommand

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -426,6 +426,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		CameraProps['sceneTransition'] | null
 	>(null)
 	const cameraCommandExecutorRef = useRef<null | ViewerCommandExecutor>(null)
+	const hotspotCommandExecutorRef = useRef<null | ViewerCommandExecutor>(null)
 	const animation = useAnimationRuntime({
 		animations,
 		options: animationOptions,
@@ -453,6 +454,9 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 			switch (command.type) {
 				case 'activate_camera':
 					cameraCommandExecutorRef.current?.execute(command)
+					break
+				case 'focus_hotspot':
+					hotspotCommandExecutorRef.current?.execute(command)
 					break
 				case 'set_controls_enabled':
 					setControlsEnabledOverride(command.enabled)
@@ -555,6 +559,13 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 			onInteractionEvent?.({ type: 'hotspot_activated', hotspotId, cameraId })
 		},
 		[onInteractionEvent]
+	)
+
+	const handleSceneHotspotsExecutorReady = useCallback(
+		(executor: null | ViewerCommandExecutor) => {
+			hotspotCommandExecutorRef.current = executor
+		},
+		[]
 	)
 
 	const handleSceneCameraExecutorReady = useCallback(
@@ -706,6 +717,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									onActivateCamera={handleActivateHotspotCamera}
 									onSelect={onHotspotSelect}
 									onHotspotActivated={handleHotspotActivated}
+									onCommandExecutorReady={handleSceneHotspotsExecutorReady}
 									onPositionSetterReady={onHotspotPositionSetterReady}
 								/>
 								{children}


### PR DESCRIPTION
## Root cause

The embed command surface could fly a camera but could not name a hotspot, so a host that built navigation from the hotspot descriptors had nothing to call when someone clicked its own list.

**Merge #823 → #825 → #826 → #827 → this.**

## What `focus_hotspot` does

What clicking the marker does: reveals what it has to say, and flies its linked camera if it has one. Plus `VectrealEmbed.focusHotspot(hotspotId)`.

## Registered in all three places, because two is a silent no-op

The union in `viewer-interactions.ts`, the `executeViewerCommand` switch, and `isViewerCommand` — whose `default` branch drops an unregistered command with no error on either side of the iframe, exactly as its own comment warns.

`protocol.spec.ts` now reads the union out of the viewer package and requires a case for every member, so the next command added cannot fall into that hole either. That is the guard worth having here rather than one assertion about this command.

## Where the executor lives

In `SceneHotspots`, not the viewer root — the same shape `SceneCamera` and `SceneAnimation` already use. The command needs the drawn marker list and the open-card state, and both live there.

**It resolves the id against the drawn markers, not the stored settings.** A hotspot the author hid or kept internal is not in that list on a public surface, so a stale host list cannot reach a marker a visitor is not allowed to see; the command falls through doing nothing.

**The marker list is read from a ref, not closed over.** A dependency that changed with the list would unregister and re-register the executor on every edit, which is the shape that has left this viewer with no executor at all before.

**No `hotspot_activated` follows a focus.** That event says a visitor touched the marker; echoing a host's own command back as a visitor action would be a lie the host cannot tell apart from the real thing.

## Mutations run

| Mutation | Result |
| --- | --- |
| Remove the `focus_hotspot` case from `isViewerCommand` | 2 failed |
| Accept a blank hotspot id | 1 failed |
| Resolve the id against stored settings instead of drawn markers | 1 failed |
| Drop the viewer's route for the command | 1 failed |

## Verification

- `npx vitest run --root .` — 158 files, 2087 tests, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vctrl/embed,vectreal-platform` — 10/10 tasks green

## Not in this PR

`seek_animation_clip` still has no `VectrealEmbed` method — accepted by the guard and executable, but unreachable from the SDK class. Pre-existing, filed rather than fixed. The new union-coverage guard deliberately does not assert SDK methods, since that gap would make it fail on unrelated ground.