### PR TITLE
feat(embed): let the host page decide how hotspots appear

### DIFF
--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router'
 import SceneEmbedInfoPopover from './scene-embed-info-popover'
 import SceneEmbedViewer from './scene-embed-viewer'
 import { useSceneEmbedScene } from './use-scene-embed-scene'
+import { resolveEmbedHotspotPresentation } from '../../lib/domain/embed/embed-presentation'
 import { useHostedPreviewBridge } from '../../lib/domain/embed/hosted-preview-bridge'
 import { isSceneCamera } from '../../lib/domain/scene/scene-camera'
 import CenteredSpinner from '../centered-spinner'
@@ -68,6 +69,23 @@ function useInitialCommands(): ViewerCommand[] {
 }
 
 /**
+ * How the embed's hotspots appear, from the same query string.
+ *
+ * A channel of its own rather than one more entry in `useInitialCommands`,
+ * because none of these is a `ViewerCommand`. Those are executed once when the
+ * viewer reports ready; suppressing the markers is not something the viewer
+ * does at a moment, it is something it is - as a command it would draw the
+ * markers first and take them away on the ready event.
+ */
+function useHotspotPresentation() {
+	const [searchParams] = useSearchParams()
+	return useMemo(
+		() => resolveEmbedHotspotPresentation(searchParams),
+		[searchParams]
+	)
+}
+
+/**
  * The full-viewport scene page shared by `/embed` and `/preview`.
  *
  * Both routes render exactly the same thing; they differ only in how their
@@ -85,6 +103,7 @@ const SceneEmbedPage = ({
 			projectId
 		})
 	const initialCommands = useInitialCommands()
+	const hotspotPresentation = useHotspotPresentation()
 	const bridge = useHostedPreviewBridge({
 		sceneId,
 		interactions: sceneData?.interactions,
@@ -185,6 +204,7 @@ const SceneEmbedPage = ({
 				sceneData={sceneData}
 				onCommandExecutorReady={onCommandExecutorReady}
 				onInteractionEvent={onInteractionEvent}
+				hotspotPresentation={hotspotPresentation}
 				popover={
 					<SceneEmbedInfoPopover
 						title={sceneData?.meta?.name?.trim() || undefined}

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-viewer.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-viewer.tsx
@@ -6,6 +6,7 @@ import { resolveBakedShadowSource } from '../../lib/domain/scene/client/baked-sh
 import CenteredSpinner from '../centered-spinner'
 import { ClientVectrealViewer } from '../viewer/client-vectreal-viewer'
 
+import type { EmbedHotspotPresentation } from '../../lib/domain/embed/embed-presentation'
 import type { ModelFile, ServerSceneData } from '@vctrl/hooks/use-load-model'
 import type { VectrealViewerProps, ViewerLoadingThumbnail } from '@vctrl/viewer'
 import type { ReactNode } from 'react'
@@ -18,6 +19,11 @@ export interface SceneEmbedViewerProps {
 	loadingThumbnail?: ViewerLoadingThumbnail
 	/** Usually `<SceneEmbedInfoPopover>`; omitted where the surface has its own. */
 	popover?: ReactNode
+	/**
+	 * How the hotspots appear, where the embedding page asked for something
+	 * other than the default. Omitted by every surface that is not an embed.
+	 */
+	hotspotPresentation?: EmbedHotspotPresentation
 	onCommandExecutorReady?: VectrealViewerProps['onCommandExecutorReady']
 	onInteractionEvent?: VectrealViewerProps['onInteractionEvent']
 }
@@ -37,6 +43,7 @@ const SceneEmbedViewer = memo(
 		className,
 		loadingThumbnail,
 		popover,
+		hotspotPresentation,
 		onCommandExecutorReady,
 		onInteractionEvent
 	}: SceneEmbedViewerProps) => {
@@ -79,6 +86,14 @@ const SceneEmbedViewer = memo(
 					  gates, and this surface must never open either.
 					*/
 					hotspots={sceneData?.hotspots}
+					/*
+					  Undefined where the surface passed no presentation, so the
+					  viewer's own defaults apply and nothing here has to restate
+					  them.
+					*/
+					hotspotColor={hotspotPresentation?.color}
+					showHotspotMarkers={hotspotPresentation?.showMarkers}
+					revealHotspotContent={hotspotPresentation?.revealContent}
 					shadowsOptions={shadowsOptions}
 					staticShadowBake
 					bakedShadow={bakedShadow}

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveEmbedHotspotPresentation } from './embed-presentation'
+
+const resolve = (query: string) =>
+	resolveEmbedHotspotPresentation(new URLSearchParams(query))
+
+describe('resolveEmbedHotspotPresentation', () => {
+	it('draws everything when the host says nothing', () => {
+		expect(resolve('')).toEqual({
+			showMarkers: true,
+			revealContent: true,
+			color: undefined
+		})
+	})
+
+	it('reads 0 as off and anything else as on, matching autoRotate', () => {
+		expect(resolve('hotspots=0').showMarkers).toBe(false)
+		expect(resolve('hotspots=1').showMarkers).toBe(true)
+		expect(resolve('hotspots=true').showMarkers).toBe(true)
+		expect(resolve('hotspotContent=0').revealContent).toBe(false)
+		expect(resolve('hotspotContent=1').revealContent).toBe(true)
+	})
+
+	it('reads a present-but-empty value as on, the same as an absent one', () => {
+		// `?hotspots=` is a host writing the parameter and leaving it blank,
+		// which says nothing and is certainly not `0`.
+		expect(resolve('hotspots=').showMarkers).toBe(true)
+		expect(resolve('hotspotContent=').revealContent).toBe(true)
+	})
+
+	it('takes a hex colour, in every length CSS allows', () => {
+		expect(resolve('hotspotColor=%23fc6c18').color).toBe('#fc6c18')
+		expect(resolve('hotspotColor=%23fff').color).toBe('#fff')
+		expect(resolve('hotspotColor=%23FC6C18AA').color).toBe('#FC6C18AA')
+	})
+
+	/**
+	 * The value lands in an inline `style` on the marker root, so anything but a
+	 * hex literal would let a query string write style into the page: a value
+	 * like `red; background: url(...)` closes the declaration and adds its own.
+	 */
+	it.each([
+		['a named colour', 'red'],
+		['a function', 'rgb(1,2,3)'],
+		['a declaration break-out', 'red; background: url(x)'],
+		['a bare url', 'url(https://a.test/x.png)'],
+		['a custom property', 'var(--brand)'],
+		['a five-digit hex, which CSS has no such length for', '#ff00f'],
+		['a hex with a non-hex digit', '#gggggg'],
+		['no hash', 'fc6c18'],
+		['an empty value', '']
+	])('refuses %s', (_label, value) => {
+		expect(
+			resolveEmbedHotspotPresentation(
+				new URLSearchParams([['hotspotColor', value]])
+			).color
+		).toBeUndefined()
+	})
+
+	it('trims the value before judging it', () => {
+		expect(
+			resolveEmbedHotspotPresentation(
+				new URLSearchParams([['hotspotColor', '  #fc6c18  ']])
+			).color
+		).toBe('#fc6c18')
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts
@@ -1,0 +1,68 @@
+/**
+ * How the embed's hotspots appear, read from the iframe's own URL.
+ *
+ * A separate channel from `useInitialCommands`, and not for tidiness: those are
+ * `ViewerCommand`s, executed once when the viewer reports ready. None of these
+ * is a command. Suppressing the markers is not something the viewer does at a
+ * moment, it is something it is - so expressing it as a command would mean the
+ * markers drawing first and disappearing on the ready event.
+ *
+ * Every option here is for a host page that has taken part of the job over:
+ * driving navigation from the hotspot descriptors in the handshake, or drawing
+ * its own panel from `hotspot_activated`. Where two UIs would otherwise compete,
+ * this is how the host says which one wins.
+ */
+
+export interface EmbedHotspotPresentation {
+	/**
+	 * Whether the viewer draws the markers at all.
+	 *
+	 * False leaves the hotspots resolved but undrawn, so `focus_hotspot` still
+	 * flies a camera by id and the handshake still lists them. A host driving
+	 * its own navigation needs exactly that: no markers on the model, and every
+	 * hotspot still reachable.
+	 */
+	showMarkers: boolean
+	/**
+	 * Whether a marker opens a card of its own.
+	 *
+	 * False still activates: the camera flies and `hotspot_activated` fires, so
+	 * a host drawing its own panel gets the event without the viewer drawing a
+	 * second copy of the same text over the model.
+	 */
+	revealContent: boolean
+	/** Overrides the marker fill. Undefined keeps the viewer's neutral default. */
+	color: string | undefined
+}
+
+/**
+ * A CSS colour a host may set the markers to.
+ *
+ * A hex literal only, and validated rather than passed through, because this
+ * value lands in an inline `style` on the marker root. Accepting arbitrary CSS
+ * there would let a URL parameter close the declaration and add its own -
+ * `red; background: url(...)` - which is a query string writing style into the
+ * page. Hex covers what a brand colour is and nothing else.
+ */
+const HEX_COLOR = /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+
+/**
+ * `0` is off and anything else is on, matching `?autoRotate`.
+ *
+ * An absent parameter reads as on, which is also the default, so there is no
+ * separate fallback to carry: both of these are drawn unless the host says
+ * otherwise.
+ */
+const isOn = (value: null | string): boolean => value !== '0'
+
+export function resolveEmbedHotspotPresentation(
+	params: URLSearchParams
+): EmbedHotspotPresentation {
+	const color = params.get('hotspotColor')?.trim()
+
+	return {
+		showMarkers: isOn(params.get('hotspots')),
+		revealContent: isOn(params.get('hotspotContent')),
+		color: color && HEX_COLOR.test(color) ? color : undefined
+	}
+}

--- a/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
@@ -101,7 +101,7 @@ describe('the hotspot layer owns which card is open', () => {
 
 	it('hands each marker its own open state and the toggle', () => {
 		expect(layer).toContain('open={marker.id === openId}')
-		expect(layer).toContain('onReveal={handleReveal}')
+		expect(layer).toContain('handleReveal')
 	})
 
 	it('closes a card whose marker went behind the model or left the list', () => {
@@ -196,6 +196,41 @@ describe('a host can focus a hotspot the way a click would', () => {
 			'onCommandExecutorReady={handleSceneHotspotsExecutorReady}'
 		)
 		expect(viewer).toContain("case 'focus_hotspot':")
+	})
+})
+
+describe('a host can take the hotspot UI over', () => {
+	it('draws nothing when the markers are suppressed', () => {
+		expect(layer).toContain('if (markers.length === 0 || !showMarkers)')
+	})
+
+	it('keeps them resolved, so a focus command still flies a camera', () => {
+		// Suppressing by passing no `hotspots` would break `focus_hotspot` and
+		// empty the handshake, which is the opposite of what a host driving its
+		// own navigation needs.
+		const markersMemo = layer
+			.split('const markers = useMemo')[1]
+			?.split(')\n')[0]
+
+		expect(markersMemo).not.toContain('showMarkers')
+	})
+
+	it('stops raycasting for an occlusion nobody can see', () => {
+		expect(layer).toContain('if (model && showMarkers) {')
+	})
+
+	it('withholds the reveal handler rather than branching inside the marker', () => {
+		// A marker with no reveal handler is not a reveal button at all - the
+		// interaction resolver already reads it that way - so the click falls
+		// through to the camera and the activation is still reported.
+		expect(layer).toContain(
+			'onReveal={revealContent ? handleReveal : undefined}'
+		)
+	})
+
+	it('reaches the viewer prop a host page sets', () => {
+		expect(viewer).toContain('showMarkers={showHotspotMarkers}')
+		expect(viewer).toContain('revealContent={revealHotspotContent}')
 	})
 })
 

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -47,6 +47,23 @@ export interface SceneHotspotsProps {
 	includeHidden?: boolean
 	/** Overrides the marker fill for every hotspot in this viewer. */
 	color?: string
+	/**
+	 * Whether the markers are drawn. Default true.
+	 *
+	 * False leaves them resolved but undrawn, so `focus_hotspot` still flies a
+	 * camera by id and a host can still list them. A host driving its own
+	 * navigation needs exactly that combination: nothing on the model, every
+	 * hotspot still reachable.
+	 */
+	showMarkers?: boolean
+	/**
+	 * Whether a marker opens a card of its own. Default true.
+	 *
+	 * False still activates - the camera flies and the activation is reported -
+	 * so a host drawing its own panel gets the event without the viewer drawing
+	 * a second copy of the same text over the model.
+	 */
+	revealContent?: boolean
 	/** The marker drawn as the current one. */
 	selectedId?: string | null
 	onActivateCamera?: (cameraId: string) => void
@@ -87,6 +104,8 @@ const SceneHotspots = ({
 	includeInternal,
 	includeHidden,
 	color,
+	showMarkers = true,
+	revealContent = true,
 	selectedId,
 	onActivateCamera,
 	onSelect,
@@ -372,7 +391,10 @@ const SceneHotspots = ({
 
 		const next = new Set<string>()
 
-		if (model) {
+		// Nothing is drawn, so nothing can be faded. The pass is one raycast per
+		// marker at 15Hz, and a host that suppressed the markers is paying for it
+		// on every visitor's machine for no visible result.
+		if (model && showMarkers) {
 			// r3f updates world matrices after every useFrame subscriber has run, and
 			// `Center` writes its offset in a layout effect, so the pass forced by a
 			// model swap would otherwise test against the previous placement.
@@ -440,7 +462,7 @@ const SceneHotspots = ({
 		)
 	})
 
-	if (markers.length === 0) return null
+	if (markers.length === 0 || !showMarkers) return null
 
 	return (
 		<>
@@ -455,7 +477,7 @@ const SceneHotspots = ({
 					onSelect={onSelect}
 					onActivated={onHotspotActivated}
 					open={marker.id === openId}
-					onReveal={handleReveal}
+					onReveal={revealContent ? handleReveal : undefined}
 					onAnchorRef={registerAnchor}
 				/>
 			))}

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -195,6 +195,24 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 * default pale fill.
 	 */
 	hotspotColor?: string
+	/**
+	 * Whether the hotspot markers are drawn at all. Default true.
+	 *
+	 * For a host page that navigates the scene itself, from the hotspots the
+	 * embed handshake reports. The hotspots stay resolved either way, so
+	 * `focus_hotspot` still flies a camera by id with nothing drawn on the
+	 * model - which is the combination that host needs, and which suppressing
+	 * them by passing no `hotspots` would not give.
+	 */
+	showHotspotMarkers?: boolean
+	/**
+	 * Whether a marker opens a card of its own. Default true.
+	 *
+	 * False still activates: the camera flies and `hotspot_activated` is
+	 * emitted, so a host drawing its own panel gets the event without the viewer
+	 * drawing a second copy of the same text over the model.
+	 */
+	revealHotspotContent?: boolean
 
 	// --- Editor affordances ---
 	// Editing-surface features (e.g. the publisher). Public/embedded viewers omit
@@ -377,6 +395,8 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		normalizationOptions,
 		hotspots,
 		hotspotColor,
+		showHotspotMarkers,
+		revealHotspotContent,
 		// Editor affordances
 		shadowLightEditable,
 		showInternalHotspots = false,
@@ -713,6 +733,8 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									includeInternal={showInternalHotspots}
 									includeHidden={showHiddenHotspots}
 									color={hotspotColor}
+									showMarkers={showHotspotMarkers}
+									revealContent={revealHotspotContent}
 									selectedId={selectedHotspotId}
 									onActivateCamera={handleActivateHotspotCamera}
 									onSelect={onHotspotSelect}


### PR DESCRIPTION
## Root cause

The embed had exactly one hotspot presentation and no way to ask for another, so a host page driving its own navigation from the handshake ended up with two competing UIs on the same model.

**Merge #823 → #825 → #826 → #827 → #829 → this.**

## Three options, on the iframe URL

| Parameter | Effect |
| --- | --- |
| `?hotspots=0` | No markers drawn |
| `?hotspotContent=0` | Markers drawn, the card left to the host |
| `?hotspotColor=%23fc6c18` | Sets the marker fill |

**A channel of its own, not more entries in `useInitialCommands`.** Those are `ViewerCommand`s, executed once when the viewer reports ready, and none of these is a command — suppressing the markers is not something the viewer *does at a moment*, it is something it *is*. As a command the markers would draw first and disappear on the ready event.

## Suppressing markers keeps the hotspots reachable

`?hotspots=0` leaves them resolved but undrawn, so `focus_hotspot` still flies a camera by id and the handshake still lists them. That combination — nothing on the model, every hotspot still reachable — is exactly what a host driving its own navigation needs, and passing no `hotspots` at all would not give it.

The occlusion pass is skipped while they are undrawn: one raycast per marker at 15Hz whose result no visitor could see.

## Suppressing content withholds the handler

Rather than branching inside the marker. A marker with no reveal handler is not a reveal button at all — the interaction resolver already reads it that way — so the click falls through to the camera and `hotspot_activated` is still emitted.

## `?hotspotColor` takes a hex literal and nothing else

The value lands in an inline `style` on the marker root. Accepting arbitrary CSS would let a query string close the declaration and add its own (`red; background: url(...)`) — a URL parameter writing style into the page. Hex covers what a brand colour is and nothing else.

## No fields in the embed options panel

`?camera`, `?autoRotate` and `?transition` have none either, and the panel states its own rule for it: a field duplicating something already editable in the snippet being handed over is a second place to make the same edit. Documented instead, which is where the existing parameters are documented too. This is a deliberate departure from the plan, which named `embed-options-panel.tsx`.

## Mutations run

| Mutation | Result |
| --- | --- |
| Draw the markers despite suppression | 1 failed |
| Drop the resolved markers along with the drawn ones | 1 failed |
| Hand over the reveal handler while content is suppressed | 1 failed |
| Pass the colour through unvalidated | 8 failed |
| Change what `0` means | 1 failed |

**One mutation could not fail on the first attempt, and that found a real problem.** `readFlag` carried a per-option fallback while both options default to on, so the fallback was dead generality and the mutation was behaviourally identical to the original. Removed, rather than kept alongside a test that passes either way.

## Verification

- `npx vitest run --root .` — 159 files, 2106 tests, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vctrl/embed,vectreal-platform` — 10/10 tasks green

## Not in this PR

The documentation, which lands in one pass across the embed guide and both package READMEs rather than three partial edits.