### PR TITLE
feat(hotspots): let a hotspot say something

### DIFF
--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
@@ -15,6 +15,7 @@ import { getDefaultStore } from 'jotai'
 import { describe, expect, it, beforeEach } from 'vitest'
 
 import HotspotsSettingsPanel from './hotspots-settings-panel'
+import { MAX_HOTSPOT_BODY_LENGTH } from '../../../../lib/domain/scene/hotspot-urls'
 import { isClickToPlaceActiveAtom } from '../../../../lib/stores/publisher-config-store'
 import {
 	activeHotspotIdAtom,
@@ -328,6 +329,103 @@ describe('HotspotsSettingsPanel selection', () => {
 		rerender(<HotspotsSettingsPanel />)
 
 		expect(screen.getByLabelText('Asset URL')).toBeTruthy()
+	})
+})
+
+describe('HotspotsSettingsPanel content', () => {
+	const openEditor = () => {
+		store.set(hotspotsAtom, [hotspot])
+		store.set(activeHotspotIdAtom, hotspot.id)
+		render(<HotspotsSettingsPanel />)
+	}
+
+	const stored = () => store.get(hotspotsAtom)[0]
+
+	it('writes body text onto the marker being edited', () => {
+		openEditor()
+
+		fireEvent.change(screen.getByLabelText('Marker body'), {
+			target: { value: 'Cast in one piece.' }
+		})
+
+		expect(stored().body).toBe('Cast in one piece.')
+	})
+
+	/**
+	 * Clearing has to leave the field unset, not empty.
+	 *
+	 * An empty string is a different value from an absent one everywhere it
+	 * lands: the dirty-check folds absent and null together and deliberately
+	 * does not fold in the empty string, so a cleared body stored as `''`
+	 * against a null column would report the scene changed on every load and
+	 * offer a save that changes nothing.
+	 */
+	it('leaves the field unset when the author clears it', () => {
+		store.set(hotspotsAtom, [
+			{ ...hotspot, body: 'Said something.', linkUrl: 'https://a.test' }
+		])
+		store.set(activeHotspotIdAtom, hotspot.id)
+		render(<HotspotsSettingsPanel />)
+
+		fireEvent.change(screen.getByLabelText('Marker body'), {
+			target: { value: '' }
+		})
+		fireEvent.change(screen.getByLabelText('Marker link'), {
+			target: { value: '' }
+		})
+
+		expect(stored().body).toBeUndefined()
+		expect(stored().linkUrl).toBeUndefined()
+	})
+
+	it('caps the body at the length the save parser will accept', () => {
+		openEditor()
+
+		expect(screen.getByLabelText('Marker body').getAttribute('maxlength')).toBe(
+			String(MAX_HOTSPOT_BODY_LENGTH)
+		)
+	})
+
+	/**
+	 * The save answers a bad link by refusing the whole scene with a message
+	 * naming an array index, which names neither the marker nor the field. So
+	 * the panel has to say it where the field is.
+	 */
+	it('marks a link the save would refuse', () => {
+		openEditor()
+		const field = screen.getByLabelText('Marker link')
+
+		fireEvent.change(field, { target: { value: 'http://a.test' } })
+
+		expect(field.getAttribute('aria-invalid')).toBe('true')
+		expect(screen.getByText(/must start with https/i)).toBeTruthy()
+		// Named by the field, so a screen reader reaches it from the input.
+		expect(field.getAttribute('aria-describedby')).toBe(
+			screen.getByText(/must start with https/i).getAttribute('id')
+		)
+	})
+
+	it('says nothing about an https link, or about no link at all', () => {
+		openEditor()
+		const field = screen.getByLabelText('Marker link')
+
+		expect(screen.queryByText(/must start with https/i)).toBeNull()
+
+		fireEvent.change(field, { target: { value: 'https://a.test/spec' } })
+
+		expect(field.getAttribute('aria-invalid')).toBeNull()
+		expect(screen.queryByText(/must start with https/i)).toBeNull()
+	})
+
+	it('stops complaining once the link is cleared again', () => {
+		openEditor()
+		const field = screen.getByLabelText('Marker link')
+
+		fireEvent.change(field, { target: { value: 'javascript:alert(1)' } })
+		expect(screen.getByText(/must start with https/i)).toBeTruthy()
+
+		fireEvent.change(field, { target: { value: '' } })
+		expect(screen.queryByText(/must start with https/i)).toBeNull()
 	})
 })
 

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.spec.tsx
@@ -164,7 +164,13 @@ describe('HotspotsSettingsPanel arming', () => {
 			fireEvent.change(field, { target: { value: entry } })
 		})
 
-		expect(field.value).not.toBe('1')
+		// Both halves, rather than 'not the old value': a handler that wrote
+		// some third thing into the field would pass a negative assertion while
+		// still being wrong. A `type="number"` input reports '' for every
+		// incomplete numeric entry, including a lone minus - that normalization
+		// is the premise of the defect, not a contradiction of it.
+		expect(field.value).toBe('')
+		expect(store.get(hotspotsAtom)[0].worldPosition[0]).toBe(1)
 	})
 
 	it('commits a decimal typed through a trailing point', () => {

--- a/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
+++ b/apps/vectreal-platform/app/components/publisher/sidebars/compose-sidebar/hotspots-settings-panel.tsx
@@ -21,6 +21,7 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@shared/components/ui/select'
+import { Textarea } from '@shared/components/ui/textarea'
 import { cn } from '@shared/utils'
 import { resolveHotspotMarkers } from '@vctrl/viewer/hotspots'
 import {
@@ -44,6 +45,10 @@ import {
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { applyHotspotPlacement } from '../../../../lib/domain/scene/client/apply-hotspot-placement'
+import {
+	isAllowedHotspotLinkUrl,
+	MAX_HOTSPOT_BODY_LENGTH
+} from '../../../../lib/domain/scene/hotspot-urls'
 import {
 	PAIRED_HOTSPOT_CAMERA_ID_PREFIX,
 	resolveDefaultSceneCameraId
@@ -786,152 +791,209 @@ const HotspotsSettingsPanel = memo(() => {
 	)
 
 	const renderEditor = useCallback(
-		(hotspot: HotspotDefinition) => (
-			<>
-				<InlineNotice tone={isClickToPlaceActive ? 'warning' : 'neutral'}>
-					{isClickToPlaceActive
-						? 'Click anywhere on the model to move this marker there.'
-						: 'Drag the marker in the scene, or place it from here.'}
-				</InlineNotice>
+		(hotspot: HotspotDefinition) => {
+			const linkErrorId = `hotspot-link-error-${hotspot.id}`
+			// An empty field is not an invalid one: clearing the link is how an
+			// author removes it.
+			const linkIsInvalid =
+				!!hotspot.linkUrl && !isAllowedHotspotLinkUrl(hotspot.linkUrl)
 
-				<Button
-					variant={isClickToPlaceActive ? 'secondary' : 'outline'}
-					size="sm"
-					aria-pressed={isClickToPlaceActive}
-					onClick={() => setIsClickToPlaceActive((active) => !active)}
-					className="publisher-shell-focus w-full gap-1.5"
-				>
-					<Crosshair
-						aria-hidden
-						className={cn(
-							'size-3.5',
-							isClickToPlaceActive && 'animate-pulse motion-reduce:animate-none'
-						)}
-					/>
-					{isClickToPlaceActive ? 'Click the model…' : 'Place on model'}
-				</Button>
+			return (
+				<>
+					<InlineNotice tone={isClickToPlaceActive ? 'warning' : 'neutral'}>
+						{isClickToPlaceActive
+							? 'Click anywhere on the model to move this marker there.'
+							: 'Drag the marker in the scene, or place it from here.'}
+					</InlineNotice>
 
-				<SettingGroup label="Position">
-					<div className="grid grid-cols-3 gap-1.5">
-						{AXES.map((axis, index) => (
-							<AxisField
-								key={axis}
-								axis={axis}
-								value={hotspot.worldPosition[index]}
-								onChange={(raw) =>
-									handlePositionChange(hotspot, index as 0 | 1 | 2, raw)
-								}
-							/>
-						))}
-					</div>
-				</SettingGroup>
-
-				<SettingGroup label="Name">
-					<Input
-						aria-label="Marker name"
-						value={hotspot.name}
-						onChange={(event) => handleRename(hotspot.id, event.target.value)}
-						placeholder="Hotspot name"
-						className="text-sm"
-					/>
-				</SettingGroup>
-
-				<SettingGroup label="Style">
-					<ToggleButtonGroup
-						options={STYLE_PRESET_OPTIONS}
-						value={hotspot.stylePreset}
-						onChange={(preset) =>
-							updateHotspot(hotspot.id, { stylePreset: preset })
-						}
-					/>
-				</SettingGroup>
-
-				<AnimatePresence initial={false}>
-					{hotspot.stylePreset !== 'dot' && (
-						<motion.div
-							key="payload-url"
-							initial={{ height: 0, opacity: 0 }}
-							animate={{ height: 'auto', opacity: 1 }}
-							exit={{ height: 0, opacity: 0 }}
-							transition={{ duration: reduceMotion ? 0 : 0.15 }}
-							className="overflow-hidden"
-						>
-							<SettingGroup label="Asset URL">
-								<Input
-									aria-label="Asset URL"
-									value={hotspot.payloadUrl ?? ''}
-									onChange={(event) =>
-										updateHotspot(hotspot.id, {
-											payloadUrl: event.target.value || undefined
-										})
-									}
-									placeholder="https://…"
-									className="text-sm"
-								/>
-							</SettingGroup>
-						</motion.div>
-					)}
-				</AnimatePresence>
-
-				<SettingGroup
-					label="Linked camera"
-					description="Viewers transition to this camera when they click the marker."
-				>
-					<Select
-						value={hotspot.linkedCameraId ?? 'none'}
-						onValueChange={(value) =>
-							handleRelink(hotspot.id, value === 'none' ? undefined : value)
-						}
+					<Button
+						variant={isClickToPlaceActive ? 'secondary' : 'outline'}
+						size="sm"
+						aria-pressed={isClickToPlaceActive}
+						onClick={() => setIsClickToPlaceActive((active) => !active)}
+						className="publisher-shell-focus w-full gap-1.5"
 					>
-						<SelectTrigger aria-label="Linked camera" className="w-full">
-							<SelectValue placeholder="None" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="none">None</SelectItem>
-							{allCameras.map((entry) => (
-								<SelectItem key={entry.cameraId} value={entry.cameraId}>
-									{entry.name || entry.cameraId}
-								</SelectItem>
+						<Crosshair
+							aria-hidden
+							className={cn(
+								'size-3.5',
+								isClickToPlaceActive &&
+									'animate-pulse motion-reduce:animate-none'
+							)}
+						/>
+						{isClickToPlaceActive ? 'Click the model…' : 'Place on model'}
+					</Button>
+
+					<SettingGroup label="Position">
+						<div className="grid grid-cols-3 gap-1.5">
+							{AXES.map((axis, index) => (
+								<AxisField
+									key={axis}
+									axis={axis}
+									value={hotspot.worldPosition[index]}
+									onChange={(raw) =>
+										handlePositionChange(hotspot, index as 0 | 1 | 2, raw)
+									}
+								/>
 							))}
-						</SelectContent>
-					</Select>
-				</SettingGroup>
+						</div>
+					</SettingGroup>
 
-				<SettingToggle
-					enabled={hotspot.sequenceIndex !== undefined}
-					onToggle={(enabled) => handleMembershipChange(hotspot.id, enabled)}
-					title="In the sequence"
-					description="Include this marker in the order viewers step through."
-				/>
+					<SettingGroup label="Name">
+						<Input
+							aria-label="Marker name"
+							value={hotspot.name}
+							onChange={(event) => handleRename(hotspot.id, event.target.value)}
+							placeholder="Hotspot name"
+							className="text-sm"
+						/>
+					</SettingGroup>
 
-				<SettingToggle
-					enabled={hotspot.visible}
-					onToggle={(enabled) =>
-						updateHotspot(hotspot.id, { visible: enabled })
-					}
-					title="Visible to viewers"
-					description="Show this marker in the published scene."
-				/>
+					<SettingGroup
+						label="Body"
+						description="Shown when a visitor opens the marker."
+					>
+						<Textarea
+							aria-label="Marker body"
+							value={hotspot.body ?? ''}
+							onChange={(event) =>
+								updateHotspot(hotspot.id, {
+									body: event.target.value || undefined
+								})
+							}
+							// The save parser refuses a longer body, and a refusal there
+							// fails the whole scene with a message naming an array index.
+							// The field is the only place an author sees the limit at the
+							// moment it applies.
+							maxLength={MAX_HOTSPOT_BODY_LENGTH}
+							placeholder="What is a visitor looking at?"
+							className="min-h-20 text-sm"
+						/>
+					</SettingGroup>
 
-				<SettingToggle
-					enabled={hotspot.internalOnly}
-					onToggle={(enabled) =>
-						updateHotspot(hotspot.id, { internalOnly: enabled })
-					}
-					title="Editor only"
-					description="Keep the marker in the publisher and leave it out of the embed."
-				/>
+					<SettingGroup label="Link">
+						<Input
+							aria-label="Marker link"
+							type="url"
+							value={hotspot.linkUrl ?? ''}
+							onChange={(event) =>
+								updateHotspot(hotspot.id, {
+									linkUrl: event.target.value || undefined
+								})
+							}
+							aria-invalid={linkIsInvalid || undefined}
+							aria-describedby={linkIsInvalid ? linkErrorId : undefined}
+							placeholder="https://…"
+							className="text-sm"
+						/>
+						{linkIsInvalid && (
+							// Said beside the field rather than left to the save, which
+							// answers a bad link by refusing the entire scene with a
+							// message naming an array index - neither the marker nor the
+							// field the author is looking at.
+							<p id={linkErrorId} className="text-destructive text-xs">
+								Links must start with https://
+							</p>
+						)}
+					</SettingGroup>
 
-				<SettingToggle
-					enabled={hotspot.occlusionEnabled ?? true}
-					onToggle={(enabled) =>
-						updateHotspot(hotspot.id, { occlusionEnabled: enabled })
-					}
-					title="Hide behind geometry"
-					description="Fade the marker when part of the model is in front of it."
-				/>
-			</>
-		),
+					<SettingGroup label="Style">
+						<ToggleButtonGroup
+							options={STYLE_PRESET_OPTIONS}
+							value={hotspot.stylePreset}
+							onChange={(preset) =>
+								updateHotspot(hotspot.id, { stylePreset: preset })
+							}
+						/>
+					</SettingGroup>
+
+					<AnimatePresence initial={false}>
+						{hotspot.stylePreset !== 'dot' && (
+							<motion.div
+								key="payload-url"
+								initial={{ height: 0, opacity: 0 }}
+								animate={{ height: 'auto', opacity: 1 }}
+								exit={{ height: 0, opacity: 0 }}
+								transition={{ duration: reduceMotion ? 0 : 0.15 }}
+								className="overflow-hidden"
+							>
+								<SettingGroup label="Asset URL">
+									<Input
+										aria-label="Asset URL"
+										value={hotspot.payloadUrl ?? ''}
+										onChange={(event) =>
+											updateHotspot(hotspot.id, {
+												payloadUrl: event.target.value || undefined
+											})
+										}
+										placeholder="https://…"
+										className="text-sm"
+									/>
+								</SettingGroup>
+							</motion.div>
+						)}
+					</AnimatePresence>
+
+					<SettingGroup
+						label="Linked camera"
+						description="Viewers transition to this camera when they click the marker."
+					>
+						<Select
+							value={hotspot.linkedCameraId ?? 'none'}
+							onValueChange={(value) =>
+								handleRelink(hotspot.id, value === 'none' ? undefined : value)
+							}
+						>
+							<SelectTrigger aria-label="Linked camera" className="w-full">
+								<SelectValue placeholder="None" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="none">None</SelectItem>
+								{allCameras.map((entry) => (
+									<SelectItem key={entry.cameraId} value={entry.cameraId}>
+										{entry.name || entry.cameraId}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</SettingGroup>
+
+					<SettingToggle
+						enabled={hotspot.sequenceIndex !== undefined}
+						onToggle={(enabled) => handleMembershipChange(hotspot.id, enabled)}
+						title="In the sequence"
+						description="Include this marker in the order viewers step through."
+					/>
+
+					<SettingToggle
+						enabled={hotspot.visible}
+						onToggle={(enabled) =>
+							updateHotspot(hotspot.id, { visible: enabled })
+						}
+						title="Visible to viewers"
+						description="Show this marker in the published scene."
+					/>
+
+					<SettingToggle
+						enabled={hotspot.internalOnly}
+						onToggle={(enabled) =>
+							updateHotspot(hotspot.id, { internalOnly: enabled })
+						}
+						title="Editor only"
+						description="Keep the marker in the publisher and leave it out of the embed."
+					/>
+
+					<SettingToggle
+						enabled={hotspot.occlusionEnabled ?? true}
+						onToggle={(enabled) =>
+							updateHotspot(hotspot.id, { occlusionEnabled: enabled })
+						}
+						title="Hide behind geometry"
+						description="Fade the marker when part of the model is in front of it."
+					/>
+				</>
+			)
+		},
 		[
 			allCameras,
 			handleMembershipChange,

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router'
 import SceneEmbedInfoPopover from './scene-embed-info-popover'
 import SceneEmbedViewer from './scene-embed-viewer'
 import { useSceneEmbedScene } from './use-scene-embed-scene'
+import { resolveEmbedHotspotPresentation } from '../../lib/domain/embed/embed-presentation'
 import { useHostedPreviewBridge } from '../../lib/domain/embed/hosted-preview-bridge'
 import { isSceneCamera } from '../../lib/domain/scene/scene-camera'
 import CenteredSpinner from '../centered-spinner'
@@ -68,6 +69,23 @@ function useInitialCommands(): ViewerCommand[] {
 }
 
 /**
+ * How the embed's hotspots appear, from the same query string.
+ *
+ * A channel of its own rather than one more entry in `useInitialCommands`,
+ * because none of these is a `ViewerCommand`. Those are executed once when the
+ * viewer reports ready; suppressing the markers is not something the viewer
+ * does at a moment, it is something it is - as a command it would draw the
+ * markers first and take them away on the ready event.
+ */
+function useHotspotPresentation() {
+	const [searchParams] = useSearchParams()
+	return useMemo(
+		() => resolveEmbedHotspotPresentation(searchParams),
+		[searchParams]
+	)
+}
+
+/**
  * The full-viewport scene page shared by `/embed` and `/preview`.
  *
  * Both routes render exactly the same thing; they differ only in how their
@@ -85,10 +103,12 @@ const SceneEmbedPage = ({
 			projectId
 		})
 	const initialCommands = useInitialCommands()
+	const hotspotPresentation = useHotspotPresentation()
 	const bridge = useHostedPreviewBridge({
 		sceneId,
 		interactions: sceneData?.interactions,
 		cameras: sceneData?.camera?.cameras,
+		hotspots: sceneData?.hotspots,
 		initialCommands
 	})
 
@@ -184,6 +204,7 @@ const SceneEmbedPage = ({
 				sceneData={sceneData}
 				onCommandExecutorReady={onCommandExecutorReady}
 				onInteractionEvent={onInteractionEvent}
+				hotspotPresentation={hotspotPresentation}
 				popover={
 					<SceneEmbedInfoPopover
 						title={sceneData?.meta?.name?.trim() || undefined}

--- a/apps/vectreal-platform/app/components/scene-embed/scene-embed-viewer.tsx
+++ b/apps/vectreal-platform/app/components/scene-embed/scene-embed-viewer.tsx
@@ -6,6 +6,7 @@ import { resolveBakedShadowSource } from '../../lib/domain/scene/client/baked-sh
 import CenteredSpinner from '../centered-spinner'
 import { ClientVectrealViewer } from '../viewer/client-vectreal-viewer'
 
+import type { EmbedHotspotPresentation } from '../../lib/domain/embed/embed-presentation'
 import type { ModelFile, ServerSceneData } from '@vctrl/hooks/use-load-model'
 import type { VectrealViewerProps, ViewerLoadingThumbnail } from '@vctrl/viewer'
 import type { ReactNode } from 'react'
@@ -18,6 +19,11 @@ export interface SceneEmbedViewerProps {
 	loadingThumbnail?: ViewerLoadingThumbnail
 	/** Usually `<SceneEmbedInfoPopover>`; omitted where the surface has its own. */
 	popover?: ReactNode
+	/**
+	 * How the hotspots appear, where the embedding page asked for something
+	 * other than the default. Omitted by every surface that is not an embed.
+	 */
+	hotspotPresentation?: EmbedHotspotPresentation
 	onCommandExecutorReady?: VectrealViewerProps['onCommandExecutorReady']
 	onInteractionEvent?: VectrealViewerProps['onInteractionEvent']
 }
@@ -37,6 +43,7 @@ const SceneEmbedViewer = memo(
 		className,
 		loadingThumbnail,
 		popover,
+		hotspotPresentation,
 		onCommandExecutorReady,
 		onInteractionEvent
 	}: SceneEmbedViewerProps) => {
@@ -79,6 +86,14 @@ const SceneEmbedViewer = memo(
 					  gates, and this surface must never open either.
 					*/
 					hotspots={sceneData?.hotspots}
+					/*
+					  Undefined where the surface passed no presentation, so the
+					  viewer's own defaults apply and nothing here has to restate
+					  them.
+					*/
+					hotspotColor={hotspotPresentation?.color}
+					showHotspotMarkers={hotspotPresentation?.showMarkers}
+					revealHotspotContent={hotspotPresentation?.revealContent}
 					shadowsOptions={shadowsOptions}
 					staticShadowBake
 					bakedShadow={bakedShadow}

--- a/apps/vectreal-platform/app/db/schema/project/scene-hotspots.ts
+++ b/apps/vectreal-platform/app/db/schema/project/scene-hotspots.ts
@@ -33,6 +33,12 @@ export const sceneHotspots = pgTable(
 
 		name: text('name').notNull(),
 
+		// What the hotspot says when revealed, and where it points. Both
+		// nullable: a marker that only flies its linked camera carries neither,
+		// and every row written before these columns existed is exactly that.
+		body: text('body'),
+		linkUrl: text('link_url'),
+
 		// World-space position stored as three real columns for direct querying.
 		worldPositionX: real('world_position_x').notNull().default(0),
 		worldPositionY: real('world_position_y').notNull().default(0),

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveEmbedHotspotPresentation } from './embed-presentation'
+
+const resolve = (query: string) =>
+	resolveEmbedHotspotPresentation(new URLSearchParams(query))
+
+describe('resolveEmbedHotspotPresentation', () => {
+	it('draws everything when the host says nothing', () => {
+		expect(resolve('')).toEqual({
+			showMarkers: true,
+			revealContent: true,
+			color: undefined
+		})
+	})
+
+	it('reads 0 as off and anything else as on, matching autoRotate', () => {
+		expect(resolve('hotspots=0').showMarkers).toBe(false)
+		expect(resolve('hotspots=1').showMarkers).toBe(true)
+		expect(resolve('hotspots=true').showMarkers).toBe(true)
+		expect(resolve('hotspotContent=0').revealContent).toBe(false)
+		expect(resolve('hotspotContent=1').revealContent).toBe(true)
+	})
+
+	it('reads a present-but-empty value as on, the same as an absent one', () => {
+		// `?hotspots=` is a host writing the parameter and leaving it blank,
+		// which says nothing and is certainly not `0`.
+		expect(resolve('hotspots=').showMarkers).toBe(true)
+		expect(resolve('hotspotContent=').revealContent).toBe(true)
+	})
+
+	it('takes a hex colour, in every length CSS allows', () => {
+		expect(resolve('hotspotColor=%23fc6c18').color).toBe('#fc6c18')
+		expect(resolve('hotspotColor=%23fff').color).toBe('#fff')
+		expect(resolve('hotspotColor=%23FC6C18AA').color).toBe('#FC6C18AA')
+	})
+
+	/**
+	 * The value lands in an inline `style` on the marker root, so anything but a
+	 * hex literal would let a query string write style into the page: a value
+	 * like `red; background: url(...)` closes the declaration and adds its own.
+	 */
+	it.each([
+		['a named colour', 'red'],
+		['a function', 'rgb(1,2,3)'],
+		['a declaration break-out', 'red; background: url(x)'],
+		['a bare url', 'url(https://a.test/x.png)'],
+		['a custom property', 'var(--brand)'],
+		['a five-digit hex, which CSS has no such length for', '#ff00f'],
+		['a hex with a non-hex digit', '#gggggg'],
+		['no hash', 'fc6c18'],
+		['an empty value', '']
+	])('refuses %s', (_label, value) => {
+		expect(
+			resolveEmbedHotspotPresentation(
+				new URLSearchParams([['hotspotColor', value]])
+			).color
+		).toBeUndefined()
+	})
+
+	it('trims the value before judging it', () => {
+		expect(
+			resolveEmbedHotspotPresentation(
+				new URLSearchParams([['hotspotColor', '  #fc6c18  ']])
+			).color
+		).toBe('#fc6c18')
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { resolveEmbedHotspotPresentation } from './embed-presentation'
@@ -64,5 +67,56 @@ describe('resolveEmbedHotspotPresentation', () => {
 				new URLSearchParams([['hotspotColor', '  #fc6c18  ']])
 			).color
 		).toBe('#fc6c18')
+	})
+})
+
+/**
+ * The parser above is thorough and reaches nothing on its own.
+ *
+ * These options are read in one place and forwarded through two components, and
+ * every link in that chain type-checks perfectly while doing nothing. A source
+ * guard rather than a render test, because reaching the embed page needs a
+ * router, a loaded model and a canvas.
+ */
+describe('the presentation reaches the viewer', () => {
+	const read = (file: string) =>
+		readFileSync(
+			join(import.meta.dirname, '../../../components/scene-embed', file),
+			'utf8'
+		)
+	const page = read('scene-embed-page.tsx')
+	const viewer = read('scene-embed-viewer.tsx')
+
+	it('is read from the same query string as the opening commands', () => {
+		expect(page).toContain('resolveEmbedHotspotPresentation(searchParams)')
+	})
+
+	it('is a channel of its own, not a ViewerCommand', () => {
+		// As a command it would execute on `viewer_ready`, so suppressed markers
+		// would draw first and vanish on the ready event.
+		const initialCommands = page
+			.split('function useInitialCommands')[1]
+			?.split('\n}')[0]
+
+		expect(initialCommands).toBeTruthy()
+		expect(initialCommands).not.toContain('hotspot')
+	})
+
+	it('reaches the embed viewer, and the viewer props behind it', () => {
+		expect(page).toContain('hotspotPresentation={hotspotPresentation}')
+		expect(viewer).toContain('hotspotColor={hotspotPresentation?.color}')
+		expect(viewer).toContain(
+			'showHotspotMarkers={hotspotPresentation?.showMarkers}'
+		)
+		expect(viewer).toContain(
+			'revealHotspotContent={hotspotPresentation?.revealContent}'
+		)
+	})
+
+	it('passes undefined where no presentation was given', () => {
+		// Optional chaining rather than a default object, so every surface that
+		// is not an embed gets the viewer's own defaults without restating them.
+		expect(viewer).toContain('hotspotPresentation?.')
+		expect(viewer).not.toContain('hotspotPresentation.showMarkers')
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts
@@ -1,0 +1,68 @@
+/**
+ * How the embed's hotspots appear, read from the iframe's own URL.
+ *
+ * A separate channel from `useInitialCommands`, and not for tidiness: those are
+ * `ViewerCommand`s, executed once when the viewer reports ready. None of these
+ * is a command. Suppressing the markers is not something the viewer does at a
+ * moment, it is something it is - so expressing it as a command would mean the
+ * markers drawing first and disappearing on the ready event.
+ *
+ * Every option here is for a host page that has taken part of the job over:
+ * driving navigation from the hotspot descriptors in the handshake, or drawing
+ * its own panel from `hotspot_activated`. Where two UIs would otherwise compete,
+ * this is how the host says which one wins.
+ */
+
+export interface EmbedHotspotPresentation {
+	/**
+	 * Whether the viewer draws the markers at all.
+	 *
+	 * False leaves the hotspots resolved but undrawn, so `focus_hotspot` still
+	 * flies a camera by id and the handshake still lists them. A host driving
+	 * its own navigation needs exactly that: no markers on the model, and every
+	 * hotspot still reachable.
+	 */
+	showMarkers: boolean
+	/**
+	 * Whether a marker opens a card of its own.
+	 *
+	 * False still activates: the camera flies and `hotspot_activated` fires, so
+	 * a host drawing its own panel gets the event without the viewer drawing a
+	 * second copy of the same text over the model.
+	 */
+	revealContent: boolean
+	/** Overrides the marker fill. Undefined keeps the viewer's neutral default. */
+	color: string | undefined
+}
+
+/**
+ * A CSS colour a host may set the markers to.
+ *
+ * A hex literal only, and validated rather than passed through, because this
+ * value lands in an inline `style` on the marker root. Accepting arbitrary CSS
+ * there would let a URL parameter close the declaration and add its own -
+ * `red; background: url(...)` - which is a query string writing style into the
+ * page. Hex covers what a brand colour is and nothing else.
+ */
+const HEX_COLOR = /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+
+/**
+ * `0` is off and anything else is on, matching `?autoRotate`.
+ *
+ * An absent parameter reads as on, which is also the default, so there is no
+ * separate fallback to carry: both of these are drawn unless the host says
+ * otherwise.
+ */
+const isOn = (value: null | string): boolean => value !== '0'
+
+export function resolveEmbedHotspotPresentation(
+	params: URLSearchParams
+): EmbedHotspotPresentation {
+	const color = params.get('hotspotColor')?.trim()
+
+	return {
+		showMarkers: isOn(params.get('hotspots')),
+		revealContent: isOn(params.get('hotspotContent')),
+		color: color && HEX_COLOR.test(color) ? color : undefined
+	}
+}

--- a/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-bridge.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-bridge.ts
@@ -2,13 +2,16 @@ import {
 	HOSTED_PREVIEW_VIEWER_SOURCE,
 	isHostedPreviewIncomingMessage,
 	type EmbedCameraDescriptor,
+	type EmbedHotspotDescriptor,
 	type HostedPreviewOutgoingMessage
 } from '@vctrl/embed'
+import { resolveHotspotMarkers } from '@vctrl/viewer/hotspots'
 import { useCallback, useEffect, useRef } from 'react'
 
 import type {
 	CameraConfig,
 	CameraProps,
+	HotspotDefinition,
 	SceneInteractionDefinition
 } from '@vctrl/core'
 import type {
@@ -21,6 +24,7 @@ interface UseHostedPreviewBridgeParams {
 	sceneId?: string
 	interactions?: SceneInteractionDefinition[]
 	cameras?: CameraProps['cameras']
+	hotspots?: HotspotDefinition[]
 	/** Commands to execute once on viewer_ready (e.g. from URL params). */
 	initialCommands?: import('@vctrl/viewer').ViewerCommand[]
 }
@@ -60,10 +64,37 @@ function buildCameraDescriptors(
 	}))
 }
 
+/**
+ * The hotspots a host page is allowed to hear about.
+ *
+ * Built through `resolveHotspotMarkers` with its default options, which is the
+ * same filter the renderer uses, so `internalOnly` and hidden markers cannot
+ * reach a parent page. That is not belt and braces here. `redactSettingsForEmbed`
+ * runs in exactly one place, `buildEmbedSceneManifest`, and `/preview` never
+ * reaches it - it always takes the session branch - so the settings this hook
+ * is handed there are unredacted, and this filter is the only thing standing
+ * between an internal marker's name and whichever origin pinged the frame.
+ *
+ * Names and camera ids only. A host builds navigation from these; the body and
+ * the link are what the viewer draws, and a second copy on the page would have
+ * nothing keeping it in step.
+ */
+export function buildHotspotDescriptors(
+	hotspots?: HotspotDefinition[]
+): EmbedHotspotDescriptor[] {
+	return resolveHotspotMarkers(hotspots).map((marker) => ({
+		id: marker.id,
+		name: marker.name,
+		cameraId: marker.linkedCameraId,
+		step: marker.step
+	}))
+}
+
 export function useHostedPreviewBridge({
 	sceneId,
 	interactions,
 	cameras,
+	hotspots,
 	initialCommands
 }: UseHostedPreviewBridgeParams): HostedPreviewBridgeProps {
 	const executorRef = useRef<null | ViewerCommandExecutor>(null)
@@ -74,11 +105,16 @@ export function useHostedPreviewBridge({
 	const firedViewerReadyInteractionIdsRef = useRef(new Set<string>())
 	const lastScrollProgressRef = useRef<null | number>(null)
 	const camerasRef = useRef(cameras)
+	const hotspotsRef = useRef(hotspots)
 	const initialCommandsFiredRef = useRef(false)
 
 	useEffect(() => {
 		camerasRef.current = cameras
 	}, [cameras])
+
+	useEffect(() => {
+		hotspotsRef.current = hotspots
+	}, [hotspots])
 
 	useEffect(() => {
 		sortedInteractionsRef.current = getSortedInteractions(interactions)
@@ -117,7 +153,8 @@ export function useHostedPreviewBridge({
 				source: HOSTED_PREVIEW_VIEWER_SOURCE,
 				type: 'pong',
 				sceneId,
-				cameras: buildCameraDescriptors(camerasRef.current)
+				cameras: buildCameraDescriptors(camerasRef.current),
+				hotspots: buildHotspotDescriptors(hotspotsRef.current)
 			}
 			window.parent.postMessage(pong, replyOrigin)
 		},

--- a/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-hotspot-descriptors.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-hotspot-descriptors.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * What the handshake is allowed to tell a host page about a scene's hotspots.
+ *
+ * The filter is the load-bearing part. `redactSettingsForEmbed`, which strips
+ * `internalOnly` hotspots, runs in exactly one place - `buildEmbedSceneManifest`
+ * - and `/preview` never reaches it, because it always takes the session
+ * branch. So on that route the settings this hook is handed are unredacted, and
+ * `resolveHotspotMarkers`' default options are the only thing standing between
+ * an internal marker's name and whichever origin pinged the frame.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { buildHotspotDescriptors } from './hosted-preview-bridge'
+
+import type { HotspotDefinition } from '@vctrl/core'
+
+const hotspot = (
+	overrides: Partial<HotspotDefinition> & Pick<HotspotDefinition, 'id'>
+): HotspotDefinition => ({
+	name: overrides.id,
+	worldPosition: [0, 0, 0],
+	visible: true,
+	internalOnly: false,
+	stylePreset: 'dot',
+	...overrides
+})
+
+describe('buildHotspotDescriptors', () => {
+	it('describes a published hotspot by what a host can navigate with', () => {
+		expect(
+			buildHotspotDescriptors([
+				hotspot({
+					id: 'a',
+					name: 'Handle',
+					linkedCameraId: 'cam-1',
+					sequenceIndex: 0
+				})
+			])
+		).toEqual([{ id: 'a', name: 'Handle', cameraId: 'cam-1', step: 1 }])
+	})
+
+	it('reports no camera as null rather than omitting it', () => {
+		// A marker that only reveals content flies nothing, and a host has to be
+		// able to tell that apart from a field it failed to read.
+		expect(buildHotspotDescriptors([hotspot({ id: 'a' })])[0]).toMatchObject({
+			cameraId: null,
+			step: null
+		})
+	})
+
+	it('never names a hotspot the author kept backstage', () => {
+		const descriptors = buildHotspotDescriptors([
+			hotspot({ id: 'public', name: 'Handle' }),
+			hotspot({
+				id: 'internal',
+				name: 'Supplier part number',
+				internalOnly: true
+			})
+		])
+
+		expect(descriptors.map((entry) => entry.id)).toEqual(['public'])
+	})
+
+	it('never names a hotspot the author hid', () => {
+		const descriptors = buildHotspotDescriptors([
+			hotspot({ id: 'public' }),
+			hotspot({ id: 'hidden', visible: false })
+		])
+
+		expect(descriptors.map((entry) => entry.id)).toEqual(['public'])
+	})
+
+	it('numbers the steps a visitor sees, not the ones the author stored', () => {
+		// An internal marker sitting in the sequence takes no number, so the
+		// steps either side of it read the same for a host as they do on screen.
+		const descriptors = buildHotspotDescriptors([
+			hotspot({ id: 'first', sequenceIndex: 0 }),
+			hotspot({ id: 'backstage', sequenceIndex: 1, internalOnly: true }),
+			hotspot({ id: 'second', sequenceIndex: 2 })
+		])
+
+		expect(descriptors.map((entry) => entry.step)).toEqual([1, 2])
+	})
+
+	it('says nothing at all about a scene with no hotspots', () => {
+		expect(buildHotspotDescriptors(undefined)).toEqual([])
+		expect(buildHotspotDescriptors([])).toEqual([])
+	})
+
+	it('carries no body and no link', () => {
+		// The content is what the viewer draws. A second copy on the host page
+		// would have nothing keeping it in step - and on `/preview` it would be
+		// a second copy of unredacted text.
+		const [descriptor] = buildHotspotDescriptors([
+			hotspot({
+				id: 'a',
+				body: 'Cast in one piece.',
+				linkUrl: 'https://a.test'
+			})
+		])
+
+		expect(Object.keys(descriptor).sort()).toEqual([
+			'cameraId',
+			'id',
+			'name',
+			'step'
+		])
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-protocol.ts
+++ b/apps/vectreal-platform/app/lib/domain/embed/hosted-preview-protocol.ts
@@ -7,6 +7,7 @@ export {
 
 export type {
 	EmbedCameraDescriptor,
+	EmbedHotspotDescriptor,
 	HostedPreviewCustomEventMessage,
 	HostedPreviewHostMessage,
 	HostedPreviewIncomingMessage,

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.spec.ts
@@ -137,7 +137,8 @@ describe('embed settings policy', () => {
 					internalOnly: false,
 					stylePreset: 'dot',
 					body: 'Unit cost 12 EUR, do not quote below 40',
-					linkUrl: 'https://internal.test/pricing'
+					linkUrl: 'https://internal.test/pricing',
+					payloadUrl: 'https://internal.test/unreleased-render.png'
 				}
 			]
 		})
@@ -147,6 +148,10 @@ describe('embed settings policy', () => {
 		expect(hidden.id).toBe('h-hidden')
 		expect(hidden.body).toBeUndefined()
 		expect(hidden.linkUrl).toBeUndefined()
+		// Artwork by the same argument: for the image and svg presets this is an
+		// author's own file, or an inline data URI of it, and a hidden marker
+		// renders none of it.
+		expect(hidden.payloadUrl).toBeUndefined()
 	})
 
 	it('leaves a visible hotspot\u2019s content alone', () => {

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.spec.ts
@@ -114,6 +114,86 @@ describe('embed settings policy', () => {
 	})
 
 	/**
+	 * Two toggles, two different promises, and only one of them was ever about
+	 * confidentiality.
+	 *
+	 * `visible: false` keeps the row - other settings may still reference the
+	 * camera it links - but strips what it has to say. "Show this marker in the
+	 * published scene", switched off, reads to an author as "this does not go
+	 * out", and the viewer never draws a hidden marker, so nothing on screen
+	 * would tell them their body text had been served to every anonymous embed
+	 * visitor. Tolerable while the only author string was a short `name`; not
+	 * tolerable for 2000 characters of prose and a link.
+	 */
+	it('strips a hidden hotspot of what it has to say, but keeps the row', () => {
+		const settings = buildSettings({
+			hotspots: [
+				{
+					id: 'h-hidden',
+					name: 'Sole',
+					worldPosition: [0, 0, 0],
+					linkedCameraId: 'cam-public-hotspot',
+					visible: false,
+					internalOnly: false,
+					stylePreset: 'dot',
+					body: 'Unit cost 12 EUR, do not quote below 40',
+					linkUrl: 'https://internal.test/pricing'
+				}
+			]
+		})
+
+		const [hidden] = redact(settings).hotspots ?? []
+
+		expect(hidden.id).toBe('h-hidden')
+		expect(hidden.body).toBeUndefined()
+		expect(hidden.linkUrl).toBeUndefined()
+	})
+
+	it('leaves a visible hotspot\u2019s content alone', () => {
+		const settings = buildSettings({
+			hotspots: [
+				{
+					id: 'h-public',
+					name: 'Sole',
+					worldPosition: [0, 0, 0],
+					visible: true,
+					internalOnly: false,
+					stylePreset: 'dot',
+					body: 'Cast in one piece.',
+					linkUrl: 'https://a.test/spec'
+				}
+			]
+		})
+
+		const [shown] = redact(settings).hotspots ?? []
+
+		expect(shown.body).toBe('Cast in one piece.')
+		expect(shown.linkUrl).toBe('https://a.test/spec')
+	})
+
+	it('does not mutate the settings it was handed', () => {
+		// The strip copies the hotspot rather than editing it: this object is
+		// the caller's, and on the session path it is the live scene settings.
+		const settings = buildSettings({
+			hotspots: [
+				{
+					id: 'h-hidden',
+					name: 'Sole',
+					worldPosition: [0, 0, 0],
+					visible: false,
+					internalOnly: false,
+					stylePreset: 'dot',
+					body: 'Still here afterwards'
+				}
+			]
+		})
+
+		redact(settings)
+
+		expect(settings.hotspots?.[0].body).toBe('Still here afterwards')
+	})
+
+	/**
 	 * The regression that matters most. The publisher only started tagging paired
 	 * cameras `kind: 'hotspot'` recently, so every scene already in the database
 	 * has an untagged one - and `isSceneCamera` reads a missing `kind` as

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts
@@ -38,9 +38,28 @@ export function redactSettingsForEmbed(
 	settings: SceneSettings,
 	{ bakeAssetId }: { bakeAssetId: string | null }
 ): SceneSettings {
-	const visibleHotspots = settings.hotspots?.filter(
-		(hotspot) => !hotspot.internalOnly
-	)
+	/*
+	  `internalOnly` drops the hotspot. `visible: false` keeps it, minus anything
+	  it has to say.
+
+	  Two toggles, two different promises, and only one of them was ever about
+	  confidentiality - which is why the row survives here at all: it may still
+	  carry a `linkedCameraId` that other settings reference.
+
+	  The text is a different matter. "Show this marker in the published scene",
+	  switched off, reads to an author as "this does not go out", and while the
+	  only author string on a hidden hotspot was a short `name` that was a
+	  tolerable gap. It is not tolerable for up to 2000 characters of body prose
+	  and a link: the viewer never draws them, so nothing on screen would ever
+	  tell the author they had been served to every anonymous embed visitor.
+	*/
+	const visibleHotspots = settings.hotspots
+		?.filter((hotspot) => !hotspot.internalOnly)
+		.map((hotspot) =>
+			hotspot.visible === false
+				? { ...hotspot, body: undefined, linkUrl: undefined }
+				: hotspot
+		)
 
 	const linkedCameraIds = (hotspots: typeof settings.hotspots) =>
 		new Set(

--- a/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts
@@ -46,18 +46,25 @@ export function redactSettingsForEmbed(
 	  confidentiality - which is why the row survives here at all: it may still
 	  carry a `linkedCameraId` that other settings reference.
 
-	  The text is a different matter. "Show this marker in the published scene",
-	  switched off, reads to an author as "this does not go out", and while the
-	  only author string on a hidden hotspot was a short `name` that was a
-	  tolerable gap. It is not tolerable for up to 2000 characters of body prose
-	  and a link: the viewer never draws them, so nothing on screen would ever
-	  tell the author they had been served to every anonymous embed visitor.
+	  What the marker carries is a different matter. "Show this marker in the
+	  published scene", switched off, reads to an author as "this does not go
+	  out", and while the only author string on a hidden hotspot was a short
+	  `name` that was a tolerable gap. It is not tolerable for up to 2000
+	  characters of body prose, a link, and an artwork URL that may be an inline
+	  data URI: the viewer draws none of them for a hidden marker, so nothing on
+	  screen would ever tell the author they had been served to every anonymous
+	  embed visitor.
 	*/
 	const visibleHotspots = settings.hotspots
 		?.filter((hotspot) => !hotspot.internalOnly)
 		.map((hotspot) =>
 			hotspot.visible === false
-				? { ...hotspot, body: undefined, linkUrl: undefined }
+				? {
+						...hotspot,
+						body: undefined,
+						linkUrl: undefined,
+						payloadUrl: undefined
+					}
 				: hotspot
 		)
 

--- a/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	isAllowedHotspotLinkUrl,
 	isAllowedHotspotPayloadUrl,
 	MAX_HOTSPOT_URL_LENGTH
 } from './hotspot-urls'
@@ -59,5 +60,41 @@ describe('isAllowedHotspotPayloadUrl', () => {
 
 	it('rejects a media type that merely starts with an allowed one', () => {
 		expect(isAllowedHotspotPayloadUrl('data:image/pngx,AAAA')).toBe(false)
+	})
+})
+
+describe('isAllowedHotspotLinkUrl', () => {
+	it.each([
+		['an https URL', 'https://vectreal.com/docs'],
+		['an uppercase scheme', 'HTTPS://vectreal.com/docs']
+	])('accepts %s', (_label, value) => {
+		expect(isAllowedHotspotLinkUrl(value)).toBe(true)
+	})
+
+	it.each([
+		['a script URL', 'javascript:alert(1)'],
+		['a script URL with mixed case', 'JavaScript:alert(1)'],
+		['plain http', 'http://vectreal.com/docs'],
+		['a bare scheme with no host', 'https://'],
+		['a relative path', '/docs'],
+		['an empty string', '']
+	])('rejects %s', (_label, value) => {
+		expect(isAllowedHotspotLinkUrl(value)).toBe(false)
+	})
+
+	it('rejects an inline document that the payload rule would allow the shape of', () => {
+		// The two rules diverge here on purpose. A payload URL reaches an
+		// `<img src>`, where a `data:` image is the point; a link URL reaches an
+		// `<a href>`, where `data:text/html` navigates to attacker markup.
+		expect(isAllowedHotspotPayloadUrl('data:image/png;base64,AAAA')).toBe(true)
+		expect(isAllowedHotspotLinkUrl('data:image/png;base64,AAAA')).toBe(false)
+		expect(isAllowedHotspotLinkUrl('data:text/html;base64,AAAA')).toBe(false)
+	})
+
+	it('shares the payload rule\u2019s length ceiling', () => {
+		const long = `https://vectreal.com/${'a'.repeat(MAX_HOTSPOT_URL_LENGTH)}`
+
+		expect(long.length).toBeGreaterThan(MAX_HOTSPOT_URL_LENGTH)
+		expect(isAllowedHotspotLinkUrl(long)).toBe(false)
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/hotspot-urls.ts
@@ -1,5 +1,6 @@
 /**
- * What a hotspot is allowed to point at.
+ * What a hotspot is allowed to carry: the URLs it may point at, and how much
+ * text it may hold.
  *
  * `payloadUrl` was added to the type and to the `payload_url` column without
  * ever being added to the save parser, so it was the one hotspot field that
@@ -18,6 +19,16 @@
  * make a scene's settings row larger than the model it describes.
  */
 export const MAX_HOTSPOT_URL_LENGTH = 8192
+
+/**
+ * Ceiling on a hotspot's body text, in characters.
+ *
+ * `body` is an unbounded `text` column that is read back into every embed
+ * manifest, so the ceiling is what keeps a scene at the hotspot limit from
+ * shipping megabytes of prose to every visitor. Sized for a paragraph or two,
+ * which is all a marker-anchored popover can show without scrolling.
+ */
+export const MAX_HOTSPOT_BODY_LENGTH = 2000
 
 const ALLOWED_IMAGE_MEDIA_TYPES = [
 	'image/png',
@@ -53,6 +64,25 @@ export function isAllowedHotspotPayloadUrl(value: string): boolean {
 	if (normalized.startsWith('data:')) {
 		return ALLOWED_IMAGE_MEDIA_TYPES.includes(dataMediaType(normalized))
 	}
+
+	return normalized.startsWith('https://') && value.length > 'https://'.length
+}
+
+/**
+ * A marker's link destination: `https:` only.
+ *
+ * Deliberately stricter than `isAllowedHotspotPayloadUrl`, which shares its
+ * length cap but accepts inline images. This value lands in an `<a href>`,
+ * where `javascript:` executes and `data:text/html` navigates to attacker
+ * markup - both inert in the `<img src>` a payload URL reaches. So the rule
+ * here is an allowlist of one scheme rather than a denylist of the schemes
+ * that are known to be dangerous today.
+ */
+export function isAllowedHotspotLinkUrl(value: string): boolean {
+	if (value.length > MAX_HOTSPOT_URL_LENGTH) return false
+
+	// Schemes are case-insensitive per RFC 3986.
+	const normalized = value.toLowerCase()
 
 	return normalized.startsWith('https://') && value.length > 'https://'.length
 }

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-comparison.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-comparison.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { haveHotspotsChanged } from './scene-hotspot-comparison'
 
 const hotspot = (overrides: Record<string, unknown> = {}) => ({
@@ -141,5 +144,110 @@ describe('haveHotspotsChanged', () => {
 				[hotspot({ worldPosition: [1.0005, 2, 3] })]
 			)
 		).toBe(true)
+	})
+})
+
+describe('hotspot content', () => {
+	// Save availability is driven by this comparison, so a field the comparator
+	// does not read is a field an author can edit with the button staying
+	// disabled - the edit looks refused rather than unsaved.
+	it('detects body text being added, changed and cleared', () => {
+		expect(
+			haveHotspotsChanged(
+				[hotspot({ body: 'Cast in one piece.' })],
+				[hotspot()]
+			)
+		).toBe(true)
+		expect(
+			haveHotspotsChanged(
+				[hotspot({ body: 'Machined.' })],
+				[hotspot({ body: 'Cast.' })]
+			)
+		).toBe(true)
+		expect(haveHotspotsChanged([hotspot()], [hotspot({ body: 'Cast.' })])).toBe(
+			true
+		)
+	})
+
+	it('detects a link being added, changed and cleared', () => {
+		expect(
+			haveHotspotsChanged([hotspot({ linkUrl: 'https://a.test' })], [hotspot()])
+		).toBe(true)
+		expect(
+			haveHotspotsChanged(
+				[hotspot({ linkUrl: 'https://b.test' })],
+				[hotspot({ linkUrl: 'https://a.test' })]
+			)
+		).toBe(true)
+		expect(
+			haveHotspotsChanged([hotspot()], [hotspot({ linkUrl: 'https://a.test' })])
+		).toBe(true)
+	})
+
+	it('reads absent and null as the same unset value on both fields', () => {
+		// The client omits a cleared field; a row read back carries null. If
+		// these differed, every scene with a text-free hotspot would report
+		// itself dirty on load and offer a save that changes nothing.
+		expect(
+			haveHotspotsChanged(
+				[hotspot({ body: undefined, linkUrl: undefined })],
+				[hotspot({ body: null, linkUrl: null })]
+			)
+		).toBe(false)
+	})
+})
+
+/**
+ * `sameHotspot` enumerates every field by hand, and this is the third
+ * hand-maintained enumeration of the hotspot shape after the draft payload and
+ * `toSceneSettings`. Both of the others dropped a field silently before anyone
+ * noticed, so rather than patch this one a third time and hope, the guard reads
+ * `HotspotDefinition` out of the core type and requires every field to appear
+ * in the comparison.
+ *
+ * A name match, not a semantic one: it cannot tell a correct comparison from a
+ * wrong one, only a present field from a missing one. That is the failure it is
+ * for - the next field added to the type and forgotten here.
+ */
+describe('sameHotspot covers HotspotDefinition', () => {
+	const coreTypes = readFileSync(
+		join(
+			import.meta.dirname,
+			'../../../../../../packages/core/src/types/scene-types.ts'
+		),
+		'utf8'
+	)
+	const comparison = readFileSync(
+		join(import.meta.dirname, 'scene-hotspot-comparison.ts'),
+		'utf8'
+	)
+
+	const interfaceBody = coreTypes
+		.split('export interface HotspotDefinition {')[1]
+		?.split('\n}')[0]
+
+	const fields = [...(interfaceBody ?? '').matchAll(/^\t(\w+)\??:/gm)].map(
+		(match) => match[1]
+	)
+
+	const sameHotspotBody = comparison
+		.split('const sameHotspot =')[1]
+		?.split('export const haveHotspotsChanged')[0]
+
+	it('found the type and the comparison to read', () => {
+		// Without this the two splits above could yield nothing and every
+		// assertion below would pass over an empty list.
+		expect(fields.length).toBeGreaterThan(5)
+		expect(sameHotspotBody).toBeTruthy()
+	})
+
+	it.each(
+		// `id` identifies which stored hotspot to compare against and is matched
+		// by `haveHotspotsChanged`; comparing it inside `sameHotspot` could only
+		// ever be true.
+		fields.filter((field) => field !== 'id')
+	)('compares %s', (field) => {
+		expect(sameHotspotBody).toContain(`a.${field}`)
+		expect(sameHotspotBody).toContain(`b.${field}`)
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-comparison.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/scene-hotspot-comparison.ts
@@ -22,6 +22,8 @@
 interface HotspotLike {
 	id?: string
 	name?: string
+	body?: string | null
+	linkUrl?: string | null
 	worldPosition?: readonly number[]
 	linkedCameraId?: string | null
 	visible?: boolean
@@ -65,6 +67,15 @@ const sameOptional = (
 	b: string | null | undefined
 ): boolean => (a ?? null) === (b ?? null)
 
+/**
+ * Every field is enumerated by hand, which is why a field added to
+ * `HotspotDefinition` and forgotten here leaves Save disabled after an author
+ * edits it - the save button is driven by this comparison. This is the third
+ * hand-maintained enumeration of the hotspot shape, after the draft payload and
+ * `toSceneSettings`, so `scene-hotspot-comparison.spec.ts` reads
+ * `HotspotDefinition` out of the core type and asserts every field name appears
+ * below. Adding a field to the type and not to this function fails that test.
+ */
 const sameHotspot = (a: HotspotLike, b: HotspotLike): boolean =>
 	a.name === b.name &&
 	a.visible === b.visible &&
@@ -74,6 +85,8 @@ const sameHotspot = (a: HotspotLike, b: HotspotLike): boolean =>
 	// authoring panel falls back to.
 	(a.occlusionEnabled ?? true) === (b.occlusionEnabled ?? true) &&
 	(a.sequenceIndex ?? null) === (b.sequenceIndex ?? null) &&
+	sameOptional(a.body, b.body) &&
+	sameOptional(a.linkUrl, b.linkUrl) &&
 	sameOptional(a.linkedCameraId, b.linkedCameraId) &&
 	sameOptional(a.payloadUrl, b.payloadUrl) &&
 	samePosition(a.worldPosition, b.worldPosition)

--- a/apps/vectreal-platform/app/lib/domain/scene/server/hotspot-upsert-wiring.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/hotspot-upsert-wiring.spec.ts
@@ -36,9 +36,16 @@ const columnsIn = (block: string | undefined): string[] =>
 const written = columnsIn(
 	replaceHotspots?.split('.values(')[1]?.split('.onConflictDoUpdate(')[0]
 )
-const updated = columnsIn(
-	replaceHotspots?.split('set: {')[1]?.split('.returning(')[0]
-)
+const setBlock = replaceHotspots?.split('set: {')[1]?.split('.returning(')[0]
+const updated = columnsIn(setBlock)
+
+/** The snake_case column each key is actually written from. */
+const excludedFor = (column: string): string | undefined =>
+	new RegExp(`\\b${column}: sql\`excluded\\.(\\w+)\``).exec(setBlock ?? '')?.[1]
+
+/** `worldPositionX` is `world_position_x`, and so on. */
+const snakeCase = (column: string): string =>
+	column.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)
 
 describe('the hotspot upsert updates every column it inserts', () => {
 	it('found both column lists to compare', () => {
@@ -57,5 +64,10 @@ describe('the hotspot upsert updates every column it inserts', () => {
 		)
 	)('updates %s on a conflict, not only on insert', (column) => {
 		expect(updated).toContain(column)
+		// The name match alone is not enough: a key present but written from the
+		// wrong `excluded.*` column updates a row with a neighbour's value, and
+		// only the two columns the opt-in integration suite covers would catch
+		// it. Every other column had no coverage on the update path at all.
+		expect(excludedFor(column)).toBe(snakeCase(column))
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/server/hotspot-upsert-wiring.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/hotspot-upsert-wiring.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * A hotspot column has to be named twice in `replaceHotspots`: once in the
+ * `values` list that writes it, and again in `onConflictDoUpdate.set` so a
+ * surviving row takes the new value. Rows that survive a save are updated in
+ * place rather than deleted and reinserted, to keep `createdAt` recording when
+ * the hotspot was authored, so the second list is not optional.
+ *
+ * A column present in the first list and absent from the second writes
+ * correctly on the save that creates the hotspot and silently no-ops on every
+ * save after it. Nothing fails: no type error, no Postgres error, no failing
+ * insert-only test. To the author it looks like an edit that will not stick.
+ *
+ * `tests/integration/scene-hotspots.integration.spec.ts` proves the behaviour
+ * against a real Postgres, but that suite is opt-in and needs a database. This
+ * guard is the half that runs on every unit run, and it reads the source rather
+ * than the module because importing the repository pulls in `getDbClient`,
+ * which throws at module scope without `DATABASE_URL`.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+	join(import.meta.dirname, 'scene-settings-repository.server.ts'),
+	'utf8'
+)
+
+const replaceHotspots = source
+	.split('export async function replaceHotspots')[1]
+	?.split('\nexport ')[0]
+
+const columnsIn = (block: string | undefined): string[] =>
+	[...(block ?? '').matchAll(/^\t+(\w+):/gm)].map((match) => match[1])
+
+const written = columnsIn(
+	replaceHotspots?.split('.values(')[1]?.split('.onConflictDoUpdate(')[0]
+)
+const updated = columnsIn(
+	replaceHotspots?.split('set: {')[1]?.split('.returning(')[0]
+)
+
+describe('the hotspot upsert updates every column it inserts', () => {
+	it('found both column lists to compare', () => {
+		// Without this the splits above could yield nothing and the assertion
+		// below would pass over two empty lists.
+		expect(written.length).toBeGreaterThan(5)
+		expect(updated.length).toBeGreaterThan(5)
+	})
+
+	it.each(
+		written.filter(
+			// `id` is the conflict target and `sceneSettingsId` is the scope the
+			// conflict is resolved within. Writing either from `excluded` would
+			// let one scene's save move another scene's hotspot.
+			(column) => column !== 'id' && column !== 'sceneSettingsId'
+		)
+	)('updates %s on a conflict, not only on insert', (column) => {
+		expect(updated).toContain(column)
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/scene/server/hotspot-upsert-wiring.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/hotspot-upsert-wiring.spec.ts
@@ -19,7 +19,10 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { getTableColumns } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
+
+import { sceneHotspots } from '../../../../db/schema/project/scene-hotspots'
 
 const source = readFileSync(
 	join(import.meta.dirname, 'scene-settings-repository.server.ts'),
@@ -39,15 +42,41 @@ const written = columnsIn(
 const setBlock = replaceHotspots?.split('set: {')[1]?.split('.returning(')[0]
 const updated = columnsIn(setBlock)
 
-/** The snake_case column each key is actually written from. */
+/**
+ * The database column each key is actually written from.
+ *
+ * Case-insensitive on the keyword: `EXCLUDED.link_url` is valid SQL, and a
+ * guard that read it as no match at all would fail for the wrong reason.
+ */
 const excludedFor = (column: string): string | undefined =>
-	new RegExp(`\\b${column}: sql\`excluded\\.(\\w+)\``).exec(setBlock ?? '')?.[1]
+	new RegExp(`\\b${column}: sql\`excluded\\.(\\w+)\``, 'i').exec(
+		setBlock ?? ''
+	)?.[1]
 
-/** `worldPositionX` is `world_position_x`, and so on. */
-const snakeCase = (column: string): string =>
-	column.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)
+/**
+ * What that column is actually called, read from the schema rather than
+ * derived from the property name.
+ *
+ * Deriving it - lower-casing at each capital - happens to reproduce all
+ * thirteen of today's columns, which is exactly why it is the wrong oracle: it
+ * would false-alarm on the first column Drizzle names off-convention, and it
+ * can never notice a schema column renamed while the `excluded.…` literal in
+ * the query stays behind.
+ */
+const columnName = (property: string): string | undefined =>
+	getTableColumns(sceneHotspots)[
+		property as keyof ReturnType<typeof getTableColumns<typeof sceneHotspots>>
+	]?.name
 
 describe('the hotspot upsert updates every column it inserts', () => {
+	it('resolved a real column name for every key it iterates', () => {
+		// Without this, a property the schema does not carry resolves to
+		// `undefined` on both sides of the comparison and passes.
+		for (const column of written) {
+			expect(columnName(column)).toBeTruthy()
+		}
+	})
+
 	it('found both column lists to compare', () => {
 		// Without this the splits above could yield nothing and the assertion
 		// below would pass over two empty lists.
@@ -68,6 +97,6 @@ describe('the hotspot upsert updates every column it inserts', () => {
 		// wrong `excluded.*` column updates a row with a neighbour's value, and
 		// only the two columns the opt-in integration suite covers would catch
 		// it. Every other column had no coverage on the update path at all.
-		expect(excludedFor(column)).toBe(snakeCase(column))
+		expect(excludedFor(column)).toBe(columnName(column))
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
@@ -1,3 +1,4 @@
+import { MAX_HOTSPOT_BODY_LENGTH } from '../hotspot-urls'
 import { SceneSettingsParser } from './scene-settings.parser.server'
 
 /**
@@ -217,5 +218,76 @@ describe('hotspot ceilings and payload URLs', () => {
 		])
 
 		expect(rejected(result)).toBe(true)
+	})
+
+	// --- body and link -----------------------------------------------------
+
+	it('accepts a hotspot carrying body text and a link', () => {
+		expect(
+			rejected(
+				parse([
+					hotspot({ body: 'Cast in one piece.', linkUrl: 'https://x.test/a' })
+				])
+			)
+		).toBe(false)
+	})
+
+	it('accepts both absent, and both explicitly null', () => {
+		// The panel clears a field to `undefined`; a value mapped off a database
+		// row arrives as null. Treating either as a value would 400 an ordinary
+		// save of a marker that only flies its camera.
+		expect(rejected(parse([hotspot()]))).toBe(false)
+		expect(rejected(parse([hotspot({ body: null, linkUrl: null })]))).toBe(
+			false
+		)
+	})
+
+	it('rejects a non-string body', () => {
+		expect(rejected(parse([hotspot({ body: 42 })]))).toBe(true)
+	})
+
+	it('bounds the body at the shared ceiling', async () => {
+		const withinCap = parse([
+			hotspot({ body: 'a'.repeat(MAX_HOTSPOT_BODY_LENGTH) })
+		])
+		const overCap = parse([
+			hotspot({ body: 'a'.repeat(MAX_HOTSPOT_BODY_LENGTH + 1) })
+		])
+
+		expect(rejected(withinCap)).toBe(false)
+		expect(rejected(overCap)).toBe(true)
+		expect(JSON.stringify(await bodyOf(overCap))).toContain('body')
+	})
+
+	it('rejects a javascript: link', async () => {
+		// This is the field that reaches an `<a href>`, so the scheme rule is the
+		// whole reason it is validated separately from payloadUrl.
+		const result = parse([hotspot({ linkUrl: 'javascript:alert(1)' })])
+
+		expect(rejected(result)).toBe(true)
+		expect(JSON.stringify(await bodyOf(result))).toContain('linkUrl')
+	})
+
+	it('rejects a non-string link', () => {
+		expect(rejected(parse([hotspot({ linkUrl: 42 })]))).toBe(true)
+	})
+
+	it('checks the link on every preset, unlike payloadUrl', () => {
+		// payloadUrl is preset-gated so that rows predating its rule stay
+		// saveable. `link_url` is a new column, so nothing stored can fail this
+		// and there is nothing to grandfather.
+		for (const preset of ['dot', 'image', 'svg']) {
+			expect(
+				rejected(
+					parse([
+						hotspot({
+							stylePreset: preset,
+							payloadUrl: preset === 'dot' ? undefined : 'https://x.test/p.png',
+							linkUrl: 'http://x.test/a'
+						})
+					])
+				)
+			).toBe(true)
+		}
 	})
 })

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
@@ -242,6 +242,32 @@ describe('hotspot ceilings and payload URLs', () => {
 		)
 	})
 
+	/**
+	 * Cleared is not empty.
+	 *
+	 * The unsaved-changes comparison folds absent and null together and
+	 * deliberately does NOT fold in the empty string, on the stated grounds that
+	 * no producer sends one. The parser is what has to make that true: an ''
+	 * stored against a null column reports the scene dirty on every load and
+	 * offers a save that changes nothing.
+	 */
+	it('reads an emptied field as unset rather than as an empty string', () => {
+		const result = parse([hotspot({ body: '   ', linkUrl: '' })])
+
+		expect(rejected(result)).toBe(false)
+		const [normalized] = (result as { settings: { hotspots: unknown[] } })
+			.settings.hotspots as { body?: unknown; linkUrl?: unknown }[]
+		expect(normalized.body).toBeUndefined()
+		expect(normalized.linkUrl).toBeUndefined()
+	})
+
+	it('clears a link sent as an empty string instead of refusing the scene', () => {
+		// `isAllowedHotspotLinkUrl('')` is false, so without the normalization a
+		// client that cleared a link by sending '' had its entire scene save
+		// refused rather than the link cleared.
+		expect(rejected(parse([hotspot({ linkUrl: '' })]))).toBe(false)
+	})
+
 	it('rejects a non-string body', () => {
 		expect(rejected(parse([hotspot({ body: 42 })]))).toBe(true)
 	})

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-hotspots.parser.spec.ts
@@ -261,6 +261,17 @@ describe('hotspot ceilings and payload URLs', () => {
 		expect(normalized.linkUrl).toBeUndefined()
 	})
 
+	it('leaves the caller\u2019s own payload alone while doing it', () => {
+		// The normalization has to write somewhere, and writing it into the
+		// request payload would mutate the caller's objects - including, on a
+		// rejection, every hotspot before the one that failed.
+		const sent = hotspot({ body: '   ' })
+
+		parse([sent])
+
+		expect((sent as { body?: unknown }).body).toBe('   ')
+	})
+
 	it('clears a link sent as an empty string instead of refusing the scene', () => {
 		// `isAllowedHotspotLinkUrl('')` is false, so without the normalization a
 		// client that cleared a link by sending '' had its entire scene save

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-repository.server.ts
@@ -174,8 +174,11 @@ export async function getHotspotsBySceneSettingsId(
 	return rows.map((r) => ({
 		id: r.id,
 		name: r.name,
-		body: r.body ?? undefined,
-		linkUrl: r.linkUrl ?? undefined,
+		// `||`, not `??`: a row written before the parser normalized an empty
+		// string can hold '', and reading that back as '' would report the scene
+		// dirty against a client that sends `undefined` for the same emptiness.
+		body: r.body || undefined,
+		linkUrl: r.linkUrl || undefined,
 		worldPosition: [r.worldPositionX, r.worldPositionY, r.worldPositionZ] as [
 			number,
 			number,

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-repository.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings-repository.server.ts
@@ -174,6 +174,8 @@ export async function getHotspotsBySceneSettingsId(
 	return rows.map((r) => ({
 		id: r.id,
 		name: r.name,
+		body: r.body ?? undefined,
+		linkUrl: r.linkUrl ?? undefined,
 		worldPosition: [r.worldPositionX, r.worldPositionY, r.worldPositionZ] as [
 			number,
 			number,
@@ -218,6 +220,8 @@ export async function replaceHotspots(
 				id: h.id,
 				sceneSettingsId,
 				name: h.name,
+				body: h.body ?? null,
+				linkUrl: h.linkUrl ?? null,
 				worldPositionX: h.worldPosition[0],
 				worldPositionY: h.worldPosition[1],
 				worldPositionZ: h.worldPosition[2],
@@ -240,6 +244,8 @@ export async function replaceHotspots(
 			setWhere: scopedToScene,
 			set: {
 				name: sql`excluded.name`,
+				body: sql`excluded.body`,
+				linkUrl: sql`excluded.link_url`,
 				worldPositionX: sql`excluded.world_position_x`,
 				worldPositionY: sql`excluded.world_position_y`,
 				worldPositionZ: sql`excluded.world_position_z`,

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
@@ -10,7 +10,9 @@ import {
 import { UUID_REGEX } from '../../../../constants/utility-constants'
 import { parseActionRequest } from '../../../http/requests.server'
 import {
+	isAllowedHotspotLinkUrl,
 	isAllowedHotspotPayloadUrl,
+	MAX_HOTSPOT_BODY_LENGTH,
 	MAX_HOTSPOT_URL_LENGTH
 } from '../hotspot-urls'
 import { parseOptimizationReport } from '../optimization-report-guard'
@@ -473,6 +475,32 @@ export class SceneSettingsParser {
 			seenIds.add(hotspot.id)
 			if (typeof hotspot.name !== 'string' || !hotspot.name.trim()) {
 				return ApiResponse.badRequest(`hotspots[${i}].name is required`)
+			}
+			if (hotspot.body !== undefined && hotspot.body !== null) {
+				if (typeof hotspot.body !== 'string') {
+					return ApiResponse.badRequest(`hotspots[${i}].body must be a string`)
+				}
+				if (hotspot.body.length > MAX_HOTSPOT_BODY_LENGTH) {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].body must be at most ${MAX_HOTSPOT_BODY_LENGTH} characters`
+					)
+				}
+			}
+			if (hotspot.linkUrl !== undefined && hotspot.linkUrl !== null) {
+				if (typeof hotspot.linkUrl !== 'string') {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].linkUrl must be a string`
+					)
+				}
+				// Checked for every preset, unlike `payloadUrl`. That field is
+				// gated on the preset because rows predating its rule would
+				// otherwise become unsaveable; `link_url` is a new column, so no
+				// stored value can fail this and there is nothing to grandfather.
+				if (!isAllowedHotspotLinkUrl(hotspot.linkUrl)) {
+					return ApiResponse.badRequest(
+						`hotspots[${i}].linkUrl must be an https URL of at most ${MAX_HOTSPOT_URL_LENGTH} characters`
+					)
+				}
 			}
 			if (
 				!Array.isArray(hotspot.worldPosition) ||

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
@@ -485,6 +485,14 @@ export class SceneSettingsParser {
 						`hotspots[${i}].body must be at most ${MAX_HOTSPOT_BODY_LENGTH} characters`
 					)
 				}
+				// Cleared, not empty. The panel writes `undefined` when an author
+				// empties the field, but a client that normalizes to '' has to
+				// land in the same place: the unsaved-changes comparison folds
+				// absent and null together and deliberately does NOT fold in the
+				// empty string, so an '' stored against a null column would report
+				// the scene dirty on every load and offer a save that changes
+				// nothing. Normalizing here is what keeps that premise true.
+				if (!hotspot.body.trim()) hotspot.body = undefined
 			}
 			if (hotspot.linkUrl !== undefined && hotspot.linkUrl !== null) {
 				if (typeof hotspot.linkUrl !== 'string') {
@@ -492,11 +500,18 @@ export class SceneSettingsParser {
 						`hotspots[${i}].linkUrl must be a string`
 					)
 				}
-				// Checked for every preset, unlike `payloadUrl`. That field is
-				// gated on the preset because rows predating its rule would
-				// otherwise become unsaveable; `link_url` is a new column, so no
-				// stored value can fail this and there is nothing to grandfather.
-				if (!isAllowedHotspotLinkUrl(hotspot.linkUrl)) {
+				// Same normalization, and here it also decides a 400 rather than
+				// a stored value: `isAllowedHotspotLinkUrl('')` is false, so
+				// without this a client clearing a link by sending '' had its
+				// entire scene save refused instead of the link cleared.
+				if (!hotspot.linkUrl.trim()) {
+					hotspot.linkUrl = undefined
+				} else if (!isAllowedHotspotLinkUrl(hotspot.linkUrl)) {
+					// Checked for every preset, unlike `payloadUrl`. That field is
+					// gated on the preset because rows predating its rule would
+					// otherwise become unsaveable; `link_url` is a new column, so
+					// no stored value can fail this and there is nothing to
+					// grandfather.
 					return ApiResponse.badRequest(
 						`hotspots[${i}].linkUrl must be an https URL of at most ${MAX_HOTSPOT_URL_LENGTH} characters`
 					)

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.parser.server.ts
@@ -426,7 +426,14 @@ export class SceneSettingsParser {
 	}
 
 	/**
-	 * Validates and passes through hotspot definitions.
+	 * Validates hotspot definitions, and normalizes an emptied text field to
+	 * absent.
+	 *
+	 * Returns a new array of new objects rather than the one it was given. The
+	 * normalization has to write somewhere, and writing it into the caller's
+	 * objects would mutate the request payload in place - including, on the
+	 * rejection path, every hotspot before the one that failed. Copying keeps
+	 * this a function of its input, which is what its callers already assume.
 	 */
 	private static normalizeHotspots(
 		hotspots: SceneSettings['hotspots'],
@@ -454,6 +461,7 @@ export class SceneSettingsParser {
 		const cameraIds = new Set(cameras.map((c) => c.cameraId))
 		const seenSequenceIndices = new Set<number>()
 		const seenIds = new Set<string>()
+		const normalized: NonNullable<SceneSettings['hotspots']> = []
 
 		for (const [i, hotspot] of hotspots.entries()) {
 			if (!isRecord(hotspot)) {
@@ -485,14 +493,6 @@ export class SceneSettingsParser {
 						`hotspots[${i}].body must be at most ${MAX_HOTSPOT_BODY_LENGTH} characters`
 					)
 				}
-				// Cleared, not empty. The panel writes `undefined` when an author
-				// empties the field, but a client that normalizes to '' has to
-				// land in the same place: the unsaved-changes comparison folds
-				// absent and null together and deliberately does NOT fold in the
-				// empty string, so an '' stored against a null column would report
-				// the scene dirty on every load and offer a save that changes
-				// nothing. Normalizing here is what keeps that premise true.
-				if (!hotspot.body.trim()) hotspot.body = undefined
 			}
 			if (hotspot.linkUrl !== undefined && hotspot.linkUrl !== null) {
 				if (typeof hotspot.linkUrl !== 'string') {
@@ -500,13 +500,14 @@ export class SceneSettingsParser {
 						`hotspots[${i}].linkUrl must be a string`
 					)
 				}
-				// Same normalization, and here it also decides a 400 rather than
-				// a stored value: `isAllowedHotspotLinkUrl('')` is false, so
-				// without this a client clearing a link by sending '' had its
-				// entire scene save refused instead of the link cleared.
-				if (!hotspot.linkUrl.trim()) {
-					hotspot.linkUrl = undefined
-				} else if (!isAllowedHotspotLinkUrl(hotspot.linkUrl)) {
+				// An emptied link is a cleared link, not a bad one:
+				// `isAllowedHotspotLinkUrl('')` is false, so without this branch a
+				// client clearing a link by sending '' had its entire scene save
+				// refused instead of the link cleared.
+				if (
+					hotspot.linkUrl.trim() &&
+					!isAllowedHotspotLinkUrl(hotspot.linkUrl)
+				) {
 					// Checked for every preset, unlike `payloadUrl`. That field is
 					// gated on the preset because rows predating its rule would
 					// otherwise become unsaveable; `link_url` is a new column, so
@@ -614,9 +615,30 @@ export class SceneSettingsParser {
 				}
 				seenSequenceIndices.add(hotspot.sequenceIndex)
 			}
+
+			/*
+			  Cleared, not empty.
+
+			  The panel writes `undefined` when an author empties a field, but a
+			  client that normalizes to '' has to land in the same place: the
+			  unsaved-changes comparison folds absent and null together and
+			  deliberately does NOT fold in the empty string, so an '' stored
+			  against a null column would report the scene dirty on every load
+			  and offer a save that changes nothing. Doing it here is what makes
+			  that comparison's stated premise - that no producer sends one -
+			  true rather than hopeful.
+			*/
+			const text = (value: unknown) =>
+				typeof value === 'string' && value.trim() ? value : undefined
+
+			normalized.push({
+				...hotspot,
+				body: text(hotspot.body),
+				linkUrl: text(hotspot.linkUrl)
+			} as NonNullable<SceneSettings['hotspots']>[number])
 		}
 
-		return hotspots
+		return normalized
 	}
 
 	private static normalizeTransitionConfig(

--- a/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
@@ -81,6 +81,9 @@ For zero-JavaScript initial configuration, add parameters to the iframe `src`:
 | `?camera=<id>` | Any saved camera ID | Activates that camera as soon as the viewer is ready |
 | `?autoRotate=0` or `?autoRotate=1` | `0` to disable, `1` to enable | Overrides the stored auto-rotate setting |
 | `?transition=<type>` | `none`, `linear`, `object_avoidance` | Overrides the stored transition type |
+| `?hotspots=0` | `0` to hide | Draws no markers. The hotspots stay reachable through `focusHotspot` and still appear in `ready()` |
+| `?hotspotContent=0` | `0` to suppress | Keeps the markers but leaves the card to you. Clicks still fly the camera and still emit `hotspot_activated` |
+| `?hotspotColor=<hex>` | A URL-encoded hex colour, e.g. `%23fc6c18` | Sets the marker fill. Hex only; any other CSS value is ignored |
 
 ```html
 <!-- Opens on a specific camera with auto-rotate off -->
@@ -114,13 +117,16 @@ other origin are dropped.
 
 | Method | Signature | Description |
 |---|---|---|
-| `ready` | `() => Promise<EmbedReadyInfo>` | Resolves when the viewer emits `viewer_ready`. Returns `{ sceneId, cameras }`. |
+| `ready` | `() => Promise<EmbedReadyInfo>` | Resolves when the viewer emits `viewer_ready`. Returns `{ sceneId, cameras, hotspots }`. |
 | `activateCamera` | `(cameraId: string) => void` | Switch to a named camera. |
+| `focusHotspot` | `(hotspotId: string) => void` | Reveal a hotspot's content and fly its camera, as clicking the marker would. |
 | `setTransition` | `(options: SetTransitionOptions) => void` | Override transition type for subsequent camera switches. |
 | `setControlsEnabled` | `(enabled: boolean) => void` | Enable or disable orbit controls. |
 | `setAutoRotate` | `(enabled: boolean, speed?: number) => void` | Toggle auto-rotate. |
 | `setZoomEnabled` | `(enabled: boolean) => void` | Toggle scroll-zoom. |
 | `setPanEnabled` | `(enabled: boolean) => void` | Toggle right-click pan. |
+| `setAnimationPlaying` | `(playing: boolean) => void` | Start or suspend animation playback. |
+| `restartAnimation` | `() => void` | Play the animation program from the beginning. |
 | `sendScrollProgress` | `(progress: number) => void` | Drive scroll-triggered interactions (0–1). |
 | `sendMessage` | `(message: string, payload?) => void` | Trigger a named `host_message` interaction. |
 | `on` | `(type, handler) => () => void` | Subscribe to an event. Returns an unsubscribe function. |
@@ -142,6 +148,9 @@ or sending a host message. `destroy()` discards anything still queued.
 | `viewer_ready` | `void` | The viewer command surface is registered and ready. |
 | `model_loaded` | `void` | The model has finished loading and initial framing is complete. Fires once per load. |
 | `camera_changed` | `{ cameraId: string }` | The active camera changed. |
+| `hotspot_activated` | `{ hotspotId: string, cameraId: string \| null }` | A visitor clicked a marker. `cameraId` is `null` for one that only reveals content. Not emitted for your own `focusHotspot` call. |
+| `animation_state_changed` | `{ playing, activeClipId, complete }` | Playback started, stopped or advanced. `activeClipId` is `null` in simultaneous mode. |
+| `animation_clip_finished` | `{ clipId: string }` | A single clip ran to its end. |
 | `auto_rotate_changed` | `{ enabled: boolean }` | Declared, but the viewer does not currently emit it. |
 | `interaction_event` | `{ eventName, interactionId?, payload? }` | A Publisher-configured `emit_custom_event` interaction fired. |
 
@@ -154,6 +163,33 @@ interface SetTransitionOptions {
   easing?: 'linear' | 'ease_in' | 'ease_out' | 'ease_in_out'
 }
 ```
+
+---
+
+## Hotspots
+
+`ready()` reports the hotspots a visitor can see, so you can build navigation of your own. Hotspots the author hid or kept internal are never listed, and never reachable by id.
+
+```js
+const { hotspots } = await embed.ready()
+// [{ id, name, cameraId, step }]
+
+embed.on('hotspot_activated', ({ hotspotId, cameraId }) => {
+  highlight(hotspotId) // your own panel, in step with the viewer
+})
+
+embed.focusHotspot(hotspots[0].id)
+```
+
+`step` is the 1-based place in the author's navigation sequence, or `null` for a hotspot outside it. Descriptors carry no body text and no link: that content is what the viewer draws, and a second copy on your page would have nothing keeping the two in step.
+
+To drive the whole thing yourself, hide the markers and keep the ids:
+
+```html
+<iframe src="https://vectreal.com/embed/<projectId>/<sceneId>?token=KEY&hotspots=0" ...></iframe>
+```
+
+`focusHotspot` still flies a camera with nothing drawn on the model. Use `?hotspotContent=0` instead to keep the markers and draw only the card yourself.
 
 ---
 
@@ -211,7 +247,7 @@ If you prefer zero dependencies, you can implement the protocol directly. Both s
 
 | `type` | Additional fields | Meaning |
 |---|---|---|
-| `pong` | `sceneId`, `cameras: EmbedCameraDescriptor[]` | Response to `ping` - scene is ready. |
+| `pong` | `sceneId`, `cameras: EmbedCameraDescriptor[]`, `hotspots?: EmbedHotspotDescriptor[]` | Response to `ping` - scene is ready. `hotspots` is absent on iframes older than the field. |
 | `viewer_event` | `event: ViewerInteractionEvent`, `sceneId?` | Viewer lifecycle event. |
 | `interaction_event` | `eventName`, `interactionId?`, `payload?` | A Publisher custom event fired. |
 
@@ -277,6 +313,11 @@ present apps/vectreal-platform/app/db/schema/project/projects.ts allowed_embed_d
 absent apps/vectreal-platform/app/db/schema/auth/api-keys.ts allowed_embed_domains
 present apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.ts requesterHost === applicationHost
 present apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts authContext.mode === 'apiKey'
+present packages/embed/src/embed.ts focusHotspot(hotspotId: string)
+present packages/embed/src/protocol.ts case 'focus_hotspot':
+present apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts params.get('hotspotColor')
+present apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts params.get('hotspotContent')
+present apps/vectreal-platform/app/lib/domain/embed/hosted-preview-bridge.ts resolveHotspotMarkers(hotspots).map
 */}
 
 ---
@@ -286,10 +327,3 @@ present apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts authContext.mod
 - [Publishing & Embedding](/docs/guides/publish-embed) - publish a scene and create a preview API key
 - [@vctrl/embed](/docs/packages/embed) - full package API reference
 - [@vctrl/viewer](/docs/packages/viewer) - embed the viewer directly in a React app without an iframe
-
----
-
-## Related package references
-
-- [@vctrl/embed](/docs/packages/embed)
-- [@vctrl/viewer](/docs/packages/viewer)

--- a/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
@@ -322,7 +322,6 @@ present apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts params
 present apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts const HEX_COLOR
 present packages/viewer/src/types/viewer-interactions.ts type: 'hotspot_activated'
 present packages/embed/src/protocol.ts hotspots?: EmbedHotspotDescriptor[]
-present apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts body: undefined, linkUrl: undefined
 present apps/vectreal-platform/app/lib/domain/embed/hosted-preview-bridge.ts resolveHotspotMarkers(hotspots).map
 */}
 

--- a/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx
@@ -13,7 +13,7 @@ Two integration paths are available:
 | Path | When to use |
 |---|---|
 | **JavaScript SDK** (`@vctrl/embed`) | You want camera control, event callbacks, or scroll interactions from your page code. |
-| **URL parameters** | You need a static initial state with no JavaScript - set the starting camera or transition type in the iframe `src`. |
+| **URL parameters** | You need no JavaScript - set the opening camera or transition, or hand the hotspot UI to your own page, in the iframe `src`. |
 | **Raw postMessage** | You want zero dependencies and are comfortable implementing the protocol yourself. |
 
 ---
@@ -82,8 +82,8 @@ For zero-JavaScript initial configuration, add parameters to the iframe `src`:
 | `?autoRotate=0` or `?autoRotate=1` | `0` to disable, `1` to enable | Overrides the stored auto-rotate setting |
 | `?transition=<type>` | `none`, `linear`, `object_avoidance` | Overrides the stored transition type |
 | `?hotspots=0` | `0` to hide | Draws no markers. The hotspots stay reachable through `focusHotspot` and still appear in `ready()` |
-| `?hotspotContent=0` | `0` to suppress | Keeps the markers but leaves the card to you. Clicks still fly the camera and still emit `hotspot_activated` |
-| `?hotspotColor=<hex>` | A URL-encoded hex colour, e.g. `%23fc6c18` | Sets the marker fill. Hex only; any other CSS value is ignored |
+| `?hotspotContent=0` | `0` to suppress | Keeps the markers, and the clicks, but draws no card. A click still flies the camera and still emits `hotspot_activated`, which is how your own panel knows to open. `focusHotspot` draws no card in this mode either |
+| `?hotspotColor=<hex>` | A URL-encoded hex colour, e.g. `%23fc6c18` | Sets the marker fill. Hex only; any other CSS value is ignored. The step numeral stays dark ink, so a dark or saturated fill makes it unreadable and an iframe cannot override the ink token - keep the fill light |
 
 ```html
 <!-- Opens on a specific camera with auto-rotate off -->
@@ -93,7 +93,9 @@ For zero-JavaScript initial configuration, add parameters to the iframe `src`:
 ></iframe>
 ```
 
-URL parameters apply once on `viewer_ready`. They do not persist to the stored scene configuration.
+`?camera`, `?autoRotate` and `?transition` apply once, on `viewer_ready`. The three hotspot parameters are not applied at a moment at all - they describe how the viewer renders for as long as it is loaded, which is why suppressing the markers does not make them flash on screen first.
+
+None of them persists to the stored scene configuration.
 
 ---
 
@@ -119,7 +121,7 @@ other origin are dropped.
 |---|---|---|
 | `ready` | `() => Promise<EmbedReadyInfo>` | Resolves when the viewer emits `viewer_ready`. Returns `{ sceneId, cameras, hotspots }`. |
 | `activateCamera` | `(cameraId: string) => void` | Switch to a named camera. |
-| `focusHotspot` | `(hotspotId: string) => void` | Reveal a hotspot's content and fly its camera, as clicking the marker would. |
+| `focusHotspot` | `(hotspotId: string) => void` | Reveal a hotspot's content and fly its camera. Sets rather than toggles, so calling it twice does not close the card; there is no close command. |
 | `setTransition` | `(options: SetTransitionOptions) => void` | Override transition type for subsequent camera switches. |
 | `setControlsEnabled` | `(enabled: boolean) => void` | Enable or disable orbit controls. |
 | `setAutoRotate` | `(enabled: boolean, speed?: number) => void` | Toggle auto-rotate. |
@@ -135,7 +137,7 @@ other origin are dropped.
 
 #### Calls made before the viewer is ready
 
-The camera and controls methods are queued and flushed once the viewer reports ready, so
+The camera, controls, hotspot and animation methods are queued and flushed once the viewer reports ready, so
 you can call them immediately after constructing the SDK. `sendScrollProgress` and
 `sendMessage` are not queued: they post straight to the iframe, and a call made before
 the viewer is ready is silently dropped. Await `ready()` before wiring a scroll handler
@@ -189,7 +191,7 @@ To drive the whole thing yourself, hide the markers and keep the ids:
 <iframe src="https://vectreal.com/embed/<projectId>/<sceneId>?token=KEY&hotspots=0" ...></iframe>
 ```
 
-`focusHotspot` still flies a camera with nothing drawn on the model. Use `?hotspotContent=0` instead to keep the markers and draw only the card yourself.
+`focusHotspot` still flies a camera with nothing drawn on the model. Use `?hotspotContent=0` instead to keep the markers and draw only the card yourself - the markers stay clickable there, so `hotspot_activated` still tells you which one to open.
 
 ---
 
@@ -315,8 +317,12 @@ present apps/vectreal-platform/app/lib/domain/embed/embed-access-policy.ts reque
 present apps/vectreal-platform/app/routes/api/scenes.$sceneId.ts authContext.mode === 'apiKey'
 present packages/embed/src/embed.ts focusHotspot(hotspotId: string)
 present packages/embed/src/protocol.ts case 'focus_hotspot':
-present apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts params.get('hotspotColor')
+present apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts params.get('hotspots')
 present apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts params.get('hotspotContent')
+present apps/vectreal-platform/app/lib/domain/embed/embed-presentation.ts const HEX_COLOR
+present packages/viewer/src/types/viewer-interactions.ts type: 'hotspot_activated'
+present packages/embed/src/protocol.ts hotspots?: EmbedHotspotDescriptor[]
+present apps/vectreal-platform/app/lib/domain/scene/embed-settings-policy.ts body: undefined, linkUrl: undefined
 present apps/vectreal-platform/app/lib/domain/embed/hosted-preview-bridge.ts resolveHotspotMarkers(hotspots).map
 */}
 

--- a/apps/vectreal-platform/app/routes/docs/packages/embed.mdx
+++ b/apps/vectreal-platform/app/routes/docs/packages/embed.mdx
@@ -46,13 +46,16 @@ other origin are dropped.
 
 | Method | Returns | Description |
 |---|---|---|
-| `ready()` | `Promise<EmbedReadyInfo>` | Resolves with `{ sceneId, cameras }` when the viewer is ready. |
+| `ready()` | `Promise<EmbedReadyInfo>` | Resolves with `{ sceneId, cameras, hotspots }` when the viewer is ready. |
 | `activateCamera(cameraId)` | `void` | Switch to a named camera. |
+| `focusHotspot(hotspotId)` | `void` | Reveal a hotspot's content and fly its camera. |
 | `setTransition(options)` | `void` | Override transition for subsequent camera switches. |
 | `setControlsEnabled(enabled)` | `void` | Enable or disable orbit controls. |
 | `setAutoRotate(enabled, speed?)` | `void` | Toggle auto-rotate. |
 | `setZoomEnabled(enabled)` | `void` | Toggle scroll-zoom. |
 | `setPanEnabled(enabled)` | `void` | Toggle right-click pan. |
+| `setAnimationPlaying(playing)` | `void` | Start or suspend animation playback. |
+| `restartAnimation()` | `void` | Play the animation program from the beginning. |
 | `sendScrollProgress(progress)` | `void` | Drive scroll interactions (0–1). |
 | `sendMessage(message, payload?)` | `void` | Trigger a named `host_message` interaction. |
 | `on(type, handler)` | `() => void` | Subscribe to an event. Returns unsubscribe. |
@@ -61,7 +64,7 @@ other origin are dropped.
 
 #### Calls made before the viewer is ready
 
-The camera and controls methods are queued and flushed once the viewer reports ready, so
+The camera, controls, hotspot and animation methods are queued and flushed once the viewer reports ready, so
 you can call them immediately after constructing the SDK. `sendScrollProgress` and
 `sendMessage` are not queued: they post straight to the iframe, and a call made before
 the viewer is ready is silently dropped. Await `ready()` before wiring a scroll handler
@@ -77,6 +80,7 @@ or sending a host message. `destroy()` discards anything still queued.
 interface EmbedReadyInfo {
   sceneId: string | undefined
   cameras: EmbedCameraDescriptor[]
+  hotspots: EmbedHotspotDescriptor[]
 }
 ```
 
@@ -89,6 +93,27 @@ interface EmbedCameraDescriptor {
   fov?: number
 }
 ```
+
+### `EmbedHotspotDescriptor`
+
+```ts
+interface EmbedHotspotDescriptor {
+  id: string
+  name: string
+  /** The camera this hotspot flies, or null when it only reveals content. */
+  cameraId: string | null
+  /** 1-based place in the navigation sequence, or null when it has none. */
+  step: number | null
+}
+```
+
+Only the hotspots a visitor can see are listed. A hotspot the author hid or kept internal
+never appears here and cannot be reached by `focusHotspot`. There is no body or link: that
+content is what the viewer draws, and a second copy on the host page would have nothing
+keeping the two in step.
+
+Absent on an iframe deployed before this field existed, in which case `ready()` reports an
+empty array.
 
 ### `SetTransitionOptions`
 
@@ -107,6 +132,13 @@ type EmbedEventMap = {
   viewer_ready: void
   model_loaded: void
   camera_changed: { cameraId: string }
+  hotspot_activated: { hotspotId: string; cameraId: string | null }
+  animation_state_changed: {
+    playing: boolean
+    activeClipId: string | null
+    complete: boolean
+  }
+  animation_clip_finished: { clipId: string }
   auto_rotate_changed: { enabled: boolean }
   interaction_event: {
     interactionId?: string
@@ -135,6 +167,8 @@ import {
 } from '@vctrl/embed'
 
 import type {
+  EmbedCameraDescriptor,
+  EmbedHotspotDescriptor,
   HostedPreviewIncomingMessage,
   HostedPreviewOutgoingMessage,
   HostedPreviewPingMessage,

--- a/apps/vectreal-platform/app/routes/docs/packages/viewer.mdx
+++ b/apps/vectreal-platform/app/routes/docs/packages/viewer.mdx
@@ -53,13 +53,14 @@ function App() {
 | `shadowsOptions` | `ShadowsProps` | No | Shadow behavior configuration |
 | `normalizationOptions` | `NormalizationOptions` | No | Clamps the model's bounding-box diagonal at runtime, without touching the model data |
 | `hotspots` | `HotspotDefinition[]` | No | Point-of-interest markers anchored in world space. Each can carry a body and a link, and fly a linked camera |
-| `hotspotColor` | `string` | No | Overrides the marker fill. The default is neutral so it does not compete with the product |
+| `hotspotColor` | `string` | No | Overrides the marker fill. The default is neutral so it does not compete with the product. The step numeral stays dark ink, so a dark or saturated fill needs `--vctrl-hotspot-ink` overridden on the container |
 | `showHotspotMarkers` | `boolean` | No | Draws the markers, default `true`. `false` leaves them resolved but undrawn, so a host can still reach them by id |
 | `revealHotspotContent` | `boolean` | No | Opens a card on click, default `true`. `false` still flies the camera and still reports the activation |
 | `selectedHotspotId` | `string \| null` | No | Draws one marker as the current one. Editing surfaces only |
 | `showInternalHotspots` | `boolean` | No | Draws hotspots the author kept backstage. Editing surfaces only |
 | `showHiddenHotspots` | `boolean` | No | Draws hotspots the author hid. Editing surfaces only |
 | `onHotspotSelect` | `(id: string) => void` | No | Picks a marker instead of activating it. Passing it makes selection win over both content and camera |
+| `onHotspotPositionSetterReady` | `(setter: HotspotPositionSetter \| null) => void` | No | Receives a setter that moves a marker without moving the hotspot, for a drag gizmo. Editing surfaces only |
 | `shadowLightEditable` | `boolean` | No | Renders an in-scene draggable handle for aiming the shadow light. Editing surfaces only |
 | `staticShadowBake` | `boolean` | No | Bakes the accumulative shadow in one pass on mount instead of fading it in (default `false`) |
 | `bakedShadow` | `BakedShadow` | No | A persisted shadow bake to render instead of recomputing one |
@@ -79,7 +80,7 @@ function App() {
 
 `model` is optional because you can also render scene content via `children`. With neither, nothing renders.
 
-The editor affordances (`shadowLightEditable`, `staticShadowBake`, `bakedShadow`, `onShadowBakeReady`, `onShadowLightChange`) exist for editing surfaces such as the Publisher. Public and embedded viewers omit them.
+The editor affordances exist for editing surfaces such as the Publisher: `shadowLightEditable`, `staticShadowBake`, `bakedShadow`, `onShadowBakeReady`, `onShadowLightChange`, and the hotspot four above - `selectedHotspotId`, `showInternalHotspots`, `showHiddenHotspots`, `onHotspotSelect` and `onHotspotPositionSetterReady`. Public and embedded viewers omit them.
 
 ---
 

--- a/apps/vectreal-platform/app/routes/docs/packages/viewer.mdx
+++ b/apps/vectreal-platform/app/routes/docs/packages/viewer.mdx
@@ -52,6 +52,14 @@ function App() {
 | `envOptions` | `EnvironmentProps` | No | Drei `Environment` configuration |
 | `shadowsOptions` | `ShadowsProps` | No | Shadow behavior configuration |
 | `normalizationOptions` | `NormalizationOptions` | No | Clamps the model's bounding-box diagonal at runtime, without touching the model data |
+| `hotspots` | `HotspotDefinition[]` | No | Point-of-interest markers anchored in world space. Each can carry a body and a link, and fly a linked camera |
+| `hotspotColor` | `string` | No | Overrides the marker fill. The default is neutral so it does not compete with the product |
+| `showHotspotMarkers` | `boolean` | No | Draws the markers, default `true`. `false` leaves them resolved but undrawn, so a host can still reach them by id |
+| `revealHotspotContent` | `boolean` | No | Opens a card on click, default `true`. `false` still flies the camera and still reports the activation |
+| `selectedHotspotId` | `string \| null` | No | Draws one marker as the current one. Editing surfaces only |
+| `showInternalHotspots` | `boolean` | No | Draws hotspots the author kept backstage. Editing surfaces only |
+| `showHiddenHotspots` | `boolean` | No | Draws hotspots the author hid. Editing surfaces only |
+| `onHotspotSelect` | `(id: string) => void` | No | Picks a marker instead of activating it. Passing it makes selection win over both content and camera |
 | `shadowLightEditable` | `boolean` | No | Renders an in-scene draggable handle for aiming the shadow light. Editing surfaces only |
 | `staticShadowBake` | `boolean` | No | Bakes the accumulative shadow in one pass on mount instead of fading it in (default `false`) |
 | `bakedShadow` | `BakedShadow` | No | A persisted shadow bake to render instead of recomputing one |
@@ -408,6 +416,7 @@ from a viewer default and override a field:
 | `SceneControls` | `defaultControlsOptions` |
 | `SceneEnvironment` | `defaultEnvOptions` |
 | `SceneShadows` | `defaultShadowsOptions` |
+| `SceneHotspots` | none |
 | `SceneModel` | none |
 | `ScenePostProcessing` | none |
 

--- a/apps/vectreal-platform/supabase/migrations/0022_polite_harpoon.sql
+++ b/apps/vectreal-platform/supabase/migrations/0022_polite_harpoon.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "scene_hotspots" ADD COLUMN "body" text;--> statement-breakpoint
+ALTER TABLE "scene_hotspots" ADD COLUMN "link_url" text;

--- a/apps/vectreal-platform/supabase/migrations/meta/0022_snapshot.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/0022_snapshot.json
@@ -1,0 +1,4075 @@
+{
+  "id": "1909e182-f73b-46e4-b13a-0f5ab6011164",
+  "prevId": "90fa1a55-bf38-4d3a-92cd-2bbf0f714368",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "users_select_self": {
+          "name": "users_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_insert_self": {
+          "name": "users_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        },
+        "users_update_self": {
+          "name": "users_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"id\" = (select auth.uid())",
+          "withCheck": "\"users\".\"id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference_code": {
+          "name": "reference_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "is_authenticated": {
+          "name": "is_authenticated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inquiry_type": {
+          "name": "inquiry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "failure_stage": {
+          "name": "failure_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "internal_message_id": {
+          "name": "internal_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_message_id": {
+          "name": "confirmation_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_status_idx": {
+          "name": "contact_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_submissions_user_id_users_id_fk": {
+          "name": "contact_submissions_user_id_users_id_fk",
+          "tableFrom": "contact_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_submissions_reference_code_unique": {
+          "name": "contact_submissions_reference_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_owner_id_idx": {
+          "name": "organizations_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_id_users_id_fk": {
+          "name": "organizations_owner_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "organizations_select_member": {
+          "name": "organizations_select_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_insert_owner": {
+          "name": "organizations_insert_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"organizations\".\"owner_id\" = (select auth.uid())"
+        },
+        "organizations_update_owner": {
+          "name": "organizations_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        },
+        "organizations_delete_owner": {
+          "name": "organizations_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organizations\".\"id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role = 'owner'\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_memberships_user_id_idx": {
+          "name": "organization_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_organization_id_idx": {
+          "name": "organization_memberships_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_invited_by_idx": {
+          "name": "organization_memberships_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_memberships_select_org_member": {
+          "name": "org_memberships_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_insert_org_admin": {
+          "name": "org_memberships_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_update_org_admin": {
+          "name": "org_memberships_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t)\n\t\t\t"
+        },
+        "org_memberships_delete_org_admin_or_self": {
+          "name": "org_memberships_delete_org_admin_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t(\n\t\t\t\t\texists (\n\t\t\t\t\t\tselect 1\n\t\t\t\t\t\tfrom organization_memberships om\n\t\t\t\t\t\twhere om.organization_id = \"organization_memberships\".\"organization_id\"\n\t\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t\t\t\tand om.role in ('owner', 'admin')\n\t\t\t\t\t)\n\t\t\t\t\tor \"organization_memberships\".\"user_id\" = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_embed_domains": {
+          "name": "allowed_embed_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "projects_select_org_member": {
+          "name": "projects_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "projects_insert_org_admin": {
+          "name": "projects_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"projects\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_update_org_admin": {
+          "name": "projects_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "projects_delete_org_admin": {
+          "name": "projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"projects\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_folders": {
+      "name": "scene_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_folders_project_id_idx": {
+          "name": "scene_folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_owner_id_idx": {
+          "name": "scene_folders_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_folders_parent_folder_id_idx": {
+          "name": "scene_folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_folders_project_id_projects_id_fk": {
+          "name": "scene_folders_project_id_projects_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_owner_id_users_id_fk": {
+          "name": "scene_folders_owner_id_users_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_folders_parent_folder_id_scene_folders_id_fk": {
+          "name": "scene_folders_parent_folder_id_scene_folders_id_fk",
+          "tableFrom": "scene_folders",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_folders_select_project_member": {
+          "name": "scene_folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_folders_insert_project_member_self_owner": {
+          "name": "scene_folders_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scene_folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_update_owner_or_admin": {
+          "name": "scene_folders_update_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        },
+        "scene_folders_delete_owner_or_admin": {
+          "name": "scene_folders_delete_owner_or_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scene_folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t or \"scene_folders\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {
+        "scene_folders_parent_not_self": {
+          "name": "scene_folders_parent_not_self",
+          "value": "\"scene_folders\".\"parent_folder_id\" is null or \"scene_folders\".\"parent_folder_id\" <> \"scene_folders\".\"id\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_folder_id": {
+          "name": "parent_folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "folders_project_id_idx": {
+          "name": "folders_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "folders_parent_folder_id_idx": {
+          "name": "folders_parent_folder_id_idx",
+          "columns": [
+            {
+              "expression": "parent_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_project_id_projects_id_fk": {
+          "name": "folders_project_id_projects_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folders_parent_folder_id_folders_id_fk": {
+          "name": "folders_parent_folder_id_folders_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "parent_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "folders_select_project_member": {
+          "name": "folders_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "folders_insert_project_admin": {
+          "name": "folders_insert_project_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"folders\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_update_project_admin": {
+          "name": "folders_update_project_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "folders_delete_project_admin": {
+          "name": "folders_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"folders\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_folder_id_idx": {
+          "name": "assets_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_owner_id_idx": {
+          "name": "assets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_folder_id_folders_id_fk": {
+          "name": "assets_folder_id_folders_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_owner_id_users_id_fk": {
+          "name": "assets_owner_id_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "assets_select_project_member": {
+          "name": "assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "assets_insert_project_member_self_owner": {
+          "name": "assets_insert_project_member_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom folders f\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere f.id = \"assets\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_update_project_member_owner": {
+          "name": "assets_update_project_member_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t and \"assets\".\"owner_id\" = (select auth.uid())"
+        },
+        "assets_delete_project_admin": {
+          "name": "assets_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"assets\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scenes": {
+      "name": "scenes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scenes_project_id_idx": {
+          "name": "scenes_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_folder_id_idx": {
+          "name": "scenes_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scenes_project_id_projects_id_fk": {
+          "name": "scenes_project_id_projects_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scenes_folder_id_scene_folders_id_fk": {
+          "name": "scenes_folder_id_scene_folders_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "scene_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scenes_select_project_member": {
+          "name": "scenes_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scenes_insert_project_member": {
+          "name": "scenes_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"scenes\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_update_project_member": {
+          "name": "scenes_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand (\"scenes\".\"folder_id\" is null or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scene_folders sf\n\t\t\tjoin projects p on p.id = sf.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere sf.id = \"scenes\".\"folder_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t)\n\t\t\t"
+        },
+        "scenes_delete_project_admin": {
+          "name": "scenes_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scenes\".\"id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_settings": {
+      "name": "scene_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "camera": {
+          "name": "camera",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controls": {
+          "name": "controls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactions": {
+          "name": "interactions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shadows": {
+          "name": "shadows",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalization": {
+          "name": "normalization",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_settings_created_by_idx": {
+          "name": "scene_settings_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_settings_scene_id_scenes_id_fk": {
+          "name": "scene_settings_scene_id_scenes_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_settings_created_by_users_id_fk": {
+          "name": "scene_settings_created_by_users_id_fk",
+          "tableFrom": "scene_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_settings_scene_id_unique": {
+          "name": "scene_settings_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_settings_select_project_member": {
+          "name": "scene_settings_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_insert_project_member_self_creator": {
+          "name": "scene_settings_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_settings\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_settings_update_project_member": {
+          "name": "scene_settings_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_settings_delete_project_admin": {
+          "name": "scene_settings_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_settings\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_hotspots": {
+      "name": "scene_hotspots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "world_position_x": {
+          "name": "world_position_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_y": {
+          "name": "world_position_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "world_position_z": {
+          "name": "world_position_z",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_camera_id": {
+          "name": "linked_camera_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "internal_only": {
+          "name": "internal_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occlusion_enabled": {
+          "name": "occlusion_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_preset": {
+          "name": "style_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dot'"
+        },
+        "payload_url": {
+          "name": "payload_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_hotspots_scene_settings_id_idx": {
+          "name": "scene_hotspots_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_hotspots_sequence_index_idx": {
+          "name": "scene_hotspots_sequence_index_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_hotspots_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_hotspots_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_hotspots",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_hotspots_select_project_member": {
+          "name": "scene_hotspots_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_insert_project_member": {
+          "name": "scene_hotspots_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_update_project_member": {
+          "name": "scene_hotspots_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t",
+          "withCheck": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_hotspots_delete_project_admin": {
+          "name": "scene_hotspots_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\twhere ss.id = \"scene_hotspots\".\"scene_settings_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = ss.scene_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_stats": {
+      "name": "scene_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized": {
+          "name": "optimized",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_scene_bytes": {
+          "name": "initial_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_scene_bytes": {
+          "name": "current_scene_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_optimizations": {
+          "name": "applied_optimizations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimization_settings": {
+          "name": "optimization_settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_metrics": {
+          "name": "additional_metrics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_stats_created_by_idx": {
+          "name": "scene_stats_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_stats_scene_id_scenes_id_fk": {
+          "name": "scene_stats_scene_id_scenes_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_stats_created_by_users_id_fk": {
+          "name": "scene_stats_created_by_users_id_fk",
+          "tableFrom": "scene_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_stats_scene_id_unique": {
+          "name": "scene_stats_scene_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id"
+          ]
+        }
+      },
+      "policies": {
+        "scene_stats_select_project_member": {
+          "name": "scene_stats_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_insert_project_member_self_creator": {
+          "name": "scene_stats_insert_project_member_self_creator",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t and \"scene_stats\".\"created_by\" = (select auth.uid())"
+        },
+        "scene_stats_update_project_member": {
+          "name": "scene_stats_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_stats_delete_project_admin": {
+          "name": "scene_stats_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_stats\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_assets": {
+      "name": "scene_assets",
+      "schema": "",
+      "columns": {
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_assets_scene_settings_id_idx": {
+          "name": "scene_assets_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_assets_asset_id_idx": {
+          "name": "scene_assets_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_assets_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_assets_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_assets_asset_id_assets_id_fk": {
+          "name": "scene_assets_asset_id_assets_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scene_assets_scene_settings_id_asset_id_pk": {
+          "name": "scene_assets_scene_settings_id_asset_id_pk",
+          "columns": [
+            "scene_settings_id",
+            "asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_assets_select_project_member": {
+          "name": "scene_assets_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_insert_project_member": {
+          "name": "scene_assets_insert_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom assets a\n\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\tjoin projects p on p.id = f.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere a.id = \"scene_assets\".\"asset_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_assets_delete_project_member": {
+          "name": "scene_assets_delete_project_member",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom scene_settings ss\n\t\t\t\t\tjoin scenes s on s.id = ss.scene_id\n\t\t\t\t\tjoin projects p on p.id = s.project_id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere ss.id = \"scene_assets\".\"scene_settings_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_published": {
+      "name": "scene_published",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_settings_id": {
+          "name": "scene_settings_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scene_published_asset_id_idx": {
+          "name": "scene_published_asset_id_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_scene_settings_id_idx": {
+          "name": "scene_published_scene_settings_id_idx",
+          "columns": [
+            {
+              "expression": "scene_settings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_published_published_by_idx": {
+          "name": "scene_published_published_by_idx",
+          "columns": [
+            {
+              "expression": "published_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_published_scene_id_scenes_id_fk": {
+          "name": "scene_published_scene_id_scenes_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_asset_id_assets_id_fk": {
+          "name": "scene_published_asset_id_assets_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scene_published_scene_settings_id_scene_settings_id_fk": {
+          "name": "scene_published_scene_settings_id_scene_settings_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "scene_settings",
+          "columnsFrom": [
+            "scene_settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scene_published_published_by_users_id_fk": {
+          "name": "scene_published_published_by_users_id_fk",
+          "tableFrom": "scene_published",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "scene_published_select_project_member": {
+          "name": "scene_published_select_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_insert_project_member_self_publisher": {
+          "name": "scene_published_insert_project_member_self_publisher",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand \"scene_published\".\"published_by\" = (select auth.uid())\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom assets a\n\t\t\t\t\tjoin folders f on f.id = a.folder_id\n\t\t\t\t\tjoin projects p on p.id = f.project_id\n\t\t\t\t\tjoin scenes s on s.project_id = p.id\n\t\t\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\t\t\tand a.id = \"scene_published\".\"asset_id\"\n\t\t\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\t)\n\t\t\t"
+        },
+        "scene_published_update_project_member": {
+          "name": "scene_published_update_project_member",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "scene_published_delete_project_admin": {
+          "name": "scene_published_delete_project_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom scenes s\n\t\t\tjoin projects p on p.id = s.project_id\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere s.id = \"scene_published\".\"scene_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_requests": {
+      "name": "scene_action_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_action_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_requests_status_idx": {
+          "name": "scene_action_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_scene_id_idx": {
+          "name": "scene_action_requests_scene_id_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_action_requests_expires_at_idx": {
+          "name": "scene_action_requests_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_action_requests_request_key_unique": {
+          "name": "scene_action_requests_request_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_action_locks": {
+      "name": "scene_action_locks",
+      "schema": "",
+      "columns": {
+        "scene_id": {
+          "name": "scene_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_key": {
+          "name": "holder_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scene_action_locks_expires_at_idx": {
+          "name": "scene_action_locks_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.scene_runtime_limits": {
+      "name": "scene_runtime_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "in_flight": {
+          "name": "in_flight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_group_id_idx": {
+          "name": "group_memberships_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_memberships_user_id_idx": {
+          "name": "group_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "group_memberships_select_owner_or_member": {
+          "name": "group_memberships_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"group_memberships\".\"group_id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_insert_owner_or_self_join": {
+          "name": "group_memberships_insert_owner_or_self_join",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        },
+        "group_memberships_update_owner": {
+          "name": "group_memberships_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "group_memberships_delete_owner_or_self": {
+          "name": "group_memberships_delete_owner_or_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom groups g\n\t\t\twhere g.id = \"group_memberships\".\"group_id\"\n\t\t\t\tand g.owner_id = (select auth.uid())\n\t\t)\n\t or \"group_memberships\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_id_idx": {
+          "name": "groups_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "groups_select_owner_or_member": {
+          "name": "groups_select_owner_or_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid()) or \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom group_memberships gm\n\t\t\twhere gm.group_id = \"groups\".\"id\"\n\t\t\t\tand gm.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "groups_insert_self_owner": {
+          "name": "groups_insert_self_owner",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_update_owner": {
+          "name": "groups_update_owner",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())",
+          "withCheck": "\"groups\".\"owner_id\" = (select auth.uid())"
+        },
+        "groups_delete_owner": {
+          "name": "groups_delete_owner",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"groups\".\"owner_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "api_key_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'embed'"
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_preview": {
+          "name": "key_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_organization_id_idx": {
+          "name": "api_keys_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_organization_id_organizations_id_fk": {
+          "name": "api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "api_keys_select_org_admin": {
+          "name": "api_keys_select_org_admin",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_insert_org_admin": {
+          "name": "api_keys_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_update_org_admin": {
+          "name": "api_keys_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "api_keys_delete_org_admin": {
+          "name": "api_keys_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"api_keys\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_key_projects": {
+      "name": "api_key_projects",
+      "schema": "",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_projects_api_key_id_idx": {
+          "name": "api_key_projects_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_projects_project_id_idx": {
+          "name": "api_key_projects_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_projects_api_key_id_api_keys_id_fk": {
+          "name": "api_key_projects_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_projects_project_id_projects_id_fk": {
+          "name": "api_key_projects_project_id_projects_id_fk",
+          "tableFrom": "api_key_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_key_projects_api_key_id_project_id_pk": {
+          "name": "api_key_projects_api_key_id_project_id_pk",
+          "columns": [
+            "api_key_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "api_key_projects_select_org_admin_and_project_member": {
+          "name": "api_key_projects_select_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_insert_org_admin_and_project_member": {
+          "name": "api_key_projects_insert_org_admin_and_project_member",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\t\t\t\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom projects p\n\t\t\tjoin organization_memberships om on om.organization_id = p.organization_id\n\t\t\twhere p.id = \"api_key_projects\".\"project_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t\n\t\t\t\tand exists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        },
+        "api_key_projects_delete_org_admin": {
+          "name": "api_key_projects_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\t\t\texists (\n\t\t\t\t\tselect 1\n\t\t\t\t\tfrom api_keys ak\n\t\t\t\t\twhere ak.id = \"api_key_projects\".\"api_key_id\"\n\t\t\t\t\t\tand \n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = ak.organization_id\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t\n\t\t\t\t)\n\t\t\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "billing_state": {
+          "name": "billing_state",
+          "type": "billing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_stripe_subscription_id_idx": {
+          "name": "org_subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_customer_id_idx": {
+          "name": "org_subscriptions_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_billing_state_idx": {
+          "name": "org_subscriptions_billing_state_idx",
+          "columns": [
+            {
+              "expression": "billing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_subscriptions_organization_id_unique": {
+          "name": "org_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {
+        "org_subscriptions_select_org_member": {
+          "name": "org_subscriptions_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_subscriptions_insert_org_admin": {
+          "name": "org_subscriptions_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_update_org_admin": {
+          "name": "org_subscriptions_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_subscriptions_delete_org_admin": {
+          "name": "org_subscriptions_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_subscriptions\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_limit_overrides": {
+      "name": "org_limit_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_key": {
+          "name": "limit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_limit_overrides_org_key_uidx": {
+          "name": "org_limit_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "limit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_limit_overrides_organization_id_organizations_id_fk": {
+          "name": "org_limit_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_limit_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_limit_overrides_select_org_member": {
+          "name": "org_limit_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_limit_overrides_insert_org_admin": {
+          "name": "org_limit_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_update_org_admin": {
+          "name": "org_limit_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_limit_overrides_delete_org_admin": {
+          "name": "org_limit_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_limit_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_entitlement_overrides": {
+      "name": "org_entitlement_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_key": {
+          "name": "entitlement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_entitlement_overrides_org_key_uidx": {
+          "name": "org_entitlement_overrides_org_key_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_entitlement_overrides_organization_id_organizations_id_fk": {
+          "name": "org_entitlement_overrides_organization_id_organizations_id_fk",
+          "tableFrom": "org_entitlement_overrides",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_entitlement_overrides_select_org_member": {
+          "name": "org_entitlement_overrides_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_insert_org_admin": {
+          "name": "org_entitlement_overrides_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_update_org_admin": {
+          "name": "org_entitlement_overrides_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_entitlement_overrides_delete_org_admin": {
+          "name": "org_entitlement_overrides_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_entitlement_overrides\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.org_usage_counters": {
+      "name": "org_usage_counters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter_key": {
+          "name": "counter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_usage_counters_org_key_window_uidx": {
+          "name": "org_usage_counters_org_key_window_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_usage_counters_window_end_idx": {
+          "name": "org_usage_counters_window_end_idx",
+          "columns": [
+            {
+              "expression": "window_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_usage_counters_organization_id_organizations_id_fk": {
+          "name": "org_usage_counters_organization_id_organizations_id_fk",
+          "tableFrom": "org_usage_counters",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_usage_counters_select_org_member": {
+          "name": "org_usage_counters_select_org_member",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t)\n\t"
+        },
+        "org_usage_counters_insert_org_admin": {
+          "name": "org_usage_counters_insert_org_admin",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_update_org_admin": {
+          "name": "org_usage_counters_update_org_admin",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t",
+          "withCheck": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        },
+        "org_usage_counters_delete_org_admin": {
+          "name": "org_usage_counters_delete_org_admin",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n\t\texists (\n\t\t\tselect 1\n\t\t\tfrom organization_memberships om\n\t\t\twhere om.organization_id = \"org_usage_counters\".\"organization_id\"\n\t\t\t\tand om.user_id = (select auth.uid())\n\t\t\t\tand om.role in ('owner', 'admin')\n\t\t)\n\t"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.billing_webhook_events": {
+      "name": "billing_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_webhook_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_webhook_events_provider_event_id_uidx": {
+          "name": "billing_webhook_events_provider_event_id_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_status_idx": {
+          "name": "billing_webhook_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_events_created_at_idx": {
+          "name": "billing_webhook_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.consent_records": {
+      "name": "consent_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "necessary": {
+          "name": "necessary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "functional": {
+          "name": "functional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_country": {
+          "name": "ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "consent_records_user_id_users_id_fk": {
+          "name": "consent_records_user_id_users_id_fk",
+          "tableFrom": "consent_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_records_user_id_unique": {
+          "name": "consent_records_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "consent_records_anonymous_id_unique": {
+          "name": "consent_records_anonymous_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anonymous_id"
+          ]
+        }
+      },
+      "policies": {
+        "consent_records_select_self": {
+          "name": "consent_records_select_self",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_insert_self": {
+          "name": "consent_records_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        },
+        "consent_records_update_self": {
+          "name": "consent_records_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"consent_records\".\"user_id\" = (select auth.uid())",
+          "withCheck": "\"consent_records\".\"user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.contact_submission_status": {
+      "name": "contact_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.membership_role": {
+      "name": "membership_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "texture",
+        "material",
+        "model",
+        "environment",
+        "other"
+      ]
+    },
+    "public.scene_status": {
+      "name": "scene_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.scene_action_request_status": {
+      "name": "scene_action_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.api_key_kind": {
+      "name": "api_key_kind",
+      "schema": "public",
+      "values": [
+        "embed"
+      ]
+    },
+    "public.billing_state": {
+      "name": "billing_state",
+      "schema": "public",
+      "values": [
+        "none",
+        "trialing",
+        "active",
+        "past_due",
+        "unpaid",
+        "canceled",
+        "paused",
+        "incomplete",
+        "incomplete_expired"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "business",
+        "enterprise"
+      ]
+    },
+    "public.billing_webhook_event_status": {
+      "name": "billing_webhook_event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/vectreal-platform/supabase/migrations/meta/_journal.json
+++ b/apps/vectreal-platform/supabase/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1788368674707,
       "tag": "0021_youthful_rawhide_kid",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1788523065966,
+      "tag": "0022_polite_harpoon",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/vectreal-platform/tests/integration/scene-hotspots.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/scene-hotspots.integration.spec.ts
@@ -153,6 +153,8 @@ describe('hotspot persistence', () => {
 			sequenceIndex: 0,
 			stylePreset: 'svg',
 			payloadUrl: 'https://example.test/marker.svg',
+			body: 'Cast in one piece, then machined flat.',
+			linkUrl: 'https://example.test/spec',
 			occlusionEnabled: false,
 			internalOnly: true,
 			visible: false
@@ -167,6 +169,57 @@ describe('hotspot persistence', () => {
 		)
 
 		expect(read).toEqual(written)
+	})
+
+	/**
+	 * The update half of the upsert, which the insert-only test above cannot
+	 * reach. A surviving hotspot is updated in place rather than deleted and
+	 * reinserted, so every column has to be named twice: once in `values` and
+	 * again in `onConflictDoUpdate.set`. A column missing from the second list
+	 * writes correctly on the save that creates the hotspot and silently
+	 * no-ops on every save after it, which reads to an author as an edit that
+	 * will not stick.
+	 */
+	it('updates a hotspot\u2019s content in place on a second save', async () => {
+		const id = randomUUID()
+
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [
+				hotspot({ id, body: 'First draft.', linkUrl: 'https://a.test/one' })
+			])
+		)
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [
+				hotspot({ id, body: 'Second draft.', linkUrl: 'https://a.test/two' })
+			])
+		)
+
+		const [read] = await db.transaction((tx) =>
+			getHotspotsBySceneSettingsId(tx, sceneSettingsId)
+		)
+
+		expect(read.body).toBe('Second draft.')
+		expect(read.linkUrl).toBe('https://a.test/two')
+	})
+
+	it('clears a hotspot\u2019s content when the author empties both fields', async () => {
+		const id = randomUUID()
+
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [
+				hotspot({ id, body: 'Said something.', linkUrl: 'https://a.test/one' })
+			])
+		)
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [hotspot({ id })])
+		)
+
+		const [read] = await db.transaction((tx) =>
+			getHotspotsBySceneSettingsId(tx, sceneSettingsId)
+		)
+
+		expect(read.body).toBeUndefined()
+		expect(read.linkUrl).toBeUndefined()
 	})
 
 	// The whole reason this file exists.

--- a/apps/vectreal-platform/tests/integration/scene-hotspots.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/scene-hotspots.integration.spec.ts
@@ -222,6 +222,37 @@ describe('hotspot persistence', () => {
 		expect(read.linkUrl).toBeUndefined()
 	})
 
+	/**
+	 * A row written before the parser normalized an empty string.
+	 *
+	 * The read maps with `||` rather than `??` for exactly this: '' coming back
+	 * as '' would report the scene dirty against a client that sends
+	 * `undefined` for the same emptiness, on every load, forever. Nothing on the
+	 * unit gate can reach this - the mapping needs a real row - so it is written
+	 * here, against the column directly rather than through `replaceHotspots`,
+	 * which no longer produces an empty string to store.
+	 */
+	it('reads a legacy empty string back as unset', async () => {
+		const id = randomUUID()
+
+		await db.transaction((tx) =>
+			replaceHotspots(tx, sceneSettingsId, [
+				hotspot({ id, body: 'Said something.' })
+			])
+		)
+		await db
+			.update(schema.sceneHotspots)
+			.set({ body: '', linkUrl: '' })
+			.where(eq(schema.sceneHotspots.id, id))
+
+		const [read] = await db.transaction((tx) =>
+			getHotspotsBySceneSettingsId(tx, sceneSettingsId)
+		)
+
+		expect(read.body).toBeUndefined()
+		expect(read.linkUrl).toBeUndefined()
+	})
+
 	// The whole reason this file exists.
 	it('refuses the legacy non-uuid id, rather than storing it', async () => {
 		const legacy = hotspot({ id: 'hotspot-1755000000000-a1b2c3' })

--- a/packages/core/src/types/scene-types.ts
+++ b/packages/core/src/types/scene-types.ts
@@ -341,6 +341,18 @@ export type HotspotStylePreset = 'dot' | 'image' | 'svg'
 export interface HotspotDefinition {
 	id: string
 	name: string
+	/**
+	 * Plain text shown when the hotspot is revealed. Plain, not markup: it is
+	 * rendered by a package that runs inside third-party pages, so there is
+	 * nothing here to sanitize on the render side.
+	 */
+	body?: string
+	/**
+	 * Optional destination for the revealed hotspot. `https:` only, and shown
+	 * with its own host as the visible text so a label cannot go stale against
+	 * where it points.
+	 */
+	linkUrl?: string
 	/** World-space 3D position [x, y, z]. */
 	worldPosition: [number, number, number]
 	/**

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -86,16 +86,10 @@ SDK after the `src` is set, or pass `iframeOrigin` explicitly.
 
 ## URL parameter shorthand
 
-For static initial configuration without JavaScript, add query parameters to the iframe `src`:
-
-| Parameter            | Example              | Effect                                |
-| -------------------- | -------------------- | ------------------------------------- |
-| `?camera=<id>`       | `?camera=hero`       | Activates a camera on `viewer_ready`. |
-| `?autoRotate=0`      | `?autoRotate=1`      | Overrides stored auto-rotate state.   |
-| `?transition=<type>` | `?transition=linear` | Overrides stored transition type.     |
-| `?hotspots=0`        | `?hotspots=0`        | Draws no markers, keeps them reachable. |
-| `?hotspotContent=0`  | `?hotspotContent=0`  | Markers stay; you draw the card.      |
-| `?hotspotColor=<hex>`| `?hotspotColor=%23fc6c18` | Sets the marker fill. Hex only.  |
+Opening state and hotspot presentation can be set with query parameters on the iframe
+`src`, no JavaScript required — `?camera`, `?autoRotate`, `?transition`, `?hotspots`,
+`?hotspotContent` and `?hotspotColor`. Values and behaviour are tabled once, in the
+[Embed SDK guide](https://vectreal.com/docs/guides/embed-sdk#url-parameters).
 
 ## Documentation
 

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -42,8 +42,9 @@ For production, pin a version (`@vctrl/embed@<version>`) and add a [Subresource 
 
 	const embed = new VectrealEmbed(document.getElementById('vectreal-scene'))
 
-	const { cameras } = await embed.ready()
+	const { cameras, hotspots } = await embed.ready()
 	console.log('Available cameras:', cameras)
+	console.log('Hotspots a visitor can see:', hotspots)
 
 	embed.on('camera_changed', ({ cameraId }) => {
 		console.log('Camera changed to:', cameraId)
@@ -62,42 +63,26 @@ For production, pin a version (`@vctrl/embed@<version>`) and add a [Subresource 
 | `iframeOrigin` | `string` | Auto-detected from `iframe.src` | Expected iframe origin for postMessage security. |
 | `readyTimeout` | `number` | `15000`                         | ms before `ready()` rejects.                     |
 
-### Methods
+### What you can control
 
-| Method                           | Description                                                    |
-| -------------------------------- | -------------------------------------------------------------- |
-| `ready()`                        | Resolves with `{ sceneId, cameras }` when the viewer is ready. |
-| `activateCamera(cameraId)`       | Switch to a named camera.                                      |
-| `setTransition(options)`         | Override transition type, duration, and easing.                |
-| `setControlsEnabled(enabled)`    | Enable or disable orbit controls.                              |
-| `setAutoRotate(enabled, speed?)` | Toggle auto-rotate.                                            |
-| `setZoomEnabled(enabled)`        | Toggle scroll-zoom.                                            |
-| `setPanEnabled(enabled)`         | Toggle right-click pan.                                        |
-| `sendScrollProgress(progress)`   | Drive scroll-triggered interactions (0–1).                     |
-| `sendMessage(message, payload?)` | Trigger a named `host_message` interaction.                    |
-| `on(type, handler)`              | Subscribe to a viewer event. Returns unsubscribe.              |
-| `off(type, handler)`             | Remove a specific handler.                                     |
-| `destroy()`                      | Remove all listeners and stop processing messages.             |
+Cameras and transitions, orbit/zoom/pan, animation playback, hotspots, scroll-driven
+interactions, and named host messages - plus events for each. The full method and event
+tables live in one place, the
+[Embed SDK guide](https://vectreal.com/docs/guides/embed-sdk#api-reference), rather than
+being repeated here where the two copies drift apart.
 
-The camera and controls methods are queued and flushed once the viewer reports ready, so
-you can call them immediately after constructing the SDK. `sendScrollProgress` and
-`sendMessage` are not queued: they post straight to the iframe, and a call made before
-the viewer is ready is silently dropped. Await `ready()` before wiring a scroll handler
-or sending a host message. `destroy()` discards anything still queued.
+Two behaviours worth knowing before you read it:
+
+The camera, controls, hotspot and animation methods are queued and flushed once the
+viewer reports ready, so you can call them immediately after constructing the SDK.
+`sendScrollProgress` and `sendMessage` are not queued: they post straight to the iframe,
+and a call made before the viewer is ready is silently dropped. Await `ready()` before
+wiring a scroll handler or sending a host message. `destroy()` discards anything still
+queued.
 
 The constructor throws when it cannot determine a target origin, which happens when
 `iframeOrigin` is omitted and the iframe's `src` is empty or unparseable. Construct the
 SDK after the `src` is set, or pass `iframeOrigin` explicitly.
-
-### Events
-
-| Type                  | Payload                                   | When                                                                         |
-| --------------------- | ----------------------------------------- | ---------------------------------------------------------------------------- |
-| `viewer_ready`        | `void`                                    | Viewer command surface is registered.                                        |
-| `model_loaded`        | `void`                                    | Model finished loading and initial framing is complete. Fires once per load. |
-| `camera_changed`      | `{ cameraId }`                            | Active camera changed.                                                       |
-| `auto_rotate_changed` | `{ enabled }`                             | Declared, but the viewer does not currently emit it.                         |
-| `interaction_event`   | `{ eventName, interactionId?, payload? }` | Publisher custom event fired.                                                |
 
 ## URL parameter shorthand
 
@@ -108,6 +93,9 @@ For static initial configuration without JavaScript, add query parameters to the
 | `?camera=<id>`       | `?camera=hero`       | Activates a camera on `viewer_ready`. |
 | `?autoRotate=0`      | `?autoRotate=1`      | Overrides stored auto-rotate state.   |
 | `?transition=<type>` | `?transition=linear` | Overrides stored transition type.     |
+| `?hotspots=0`        | `?hotspots=0`        | Draws no markers, keeps them reachable. |
+| `?hotspotContent=0`  | `?hotspotContent=0`  | Markers stay; you draw the card.      |
+| `?hotspotColor=<hex>`| `?hotspotColor=%23fc6c18` | Sets the marker fill. Hex only.  |
 
 ## Documentation
 

--- a/packages/embed/src/embed.ts
+++ b/packages/embed/src/embed.ts
@@ -2,6 +2,7 @@ import {
 	HOSTED_PREVIEW_HOST_SOURCE,
 	HOSTED_PREVIEW_VIEWER_SOURCE,
 	type EmbedCameraDescriptor,
+	type EmbedHotspotDescriptor,
 	type HostedPreviewOutgoingMessage
 } from './protocol'
 
@@ -21,6 +22,11 @@ export interface EmbedOptions {
 export interface EmbedReadyInfo {
 	sceneId: string | undefined
 	cameras: EmbedCameraDescriptor[]
+	/**
+	 * The hotspots a visitor can see. Empty for a scene with none, and also for
+	 * an iframe older than this field - see `HostedPreviewPongMessage`.
+	 */
+	hotspots: EmbedHotspotDescriptor[]
 }
 
 export interface SetTransitionOptions {
@@ -42,6 +48,7 @@ export type EmbedEventMap = {
 		complete: boolean
 	}
 	animation_clip_finished: { clipId: string }
+	hotspot_activated: { hotspotId: string; cameraId: string | null }
 	interaction_event: {
 		interactionId?: string
 		eventName: string
@@ -130,13 +137,18 @@ export class VectrealEmbed {
 				window.clearTimeout(timer)
 				resolve({
 					sceneId: this.sceneId,
-					cameras: this.cameras
+					cameras: this.cameras,
+					hotspots: this.hotspots
 				})
 			}
 
 			if (this.isReady) {
 				window.clearTimeout(timer)
-				resolve({ sceneId: this.sceneId, cameras: this.cameras })
+				resolve({
+					sceneId: this.sceneId,
+					cameras: this.cameras,
+					hotspots: this.hotspots
+				})
 				return
 			}
 
@@ -159,6 +171,18 @@ export class VectrealEmbed {
 	/** Switch to a named camera. */
 	activateCamera(cameraId: string): void {
 		this.sendCommand({ type: 'activate_camera', cameraId })
+	}
+
+	/**
+	 * Focus a hotspot: reveal what it says and fly its camera, as clicking the
+	 * marker would.
+	 *
+	 * Ids come from `ready()`, which reports only the hotspots a visitor can
+	 * see. A hotspot the author hid or kept internal is not drawn, and naming
+	 * one here does nothing.
+	 */
+	focusHotspot(hotspotId: string): void {
+		this.sendCommand({ type: 'focus_hotspot', hotspotId })
 	}
 
 	/** Override the transition behaviour for subsequent camera switches. */
@@ -254,6 +278,9 @@ export class VectrealEmbed {
 
 	private sceneId: string | undefined = undefined
 	private cameras: EmbedCameraDescriptor[] = []
+	// Defaulted rather than left undefined: `ready()` promises an array, and an
+	// iframe older than this field sends no `hotspots` at all.
+	private hotspots: EmbedHotspotDescriptor[] = []
 
 	// ---------------------------------------------------------------------------
 	// Private helpers
@@ -337,6 +364,7 @@ export class VectrealEmbed {
 				this.stopPingPolling()
 				this.sceneId = data.sceneId
 				this.cameras = data.cameras
+				this.hotspots = data.hotspots ?? []
 				this.isReady = true
 				this.flushPendingCommands()
 				break
@@ -367,6 +395,12 @@ export class VectrealEmbed {
 				break
 			case 'camera_changed':
 				this.emit('camera_changed', { cameraId: event.cameraId })
+				break
+			case 'hotspot_activated':
+				this.emit('hotspot_activated', {
+					hotspotId: event.hotspotId,
+					cameraId: event.cameraId
+				})
 				break
 			case 'auto_rotate_changed':
 				this.emit('auto_rotate_changed', { enabled: event.enabled })

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from './protocol'
 export type {
 	EmbedCameraDescriptor,
+	EmbedHotspotDescriptor,
 	HostedPreviewCustomEventMessage,
 	HostedPreviewHostMessage,
 	HostedPreviewIncomingMessage,

--- a/packages/embed/src/protocol.spec.ts
+++ b/packages/embed/src/protocol.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { isViewerCommand } from './protocol'
@@ -11,6 +14,7 @@ import { isViewerCommand } from './protocol'
 describe('isViewerCommand', () => {
 	it.each([
 		{ type: 'activate_camera', cameraId: 'front' },
+		{ type: 'focus_hotspot', hotspotId: 'handle' },
 		{ type: 'set_controls_enabled', enabled: false },
 		{ type: 'set_auto_rotate', enabled: true },
 		{ type: 'set_auto_rotate', enabled: true, speed: 0.5 },
@@ -47,5 +51,54 @@ describe('isViewerCommand', () => {
 		{ type: 'seek_animation_clip', clipId: 'spin', time: '1' }
 	])('rejects %j', (command) => {
 		expect(isViewerCommand(command)).toBe(false)
+	})
+})
+
+describe('focus_hotspot', () => {
+	it.each([
+		['no id at all', { type: 'focus_hotspot' }],
+		['a blank id', { type: 'focus_hotspot', hotspotId: '   ' }],
+		['a non-string id', { type: 'focus_hotspot', hotspotId: 42 }]
+	])('refuses %s', (_label, command) => {
+		expect(isViewerCommand(command)).toBe(false)
+	})
+})
+
+/**
+ * Every command in the union has a case in the guard.
+ *
+ * `isViewerCommand`'s `default: return false` drops an unregistered command
+ * silently, with no error on either side of the iframe - so a command added to
+ * the union and forgotten here type-checks, sends, and simply never arrives.
+ * The guard reads the union out of the viewer package rather than repeating it,
+ * so it covers the next command added, not just this one.
+ */
+describe('the guard covers the command union', () => {
+	const viewerTypes = readFileSync(
+		join(import.meta.dirname, '../../viewer/src/types/viewer-interactions.ts'),
+		'utf8'
+	)
+	const protocol = readFileSync(
+		join(import.meta.dirname, 'protocol.ts'),
+		'utf8'
+	)
+
+	const commandTypes = [
+		...viewerTypes.matchAll(
+			/export interface \w+ViewerCommand \{\n\ttype: '(\w+)'/g
+		)
+	].map((match) => match[1])
+
+	const guard = protocol
+		.split('export function isViewerCommand')[1]
+		?.split('\nexport ')[0]
+
+	it('found the union and the guard to compare', () => {
+		expect(commandTypes.length).toBeGreaterThan(5)
+		expect(guard).toBeTruthy()
+	})
+
+	it.each(commandTypes)('registers %s', (type) => {
+		expect(guard).toContain(`case '${type}':`)
 	})
 })

--- a/packages/embed/src/protocol.ts
+++ b/packages/embed/src/protocol.ts
@@ -47,11 +47,37 @@ export interface EmbedCameraDescriptor {
 	fov?: number
 }
 
+/**
+ * One hotspot, as a host page sees it.
+ *
+ * Carries no body, no link and no world position: a host builds navigation
+ * from these, and the content is what the viewer draws. Adding the text here
+ * would put a second copy of it on the page with nothing keeping the two in
+ * step.
+ */
+export interface EmbedHotspotDescriptor {
+	id: string
+	name: string
+	/** The camera this hotspot flies, or null when it only reveals content. */
+	cameraId: string | null
+	/** 1-based place in the navigation sequence, or null when it has none. */
+	step: number | null
+}
+
 export interface HostedPreviewPongMessage {
 	source: typeof HOSTED_PREVIEW_VIEWER_SOURCE
 	type: 'pong'
 	sceneId?: string
 	cameras: EmbedCameraDescriptor[]
+	/**
+	 * Optional, unlike `cameras`.
+	 *
+	 * An iframe and the SDK on the page around it are two separately deployed
+	 * artifacts and can be versions apart. A required field here would make an
+	 * older iframe's pong fail a newer SDK's parse, and the host would then hang
+	 * waiting for a handshake that already arrived.
+	 */
+	hotspots?: EmbedHotspotDescriptor[]
 }
 
 export interface HostedPreviewViewerEventMessage {
@@ -92,6 +118,10 @@ export function isViewerCommand(value: unknown): value is ViewerCommand {
 		case 'activate_camera':
 			return (
 				typeof value.cameraId === 'string' && value.cameraId.trim().length > 0
+			)
+		case 'focus_hotspot':
+			return (
+				typeof value.hotspotId === 'string' && value.hotspotId.trim().length > 0
 			)
 		case 'set_controls_enabled':
 			return typeof value.enabled === 'boolean'

--- a/packages/embed/src/viewer-event-coverage.spec.ts
+++ b/packages/embed/src/viewer-event-coverage.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Every viewer event the SDK can receive has a case that re-emits it.
+ *
+ * `handleViewerEvent` is a hand-maintained switch over a union declared in a
+ * different package. A member added there and forgotten here is dropped
+ * silently: the message crosses the iframe boundary, parses, and reaches a
+ * `switch` with no matching case and no default, so nothing fails and nothing
+ * arrives. That is the same silent-drop shape `isViewerCommand`'s own comment
+ * warns about, one direction over.
+ *
+ * A name match, not a semantic one. It cannot tell a correct re-emission from
+ * a wrong one; it can tell a handled event from an unhandled one, which is the
+ * failure that has no other symptom.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const viewerTypes = readFileSync(
+	join(import.meta.dirname, '../../viewer/src/types/viewer-interactions.ts'),
+	'utf8'
+)
+const embed = readFileSync(join(import.meta.dirname, 'embed.ts'), 'utf8')
+
+const handleViewerEvent = embed
+	.split('private handleViewerEvent')[1]
+	?.split('\n\t}')[0]
+
+/** Every `type: '...'` literal declared on an interaction-event interface. */
+const eventTypes = [
+	...viewerTypes.matchAll(
+		/export interface \w+InteractionEvent \{\n\ttype: '(\w+)'/g
+	)
+].map((match) => match[1])
+
+describe('handleViewerEvent', () => {
+	it('found the union and the switch to compare', () => {
+		// Without this the two reads could yield nothing and every assertion
+		// below would pass over an empty list.
+		expect(eventTypes.length).toBeGreaterThan(5)
+		expect(handleViewerEvent).toBeTruthy()
+	})
+
+	it.each(eventTypes)('re-emits %s', (type) => {
+		expect(handleViewerEvent).toContain(`case '${type}':`)
+	})
+})

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -52,6 +52,14 @@ function App() {
 | `envOptions`                   | `EnvironmentProps`                                      | No       | Drei `Environment` configuration                                                 |
 | `shadowsOptions`               | `ShadowsProps`                                          | No       | Shadow behavior configuration                                                    |
 | `normalizationOptions`         | `NormalizationOptions`                                  | No       | Clamps the model's bounding-box diagonal at runtime, without touching the model data |
+| `hotspots`                     | `HotspotDefinition[]`                                   | No       | Point-of-interest markers anchored in world space. Each can carry a body and a link, and fly a linked camera |
+| `hotspotColor`                 | `string`                                                | No       | Overrides the marker fill. The default is neutral so it does not compete with the product |
+| `showHotspotMarkers`           | `boolean`                                               | No       | Draws the markers, default `true`. `false` leaves them resolved but undrawn, so a host can still reach them by id |
+| `revealHotspotContent`         | `boolean`                                               | No       | Opens a card on click, default `true`. `false` still flies the camera and still reports the activation |
+| `selectedHotspotId`            | `string \| null`                                        | No       | Draws one marker as the current one. Editing surfaces only                       |
+| `showInternalHotspots`         | `boolean`                                               | No       | Draws hotspots the author kept backstage. Editing surfaces only                  |
+| `showHiddenHotspots`           | `boolean`                                               | No       | Draws hotspots the author hid. Editing surfaces only                             |
+| `onHotspotSelect`              | `(id: string) => void`                                  | No       | Picks a marker instead of activating it. Passing it makes selection win over both content and camera |
 | `shadowLightEditable`          | `boolean`                                               | No       | Renders an in-scene draggable handle for aiming the shadow light. Editing surfaces only |
 | `staticShadowBake`             | `boolean`                                               | No       | Bakes the accumulative shadow in one pass on mount instead of fading it in, default `false` |
 | `bakedShadow`                  | `BakedShadow`                                           | No       | A persisted shadow bake to render instead of recomputing one                     |
@@ -419,6 +427,7 @@ from a viewer default and override a field:
 | `SceneControls`       | `defaultControlsOptions` |
 | `SceneEnvironment`    | `defaultEnvOptions`      |
 | `SceneShadows`        | `defaultShadowsOptions`  |
+| `SceneHotspots`       | none                     |
 | `SceneModel`          | none                     |
 | `ScenePostProcessing` | none                     |
 

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -53,13 +53,14 @@ function App() {
 | `shadowsOptions`               | `ShadowsProps`                                          | No       | Shadow behavior configuration                                                    |
 | `normalizationOptions`         | `NormalizationOptions`                                  | No       | Clamps the model's bounding-box diagonal at runtime, without touching the model data |
 | `hotspots`                     | `HotspotDefinition[]`                                   | No       | Point-of-interest markers anchored in world space. Each can carry a body and a link, and fly a linked camera |
-| `hotspotColor`                 | `string`                                                | No       | Overrides the marker fill. The default is neutral so it does not compete with the product |
+| `hotspotColor`                 | `string`                                                | No       | Overrides the marker fill. The default is neutral so it does not compete with the product. The step numeral stays dark ink, so a dark or saturated fill needs `--vctrl-hotspot-ink` overridden on the container |
 | `showHotspotMarkers`           | `boolean`                                               | No       | Draws the markers, default `true`. `false` leaves them resolved but undrawn, so a host can still reach them by id |
 | `revealHotspotContent`         | `boolean`                                               | No       | Opens a card on click, default `true`. `false` still flies the camera and still reports the activation |
 | `selectedHotspotId`            | `string \| null`                                        | No       | Draws one marker as the current one. Editing surfaces only                       |
 | `showInternalHotspots`         | `boolean`                                               | No       | Draws hotspots the author kept backstage. Editing surfaces only                  |
 | `showHiddenHotspots`           | `boolean`                                               | No       | Draws hotspots the author hid. Editing surfaces only                             |
 | `onHotspotSelect`              | `(id: string) => void`                                  | No       | Picks a marker instead of activating it. Passing it makes selection win over both content and camera |
+| `onHotspotPositionSetterReady`  | `(setter: HotspotPositionSetter \| null) => void`        | No       | Receives a setter that moves a marker without moving the hotspot, for a drag gizmo. Editing surfaces only |
 | `shadowLightEditable`          | `boolean`                                               | No       | Renders an in-scene draggable handle for aiming the shadow light. Editing surfaces only |
 | `staticShadowBake`             | `boolean`                                               | No       | Bakes the accumulative shadow in one pass on mount instead of fading it in, default `false` |
 | `bakedShadow`                  | `BakedShadow`                                           | No       | A persisted shadow bake to render instead of recomputing one                     |
@@ -79,9 +80,7 @@ function App() {
 
 `model` is optional because you can also render scene content via `children`. With neither, nothing renders.
 
-The editor affordances (`shadowLightEditable`, `staticShadowBake`, `bakedShadow`,
-`onShadowBakeReady`, `onShadowLightChange`) exist for editing surfaces such as the
-Publisher. Public and embedded viewers omit them.
+The editor affordances exist for editing surfaces such as the Publisher: `shadowLightEditable`, `staticShadowBake`, `bakedShadow`, `onShadowBakeReady`, `onShadowLightChange`, and the hotspot four above - `selectedHotspotId`, `showInternalHotspots`, `showHiddenHotspots`, `onHotspotSelect` and `onHotspotPositionSetterReady`. Public and embedded viewers omit them.
 
 ---
 

--- a/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
@@ -190,7 +190,12 @@ describe('resolveHotspotInteraction', () => {
 	})
 
 	describe('revealing content', () => {
-		const reveal = { occluded: false, canActivate: false, canReveal: true }
+		const reveal = {
+			occluded: false,
+			canActivate: false,
+			canReveal: true,
+			revealsInPlace: true
+		}
 
 		it('makes a marker with something to say a button', () => {
 			const interaction = resolveHotspotInteraction(unlinked, reveal)
@@ -207,6 +212,27 @@ describe('resolveHotspotInteraction', () => {
 			expect(resolveHotspotInteraction(unlinked, reveal).announces).toBe(
 				'expanded'
 			)
+		})
+
+		/**
+		 * A host that suppressed the card still needs the click: the event is
+		 * how it knows to open its own panel. Wiring `canReveal` to the presence
+		 * of a reveal handler instead made this marker a `role="img"` with no
+		 * click handler at all - no flight, no event, nothing.
+		 */
+		it('stays a button when the host draws the card, and announces nothing', () => {
+			const interaction = resolveHotspotInteraction(unlinked, {
+				occluded: false,
+				canActivate: false,
+				canReveal: true,
+				revealsInPlace: false
+			})
+
+			expect(interaction.role).toBe('button')
+			expect(interaction.action).toBe('reveal')
+			expect(interaction.focusable).toBe(true)
+			// `aria-expanded` would claim something that never expands.
+			expect(interaction.announces).toBeNull()
 		})
 
 		it('lets selection win, and announces the selection', () => {
@@ -253,7 +279,8 @@ describe('resolveHotspotInteraction', () => {
 			const interaction = resolveHotspotInteraction(linked, {
 				occluded: true,
 				canActivate: true,
-				canReveal: true
+				canReveal: true,
+				revealsInPlace: true
 			})
 
 			expect(interaction.action).toBe('none')

--- a/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
@@ -63,6 +63,25 @@ describe('resolveHotspotInteraction', () => {
 		).toBe('activate')
 	})
 
+	/**
+	 * A marker with nothing to activate still carries a name, and hover was the
+	 * only way to read it. So a keyboard-only visitor, or anyone on a device
+	 * with no hover at all, could not read a published marker that names no
+	 * camera - which is every marker in a scene that carries no cameras.
+	 */
+	it('keeps a marker with nothing to do in the tab order', () => {
+		const inert = resolveHotspotInteraction(unlinked, {
+			occluded: false,
+			canActivate: false
+		})
+
+		expect(inert.focusable).toBe(true)
+		// A focus stop, not a button: the role is what says whether a press does
+		// anything, and here it does not.
+		expect(inert.role).toBe('image')
+		expect(inert.action).toBe('none')
+	})
+
 	it('drops an occluded marker out of the tab order', () => {
 		expect(
 			resolveHotspotInteraction(linked, { occluded: true, canActivate: true })
@@ -72,6 +91,14 @@ describe('resolveHotspotInteraction', () => {
 			resolveHotspotInteraction(linked, { occluded: false, canActivate: true })
 				.focusable
 		).toBe(true)
+		// Including one that offers nothing: it is invisible, so its name is not
+		// worth a stop either.
+		expect(
+			resolveHotspotInteraction(unlinked, {
+				occluded: true,
+				canActivate: false
+			}).focusable
+		).toBe(false)
 	})
 
 	describe('an editing surface that can select', () => {
@@ -151,14 +178,88 @@ describe('resolveHotspotInteraction', () => {
 					occluded: true,
 					canActivate: false,
 					canSelect: true
-				}).toggles
-			).toBe(true)
+				}).announces
+			).toBe('pressed')
 			expect(
 				resolveHotspotInteraction(linked, {
 					occluded: false,
 					canActivate: true
-				}).toggles
-			).toBe(false)
+				}).announces
+			).toBeNull()
+		})
+	})
+
+	describe('revealing content', () => {
+		const reveal = { occluded: false, canActivate: false, canReveal: true }
+
+		it('makes a marker with something to say a button', () => {
+			const interaction = resolveHotspotInteraction(unlinked, reveal)
+
+			expect(interaction.role).toBe('button')
+			expect(interaction.action).toBe('reveal')
+			expect(interaction.focusable).toBe(true)
+		})
+
+		it('announces a reveal as expanded, never as pressed', () => {
+			// The two are different claims about the same control. A reveal shows
+			// content; a press picks the marker up. Announcing one as the other
+			// tells a screen reader the wrong thing about what a click will do.
+			expect(resolveHotspotInteraction(unlinked, reveal).announces).toBe(
+				'expanded'
+			)
+		})
+
+		it('lets selection win, and announces the selection', () => {
+			// Selecting is local and reversible. An editing surface that offers
+			// both has to give a click the cheap one.
+			const interaction = resolveHotspotInteraction(linked, {
+				occluded: false,
+				canActivate: true,
+				canReveal: true,
+				canSelect: true
+			})
+
+			expect(interaction.action).toBe('select')
+			expect(interaction.announces).toBe('pressed')
+			// And never flies away from the viewpoint the author is composing in.
+			expect(interaction.fliesCamera).toBe(false)
+		})
+
+		it('reveals and flies on the same click', () => {
+			// A marker that has something to say and a camera to fly says "look
+			// here, and here is why". The flight is what puts the content's
+			// subject on screen, so they are not alternatives.
+			const interaction = resolveHotspotInteraction(linked, {
+				occluded: false,
+				canActivate: true,
+				canReveal: true
+			})
+
+			expect(interaction.action).toBe('reveal')
+			expect(interaction.fliesCamera).toBe(true)
+		})
+
+		it('flies alone when there is nothing to reveal', () => {
+			const interaction = resolveHotspotInteraction(linked, {
+				occluded: false,
+				canActivate: true
+			})
+
+			expect(interaction.action).toBe('activate')
+			expect(interaction.fliesCamera).toBe(true)
+		})
+
+		it('does neither while occluded, and still announces expanded', () => {
+			const interaction = resolveHotspotInteraction(linked, {
+				occluded: true,
+				canActivate: true,
+				canReveal: true
+			})
+
+			expect(interaction.action).toBe('none')
+			expect(interaction.fliesCamera).toBe(false)
+			expect(interaction.announces).toBe('expanded')
+			expect(interaction.pointerEvents).toBe('none')
 		})
 	})
 })

--- a/packages/viewer/src/components/scene/hotspot-interaction.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.ts
@@ -43,6 +43,9 @@ export interface HotspotInteraction {
 	 * a marker carrying both would otherwise announce itself wrongly. Independent
 	 * of occlusion for the same reason `role` is: a marker must not change what
 	 * it announces itself to be mid-orbit.
+	 *
+	 * Null for a marker that reports its activation without drawing anything -
+	 * `aria-expanded` would then claim something that never expands.
 	 */
 	announces: 'pressed' | 'expanded' | null
 	/**
@@ -69,7 +72,8 @@ export function resolveHotspotInteraction(
 		occluded,
 		canActivate,
 		canSelect = false,
-		canReveal = false
+		canReveal = false,
+		revealsInPlace = false
 	}: {
 		occluded: boolean
 		/** Whether the viewer was given somewhere to send an activation. */
@@ -79,8 +83,23 @@ export function resolveHotspotInteraction(
 		 * refuse to draw is not content: `resolveHotspotPopoverContent` decides,
 		 * so a marker whose only body is an unsafe link stays inert rather than
 		 * becoming a button that opens an empty card.
+		 *
+		 * Deliberately independent of whether the viewer will DRAW that content -
+		 * see `revealsInPlace`. A host that suppressed the card still needs the
+		 * click, because the event is how it knows to open its own.
 		 */
 		canReveal?: boolean
+		/**
+		 * Whether this viewer draws the card itself, rather than leaving it to
+		 * the page around it.
+		 *
+		 * Only affects what the control announces. Wiring this to `canReveal`
+		 * instead made a content-only marker completely inert under
+		 * `?hotspotContent=0`: no button, no click handler, and therefore no
+		 * event for the host that asked to draw the card itself - which is the
+		 * one marker that option exists for.
+		 */
+		revealsInPlace?: boolean
 		/**
 		 * Whether the viewer was given somewhere to send a selection. An editing
 		 * surface passes a select handler only while its own tool is armed, so
@@ -110,7 +129,11 @@ export function resolveHotspotInteraction(
 		// flying away from the viewpoint the author is composing in is the one
 		// thing selection exists to avoid.
 		fliesCamera: !occluded && !canSelect && canFly,
-		announces: canSelect ? 'pressed' : canReveal ? 'expanded' : null,
+		announces: canSelect
+			? 'pressed'
+			: canReveal && revealsInPlace
+				? 'expanded'
+				: null,
 		// Not `isButton && !occluded`. A marker with nothing to activate is still
 		// a marker with a name, and focus is what reveals that name where hover
 		// cannot - which is every keyboard, and every touch device.

--- a/packages/viewer/src/components/scene/hotspot-interaction.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.ts
@@ -15,21 +15,44 @@ export interface HotspotInteraction {
 	 * What a click does. `none` while occluded, and for a marker that offers
 	 * nothing.
 	 *
-	 * Selecting beats activating wherever a surface offers both. Selecting is
-	 * local and reversible; activating throws away the viewpoint the author was
-	 * working from, so the cheap one has to be what a click gets. A surface that
-	 * wants the camera instead says so by not passing a select handler.
+	 * Precedence is select, then reveal, then activate. Selecting beats
+	 * everything wherever a surface offers it: it is local and reversible, while
+	 * the others throw away the viewpoint the author was working from, so the
+	 * cheap one has to be what a click gets. A surface that wants the content or
+	 * the camera instead says so by not passing a select handler.
+	 *
+	 * Revealing beats activating only in the sense of naming what the button
+	 * announces itself as. A marker that has something to say *and* a camera to
+	 * fly does both on one click - see `fliesCamera`.
 	 */
-	action: 'select' | 'activate' | 'none'
+	action: 'select' | 'reveal' | 'activate' | 'none'
 	/**
-	 * True when this button is a selection toggle, so it can carry
-	 * `aria-pressed`. Independent of occlusion for the same reason `role` is: a
-	 * marker must not change what it announces itself to be mid-orbit.
+	 * Whether a click should also move the camera.
+	 *
+	 * Separate from `action` because the two are not alternatives. A marker
+	 * carrying content and a linked camera says "look here, and here is why";
+	 * making the author choose which of those a click gets would be a false
+	 * choice, and the flight is what puts the popover's subject on screen.
 	 */
-	toggles: boolean
+	fliesCamera: boolean
+	/**
+	 * Which state this button announces, or null when it announces none.
+	 *
+	 * A discriminant rather than two booleans: a selection is `aria-pressed` and
+	 * a reveal is `aria-expanded`, they cannot both be true of one control, and
+	 * a marker carrying both would otherwise announce itself wrongly. Independent
+	 * of occlusion for the same reason `role` is: a marker must not change what
+	 * it announces itself to be mid-orbit.
+	 */
+	announces: 'pressed' | 'expanded' | null
 	/**
 	 * False while occluded, so an invisible marker is not a tab stop. Focus that
 	 * is already on it survives, which `disabled` would not allow.
+	 *
+	 * True for a marker that offers nothing to do, which is not a contradiction:
+	 * such a marker still carries a name, and hover is the only other way to
+	 * read it. Someone on a keyboard, or on a device with no hover at all, had
+	 * no way to reach that name while this tracked `role`.
 	 */
 	focusable: boolean
 	/**
@@ -45,11 +68,19 @@ export function resolveHotspotInteraction(
 	{
 		occluded,
 		canActivate,
-		canSelect = false
+		canSelect = false,
+		canReveal = false
 	}: {
 		occluded: boolean
 		/** Whether the viewer was given somewhere to send an activation. */
 		canActivate: boolean
+		/**
+		 * Whether this marker has anything to reveal. Content the renderer would
+		 * refuse to draw is not content: `resolveHotspotPopoverContent` decides,
+		 * so a marker whose only body is an unsafe link stays inert rather than
+		 * becoming a button that opens an empty card.
+		 */
+		canReveal?: boolean
 		/**
 		 * Whether the viewer was given somewhere to send a selection. An editing
 		 * surface passes a select handler only while its own tool is armed, so
@@ -62,7 +93,7 @@ export function resolveHotspotInteraction(
 	const canFly = marker.linkedCameraId !== null && canActivate
 	// Selection needs no camera: an editing surface has to be able to pick a
 	// marker that names none, which is the whole point of drawing it.
-	const isButton = canSelect || canFly
+	const isButton = canSelect || canReveal || canFly
 
 	return {
 		role: isButton ? 'button' : 'image',
@@ -70,11 +101,20 @@ export function resolveHotspotInteraction(
 			? 'none'
 			: canSelect
 				? 'select'
-				: canFly
-					? 'activate'
-					: 'none',
-		toggles: canSelect,
-		focusable: isButton && !occluded,
+				: canReveal
+					? 'reveal'
+					: canFly
+						? 'activate'
+						: 'none',
+		// Not on an editing surface: there a click picks the marker up, and
+		// flying away from the viewpoint the author is composing in is the one
+		// thing selection exists to avoid.
+		fliesCamera: !occluded && !canSelect && canFly,
+		announces: canSelect ? 'pressed' : canReveal ? 'expanded' : null,
+		// Not `isButton && !occluded`. A marker with nothing to activate is still
+		// a marker with a name, and focus is what reveals that name where hover
+		// cannot - which is every keyboard, and every touch device.
+		focusable: !occluded,
 		pointerEvents: occluded ? 'none' : 'auto'
 	}
 }

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -3,6 +3,8 @@ import { cn } from '@shared/utils'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { resolveHotspotInteraction } from './hotspot-interaction'
+import HotspotPopover from './hotspot-popover'
+import { resolveHotspotPopoverContent } from './resolve-hotspot-popover'
 
 import type { HotspotMarker as HotspotMarkerModel } from './resolve-hotspot-markers'
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react'
@@ -15,6 +17,17 @@ import type { Group } from 'three'
  * frame, which is also what decides how two overlapping markers stack.
  */
 const HOTSPOT_Z_INDEX_RANGE = [40, 0]
+
+/**
+ * The band an open marker moves into, above every closed one and still under
+ * the viewer's own chrome at 100.
+ *
+ * The whole marker moves, not just the card. drei writes its depth-derived
+ * value as a z-index on the wrapper div, which makes that div a stacking
+ * context - so a card inside it cannot paint over a marker that happens to sit
+ * nearer the camera, however high its own z-index is.
+ */
+const HOTSPOT_OPEN_Z_INDEX_RANGE = [99, 41]
 
 /**
  * How long the name stays up after a tap.
@@ -114,6 +127,20 @@ export interface HotspotMarkerProps {
 	/** Runs when a marker is picked on a surface that selects rather than flies. */
 	onSelect?: (id: string) => void
 	/**
+	 * Runs whenever a visitor activates this marker - a reveal, a flight, or
+	 * both. Never for a selection, which is an editing surface picking the
+	 * marker up rather than a visitor doing anything with it.
+	 */
+	onActivated?: (id: string, cameraId: string | null) => void
+	/** Whether this marker's content is open. Owned by `SceneHotspots`. */
+	open?: boolean
+	/**
+	 * Toggles this marker's content open or closed. A marker with nothing to
+	 * say never calls it, and a surface that does not pass it gets no reveal
+	 * behaviour at all - which is how a host page takes the content for itself.
+	 */
+	onReveal?: (id: string) => void
+	/**
 	 * Hands `SceneHotspots` the anchor group it moves during a drag, and `null`
 	 * on unmount. See the group below.
 	 */
@@ -135,15 +162,24 @@ const HotspotMarker = ({
 	color,
 	onActivate,
 	onSelect,
+	onActivated,
+	open = false,
+	onReveal,
 	onAnchorRef
 }: HotspotMarkerProps) => {
 	const [labelVisible, setLabelVisible] = useState(false)
 	const touchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const rootRef = useRef<HTMLDivElement>(null)
+	const buttonRef = useRef<HTMLButtonElement>(null)
+
+	const content = resolveHotspotPopoverContent(marker)
+	const popoverId = `vctrl-hotspot-popover-${marker.id}`
 
 	const interaction = resolveHotspotInteraction(marker, {
 		occluded,
 		canActivate: !!onActivate,
-		canSelect: !!onSelect
+		canSelect: !!onSelect,
+		canReveal: !!content && !!onReveal
 	})
 
 	// A block body, not a concise one. React 19 treats a *function* returned from
@@ -204,16 +240,49 @@ const HotspotMarker = ({
 	const handleClick = useCallback(() => {
 		if (interaction.action === 'select') {
 			onSelect?.(marker.id)
-		} else if (interaction.action === 'activate' && marker.linkedCameraId) {
+			return
+		}
+		if (interaction.action === 'none') return
+
+		// Reported once for the whole activation, before either half of it, so a
+		// host hears about a marker whether it reveals, flies, or does both.
+		onActivated?.(marker.id, marker.linkedCameraId)
+
+		if (interaction.action === 'reveal') onReveal?.(marker.id)
+		// Not an `else`. A marker that has something to say and a camera to fly
+		// does both on one click: the flight is what puts the card's subject on
+		// screen, so making them alternatives would be a false choice.
+		if (interaction.fliesCamera && marker.linkedCameraId) {
 			onActivate?.(marker.linkedCameraId)
 		}
 	}, [
 		interaction.action,
+		interaction.fliesCamera,
 		marker.id,
 		marker.linkedCameraId,
 		onActivate,
+		onActivated,
+		onReveal,
 		onSelect
 	])
+
+	/**
+	 * Escape closes the card and puts focus back on the marker.
+	 *
+	 * On the root rather than the card, because focus can be on either: the
+	 * marker's own button opens it and stays focused, and this is the only
+	 * ancestor both share. Nothing is trapped - a visitor has to be able to tab
+	 * straight out to the next marker while this is open.
+	 */
+	const handleKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLDivElement>) => {
+			if (event.key !== 'Escape' || !open) return
+			event.stopPropagation()
+			onReveal?.(marker.id)
+			buttonRef.current?.focus()
+		},
+		[marker.id, onReveal, open]
+	)
 
 	// Set on the marker root rather than the viewer container: drei portals every
 	// Html separately, so there is no shared ancestor inside the marker layer.
@@ -286,21 +355,24 @@ const HotspotMarker = ({
 			*/}
 			<Html
 				center
-				zIndexRange={HOTSPOT_Z_INDEX_RANGE}
+				zIndexRange={open ? HOTSPOT_OPEN_Z_INDEX_RANGE : HOTSPOT_Z_INDEX_RANGE}
 				style={HTML_WRAPPER_STYLE}
 			>
 				<div
+					ref={rootRef}
 					className={cn(markerClasses.root, occluded && markerClasses.occluded)}
 					style={colorStyle}
 					data-selected={selected || undefined}
 					data-hidden={marker.hidden || undefined}
 					onPointerEnter={handlePointerEnter}
 					onPointerLeave={handlePointerLeave}
+					onKeyDown={handleKeyDown}
 				>
 					<span aria-hidden="true" className={markerClasses.pulse} />
 
 					{interaction.role === 'button' ? (
 						<button
+							ref={buttonRef}
 							type="button"
 							className={cn(
 								bodyClasses,
@@ -308,7 +380,17 @@ const HotspotMarker = ({
 								interaction.action !== 'none' && markerClasses.interactive
 							)}
 							aria-label={marker.accessibleName}
-							aria-pressed={interaction.toggles ? selected : undefined}
+							aria-pressed={
+								interaction.announces === 'pressed' ? selected : undefined
+							}
+							aria-expanded={
+								interaction.announces === 'expanded' ? open : undefined
+							}
+							aria-controls={
+								interaction.announces === 'expanded' && open
+									? popoverId
+									: undefined
+							}
 							aria-disabled={interaction.action === 'none' ? true : undefined}
 							tabIndex={interaction.focusable ? undefined : -1}
 							onClick={handleClick}
@@ -319,16 +401,37 @@ const HotspotMarker = ({
 						</button>
 					) : (
 						<div
-							className={bodyClasses}
+							className={cn(bodyClasses, FOCUS_RING)}
 							role="img"
 							aria-label={marker.accessibleName}
+							// A focus stop, not a button. Promoting it would announce
+							// something a press does not do; leaving it out left the
+							// marker's name reachable by hover alone, so a keyboard-only
+							// visitor, or anyone on a device with no hover, could not read
+							// it at all.
+							tabIndex={interaction.focusable ? 0 : -1}
+							onFocus={showLabel}
+							onBlur={hideLabel}
 						>
 							{body}
 						</div>
 					)}
 
-					{labelVisible && (
+					{/*
+					  The name is already the card's heading, so showing the label over
+					  an open card would print it twice, one above the other.
+					*/}
+					{labelVisible && !open && (
 						<span className={markerClasses.label}>{marker.name}</span>
+					)}
+
+					{open && content && (
+						<HotspotPopover
+							id={popoverId}
+							title={marker.name}
+							content={content}
+							anchorRef={rootRef}
+						/>
 					)}
 				</div>
 			</Html>

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -39,8 +39,13 @@ const HOTSPOT_Z_INDEX_RANGE = [40, 0]
  * drei only writes the z-index on a frame where the projection actually moved
  * (`Html.js:224`), so opening a card on a still camera - which is every
  * content-only marker, since nothing moves the camera - left the old value in
- * place until the visitor happened to orbit. A freshly mounted `Html` has no
- * such problem: it takes `floor(zIndexRange[0] / 2)` immediately on mount.
+ * place until the visitor happened to orbit.
+ *
+ * A freshly mounted `Html` escapes that by accident rather than by design, and
+ * the mechanism is worth naming because it is not the obvious one: drei seeds
+ * `oldZoom` to 0 (`Html.js:118`), so `|oldZoom - camera.zoom| > eps` is true on
+ * the first frame after mount whatever the camera is doing, and the write at
+ * `Html.js:247` runs. Nothing sets a z-index in the mount effect itself.
  */
 const HOTSPOT_OPEN_Z_INDEX_RANGE = [99, 41]
 
@@ -213,8 +218,18 @@ const HotspotMarker = ({
 	const rootRef = useRef<HTMLDivElement>(null)
 	const buttonRef = useRef<HTMLButtonElement>(null)
 	const cardRef = useRef<HTMLDivElement>(null)
-	// Seeded at the interval so the first frame after opening measures rather
-	// than waiting one out.
+	/**
+	 * Seeded at the interval so the first frame after opening measures rather
+	 * than waiting one out, and reseeded on close for the same reason.
+	 *
+	 * The reseed is not tidiness. This ref outlives the card - it used to live
+	 * in the card itself, which mounted and unmounted with it - so without a
+	 * reset the next open resumes from wherever the last one stopped, some
+	 * fraction of the interval in. A card reopened after the camera moved then
+	 * draws at the previous open's placement for up to a tenth of a second,
+	 * which is long enough to render it off the edge of the canvas and animate
+	 * it in the wrong direction before the first measurement corrects it.
+	 */
 	const placementElapsed = useRef(PLACEMENT_INTERVAL_SECONDS)
 	const [placement, setPlacement] =
 		useState<HotspotPopoverPlacement>(DEFAULT_PLACEMENT)
@@ -228,14 +243,20 @@ const HotspotMarker = ({
 	const popoverId = `vctrl-hotspot-popover-${marker.id}`
 
 	useFrame((_state, delta) => {
-		if (!open) return
+		if (!open) {
+			placementElapsed.current = PLACEMENT_INTERVAL_SECONDS
+			return
+		}
 		placementElapsed.current += delta
 		if (placementElapsed.current < PLACEMENT_INTERVAL_SECONDS) return
-		placementElapsed.current = 0
 
 		const anchor = rootRef.current
 		const card = cardRef.current
+		// Before the reset, not after: a qualifying frame that finds the card
+		// not yet committed would otherwise burn a whole interval waiting to
+		// try again.
 		if (!anchor || !card) return
+		placementElapsed.current = 0
 
 		const anchorBox = anchor.getBoundingClientRect()
 		const canvasBox = canvas.getBoundingClientRect()

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -1,12 +1,17 @@
 import { Html } from '@react-three/drei'
+import { useFrame, useThree } from '@react-three/fiber'
 import { cn } from '@shared/utils'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { resolveHotspotInteraction } from './hotspot-interaction'
 import HotspotPopover from './hotspot-popover'
-import { resolveHotspotPopoverContent } from './resolve-hotspot-popover'
+import {
+	resolveHotspotPopoverContent,
+	resolveHotspotPopoverPlacement
+} from './resolve-hotspot-popover'
 
 import type { HotspotMarker as HotspotMarkerModel } from './resolve-hotspot-markers'
+import type { HotspotPopoverPlacement } from './resolve-hotspot-popover'
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react'
 import type { Group } from 'three'
 
@@ -19,15 +24,51 @@ import type { Group } from 'three'
 const HOTSPOT_Z_INDEX_RANGE = [40, 0]
 
 /**
- * The band an open marker moves into, above every closed one and still under
- * the viewer's own chrome at 100.
+ * The band the open card's own portal occupies, above every marker and still
+ * under the viewer's chrome at 100.
  *
- * The whole marker moves, not just the card. drei writes its depth-derived
- * value as a z-index on the wrapper div, which makes that div a stacking
- * context - so a card inside it cannot paint over a marker that happens to sit
- * nearer the camera, however high its own z-index is.
+ * The card gets an `Html` of its own rather than riding the marker's. Two
+ * reasons, both of them drei's:
+ *
+ * A card inside the marker's wrapper cannot escape it. drei writes a
+ * depth-derived z-index onto that wrapper, which makes it a stacking context,
+ * so the card could never paint over a marker sitting nearer the camera
+ * however high its own z-index was.
+ *
+ * And swapping the marker's `zIndexRange` while it is mounted does not work:
+ * drei only writes the z-index on a frame where the projection actually moved
+ * (`Html.js:224`), so opening a card on a still camera - which is every
+ * content-only marker, since nothing moves the camera - left the old value in
+ * place until the visitor happened to orbit. A freshly mounted `Html` has no
+ * such problem: it takes `floor(zIndexRange[0] / 2)` immediately on mount.
  */
 const HOTSPOT_OPEN_Z_INDEX_RANGE = [99, 41]
+
+/**
+ * Clearance between the marker's centre and the card's near edge, and between
+ * the card and the edge of the canvas.
+ *
+ * From the CENTRE, not the marker's edge: the card's own portal is centred on
+ * the anchor point, so its CSS offset and the placement resolver's arithmetic
+ * are in one frame. That is why it has to exceed half the 24px hit box (14px
+ * for the image and svg presets) rather than being pure taste.
+ */
+const ANCHOR_GAP_PX = 22
+const CANVAS_MARGIN_PX = 8
+
+/**
+ * How often the placement is re-decided while a card is open, in seconds.
+ *
+ * The card follows its marker for free - both portals are anchored to the same
+ * group - so this only has to catch the marker crossing an edge as the camera
+ * moves. Two `getBoundingClientRect` calls at 10Hz, for at most one open card.
+ */
+const PLACEMENT_INTERVAL_SECONDS = 0.1
+
+const DEFAULT_PLACEMENT: HotspotPopoverPlacement = {
+	side: 'above',
+	offsetX: 0
+}
 
 /**
  * How long the name stays up after a tap.
@@ -171,15 +212,63 @@ const HotspotMarker = ({
 	const touchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 	const rootRef = useRef<HTMLDivElement>(null)
 	const buttonRef = useRef<HTMLButtonElement>(null)
+	const cardRef = useRef<HTMLDivElement>(null)
+	// Seeded at the interval so the first frame after opening measures rather
+	// than waiting one out.
+	const placementElapsed = useRef(PLACEMENT_INTERVAL_SECONDS)
+	const [placement, setPlacement] =
+		useState<HotspotPopoverPlacement>(DEFAULT_PLACEMENT)
+
+	// Valid here and not one level down: this component is in the R3F tree,
+	// while everything inside the `Html` below is in a ReactDOM root of drei's
+	// own, where these hooks throw. See `hotspot-popover.tsx`.
+	const canvas = useThree((state) => state.gl.domElement)
 
 	const content = resolveHotspotPopoverContent(marker)
 	const popoverId = `vctrl-hotspot-popover-${marker.id}`
+
+	useFrame((_state, delta) => {
+		if (!open) return
+		placementElapsed.current += delta
+		if (placementElapsed.current < PLACEMENT_INTERVAL_SECONDS) return
+		placementElapsed.current = 0
+
+		const anchor = rootRef.current
+		const card = cardRef.current
+		if (!anchor || !card) return
+
+		const anchorBox = anchor.getBoundingClientRect()
+		const canvasBox = canvas.getBoundingClientRect()
+
+		const next = resolveHotspotPopoverPlacement({
+			anchor: {
+				x: anchorBox.left + anchorBox.width / 2 - canvasBox.left,
+				y: anchorBox.top + anchorBox.height / 2 - canvasBox.top
+			},
+			size: { width: card.offsetWidth, height: card.offsetHeight },
+			bounds: { width: canvasBox.width, height: canvasBox.height },
+			gap: ANCHOR_GAP_PX,
+			margin: CANVAS_MARGIN_PX
+		})
+
+		// One state write only when the answer moved: this runs in the frame
+		// loop, where an unconditional write would re-render both portals ten
+		// times a second for as long as the card is open.
+		setPlacement((previous) =>
+			previous.side === next.side && previous.offsetX === next.offsetX
+				? previous
+				: next
+		)
+	})
 
 	const interaction = resolveHotspotInteraction(marker, {
 		occluded,
 		canActivate: !!onActivate,
 		canSelect: !!onSelect,
-		canReveal: !!content && !!onReveal
+		// Having something to say makes it a button; whether this viewer draws
+		// the card decides only what it announces.
+		canReveal: !!content,
+		revealsInPlace: !!onReveal
 	})
 
 	// A block body, not a concise one. React 19 treats a *function* returned from
@@ -355,7 +444,7 @@ const HotspotMarker = ({
 			*/}
 			<Html
 				center
-				zIndexRange={open ? HOTSPOT_OPEN_Z_INDEX_RANGE : HOTSPOT_Z_INDEX_RANGE}
+				zIndexRange={HOTSPOT_Z_INDEX_RANGE}
 				style={HTML_WRAPPER_STYLE}
 			>
 				<div
@@ -424,17 +513,40 @@ const HotspotMarker = ({
 					{labelVisible && !open && (
 						<span className={markerClasses.label}>{marker.name}</span>
 					)}
+				</div>
+			</Html>
 
-					{open && content && (
+			{/*
+			  A portal of its own, mounted only while the card is open.
+
+			  Anchored to the same group, so it tracks the marker for free, and
+			  centred on the same point - which is what lets the card's CSS offset
+			  and the placement resolver share one coordinate frame.
+			*/}
+			{open && content && (
+				<Html
+					center
+					zIndexRange={HOTSPOT_OPEN_Z_INDEX_RANGE}
+					style={HTML_WRAPPER_STYLE}
+				>
+					{/*
+					  Zero-size on purpose: it shrink-wraps an absolutely positioned
+					  child, so its box is a point at the marker's centre, and the
+					  card's `bottom`/`top` offset is measured from there.
+					*/}
+					<div className="relative">
 						<HotspotPopover
 							id={popoverId}
 							title={marker.name}
 							content={content}
-							anchorRef={rootRef}
+							placement={placement}
+							gap={ANCHOR_GAP_PX}
+							cardRef={cardRef}
+							onKeyDown={handleKeyDown}
 						/>
-					)}
-				</div>
-			</Html>
+					</div>
+				</Html>
+			)}
 		</group>
 	)
 }

--- a/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
@@ -26,7 +26,6 @@ const marker = read('hotspot-marker.tsx')
 const layer = read('scene-hotspots.tsx')
 const popover = read('hotspot-popover.tsx')
 const viewer = read('../../vectreal-viewer.tsx')
-const interaction = read('hotspot-interaction.ts')
 
 describe('the marker reaches the reveal decisions', () => {
 	it('asks the resolver what there is to reveal, rather than reading fields', () => {
@@ -74,6 +73,48 @@ describe('the card is placed by the resolver that was tested', () => {
 	it('hands the card its placement rather than letting it decide', () => {
 		expect(marker).toContain('placement={placement}')
 		expect(popover).toContain('popoverClasses[placement.side]')
+		// `offsetX` is the half that stops the card clipping at the LEFT and
+		// right edges, and its only route to the screen is this one custom
+		// property. Pinning `side` alone left four resolver cases unreachable.
+		expect(popover).toContain(
+			"'--vctrl-hotspot-popover-shift': `calc(-50% + ${placement.offsetX}px)`"
+		)
+	})
+
+	it('measures the gap from the same point the resolver does', () => {
+		// The resolver treats `gap` as clearance from the marker's CENTRE. The
+		// card's CSS offset has to agree: `calc(100% + gap)` measured from the
+		// marker root's edge instead, so both `roomAbove` and `roomBelow` were
+		// over-permissive by half the hit box and a card that "fit" drew off
+		// the canvas.
+		expect(popover).not.toContain('calc(100%')
+		expect(popover).toContain(
+			"above: 'bottom-[var(--vctrl-hotspot-popover-gap)]'"
+		)
+		expect(popover).toContain("below: 'top-[var(--vctrl-hotspot-popover-gap)]'")
+		// And being centre-relative, it has to clear half the 24px hit box -
+		// 14px for the image and svg presets.
+		const gap = /const ANCHOR_GAP_PX = (\d+)/.exec(marker)?.[1]
+		expect(Number(gap)).toBeGreaterThan(14)
+	})
+
+	it('reseeds the placement timer when the card closes', () => {
+		// The ref outlives the card, unlike the one it replaced. Without the
+		// reseed the next open resumes part-way through the interval and draws
+		// at the previous open's placement until the first measurement lands.
+		const frame = marker
+			.split('useFrame((_state, delta) => {')[1]
+			?.split('\n\t})')[0]
+
+		expect(frame).toBeTruthy()
+		expect((frame ?? '').length).toBeLessThan(1600)
+		expect(frame).toContain(
+			'if (!open) {\n\t\t\tplacementElapsed.current = PLACEMENT_INTERVAL_SECONDS'
+		)
+		// And the reset only counts a frame that actually measured.
+		expect((frame ?? '').indexOf('if (!anchor || !card) return')).toBeLessThan(
+			(frame ?? '').indexOf('placementElapsed.current = 0')
+		)
 	})
 
 	it('gives the open card a portal of its own for the z-index', () => {
@@ -83,7 +124,6 @@ describe('the card is placed by the resolver that was tested', () => {
 		// happens for a content-only marker on a still camera.
 		expect(marker).toContain('zIndexRange={HOTSPOT_OPEN_Z_INDEX_RANGE}')
 		expect(marker).toContain('zIndexRange={HOTSPOT_Z_INDEX_RANGE}')
-		expect(marker).not.toContain('open ? HOTSPOT_OPEN_Z_INDEX_RANGE')
 	})
 
 	it('renders what the content resolver returned', () => {
@@ -117,6 +157,13 @@ describe('the marker announces the card it opens', () => {
 	it('keeps the two z-index bands apart', () => {
 		expect(marker).toContain('const HOTSPOT_OPEN_Z_INDEX_RANGE = [99, 41]')
 		expect(marker).toContain('const HOTSPOT_Z_INDEX_RANGE = [40, 0]')
+	})
+
+	it('gives the marker one fixed band, whatever the card is doing', () => {
+		// Asserted as a count rather than as the absence of one prior spelling:
+		// a differently-named ternary, or the same one wrapped across lines by
+		// the formatter, would slip past a `not.toContain`.
+		expect(marker.split('HOTSPOT_Z_INDEX_RANGE').length - 1).toBe(2)
 	})
 })
 
@@ -180,9 +227,17 @@ describe('an activation is reported to whoever is listening', () => {
 		// it: `indexOf` answers -1 for a call that is not there at all, and -1
 		// is less than every real index, so the ordering check alone passed
 		// with the report deleted outright.
-		expect(click).toContain('onActivated?.(marker.id, marker.linkedCameraId)')
-		// Reported once for the whole activation rather than per branch, so a
-		// marker that reveals and flies is not reported twice.
+		expect((click ?? '').length).toBeLessThan(1000)
+		// A COUNT, which is what "once" means. `indexOf` finds the first match,
+		// so an ordering check alone passed both with the call deleted (-1 is
+		// less than everything) and with a second call added inside the reveal
+		// branch - the duplication this comment is about.
+		expect(
+			(click ?? '').split('onActivated?.(marker.id, marker.linkedCameraId)')
+				.length - 1
+		).toBe(1)
+		// Reported before either half, so a marker that reveals and flies is
+		// reported once rather than per branch.
 		expect(
 			(click ?? '').indexOf('onActivated?.(marker.id, marker.linkedCameraId)')
 		).toBeLessThan((click ?? '').indexOf("interaction.action === 'reveal'"))
@@ -262,6 +317,10 @@ describe('a host can take the hotspot UI over', () => {
 			.split('const markers = useMemo')[1]
 			?.split(')\n')[0]
 
+		// A negative assertion over a slice that could be empty passes
+		// vacuously, and a broken anchor makes that MORE likely - so the slice
+		// is pinned before it is judged.
+		expect(markersMemo).toContain('resolveHotspotMarkers(hotspots, {')
 		expect(markersMemo).not.toContain('showMarkers')
 	})
 
@@ -286,10 +345,6 @@ describe('a host can take the hotspot UI over', () => {
 		expect(marker).toContain('revealsInPlace: !!onReveal')
 	})
 
-	it('does not claim a card expands when this viewer draws none', () => {
-		expect(interaction).toContain('canReveal && revealsInPlace')
-	})
-
 	it('will not open a card the host asked it not to draw', () => {
 		// Otherwise a host that suppressed the card and then called
 		// `focusHotspot` got one drawn anyway - and could not close it, since
@@ -299,6 +354,7 @@ describe('a host can take the hotspot UI over', () => {
 			?.split('\t\t[invalidate')[0]
 
 		expect(focus).toBeTruthy()
+		expect((focus ?? '').length).toBeLessThan(800)
 		expect(focus).toContain('revealContent && resolveHotspotPopoverContent(')
 	})
 

--- a/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
@@ -26,6 +26,7 @@ const marker = read('hotspot-marker.tsx')
 const layer = read('scene-hotspots.tsx')
 const popover = read('hotspot-popover.tsx')
 const viewer = read('../../vectreal-viewer.tsx')
+const interaction = read('hotspot-interaction.ts')
 
 describe('the marker reaches the reveal decisions', () => {
 	it('asks the resolver what there is to reveal, rather than reading fields', () => {
@@ -36,12 +37,59 @@ describe('the marker reaches the reveal decisions', () => {
 	})
 
 	it('tells the interaction resolver whether there is anything to reveal', () => {
-		expect(marker).toContain('canReveal: !!content && !!onReveal')
+		expect(marker).toContain('canReveal: !!content')
 	})
 
 	it('mounts the card only when it is open and has content', () => {
 		expect(marker).toContain('{open && content && (')
 		expect(marker).toContain('<HotspotPopover')
+	})
+})
+
+describe('the card is placed by the resolver that was tested', () => {
+	/**
+	 * The failure this exists for: ten thorough tests over
+	 * `resolveHotspotPopoverPlacement` say nothing about whether anything calls
+	 * it. Delete the measurement and every one of them stays green while the
+	 * card reverts to its default placement and clips at every edge.
+	 */
+	it('measures and calls the resolver', () => {
+		expect(marker).toContain('resolveHotspotPopoverPlacement({')
+		expect(marker).toContain('getBoundingClientRect()')
+		expect(marker).toContain('setPlacement((previous) =>')
+	})
+
+	it('measures in the R3F tree, never inside the portal', () => {
+		// drei renders `Html` children through `ReactDOM.createRoot`, so a
+		// component in there inherits no canvas context: `useThree` and
+		// `useFrame` throw, and the failing root empties its container, taking
+		// the marker's own DOM with it. The card must stay presentational.
+		expect(marker).toContain('useThree((state) => state.gl.domElement)')
+		// The calls, not the words: the card's own docblock names both hooks in
+		// prose to explain why it must not call them.
+		expect(popover).not.toContain('useFrame(')
+		expect(popover).not.toContain('useThree(')
+	})
+
+	it('hands the card its placement rather than letting it decide', () => {
+		expect(marker).toContain('placement={placement}')
+		expect(popover).toContain('popoverClasses[placement.side]')
+	})
+
+	it('gives the open card a portal of its own for the z-index', () => {
+		// Two reasons, both drei's: the marker's wrapper is a stacking context
+		// the card cannot escape, and swapping `zIndexRange` on a mounted `Html`
+		// only takes effect on a frame where the projection moved - which never
+		// happens for a content-only marker on a still camera.
+		expect(marker).toContain('zIndexRange={HOTSPOT_OPEN_Z_INDEX_RANGE}')
+		expect(marker).toContain('zIndexRange={HOTSPOT_Z_INDEX_RANGE}')
+		expect(marker).not.toContain('open ? HOTSPOT_OPEN_Z_INDEX_RANGE')
+	})
+
+	it('renders what the content resolver returned', () => {
+		expect(popover).toContain('{content.body}')
+		expect(popover).toContain('href={content.link.href}')
+		expect(popover).toContain('{content.link.label}')
 	})
 })
 
@@ -66,10 +114,7 @@ describe('the marker announces the card it opens', () => {
 		expect(marker).not.toContain('focusTrap')
 	})
 
-	it('lifts the whole marker out of the closed markers band while open', () => {
-		// The card cannot escape the wrapper drei writes a z-index onto, so the
-		// wrapper is what has to move.
-		expect(marker).toContain('open ? HOTSPOT_OPEN_Z_INDEX_RANGE')
+	it('keeps the two z-index bands apart', () => {
 		expect(marker).toContain('const HOTSPOT_OPEN_Z_INDEX_RANGE = [99, 41]')
 		expect(marker).toContain('const HOTSPOT_Z_INDEX_RANGE = [40, 0]')
 	})
@@ -131,8 +176,13 @@ describe('an activation is reported to whoever is listening', () => {
 			?.split('\t}, [')[0]
 
 		expect(click).toBeTruthy()
-		// Ordering matters: reported once for the whole activation rather than
-		// per branch, so a marker that reveals and flies is not reported twice.
+		// Asserted present BEFORE the ordering comparison, and not folded into
+		// it: `indexOf` answers -1 for a call that is not there at all, and -1
+		// is less than every real index, so the ordering check alone passed
+		// with the report deleted outright.
+		expect(click).toContain('onActivated?.(marker.id, marker.linkedCameraId)')
+		// Reported once for the whole activation rather than per branch, so a
+		// marker that reveals and flies is not reported twice.
 		expect(
 			(click ?? '').indexOf('onActivated?.(marker.id, marker.linkedCameraId)')
 		).toBeLessThan((click ?? '').indexOf("interaction.action === 'reveal'"))
@@ -220,12 +270,36 @@ describe('a host can take the hotspot UI over', () => {
 	})
 
 	it('withholds the reveal handler rather than branching inside the marker', () => {
-		// A marker with no reveal handler is not a reveal button at all - the
-		// interaction resolver already reads it that way - so the click falls
-		// through to the camera and the activation is still reported.
 		expect(layer).toContain(
 			'onReveal={revealContent ? handleReveal : undefined}'
 		)
+	})
+
+	it('keeps a content-only marker activatable when the host draws the card', () => {
+		// The defect this replaced: `canReveal` was `!!content && !!onReveal`,
+		// so suppressing the card made a marker with body text and no camera a
+		// role="img" with no click handler - no flight, no event, nothing for
+		// the host to draw its own card from. Which is the one marker the
+		// option exists for.
+		expect(marker).toContain('canReveal: !!content')
+		expect(marker).not.toContain('canReveal: !!content && !!onReveal')
+		expect(marker).toContain('revealsInPlace: !!onReveal')
+	})
+
+	it('does not claim a card expands when this viewer draws none', () => {
+		expect(interaction).toContain('canReveal && revealsInPlace')
+	})
+
+	it('will not open a card the host asked it not to draw', () => {
+		// Otherwise a host that suppressed the card and then called
+		// `focusHotspot` got one drawn anyway - and could not close it, since
+		// neither the click path nor Escape reaches a handler never passed.
+		const focus = layer
+			.split('const focusHotspot = useCallback')[1]
+			?.split('\t\t[invalidate')[0]
+
+		expect(focus).toBeTruthy()
+		expect(focus).toContain('revealContent && resolveHotspotPopoverContent(')
 	})
 
 	it('reaches the viewer prop a host page sets', () => {

--- a/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-popover-wiring.spec.ts
@@ -1,0 +1,248 @@
+/**
+ * The `.tsx` half of the reveal, pinned by reading the source.
+ *
+ * This package's test runner loads only spec files ending in `.ts`, under
+ * `environment: 'node'`, deliberately, so a component cannot be rendered here at all. Every
+ * decision the reveal makes therefore lives in `resolve-hotspot-popover.ts` and
+ * `hotspot-interaction.ts`, which have their own specs. What is left in the
+ * components is wiring - and wiring is exactly what type-checks cleanly while
+ * doing nothing, which is how a complete renderer once shipped with no surface
+ * calling it.
+ *
+ * So this asserts the calls, not the behaviour. It cannot tell a correct
+ * popover from a broken one; it can tell one that is mounted from one that is
+ * not. Renaming a local here is meant to fail it - re-point the guard rather
+ * than deleting it.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const read = (file: string) =>
+	readFileSync(join(import.meta.dirname, file), 'utf8')
+
+const marker = read('hotspot-marker.tsx')
+const layer = read('scene-hotspots.tsx')
+const popover = read('hotspot-popover.tsx')
+const viewer = read('../../vectreal-viewer.tsx')
+
+describe('the marker reaches the reveal decisions', () => {
+	it('asks the resolver what there is to reveal, rather than reading fields', () => {
+		expect(marker).toContain('resolveHotspotPopoverContent(marker)')
+		// The link rule lives behind that resolver. A marker reading `linkUrl`
+		// straight would be rendering an unchecked href.
+		expect(marker).not.toContain('marker.linkUrl')
+	})
+
+	it('tells the interaction resolver whether there is anything to reveal', () => {
+		expect(marker).toContain('canReveal: !!content && !!onReveal')
+	})
+
+	it('mounts the card only when it is open and has content', () => {
+		expect(marker).toContain('{open && content && (')
+		expect(marker).toContain('<HotspotPopover')
+	})
+})
+
+describe('the marker announces the card it opens', () => {
+	it('carries aria-expanded from the interaction, not from the content', () => {
+		// Occlusion changes what a click does but must not change what the
+		// control claims to be, which is why this reads `announces`.
+		expect(marker).toContain("interaction.announces === 'expanded' ? open")
+	})
+
+	it('names the open card from the button', () => {
+		expect(marker).toContain('aria-controls')
+		expect(marker).toContain('popoverId')
+		expect(popover).toContain('id={id}')
+	})
+
+	it('closes on Escape and puts focus back on the marker', () => {
+		expect(marker).toContain("event.key !== 'Escape'")
+		expect(marker).toContain('buttonRef.current?.focus()')
+		// Non-modal: a visitor has to be able to tab out to the next marker
+		// while this is open, so nothing may trap focus.
+		expect(marker).not.toContain('focusTrap')
+	})
+
+	it('lifts the whole marker out of the closed markers band while open', () => {
+		// The card cannot escape the wrapper drei writes a z-index onto, so the
+		// wrapper is what has to move.
+		expect(marker).toContain('open ? HOTSPOT_OPEN_Z_INDEX_RANGE')
+		expect(marker).toContain('const HOTSPOT_OPEN_Z_INDEX_RANGE = [99, 41]')
+		expect(marker).toContain('const HOTSPOT_Z_INDEX_RANGE = [40, 0]')
+	})
+})
+
+describe('a marker with nothing to do is still reachable', () => {
+	it('takes a focus stop on the non-button branch', () => {
+		const imageBranch = marker.split('role="img"')[1]?.split('>')[0]
+
+		expect(imageBranch).toContain('tabIndex={interaction.focusable ? 0 : -1}')
+	})
+
+	it('shows its name on focus, which is the only reason the stop exists', () => {
+		const imageBranch = marker.split('role="img"')[1]?.split('>')[0]
+
+		expect(imageBranch).toContain('onFocus={showLabel}')
+		expect(imageBranch).toContain('onBlur={hideLabel}')
+	})
+
+	it('draws a focus ring, so the stop is visible as well as reachable', () => {
+		expect(marker).toContain('cn(bodyClasses, FOCUS_RING)')
+	})
+})
+
+describe('the hotspot layer owns which card is open', () => {
+	it('opens at most one, toggling the one already open shut', () => {
+		expect(layer).toContain('previous === id ? null : id')
+	})
+
+	it('hands each marker its own open state and the toggle', () => {
+		expect(layer).toContain('open={marker.id === openId}')
+		expect(layer).toContain('handleReveal')
+	})
+
+	it('closes a card whose marker went behind the model or left the list', () => {
+		// An occluded marker takes no pointer events and offers no action, so a
+		// card left open over it is the one state with no way to dismiss.
+		expect(layer).toContain('occludedIds.has(openId)')
+		expect(layer).toContain('!markers.some((marker) => marker.id === openId)')
+	})
+
+	it('asks for a frame when a card opens', () => {
+		// The card measures its own placement from a frame, and under
+		// `frameloop="demand"` nothing else would request one.
+		const handleReveal = layer
+			.split('const handleReveal =')[1]
+			?.split('\n\t/**')[0]
+
+		expect(handleReveal).toBeTruthy()
+		expect(handleReveal).toContain('setOpenId(')
+		expect(handleReveal).toContain('invalidate()')
+	})
+})
+
+describe('an activation is reported to whoever is listening', () => {
+	it('reports before either half of the activation, so both are covered', () => {
+		const click = marker
+			.split('const handleClick = useCallback')[1]
+			?.split('\t}, [')[0]
+
+		expect(click).toBeTruthy()
+		// Ordering matters: reported once for the whole activation rather than
+		// per branch, so a marker that reveals and flies is not reported twice.
+		expect(
+			(click ?? '').indexOf('onActivated?.(marker.id, marker.linkedCameraId)')
+		).toBeLessThan((click ?? '').indexOf("interaction.action === 'reveal'"))
+	})
+
+	it('reports nothing for a selection, or for an inert marker', () => {
+		const click = marker
+			.split('const handleClick = useCallback')[1]
+			?.split('\t}, [')[0]
+
+		// Selection returns before the report: an editing surface picking a
+		// marker up is not a visitor doing anything with it.
+		expect(click).toContain("if (interaction.action === 'select') {")
+		expect(click).toContain("if (interaction.action === 'none') return")
+	})
+
+	it('reaches the viewer, which turns it into an interaction event', () => {
+		expect(layer).toContain('onActivated={onHotspotActivated}')
+		expect(viewer).toContain('onHotspotActivated={handleHotspotActivated}')
+		expect(viewer).toContain("type: 'hotspot_activated'")
+	})
+})
+
+describe('a host can focus a hotspot the way a click would', () => {
+	const focusHotspot = layer
+		.split('const focusHotspot = useCallback')[1]
+		?.split('\t\t[invalidate')[0]
+
+	it('found the executor to read', () => {
+		expect(focusHotspot).toBeTruthy()
+	})
+
+	it('resolves the id against the drawn markers, never the stored settings', () => {
+		// A hotspot the author hid or kept internal is not in that list on a
+		// public surface, so a stale host list cannot reach one by id.
+		expect(focusHotspot).toContain('markersRef.current.find(')
+		expect(focusHotspot).toContain('if (!marker) return')
+	})
+
+	it('does what a click does: reveal, and fly if there is a camera', () => {
+		expect(focusHotspot).toContain('resolveHotspotPopoverContent(marker)')
+		expect(focusHotspot).toContain('setOpenId(marker.id)')
+		expect(focusHotspot).toContain('onActivateCamera?.(marker.linkedCameraId)')
+	})
+
+	it('reports no activation, which would echo the host back to itself', () => {
+		expect(focusHotspot).not.toContain('onHotspotActivated')
+	})
+
+	it('reads the list from a ref, so registering it is not re-run per edit', () => {
+		// A dependency that changed with the list would unregister and
+		// re-register the executor on every edit, which is the shape that has
+		// left this viewer with no executor at all before.
+		expect(layer).toContain('const markersRef = useRef(markers)')
+		expect(focusHotspot).not.toContain('markers.find(')
+	})
+
+	it('is registered with the viewer, which routes the command to it', () => {
+		expect(layer).toContain("command.type === 'focus_hotspot'")
+		expect(viewer).toContain(
+			'onCommandExecutorReady={handleSceneHotspotsExecutorReady}'
+		)
+		expect(viewer).toContain("case 'focus_hotspot':")
+	})
+})
+
+describe('a host can take the hotspot UI over', () => {
+	it('draws nothing when the markers are suppressed', () => {
+		expect(layer).toContain('if (markers.length === 0 || !showMarkers)')
+	})
+
+	it('keeps them resolved, so a focus command still flies a camera', () => {
+		// Suppressing by passing no `hotspots` would break `focus_hotspot` and
+		// empty the handshake, which is the opposite of what a host driving its
+		// own navigation needs.
+		const markersMemo = layer
+			.split('const markers = useMemo')[1]
+			?.split(')\n')[0]
+
+		expect(markersMemo).not.toContain('showMarkers')
+	})
+
+	it('stops raycasting for an occlusion nobody can see', () => {
+		expect(layer).toContain('if (model && showMarkers) {')
+	})
+
+	it('withholds the reveal handler rather than branching inside the marker', () => {
+		// A marker with no reveal handler is not a reveal button at all - the
+		// interaction resolver already reads it that way - so the click falls
+		// through to the camera and the activation is still reported.
+		expect(layer).toContain(
+			'onReveal={revealContent ? handleReveal : undefined}'
+		)
+	})
+
+	it('reaches the viewer prop a host page sets', () => {
+		expect(viewer).toContain('showMarkers={showHotspotMarkers}')
+		expect(viewer).toContain('revealContent={revealHotspotContent}')
+	})
+})
+
+describe('the card is safe to put inside a third-party page', () => {
+	it('opens a link in a new context that cannot reach back', () => {
+		expect(popover).toContain('rel="noopener noreferrer"')
+		expect(popover).toContain('target="_blank"')
+	})
+
+	it('takes the pointer back from the wrapper that refuses it', () => {
+		// The marker's `Html` wrapper is `pointerEvents: 'none'`, so anything
+		// inside it that has to be clickable says so itself.
+		expect(popover).toContain('pointer-events-auto')
+	})
+})

--- a/packages/viewer/src/components/scene/hotspot-popover.stories.tsx
+++ b/packages/viewer/src/components/scene/hotspot-popover.stories.tsx
@@ -1,0 +1,149 @@
+import { createRef } from 'react'
+
+import HotspotPopover from './hotspot-popover'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+/**
+ * A real destination, deliberately.
+ *
+ * The label is the URL's own host rather than a second author-supplied field,
+ * so a fictional host in a story is a small lie told twice: it shows a link
+ * nobody can follow, and it shows a label for a site that does not exist.
+ */
+const link = {
+	href: 'https://vectreal.com/docs/packages/viewer',
+	label: 'vectreal.com'
+}
+
+/**
+ * The card a marker opens, on its own.
+ *
+ * Rendered without a canvas, and that is the point rather than a shortcut. In
+ * the viewer this card only exists after a click, and nothing in a snapshot
+ * clicks anything, so the viewer stories catch markers and never the thing they
+ * open - which is how the card came to ship with no visual coverage at all.
+ *
+ * It is reachable this way because it is presentational: `HotspotMarker`
+ * measures, decides the placement and hands the answer down, because the hooks
+ * that do the measuring cannot run inside drei's `Html`.
+ *
+ * These get both themes, unlike the viewer stories that opt out to avoid
+ * mounting two WebGL canvases. The card is built on the same surface tokens as
+ * the rest of the design system, so a token that resolves differently in dark
+ * is exactly the regression worth catching here.
+ */
+const meta = {
+	title: 'Viewer/Hotspot Popover',
+	component: HotspotPopover,
+	parameters: { layout: 'centered' },
+	args: {
+		id: 'story-popover',
+		title: 'Machined face',
+		placement: { side: 'above', offsetX: 0 },
+		// The real constant. Measured from the marker's centre, which is why it
+		// has to clear half the hit box rather than being pure taste.
+		gap: 22,
+		cardRef: createRef<HTMLDivElement>(),
+		onKeyDown: () => {},
+		content: { body: null, link: null }
+	},
+	decorators: [
+		/**
+		 * Stands in for the marker the card hangs off, over something to stand on.
+		 *
+		 * The card is absolutely positioned against the nearest positioned
+		 * ancestor and offset by the gap, so it needs a point to hang off before
+		 * any of its own geometry means anything. The dot is drawn at that point
+		 * so a diff shows the spacing, not only the card.
+		 *
+		 * The mid-tone backdrop is not decoration. This card is a light surface
+		 * in light and a dark one in dark, and it never appears over a blank
+		 * page - it sits over rendered geometry. On the story background it was
+		 * white on white and black on black, legible only by its shadow, which
+		 * is both untrue to the product and close to useless as a baseline to
+		 * diff against.
+		 */
+		(Story) => (
+			<div className="flex h-[240px] w-[340px] items-center justify-center rounded-[0.75rem] bg-neutral-500">
+				<div className="relative">
+					<div className="absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-100 ring-1 ring-black/30" />
+					<Story />
+				</div>
+			</div>
+		)
+	]
+} satisfies Meta<typeof HotspotPopover>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Prose alone. The common case, and the one with no camera to fly. */
+export const BodyOnly: Story = {
+	args: {
+		content: {
+			body: 'Cast in one piece, then machined flat so the two halves meet without a shim.',
+			link: null
+		}
+	}
+}
+
+/**
+ * A link alone, labelled with its own host.
+ *
+ * There is no second field for the anchor text, so the visible label cannot go
+ * stale against where the link actually points.
+ */
+export const LinkOnly: Story = {
+	args: { content: { body: null, link } }
+}
+
+/** Both, which is what a marker with something to say and somewhere to send you draws. */
+export const BodyAndLink: Story = {
+	args: {
+		content: { body: 'The same joint, seen from the other side.', link }
+	}
+}
+
+/**
+ * Flipped below, as it is drawn for a marker too near the top of the canvas to
+ * fit a card above it. The entry animation rises the other way in this state.
+ */
+export const Below: Story = {
+	args: {
+		placement: { side: 'below', offsetX: 0 },
+		content: {
+			body: 'Its card flips below, because there is no room for it above.',
+			link
+		}
+	}
+}
+
+/**
+ * Shifted horizontally, as it is for a marker near the left or right edge.
+ * Centred on its marker the card would leave the canvas, so the resolver moves
+ * it back by the overhang and no further.
+ */
+export const ShiftedFromTheEdge: Story = {
+	args: {
+		placement: { side: 'above', offsetX: 64 },
+		content: {
+			body: 'Nudged back from the edge it would otherwise hang over.',
+			link
+		}
+	}
+}
+
+/**
+ * At the width cap, which is where the wrapping and the link's truncation are
+ * worth looking at. Author text runs to 2000 characters, so this is ordinary
+ * rather than exceptional.
+ */
+export const LongBody: Story = {
+	args: {
+		content: {
+			body: 'Cast in one piece, then machined flat so the two halves meet without a shim. The tolerance is held across the whole face rather than at the bolt circle alone, which is what lets the assembly seal without a gasket at working temperature.',
+			link
+		}
+	}
+}

--- a/packages/viewer/src/components/scene/hotspot-popover.stories.tsx
+++ b/packages/viewer/src/components/scene/hotspot-popover.stories.tsx
@@ -36,7 +36,19 @@ const link = {
 const meta = {
 	title: 'Viewer/Hotspot Popover',
 	component: HotspotPopover,
-	parameters: { layout: 'centered' },
+	parameters: {
+		layout: 'centered',
+		/*
+		  The workspace decorator renders every story twice and switches themes
+		  with the app's `.dark` class. That is the wrong mechanism here: this
+		  package's tokens hang off `.viewer` and are switched by `data-theme` on
+		  that same element, so `.dark` moves nothing and both panes came out
+		  identical - a card with no resolved background at all, showing the
+		  backdrop straight through itself.
+		*/
+		dualTheme: false,
+		viewerTheme: 'light'
+	},
 	args: {
 		id: 'story-popover',
 		title: 'Machined face',
@@ -50,25 +62,34 @@ const meta = {
 	},
 	decorators: [
 		/**
-		 * Stands in for the marker the card hangs off, over something to stand on.
+		 * A marker to hang off, a surface to sit on, and the token scope both
+		 * need.
+		 *
+		 * `.viewer` is not decoration: every colour this card uses is declared
+		 * there, so without it `--vctrl-bg` and `--vctrl-text` do not resolve and
+		 * the card renders transparent with inherited text - which is how this
+		 * story first shipped, looking plausible because the shadow still drew.
 		 *
 		 * The card is absolutely positioned against the nearest positioned
-		 * ancestor and offset by the gap, so it needs a point to hang off before
-		 * any of its own geometry means anything. The dot is drawn at that point
-		 * so a diff shows the spacing, not only the card.
+		 * ancestor and offset by the gap, so it also needs a point to hang off
+		 * before any of its own geometry means anything. The dot is drawn at that
+		 * point so a diff shows the spacing, not only the card.
 		 *
-		 * The mid-tone backdrop is not decoration. This card is a light surface
-		 * in light and a dark one in dark, and it never appears over a blank
-		 * page - it sits over rendered geometry. On the story background it was
-		 * white on white and black on black, legible only by its shadow, which
-		 * is both untrue to the product and close to useless as a baseline to
-		 * diff against.
+		 * The mid-tone backdrop stands in for the model. This card is a near-white
+		 * surface in light and a near-black one in dark, and it never appears over
+		 * a blank page - on the story background each theme's card all but
+		 * disappeared into it.
 		 */
-		(Story) => (
-			<div className="flex h-[240px] w-[340px] items-center justify-center rounded-[0.75rem] bg-neutral-500">
-				<div className="relative">
-					<div className="absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-100 ring-1 ring-black/30" />
-					<Story />
+		(Story, context) => (
+			<div
+				className="viewer"
+				data-theme={context.parameters.viewerTheme as 'light' | 'dark'}
+			>
+				<div className="flex h-[240px] w-[340px] items-center justify-center rounded-[0.75rem] bg-neutral-500">
+					<div className="relative">
+						<div className="absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-100 ring-1 ring-black/30" />
+						<Story />
+					</div>
 				</div>
 			</div>
 		)
@@ -145,5 +166,20 @@ export const LongBody: Story = {
 			body: 'Cast in one piece, then machined flat so the two halves meet without a shim. The tolerance is held across the whole face rather than at the bolt circle alone, which is what lets the assembly seal without a gasket at working temperature.',
 			link
 		}
+	}
+}
+
+/**
+ * The same card on the viewer's dark surface.
+ *
+ * A story of its own rather than a second pane, because the theme is a property
+ * of the `.viewer` element the card lives inside, and rendering the card twice
+ * in one snapshot would put two elements carrying the same `id` in the document
+ * - the id the marker's `aria-controls` points at.
+ */
+export const DarkSurface: Story = {
+	parameters: { viewerTheme: 'dark' },
+	args: {
+		content: { body: 'The same joint, seen from the other side.', link }
 	}
 }

--- a/packages/viewer/src/components/scene/hotspot-popover.tsx
+++ b/packages/viewer/src/components/scene/hotspot-popover.tsx
@@ -1,47 +1,16 @@
-import { useFrame, useThree } from '@react-three/fiber'
 import { cn } from '@shared/utils'
-import { useRef, useState } from 'react'
 
-import { resolveHotspotPopoverPlacement } from './resolve-hotspot-popover'
-
-import type {
-	HotspotPopoverContent,
-	HotspotPopoverPlacement
-} from './resolve-hotspot-popover'
-import type { CSSProperties } from 'react'
-
-/**
- * Clearance between the marker's centre and the popover's near edge, and
- * between the popover and the edge of the canvas.
- *
- * The gap clears the 24px marker box plus a little air; the margin is what
- * stops a card from sitting flush against the canvas edge, where it reads as
- * clipped whether or not it is.
- */
-const ANCHOR_GAP_PX = 20
-const CANVAS_MARGIN_PX = 8
-
-/**
- * How often the placement is re-decided while the popover is open, in seconds.
- *
- * The card follows its marker for free - it is inside the same portal - so this
- * only has to catch the marker crossing an edge as the camera moves. Two
- * `getBoundingClientRect` calls at 10Hz, for at most one open popover.
- */
-const PLACEMENT_INTERVAL_SECONDS = 0.1
-
-const DEFAULT_PLACEMENT: HotspotPopoverPlacement = {
-	side: 'above',
-	offsetX: 0
-}
+import type { HotspotPopoverContent } from './resolve-hotspot-popover'
+import type { HotspotPopoverPlacement } from './resolve-hotspot-popover'
+import type { CSSProperties, KeyboardEvent, RefObject } from 'react'
 
 const popoverClasses = {
 	// `rounded-[0.5rem]`, never a named radius: this package clears Tailwind's
 	// radius namespace, so every named token but `full` compiles to nothing once
 	// the package is consumed from npm.
 	root: 'vctrl-hotspot-popover pointer-events-auto absolute left-1/2 w-max max-w-[240px] rounded-[0.5rem] bg-[var(--vctrl-bg)] px-3 py-2 text-left text-[var(--vctrl-text)] shadow-[0_2px_12px_rgba(0,0,0,0.35)]',
-	above: 'bottom-[calc(100%+var(--vctrl-hotspot-popover-gap))]',
-	below: 'top-[calc(100%+var(--vctrl-hotspot-popover-gap))]',
+	above: 'bottom-[var(--vctrl-hotspot-popover-gap)]',
+	below: 'top-[var(--vctrl-hotspot-popover-gap)]',
 	// `font-[600]` rather than the named scale: a named weight registers its
 	// theme variable in the published stylesheet's `:root, :host` block, which
 	// lands in a host application after hydration. See styles.css.
@@ -58,104 +27,82 @@ export interface HotspotPopoverProps {
 	content: HotspotPopoverContent
 	/** Names the card from the marker's `aria-controls`. */
 	id: string
-	/** The marker root, which the card is placed against. */
-	anchorRef: React.RefObject<HTMLDivElement | null>
+	/** Where to draw it, decided by the marker. See below. */
+	placement: HotspotPopoverPlacement
+	/** Clearance from the marker's centre, in pixels. */
+	gap: number
+	/** The marker measures this element to decide the placement. */
+	cardRef: RefObject<HTMLDivElement | null>
+	/**
+	 * Escape, handled here as well as on the marker.
+	 *
+	 * Both are needed, and not by accident: this card is rendered into a drei
+	 * `Html`, which mounts its children in a ReactDOM root of its own. A React
+	 * event handler on the marker's tree therefore never sees a key pressed
+	 * inside the card, because the two are separate roots over separate DOM
+	 * subtrees.
+	 */
+	onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void
 }
 
 /**
- * What a marker says when a visitor opens it.
+ * What a marker says when a visitor opens it. Presentational only.
+ *
+ * Every decision reaches it as a prop, and that is a hard constraint rather
+ * than a preference: drei's `Html` renders its children through
+ * `ReactDOM.createRoot`, so this component sits in a React root that inherits
+ * no context from the canvas. `useThree` and `useFrame` here would not merely
+ * misbehave - they throw "Hooks can only be used within the Canvas component",
+ * and the failing root empties its own container, so the marker itself
+ * disappears rather than just the card. `HotspotMarker` does the measuring,
+ * because it is in the R3F tree.
  *
  * Non-modal by design: no focus trap and no scroll lock, because the visitor
  * has to be able to keep orbiting the model and reach the other markers while
  * this is open. `info-popover.tsx`'s document-global trap is the right shape
  * for a chrome panel and the wrong one here.
- *
- * Placement is re-decided from the canvas box rather than fixed, so a marker
- * near the top of the frame flips its card below instead of drawing it off the
- * viewport - which is also what the hover label does not do yet.
  */
 const HotspotPopover = ({
 	title,
 	content,
 	id,
-	anchorRef
-}: HotspotPopoverProps) => {
-	const canvas = useThree((state) => state.gl.domElement)
-	const cardRef = useRef<HTMLDivElement>(null)
-	// Seeded at the interval so the very first frame measures rather than
-	// waiting one out. Under `frameloop="demand"` that first frame is the only
-	// one the card is guaranteed, and until it runs the placement is the default
-	// rather than the measured answer.
-	const elapsed = useRef(PLACEMENT_INTERVAL_SECONDS)
-	const [placement, setPlacement] =
-		useState<HotspotPopoverPlacement>(DEFAULT_PLACEMENT)
-
-	useFrame((_state, delta) => {
-		elapsed.current += delta
-		if (elapsed.current < PLACEMENT_INTERVAL_SECONDS) return
-		elapsed.current = 0
-
-		const anchor = anchorRef.current
-		const card = cardRef.current
-		if (!anchor || !card) return
-
-		const anchorBox = anchor.getBoundingClientRect()
-		const canvasBox = canvas.getBoundingClientRect()
-
-		const next = resolveHotspotPopoverPlacement({
-			anchor: {
-				x: anchorBox.left + anchorBox.width / 2 - canvasBox.left,
-				y: anchorBox.top + anchorBox.height / 2 - canvasBox.top
-			},
-			size: { width: card.offsetWidth, height: card.offsetHeight },
-			bounds: { width: canvasBox.width, height: canvasBox.height },
-			gap: ANCHOR_GAP_PX,
-			margin: CANVAS_MARGIN_PX
-		})
-
-		// One state write only when the answer moved: this runs in the frame
-		// loop, where an unconditional write would re-render the marker's portal
-		// ten times a second for as long as the card is open.
-		setPlacement((previous) =>
-			previous.side === next.side && previous.offsetX === next.offsetX
-				? previous
-				: next
-		)
-	})
-
-	return (
-		<div
-			ref={cardRef}
-			id={id}
-			className={cn(popoverClasses.root, popoverClasses[placement.side])}
-			// Read by the stylesheet, which owns the transform so the entry
-			// animation can reuse the same X and move nothing but opacity and Y.
-			data-side={placement.side}
-			style={
-				{
-					'--vctrl-hotspot-popover-gap': `${ANCHOR_GAP_PX}px`,
-					'--vctrl-hotspot-popover-shift': `calc(-50% + ${placement.offsetX}px)`
-				} as CSSProperties
-			}
-		>
-			<p className={popoverClasses.title}>{title}</p>
-			{content.body && <p className={popoverClasses.body}>{content.body}</p>}
-			{content.link && (
-				<a
-					className={popoverClasses.link}
-					href={content.link.href}
-					target="_blank"
-					// `noopener` is the one that matters - it denies the opened page a
-					// handle on this one, which for an embedded viewer is somebody
-					// else's page. `noreferrer` follows it because a target of `_blank`
-					// implies opener in older engines that do not honour the first.
-					rel="noopener noreferrer"
-				>
-					{content.link.label}
-				</a>
-			)}
-		</div>
-	)
-}
+	placement,
+	gap,
+	cardRef,
+	onKeyDown
+}: HotspotPopoverProps) => (
+	<div
+		ref={cardRef}
+		id={id}
+		className={cn(popoverClasses.root, popoverClasses[placement.side])}
+		// Read by the stylesheet, which owns the transform so the entry
+		// animation can reuse the same X and move nothing but opacity and Y.
+		data-side={placement.side}
+		onKeyDown={onKeyDown}
+		style={
+			{
+				'--vctrl-hotspot-popover-gap': `${gap}px`,
+				'--vctrl-hotspot-popover-shift': `calc(-50% + ${placement.offsetX}px)`
+			} as CSSProperties
+		}
+	>
+		<p className={popoverClasses.title}>{title}</p>
+		{content.body && <p className={popoverClasses.body}>{content.body}</p>}
+		{content.link && (
+			<a
+				className={popoverClasses.link}
+				href={content.link.href}
+				target="_blank"
+				// `noopener` is the one that matters - it denies the opened page a
+				// handle on this one, which for an embedded viewer is somebody
+				// else's page. `noreferrer` follows it because a target of `_blank`
+				// implies opener in older engines that do not honour the first.
+				rel="noopener noreferrer"
+			>
+				{content.link.label}
+			</a>
+		)}
+	</div>
+)
 
 export default HotspotPopover

--- a/packages/viewer/src/components/scene/hotspot-popover.tsx
+++ b/packages/viewer/src/components/scene/hotspot-popover.tsx
@@ -1,0 +1,161 @@
+import { useFrame, useThree } from '@react-three/fiber'
+import { cn } from '@shared/utils'
+import { useRef, useState } from 'react'
+
+import { resolveHotspotPopoverPlacement } from './resolve-hotspot-popover'
+
+import type {
+	HotspotPopoverContent,
+	HotspotPopoverPlacement
+} from './resolve-hotspot-popover'
+import type { CSSProperties } from 'react'
+
+/**
+ * Clearance between the marker's centre and the popover's near edge, and
+ * between the popover and the edge of the canvas.
+ *
+ * The gap clears the 24px marker box plus a little air; the margin is what
+ * stops a card from sitting flush against the canvas edge, where it reads as
+ * clipped whether or not it is.
+ */
+const ANCHOR_GAP_PX = 20
+const CANVAS_MARGIN_PX = 8
+
+/**
+ * How often the placement is re-decided while the popover is open, in seconds.
+ *
+ * The card follows its marker for free - it is inside the same portal - so this
+ * only has to catch the marker crossing an edge as the camera moves. Two
+ * `getBoundingClientRect` calls at 10Hz, for at most one open popover.
+ */
+const PLACEMENT_INTERVAL_SECONDS = 0.1
+
+const DEFAULT_PLACEMENT: HotspotPopoverPlacement = {
+	side: 'above',
+	offsetX: 0
+}
+
+const popoverClasses = {
+	// `rounded-[0.5rem]`, never a named radius: this package clears Tailwind's
+	// radius namespace, so every named token but `full` compiles to nothing once
+	// the package is consumed from npm.
+	root: 'vctrl-hotspot-popover pointer-events-auto absolute left-1/2 w-max max-w-[240px] rounded-[0.5rem] bg-[var(--vctrl-bg)] px-3 py-2 text-left text-[var(--vctrl-text)] shadow-[0_2px_12px_rgba(0,0,0,0.35)]',
+	above: 'bottom-[calc(100%+var(--vctrl-hotspot-popover-gap))]',
+	below: 'top-[calc(100%+var(--vctrl-hotspot-popover-gap))]',
+	// `font-[600]` rather than the named scale: a named weight registers its
+	// theme variable in the published stylesheet's `:root, :host` block, which
+	// lands in a host application after hydration. See styles.css.
+	title: 'text-[12px] leading-[1.35] font-[600]',
+	// `whitespace-pre-wrap` so the line breaks an author typed survive. The body
+	// is plain text, never markup, so this is the only formatting it carries.
+	body: 'mt-1 text-[11px] leading-[1.5] whitespace-pre-wrap opacity-90',
+	link: 'mt-2 inline-block max-w-full truncate text-[11px] leading-[1.5] underline underline-offset-2 opacity-90 hover:opacity-100'
+} as const
+
+export interface HotspotPopoverProps {
+	/** Heads the card. The marker's own name, so the two cannot drift apart. */
+	title: string
+	content: HotspotPopoverContent
+	/** Names the card from the marker's `aria-controls`. */
+	id: string
+	/** The marker root, which the card is placed against. */
+	anchorRef: React.RefObject<HTMLDivElement | null>
+}
+
+/**
+ * What a marker says when a visitor opens it.
+ *
+ * Non-modal by design: no focus trap and no scroll lock, because the visitor
+ * has to be able to keep orbiting the model and reach the other markers while
+ * this is open. `info-popover.tsx`'s document-global trap is the right shape
+ * for a chrome panel and the wrong one here.
+ *
+ * Placement is re-decided from the canvas box rather than fixed, so a marker
+ * near the top of the frame flips its card below instead of drawing it off the
+ * viewport - which is also what the hover label does not do yet.
+ */
+const HotspotPopover = ({
+	title,
+	content,
+	id,
+	anchorRef
+}: HotspotPopoverProps) => {
+	const canvas = useThree((state) => state.gl.domElement)
+	const cardRef = useRef<HTMLDivElement>(null)
+	// Seeded at the interval so the very first frame measures rather than
+	// waiting one out. Under `frameloop="demand"` that first frame is the only
+	// one the card is guaranteed, and until it runs the placement is the default
+	// rather than the measured answer.
+	const elapsed = useRef(PLACEMENT_INTERVAL_SECONDS)
+	const [placement, setPlacement] =
+		useState<HotspotPopoverPlacement>(DEFAULT_PLACEMENT)
+
+	useFrame((_state, delta) => {
+		elapsed.current += delta
+		if (elapsed.current < PLACEMENT_INTERVAL_SECONDS) return
+		elapsed.current = 0
+
+		const anchor = anchorRef.current
+		const card = cardRef.current
+		if (!anchor || !card) return
+
+		const anchorBox = anchor.getBoundingClientRect()
+		const canvasBox = canvas.getBoundingClientRect()
+
+		const next = resolveHotspotPopoverPlacement({
+			anchor: {
+				x: anchorBox.left + anchorBox.width / 2 - canvasBox.left,
+				y: anchorBox.top + anchorBox.height / 2 - canvasBox.top
+			},
+			size: { width: card.offsetWidth, height: card.offsetHeight },
+			bounds: { width: canvasBox.width, height: canvasBox.height },
+			gap: ANCHOR_GAP_PX,
+			margin: CANVAS_MARGIN_PX
+		})
+
+		// One state write only when the answer moved: this runs in the frame
+		// loop, where an unconditional write would re-render the marker's portal
+		// ten times a second for as long as the card is open.
+		setPlacement((previous) =>
+			previous.side === next.side && previous.offsetX === next.offsetX
+				? previous
+				: next
+		)
+	})
+
+	return (
+		<div
+			ref={cardRef}
+			id={id}
+			className={cn(popoverClasses.root, popoverClasses[placement.side])}
+			// Read by the stylesheet, which owns the transform so the entry
+			// animation can reuse the same X and move nothing but opacity and Y.
+			data-side={placement.side}
+			style={
+				{
+					'--vctrl-hotspot-popover-gap': `${ANCHOR_GAP_PX}px`,
+					'--vctrl-hotspot-popover-shift': `calc(-50% + ${placement.offsetX}px)`
+				} as CSSProperties
+			}
+		>
+			<p className={popoverClasses.title}>{title}</p>
+			{content.body && <p className={popoverClasses.body}>{content.body}</p>}
+			{content.link && (
+				<a
+					className={popoverClasses.link}
+					href={content.link.href}
+					target="_blank"
+					// `noopener` is the one that matters - it denies the opened page a
+					// handle on this one, which for an embedded viewer is somebody
+					// else's page. `noreferrer` follows it because a target of `_blank`
+					// implies opener in older engines that do not honour the first.
+					rel="noopener noreferrer"
+				>
+					{content.link.label}
+				</a>
+			)}
+		</div>
+	)
+}
+
+export default HotspotPopover

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
@@ -437,6 +437,63 @@ describe('resolveHotspotMarkers', () => {
 		})
 	})
 
+	describe('content', () => {
+		it('carries body text and a link through, trimmed', () => {
+			const [drawn] = resolveHotspotMarkers([
+				hotspot({
+					id: 'a',
+					body: '  Cast in one piece.  ',
+					linkUrl: '  https://a.test/spec  '
+				})
+			])
+
+			expect(drawn.body).toBe('Cast in one piece.')
+			expect(drawn.linkUrl).toBe('https://a.test/spec')
+		})
+
+		it('reads a missing or whitespace-only field as no content at all', () => {
+			const [absent] = resolveHotspotMarkers([hotspot({ id: 'a' })])
+			const [blank] = resolveHotspotMarkers([
+				hotspot({ id: 'b', body: '   ', linkUrl: '' })
+			])
+
+			expect(absent.body).toBeNull()
+			expect(absent.linkUrl).toBeNull()
+			expect(blank.body).toBeNull()
+			expect(blank.linkUrl).toBeNull()
+		})
+
+		it('survives a non-string body, which would throw on trim mid-render', () => {
+			// A direct consumer of this package goes through no parser at all.
+			const [drawn] = resolveHotspotMarkers([
+				malformed({
+					id: 'a',
+					name: 'Handle',
+					worldPosition: [0, 0, 0],
+					visible: true,
+					internalOnly: false,
+					stylePreset: 'dot',
+					body: 42,
+					linkUrl: { href: 'https://a.test' }
+				})
+			])
+
+			expect(drawn.body).toBeNull()
+			expect(drawn.linkUrl).toBeNull()
+		})
+
+		it('leaves the scheme to the renderer rather than filtering here', () => {
+			// `resolveHotspotLink` owns that rule, and it is what decides whether
+			// the marker has anything to reveal. Dropping the value here would
+			// hide the field from any consumer drawing its own card.
+			const [drawn] = resolveHotspotMarkers([
+				hotspot({ id: 'a', linkUrl: 'javascript:alert(1)' })
+			])
+
+			expect(drawn.linkUrl).toBe('javascript:alert(1)')
+		})
+	})
+
 	it('does not mutate the settings it was given', () => {
 		const stored = [
 			hotspot({ id: 'b', sequenceIndex: 1 }),

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
@@ -11,6 +11,14 @@ export interface HotspotMarker {
 	id: string
 	/** Trimmed, and never empty. */
 	name: string
+	/** Trimmed, or null when the hotspot carries no body text. */
+	body: string | null
+	/**
+	 * Trimmed, or null when the hotspot names no link. Not yet checked for a
+	 * scheme the renderer will accept - `resolveHotspotLink` owns that, and it
+	 * is what decides whether the marker has anything to reveal.
+	 */
+	linkUrl: string | null
 	/** What a screen reader announces, including the step and how many there are. */
 	accessibleName: string
 	position: [number, number, number]
@@ -124,10 +132,10 @@ interface DrawableEntry {
  * mount and never reorders, so document order - and with it tab order - follows
  * whichever order the markers first mounted in.)
  *
- * Everything else here is hardening. The platform's own parser validates most of
- * these fields on save, but it never sees `payloadUrl`, and a direct consumer of
- * `@vctrl/viewer` goes through no parser at all: a non-string `name` would throw
- * on `.trim()` mid-render, and a `NaN` sequence index would make the comparator
+ * Everything else here is hardening. The platform's own parser validates every
+ * one of these fields on save, but a direct consumer of `@vctrl/viewer` goes
+ * through no parser at all: a non-string `name` or `body` would throw on
+ * `.trim()` mid-render, and a `NaN` sequence index would make the comparator
  * return `NaN` and leave the order to the sort implementation.
  */
 export function resolveHotspotMarkers(
@@ -231,6 +239,8 @@ function toMarker(
 		id,
 		name,
 		accessibleName: accessibleName(name, step, stepCount, hidden),
+		body: text(hotspot.body),
+		linkUrl: text(hotspot.linkUrl),
 		position,
 		step,
 		stepCount,

--- a/packages/viewer/src/components/scene/resolve-hotspot-popover.spec.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-popover.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	resolveHotspotLink,
+	resolveHotspotPopoverContent,
+	resolveHotspotPopoverPlacement
+} from './resolve-hotspot-popover'
+
+describe('resolveHotspotLink', () => {
+	it('takes an https URL and names it by its host', () => {
+		expect(resolveHotspotLink('https://docs.vectreal.com/specs?a=1')).toEqual({
+			href: 'https://docs.vectreal.com/specs?a=1',
+			label: 'docs.vectreal.com'
+		})
+	})
+
+	it('keeps a non-default port in the label, which is part of the host', () => {
+		expect(resolveHotspotLink('https://staging.test:8443/a')?.label).toBe(
+			'staging.test:8443'
+		)
+	})
+
+	it.each([
+		['a script URL', 'javascript:alert(1)'],
+		['a script URL in mixed case', 'JavaScript:alert(1)'],
+		['an inline document', 'data:text/html;base64,AAAA'],
+		['plain http', 'http://vectreal.com'],
+		['a protocol-relative URL', '//vectreal.com'],
+		['a relative path', '/docs'],
+		['a bare scheme', 'https://'],
+		['an unparseable value behind the right prefix', 'https:// spaced'],
+		['nothing at all', null]
+	])('refuses %s', (_label, value) => {
+		expect(resolveHotspotLink(value)).toBeNull()
+	})
+
+	/**
+	 * The prefix is the gate, not the parsed protocol.
+	 *
+	 * `new URL('https:evil')` yields protocol `https:` with no host at all, so a
+	 * rule written as "parse it and check `url.protocol`" accepts a value that
+	 * is not an absolute https URL.
+	 */
+	it('refuses a scheme-only form that parses as https', () => {
+		expect(resolveHotspotLink('https:evil')).toBeNull()
+	})
+})
+
+describe('resolveHotspotPopoverContent', () => {
+	it('carries a body on its own', () => {
+		expect(
+			resolveHotspotPopoverContent({
+				body: 'Cast in one piece.',
+				linkUrl: null
+			})
+		).toEqual({ body: 'Cast in one piece.', link: null })
+	})
+
+	it('carries a link on its own', () => {
+		expect(
+			resolveHotspotPopoverContent({ body: null, linkUrl: 'https://a.test/x' })
+		).toEqual({
+			body: null,
+			link: { href: 'https://a.test/x', label: 'a.test' }
+		})
+	})
+
+	it('has nothing to reveal when it carries neither', () => {
+		expect(
+			resolveHotspotPopoverContent({ body: null, linkUrl: null })
+		).toBeNull()
+	})
+
+	/**
+	 * A marker whose only content is a link the renderer refuses has nothing to
+	 * reveal. Without this it would become a button that opens an empty card,
+	 * which is worse than the inert marker it was.
+	 */
+	it('has nothing to reveal when its only link is one the renderer refuses', () => {
+		expect(
+			resolveHotspotPopoverContent({
+				body: null,
+				linkUrl: 'javascript:alert(1)'
+			})
+		).toBeNull()
+	})
+})
+
+describe('resolveHotspotPopoverPlacement', () => {
+	const bounds = { width: 800, height: 600 }
+	const size = { width: 200, height: 100 }
+	const place = (anchor: { x: number; y: number }, overrides = {}) =>
+		resolveHotspotPopoverPlacement({
+			anchor,
+			size,
+			bounds,
+			gap: 20,
+			margin: 8,
+			...overrides
+		})
+
+	it('sits above a marker with room above it', () => {
+		expect(place({ x: 400, y: 300 })).toEqual({ side: 'above', offsetX: 0 })
+	})
+
+	// The clipped-label defect, in the shape the popover would have inherited.
+	it('flips below a marker near the top edge', () => {
+		expect(place({ x: 400, y: 40 }).side).toBe('below')
+	})
+
+	it('goes back above once there is room for it again', () => {
+		// 100 tall, 20 of gap and 8 of margin: 128 is the first y that fits.
+		expect(place({ x: 400, y: 127 }).side).toBe('below')
+		expect(place({ x: 400, y: 128 }).side).toBe('above')
+	})
+
+	it('shifts right off the left edge, by exactly what it takes', () => {
+		// Centred would put the left edge at 20 - 100 = -80; the margin wants 8.
+		expect(place({ x: 20, y: 300 }).offsetX).toBe(88)
+	})
+
+	it('shifts left off the right edge, by exactly what it takes', () => {
+		// Centred would put the right edge at 780 + 100 = 880; the margin wants
+		// it at 792.
+		expect(place({ x: 780, y: 300 }).offsetX).toBe(-88)
+	})
+
+	it('leaves a marker that already fits alone', () => {
+		expect(place({ x: 108, y: 300 }).offsetX).toBe(0)
+		expect(place({ x: 692, y: 300 }).offsetX).toBe(0)
+	})
+
+	it('pins a card wider than the canvas to the left margin', () => {
+		// The clamp that keeps the right edge on screen would otherwise push the
+		// left edge off it, which is the worse of the two.
+		const wide = resolveHotspotPopoverPlacement({
+			anchor: { x: 400, y: 300 },
+			size: { width: 900, height: 100 },
+			bounds,
+			gap: 20,
+			margin: 8
+		})
+
+		expect(400 - 900 / 2 + wide.offsetX).toBe(8)
+	})
+
+	it('picks the roomier side when the card fits on neither', () => {
+		const tall = { width: 200, height: 560 }
+		const near = (y: number) =>
+			resolveHotspotPopoverPlacement({
+				anchor: { x: 400, y },
+				size: tall,
+				bounds,
+				gap: 20,
+				margin: 8
+			}).side
+
+		expect(near(500)).toBe('above')
+		expect(near(100)).toBe('below')
+	})
+})

--- a/packages/viewer/src/components/scene/resolve-hotspot-popover.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-popover.ts
@@ -1,0 +1,135 @@
+import type { HotspotMarker } from './resolve-hotspot-markers'
+
+/** A link a marker's popover can offer, once it is safe to render. */
+export interface HotspotLink {
+	href: string
+	/**
+	 * What the anchor says. The URL's host, never an author-supplied label:
+	 * there is no second field to keep in step with the destination, so the
+	 * visible text cannot go stale against where the link points.
+	 */
+	label: string
+}
+
+/** What a marker has to say, or null when it has nothing. */
+export interface HotspotPopoverContent {
+	body: string | null
+	link: HotspotLink | null
+}
+
+/** Which side of the marker the popover sits on. */
+export type HotspotPopoverSide = 'above' | 'below'
+
+export interface HotspotPopoverPlacement {
+	side: HotspotPopoverSide
+	/**
+	 * Horizontal shift from centred on the marker, in pixels. Non-zero only
+	 * where a centred popover would leave the canvas.
+	 */
+	offsetX: number
+}
+
+export interface HotspotPopoverPlacementInput {
+	/** The marker's centre, in canvas coordinates. */
+	anchor: { x: number; y: number }
+	/** The popover's measured size. */
+	size: { width: number; height: number }
+	/** The canvas the popover has to stay inside. */
+	bounds: { width: number; height: number }
+	/** Clearance between the marker's centre and the popover's near edge. */
+	gap: number
+	/** Clearance kept between the popover and the edge of the canvas. */
+	margin: number
+}
+
+/**
+ * A marker's link, or null.
+ *
+ * `https:` only, and the check is the prefix rather than the parsed protocol,
+ * because this is a security gate and a prefix cannot be talked out of its
+ * answer. The parse that follows only reads the host for the label.
+ *
+ * The platform's save parser applies the same rule, so this is the second of
+ * two independent gates rather than the only one - the same arrangement
+ * `internalOnly` has. It is load-bearing here for the same reason: this package
+ * ships to npm, a consumer can hand it any settings object at all, and this
+ * value lands in an `<a href>` where `javascript:` executes.
+ */
+export function resolveHotspotLink(value: string | null): HotspotLink | null {
+	if (!value) return null
+	if (!value.toLowerCase().startsWith('https://')) return null
+
+	try {
+		// Behind that prefix, `new URL` either throws or yields a non-empty host -
+		// `https://`, `https://?a=1` and `https://:443` all throw - so there is no
+		// empty-host case left to branch on here.
+		return { href: value, label: new URL(value).host }
+	} catch {
+		// It does still throw on values the prefix check alone does not rule out:
+		// `https://` followed by a bare space is one.
+		return null
+	}
+}
+
+/**
+ * What a marker reveals when it is opened, or null when it reveals nothing.
+ *
+ * A marker whose only content is a link the rule above refuses has nothing to
+ * reveal, which is what keeps an unsafe link from turning an otherwise inert
+ * marker into a button that opens an empty card.
+ */
+export function resolveHotspotPopoverContent(
+	marker: Pick<HotspotMarker, 'body' | 'linkUrl'>
+): HotspotPopoverContent | null {
+	const body = marker.body
+	const link = resolveHotspotLink(marker.linkUrl)
+
+	if (!body && !link) return null
+	return { body, link }
+}
+
+/**
+ * Where to draw an open popover so it stays on the canvas.
+ *
+ * Above the marker by default, because that is where the hover label already
+ * appears and a card below a marker covers the geometry the marker is pointing
+ * at. It flips below only when it does not fit above, and shifts sideways only
+ * as far as it takes to stay inside the canvas.
+ *
+ * Total by construction: when neither side fits, the roomier one wins rather
+ * than a default that guarantees a clipped card.
+ *
+ * Pure, and measured in canvas coordinates rather than page coordinates, so
+ * an embedded viewer inside a scrolled host page places the same as a
+ * full-page one.
+ */
+export function resolveHotspotPopoverPlacement({
+	anchor,
+	size,
+	bounds,
+	gap,
+	margin
+}: HotspotPopoverPlacementInput): HotspotPopoverPlacement {
+	const roomAbove = anchor.y - gap - margin
+	const roomBelow = bounds.height - anchor.y - gap - margin
+
+	const side: HotspotPopoverSide =
+		size.height <= roomAbove
+			? 'above'
+			: size.height <= roomBelow
+				? 'below'
+				: roomBelow > roomAbove
+					? 'below'
+					: 'above'
+
+	const centredLeft = anchor.x - size.width / 2
+	// `max` last, so a popover wider than the canvas pins to the left margin
+	// rather than being pushed off the other side by the clamp meant to keep it
+	// on screen.
+	const clampedLeft = Math.max(
+		margin,
+		Math.min(centredLeft, bounds.width - size.width - margin)
+	)
+
+	return { side, offsetX: clampedLeft - centredLeft }
+}

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -8,7 +8,9 @@ import {
 	occlusionRayFar
 } from './hotspot-occlusion'
 import { resolveHotspotMarkers } from './resolve-hotspot-markers'
+import { resolveHotspotPopoverContent } from './resolve-hotspot-popover'
 
+import type { ViewerCommandExecutor } from '../../types/viewer-interactions'
 import type { HotspotDefinition } from '@vctrl/core'
 import type { Group, Object3D } from 'three'
 
@@ -45,10 +47,39 @@ export interface SceneHotspotsProps {
 	includeHidden?: boolean
 	/** Overrides the marker fill for every hotspot in this viewer. */
 	color?: string
+	/**
+	 * Whether the markers are drawn. Default true.
+	 *
+	 * False leaves them resolved but undrawn, so `focus_hotspot` still flies a
+	 * camera by id and a host can still list them. A host driving its own
+	 * navigation needs exactly that combination: nothing on the model, every
+	 * hotspot still reachable.
+	 */
+	showMarkers?: boolean
+	/**
+	 * Whether a marker opens a card of its own. Default true.
+	 *
+	 * False still activates - the camera flies and the activation is reported -
+	 * so a host drawing its own panel gets the event without the viewer drawing
+	 * a second copy of the same text over the model.
+	 */
+	revealContent?: boolean
 	/** The marker drawn as the current one. */
 	selectedId?: string | null
 	onActivateCamera?: (cameraId: string) => void
 	onSelect?: (id: string) => void
+	/**
+	 * Runs when a visitor activates a marker, with the camera it flies or null.
+	 * Never for a selection.
+	 */
+	onHotspotActivated?: (id: string, cameraId: string | null) => void
+	/**
+	 * Registers the executor that handles `focus_hotspot`, and `null` on
+	 * unmount. The same shape `SceneCamera` and `SceneAnimation` use: the
+	 * command needs the drawn marker list and the open-card state, both of
+	 * which live here.
+	 */
+	onCommandExecutorReady?: (executor: null | ViewerCommandExecutor) => void
 	onPositionSetterReady?: (setter: null | HotspotPositionSetter) => void
 }
 
@@ -73,20 +104,44 @@ const SceneHotspots = ({
 	includeInternal,
 	includeHidden,
 	color,
+	showMarkers = true,
+	revealContent = true,
 	selectedId,
 	onActivateCamera,
 	onSelect,
+	onHotspotActivated,
+	onCommandExecutorReady,
 	onPositionSetterReady
 }: SceneHotspotsProps) => {
 	const camera = useThree((state) => state.camera)
 	const invalidate = useThree((state) => state.invalidate)
 	const [occludedIds, setOccludedIds] =
 		useState<ReadonlySet<string>>(NO_OCCLUSIONS)
+	/**
+	 * Which marker has its content open, at most one.
+	 *
+	 * Owned here rather than by each marker so opening one closes the last: the
+	 * cards are non-modal and anchored to points that can overlap on screen, and
+	 * several open at once is unreadable. It also puts the open marker in reach
+	 * of the occlusion pass below.
+	 */
+	const [openId, setOpenId] = useState<string | null>(null)
 
 	const markers = useMemo(
 		() => resolveHotspotMarkers(hotspots, { includeInternal, includeHidden }),
 		[hotspots, includeInternal, includeHidden]
 	)
+
+	/**
+	 * The drawn list, for the command executor to resolve an id against.
+	 *
+	 * A ref rather than a closure over `markers`: the executor is registered by
+	 * an effect, and a dependency that changes whenever the list does would
+	 * unregister and re-register it on every edit. That is the shape that has
+	 * silently left this viewer with no executor before.
+	 */
+	const markersRef = useRef(markers)
+	markersRef.current = markers
 
 	/**
 	 * Where the gizmo is while a drag is in flight, and whose drag it is.
@@ -132,6 +187,66 @@ const SceneHotspots = ({
 	 * nothing - which is the correct thing for it to find.
 	 */
 	const anchors = useRef(new Map<string, Group>())
+
+	const handleReveal = useCallback(
+		(id: string) => {
+			setOpenId((previous) => (previous === id ? null : id))
+			// Under `frameloop="demand"` nothing else asks for a frame here, and
+			// the card measures its own placement from one.
+			invalidate()
+		},
+		[invalidate]
+	)
+
+	/**
+	 * An open card closes when its marker goes behind the model or leaves the
+	 * list.
+	 *
+	 * An occluded marker takes no pointer events and offers no action, so a card
+	 * left open over hidden geometry would be the one state with no way to
+	 * dismiss it - and it would be describing something the visitor cannot see.
+	 */
+	useEffect(() => {
+		if (!openId) return
+		if (
+			occludedIds.has(openId) ||
+			!markers.some((marker) => marker.id === openId)
+		) {
+			setOpenId(null)
+		}
+	}, [markers, occludedIds, openId])
+
+	/**
+	 * A host focusing a hotspot does what clicking the marker does.
+	 *
+	 * Resolved against `markers` rather than the stored settings, so a hotspot
+	 * the author hid or kept internal cannot be reached by id: it is not in that
+	 * list on a public surface, and the command falls through doing nothing.
+	 *
+	 * No `hotspot_activated` event follows. That event says a visitor touched
+	 * the marker, and echoing a host's own command back to it as a visitor
+	 * action would be a lie the host cannot tell apart from the real thing.
+	 */
+	const focusHotspot = useCallback(
+		(hotspotId: string) => {
+			const marker = markersRef.current.find((entry) => entry.id === hotspotId)
+			if (!marker) return
+
+			if (resolveHotspotPopoverContent(marker)) setOpenId(marker.id)
+			if (marker.linkedCameraId) onActivateCamera?.(marker.linkedCameraId)
+			invalidate()
+		},
+		[invalidate, onActivateCamera]
+	)
+
+	useEffect(() => {
+		onCommandExecutorReady?.({
+			execute: (command) => {
+				if (command.type === 'focus_hotspot') focusHotspot(command.hotspotId)
+			}
+		})
+		return () => onCommandExecutorReady?.(null)
+	}, [focusHotspot, onCommandExecutorReady])
 
 	const registerAnchor = useCallback((id: string, node: Group | null) => {
 		if (node) anchors.current.set(id, node)
@@ -276,7 +391,10 @@ const SceneHotspots = ({
 
 		const next = new Set<string>()
 
-		if (model) {
+		// Nothing is drawn, so nothing can be faded. The pass is one raycast per
+		// marker at 15Hz, and a host that suppressed the markers is paying for it
+		// on every visitor's machine for no visible result.
+		if (model && showMarkers) {
 			// r3f updates world matrices after every useFrame subscriber has run, and
 			// `Center` writes its offset in a layout effect, so the pass forced by a
 			// model swap would otherwise test against the previous placement.
@@ -344,7 +462,7 @@ const SceneHotspots = ({
 		)
 	})
 
-	if (markers.length === 0) return null
+	if (markers.length === 0 || !showMarkers) return null
 
 	return (
 		<>
@@ -357,6 +475,9 @@ const SceneHotspots = ({
 					color={color}
 					onActivate={onActivateCamera}
 					onSelect={onSelect}
+					onActivated={onHotspotActivated}
+					open={marker.id === openId}
+					onReveal={revealContent ? handleReveal : undefined}
 					onAnchorRef={registerAnchor}
 				/>
 			))}

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -232,11 +232,17 @@ const SceneHotspots = ({
 			const marker = markersRef.current.find((entry) => entry.id === hotspotId)
 			if (!marker) return
 
-			if (resolveHotspotPopoverContent(marker)) setOpenId(marker.id)
+			// Gated on `revealContent`, or a host that asked this viewer NOT to
+			// draw cards would get one drawn by its own focus call - and could
+			// not close it, since neither the click path nor Escape reaches a
+			// reveal handler that was never passed.
+			if (revealContent && resolveHotspotPopoverContent(marker)) {
+				setOpenId(marker.id)
+			}
 			if (marker.linkedCameraId) onActivateCamera?.(marker.linkedCameraId)
 			invalidate()
 		},
-		[invalidate, onActivateCamera]
+		[invalidate, onActivateCamera, revealContent]
 	)
 
 	useEffect(() => {

--- a/packages/viewer/src/hotspots.ts
+++ b/packages/viewer/src/hotspots.ts
@@ -22,3 +22,20 @@ export {
 	type HotspotMarker,
 	type ResolveHotspotMarkersOptions
 } from './components/scene/resolve-hotspot-markers'
+
+/*
+  The link rule travels with the field it governs.
+
+  `HotspotMarker.linkUrl` is author-supplied and deliberately unchecked - the
+  marker resolver carries it through so a consumer drawing its own hotspot UI
+  can see it. That only works if the consumer can also reach the rule deciding
+  whether it is safe to put in an `href`, which is the whole reason this module
+  exists rather than the package root: it imports nothing at runtime, so a
+  consumer gets the rule without three and drei behind it.
+*/
+export {
+	resolveHotspotLink,
+	resolveHotspotPopoverContent,
+	type HotspotLink,
+	type HotspotPopoverContent
+} from './components/scene/resolve-hotspot-popover'

--- a/packages/viewer/src/styles-contrast.spec.ts
+++ b/packages/viewer/src/styles-contrast.spec.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The viewer's own text has to be readable on the viewer's own surface, in
+ * every theme it declares.
+ *
+ * This is not a style preference dressed up as a test. `--vctrl-text` shipped
+ * at #959595 on a #141414 surface, which is dimmer than the host design
+ * system's *muted* foreground and was carrying primary text at 11px. It cleared
+ * AA and looked wrong anyway, because the same roles in light mode ran at more
+ * than double the contrast. Nothing caught it: a colour token has no types, and
+ * the two stories that render dark viewer chrome had no baseline to diff
+ * against when it was introduced.
+ *
+ * Computed from the stylesheet rather than asserted as a literal, so the guard
+ * is about the relationship between the two values and not about either of them
+ * staying a particular string.
+ */
+
+const styles = readFileSync(join(import.meta.dirname, 'styles.css'), 'utf8')
+
+/** WCAG 2.1 relative luminance. */
+const channel = (value: number) => {
+	const c = value / 255
+	return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+const luminance = (hex: string) => {
+	const n = parseInt(hex.slice(1), 16)
+	return (
+		0.2126 * channel((n >> 16) & 255) +
+		0.7152 * channel((n >> 8) & 255) +
+		0.0722 * channel(n & 255)
+	)
+}
+
+const contrast = (a: string, b: string) => {
+	const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+	return (hi + 0.05) / (lo + 0.05)
+}
+
+/** What a colour at `alpha` actually looks like once composited on `over`. */
+const flatten = (hex: string, over: string, alpha: number) => {
+	const fg = parseInt(hex.slice(1), 16)
+	const bg = parseInt(over.slice(1), 16)
+	const mix = (shift: number) =>
+		Math.round(
+			alpha * ((fg >> shift) & 255) + (1 - alpha) * ((bg >> shift) & 255)
+		)
+	return `#${[mix(16), mix(8), mix(0)]
+		.map((v) => v.toString(16).padStart(2, '0'))
+		.join('')}`
+}
+
+/**
+ * Every block that sets both tokens, including the one inside the
+ * `prefers-color-scheme` media query - which is a second, separately
+ * maintained copy of the dark values and the one most likely to be forgotten.
+ */
+const themedBlocks = () => {
+	const found: { selector: string; bg: string; text: string }[] = []
+	const blocks = styles.matchAll(/(\.viewer[^{]*)\{([^}]*--vctrl-text[^}]*)\}/g)
+
+	for (const [, selector, body] of blocks) {
+		const bg = /--vctrl-bg:\s*(#[0-9a-fA-F]{6})/.exec(body)?.[1]
+		const text = /--vctrl-text:\s*(#[0-9a-fA-F]{6})/.exec(body)?.[1]
+		if (bg && text) found.push({ selector: selector.trim(), bg, text })
+	}
+
+	return found
+}
+
+describe('the viewer reads on its own surfaces', () => {
+	const blocks = themedBlocks()
+
+	it('found every themed block, not just the first', () => {
+		// Four: the base, the two explicit themes, and `system` - which appears
+		// twice, once per colour scheme.
+		expect(blocks.length).toBeGreaterThanOrEqual(5)
+		expect(blocks.some(({ text }) => text.toLowerCase() === '#141414')).toBe(
+			false
+		)
+	})
+
+	it.each(themedBlocks())(
+		'$selector clears AAA for body copy at 90% opacity',
+		({ bg, text }) => {
+			/*
+			  AAA rather than AA, and measured at the opacity the surfaces actually
+			  use. The smallest text in this package is 11px - the popover body and
+			  the marker's hover label - which is well under the 18.66px that would
+			  let a lower floor apply. AA's 4.5 is calibrated for ordinary body
+			  copy and was what the old value technically satisfied.
+			*/
+			expect(contrast(flatten(text, bg, 0.9), bg)).toBeGreaterThanOrEqual(7)
+		}
+	)
+
+	it('does not read far worse in one theme than the other', () => {
+		/*
+		  The complaint that surfaced this was never "dark fails a threshold", it
+		  was "dark looks wrong next to light". A theme at half its counterpart's
+		  contrast reads as a mistake even while passing, so the relationship is
+		  worth pinning and not only the floor.
+		*/
+		const ratios = blocks.map(({ bg, text }) => contrast(text, bg))
+		const worst = Math.min(...ratios)
+		const best = Math.max(...ratios)
+
+		expect(worst / best).toBeGreaterThan(0.6)
+	})
+})

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -236,6 +236,52 @@
 	animation: none;
 }
 
+/*
+  The card a marker opens.
+
+  It rises from the marker it belongs to rather than fading in place, so the
+  connection between the two is carried by the motion and the card needs no
+  caret of its own - which it could not have had cheaply anyway: the placement
+  resolver shifts the card sideways to keep it on the canvas, and a caret would
+  have to counter that shift and then stay clear of the corner radius.
+
+  8px of travel, not more. The card is anchored 20px from a marker that stays
+  drawn the whole time, so this only has to read as "from here"; a longer throw
+  turns a 150ms reveal into something the visitor waits out.
+*/
+@keyframes vctrl-hotspot-popover-in {
+	from {
+		opacity: 0;
+		transform: translateX(var(--vctrl-hotspot-popover-shift, -50%))
+			translateY(var(--vctrl-hotspot-popover-rise));
+	}
+}
+
+.vctrl-hotspot-popover {
+	--vctrl-hotspot-popover-rise: 8px;
+	/*
+	  The centring and the resolver's shift, in one place. The component supplies
+	  only the shift, as a custom property, so the animation's `from` can reuse
+	  the same X and move nothing but opacity and Y.
+	*/
+	transform: translateX(var(--vctrl-hotspot-popover-shift, -50%));
+	animation: vctrl-hotspot-popover-in 150ms ease-out;
+}
+
+/*
+  Below the marker, the card rises from the other direction, so both sides read
+  as coming out of the marker rather than one of them sliding past it.
+*/
+.vctrl-hotspot-popover[data-side='below'] {
+	--vctrl-hotspot-popover-rise: -8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.vctrl-hotspot-popover {
+		animation: none;
+	}
+}
+
 @media (prefers-color-scheme: dark) {
 	.viewer[data-theme='system'] {
 		--vctrl-bg: #141414;

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -68,7 +68,21 @@
 	--vctrl-bg: #141414;
 	--vctrl-hover-bg: #363636;
 	--vctrl-active-bg: #585858;
-	--vctrl-text: #959595;
+	/*
+	  The same #e5e7eb the border below is built from, at full strength.
+
+	  It was #959595, which is dimmer than the host design system's *muted*
+	  foreground and was carrying primary text: 6.2:1 for a title and 5.2:1 for
+	  body at the 90% opacity the surfaces use. Both clear AA, but that floor
+	  assumes ordinary body copy and the smallest of these is 11px. Light mode
+	  ran at 13.3:1 and 10.0:1 for the same roles, so dark was at roughly half
+	  the contrast of its own counterpart - which is the part that reads as
+	  wrong rather than the absolute number.
+
+	  This lands at 14.9:1 and 12.2:1. The value is not new to the palette,
+	  which is why it was picked over a shade tuned to mirror light exactly.
+	*/
+	--vctrl-text: #e5e7eb;
 	--vctrl-border: rgba(229, 231, 235, 0.5);
 }
 
@@ -287,7 +301,8 @@
 		--vctrl-bg: #141414;
 		--vctrl-hover-bg: #363636;
 		--vctrl-active-bg: #585858;
-		--vctrl-text: #959595;
+		/* Kept in step with the explicit dark block above, deliberately. */
+		--vctrl-text: #e5e7eb;
 		--vctrl-border: rgba(229, 231, 235, 0.5);
 	}
 }

--- a/packages/viewer/src/types/viewer-interactions.ts
+++ b/packages/viewer/src/types/viewer-interactions.ts
@@ -32,6 +32,20 @@ export interface SetControlsOptionsViewerCommand {
 	pan?: boolean
 }
 
+/**
+ * Command that focuses a single hotspot: reveals whatever it has to say and
+ * flies its linked camera, exactly as clicking the marker would.
+ *
+ * For a host driving its own navigation from the hotspot descriptors in the
+ * handshake. Naming a hotspot that is not drawn - one the author hid or kept
+ * internal - does nothing, so a stale host list cannot reach a marker a
+ * visitor is not allowed to see.
+ */
+export interface FocusHotspotViewerCommand {
+	type: 'focus_hotspot'
+	hotspotId: string
+}
+
 /** Command that plays the animation program from the beginning. */
 export interface RestartAnimationViewerCommand {
 	type: 'restart_animation'
@@ -59,6 +73,7 @@ export interface SetAnimationPlayingViewerCommand {
 /** Minimal imperative command surface currently supported by the viewer runtime. */
 export type ViewerCommand =
 	| ActivateCameraViewerCommand
+	| FocusHotspotViewerCommand
 	| RestartAnimationViewerCommand
 	| SeekAnimationClipViewerCommand
 	| SetAnimationPlayingViewerCommand
@@ -89,6 +104,23 @@ export interface CameraChangedInteractionEvent {
 	cameraId: string
 }
 
+/**
+ * Emitted when a visitor activates a hotspot.
+ *
+ * The host already sees `camera_changed` when a marker flies its camera, but
+ * not which marker caused it - and a marker that only reveals content moves no
+ * camera at all, so nothing reached the host for it. `cameraId` is null for
+ * exactly that case.
+ *
+ * Never emitted for a selection: that is an editing surface picking a marker
+ * up, not a visitor doing anything with it.
+ */
+export interface HotspotActivatedInteractionEvent {
+	type: 'hotspot_activated'
+	hotspotId: string
+	cameraId: null | string
+}
+
 /** Emitted when auto-rotate state changes at runtime. */
 export interface AutoRotateChangedInteractionEvent {
 	type: 'auto_rotate_changed'
@@ -117,6 +149,7 @@ export type ViewerInteractionEvent =
 	| AnimationStateChangedInteractionEvent
 	| AutoRotateChangedInteractionEvent
 	| CameraChangedInteractionEvent
+	| HotspotActivatedInteractionEvent
 	| InitialFramingCompletedInteractionEvent
 	| ModelLoadedInteractionEvent
 	| ViewerReadyInteractionEvent

--- a/packages/viewer/src/vectreal-viewer.stories.tsx
+++ b/packages/viewer/src/vectreal-viewer.stories.tsx
@@ -253,6 +253,42 @@ const occlusionHotspots: StoryHotspot[] = [
 	}
 ]
 
+/**
+ * Content, and the three shapes it comes in. Click a marker to open its card.
+ *
+ * The last two are the rules worth looking at rather than decoration: a marker
+ * near the top of the frame flips its card below instead of drawing it off the
+ * canvas, and a marker whose only content is a link the renderer refuses stays
+ * inert rather than becoming a button that opens an empty card.
+ */
+const contentHotspots: StoryHotspot[] = [
+	{
+		...base('body-only', 'Body only', [-0.75, 0.15, 0.7]),
+		body: 'Cast in one piece, then machined flat so the two halves meet without a shim.'
+	},
+	{
+		...base('link-only', 'Link only', [-0.2, 0.15, 0.7]),
+		linkUrl: 'https://docs.vectreal.com/packages/viewer'
+	},
+	{
+		...base('both', 'Body and link', [0.35, 0.15, 0.7]),
+		sequenceIndex: 0,
+		body: 'The same joint, seen from the other side.',
+		linkUrl: 'https://docs.vectreal.com/packages/viewer'
+	},
+	{
+		// High enough that the card cannot fit above it.
+		...base('near-top', 'Near the top edge', [0.9, 0.95, 0.7]),
+		body: 'Its card flips below, because there is no room for it above.'
+	},
+	{
+		// Refused by `resolveHotspotLink`, so this marker reveals nothing and
+		// stays a plain label.
+		...base('unsafe-link', 'Link the renderer refuses', [-1.2, 0.15, 0.7]),
+		linkUrl: 'javascript:alert(1)'
+	}
+]
+
 const hotspotRender: Story['render'] = (args) => (
 	<VectrealViewer {...args}>
 		<ambientLight intensity={0.8} />
@@ -333,6 +369,24 @@ export const HotspotSelection: Story = {
 		showHiddenHotspots: true,
 		selectedHotspotId: 'step-2',
 		onHotspotSelect: () => {}
+	},
+	render: hotspotRender
+}
+
+/**
+ * A marker with something to say opens a card anchored to it.
+ *
+ * Non-modal on purpose: the card does not trap focus and does not stop the
+ * orbit, so a visitor can keep turning the model while reading it and tab
+ * straight on to the next marker. Escape closes it and puts focus back on the
+ * marker it came from.
+ *
+ * A marker carrying content *and* a linked camera does both on one click. None
+ * of these names a camera, so what is on show here is the card alone.
+ */
+export const HotspotContent: Story = {
+	args: {
+		hotspots: contentHotspots
 	},
 	render: hotspotRender
 }

--- a/packages/viewer/src/vectreal-viewer.stories.tsx
+++ b/packages/viewer/src/vectreal-viewer.stories.tsx
@@ -268,13 +268,13 @@ const contentHotspots: StoryHotspot[] = [
 	},
 	{
 		...base('link-only', 'Link only', [-0.2, 0.15, 0.7]),
-		linkUrl: 'https://docs.vectreal.com/packages/viewer'
+		linkUrl: 'https://vectreal.com/docs/packages/viewer'
 	},
 	{
 		...base('both', 'Body and link', [0.35, 0.15, 0.7]),
 		sequenceIndex: 0,
 		body: 'The same joint, seen from the other side.',
-		linkUrl: 'https://docs.vectreal.com/packages/viewer'
+		linkUrl: 'https://vectreal.com/docs/packages/viewer'
 	},
 	{
 		// High enough that the card cannot fit above it.

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -195,6 +195,24 @@ export interface VectrealViewerProps extends PropsWithChildren {
 	 * default pale fill.
 	 */
 	hotspotColor?: string
+	/**
+	 * Whether the hotspot markers are drawn at all. Default true.
+	 *
+	 * For a host page that navigates the scene itself, from the hotspots the
+	 * embed handshake reports. The hotspots stay resolved either way, so
+	 * `focus_hotspot` still flies a camera by id with nothing drawn on the
+	 * model - which is the combination that host needs, and which suppressing
+	 * them by passing no `hotspots` would not give.
+	 */
+	showHotspotMarkers?: boolean
+	/**
+	 * Whether a marker opens a card of its own. Default true.
+	 *
+	 * False still activates: the camera flies and `hotspot_activated` is
+	 * emitted, so a host drawing its own panel gets the event without the viewer
+	 * drawing a second copy of the same text over the model.
+	 */
+	revealHotspotContent?: boolean
 
 	// --- Editor affordances ---
 	// Editing-surface features (e.g. the publisher). Public/embedded viewers omit
@@ -377,6 +395,8 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		normalizationOptions,
 		hotspots,
 		hotspotColor,
+		showHotspotMarkers,
+		revealHotspotContent,
 		// Editor affordances
 		shadowLightEditable,
 		showInternalHotspots = false,
@@ -426,6 +446,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		CameraProps['sceneTransition'] | null
 	>(null)
 	const cameraCommandExecutorRef = useRef<null | ViewerCommandExecutor>(null)
+	const hotspotCommandExecutorRef = useRef<null | ViewerCommandExecutor>(null)
 	const animation = useAnimationRuntime({
 		animations,
 		options: animationOptions,
@@ -453,6 +474,9 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 			switch (command.type) {
 				case 'activate_camera':
 					cameraCommandExecutorRef.current?.execute(command)
+					break
+				case 'focus_hotspot':
+					hotspotCommandExecutorRef.current?.execute(command)
 					break
 				case 'set_controls_enabled':
 					setControlsEnabledOverride(command.enabled)
@@ -548,6 +572,20 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 			executeViewerCommand({ type: 'activate_camera', cameraId })
 		},
 		[executeViewerCommand]
+	)
+
+	const handleHotspotActivated = useCallback(
+		(hotspotId: string, cameraId: string | null) => {
+			onInteractionEvent?.({ type: 'hotspot_activated', hotspotId, cameraId })
+		},
+		[onInteractionEvent]
+	)
+
+	const handleSceneHotspotsExecutorReady = useCallback(
+		(executor: null | ViewerCommandExecutor) => {
+			hotspotCommandExecutorRef.current = executor
+		},
+		[]
 	)
 
 	const handleSceneCameraExecutorReady = useCallback(
@@ -695,9 +733,13 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									includeInternal={showInternalHotspots}
 									includeHidden={showHiddenHotspots}
 									color={hotspotColor}
+									showMarkers={showHotspotMarkers}
+									revealContent={revealHotspotContent}
 									selectedId={selectedHotspotId}
 									onActivateCamera={handleActivateHotspotCamera}
 									onSelect={onHotspotSelect}
+									onHotspotActivated={handleHotspotActivated}
+									onCommandExecutorReady={handleSceneHotspotsExecutorReady}
 									onPositionSetterReady={onHotspotPositionSetterReady}
 								/>
 								{children}


### PR DESCRIPTION
## Root cause

A hotspot could carry a name and rendering metadata and nothing else, so the only thing it could ever do was fly a camera. The gap runs the length of the feature — type, schema, parser, repository, dirty-check, publisher, viewer, embed protocol — and closing it in one place would have left every other layer with nothing to carry.

## What a hotspot can now do

Carry a **body** and an optional **link**, authored in the publisher, drawn by the viewer as a card anchored to the marker, and reported to an embedding page that wants to draw its own.

## Two columns, not three

The card heads with the existing `name`, so the hover label, the accessible name and the heading cannot drift apart, and there is no second field to validate. The link shows its own URL's host for the same reason — a label cannot go stale against where it points.

## The link rule exists twice, deliberately

`isAllowedHotspotLinkUrl` on the save path and `resolveHotspotLink` on the render path — the arrangement `internalOnly` already has. The viewer ships to npm and a consumer can hand it any settings object at all, so the storage gate cannot be the only one.

Both gate on the `https://` **prefix**, not the parsed protocol: `new URL('https:evil')` reports protocol `https:` with no authority at all, so a rule written the obvious way accepts something that is not an absolute https URL.

`payloadUrl` keeps its preset-gated check, because rows written before that rule exist and would otherwise become unsaveable. `link_url` is a new column — nothing stored can fail it, and there is nothing to grandfather.

## Four guards against enumerations that drift

Four hand-maintained lists of the hotspot/protocol shape exist, and two had already dropped a field silently before anyone noticed. Rather than patch each one again, each guard now reads the union out of the source, so it covers the *next* member added:

| Guard | The failure it has no other symptom for |
| --- | --- |
| `sameHotspot` vs `HotspotDefinition` | An author edits a field and Save stays disabled — the edit reads as refused |
| `replaceHotspots` insert vs `set` | Writes on the save that creates a hotspot, silently no-ops on every save after |
| SDK `handleViewerEvent` vs the event union | The message crosses the iframe, parses, hits a switch with no case and no default |
| `isViewerCommand` vs the command union | Exactly the silent drop that file's own comment warns about |

## Rendering

Every decision lives in `resolve-hotspot-popover.ts`, a pure module — this package's runner loads only `.ts` under `environment: 'node'`, so anything left inside the component could not be covered at all. `hotspot-popover-wiring.spec.ts` pins the calls the components make, and says plainly it can tell a mounted card from an unmounted one and nothing more.

Placement flips below near the top edge and shifts sideways to stay on the canvas; when the card fits on neither side the roomier one wins, rather than a default that guarantees a clipped card. Measured in canvas coordinates, so an embedded viewer inside a scrolled host page places the same as a full-page one.

**The hover label has the same defect and is deliberately left alone.** It can now reuse that function, but fixing it would change what every published scene looks like on hover — its own change.

Non-modal: no focus trap, no scroll lock, so a visitor can keep orbiting and tab on to the next marker. Escape closes and returns focus to the marker. An open card closes when its marker goes behind the model, which is otherwise the one state with no way to dismiss it.

**The whole marker moves into the free 41–99 z-index band while open, not just the card.** drei writes a depth-derived z-index onto the wrapper div, making it a stacking context, so a card inside it cannot paint over a nearer marker however high its own z-index is.

## Keyboard

`focusable` no longer tracks whether the marker is a button. A marker with nothing to activate still carries a name, and hover was the only way to read it — so on a phone, a scene carrying no cameras was a row of dots with no way to find out what any of them meant. `tabIndex={0}` on the `role="img"` branch, not a promotion to button: pressing it does nothing, and a button says otherwise.

## The embed surface

`hotspot_activated`, an optional `hotspots` array on the handshake, a `focus_hotspot` command with `VectrealEmbed.focusHotspot` to match, and three URL parameters (`?hotspots`, `?hotspotContent`, `?hotspotColor`).

**Descriptors are built through `resolveHotspotMarkers` with its default options** — the same filter the renderer uses — so internal and hidden markers cannot reach a parent page. Load-bearing, not redundant: `redactSettingsForEmbed` runs only in `buildEmbedSceneManifest` and `/preview` never reaches it, so on that route this filter is the only thing between an internal marker's name and whichever origin pinged the frame. The wider `/preview` exposure (no `frame-ancestors`, first-origin trust) predates hotspots and is filed separately.

`?hotspots=0` leaves them resolved but undrawn, so `focus_hotspot` still flies a camera and the handshake still lists them — which passing no `hotspots` at all would not give. `?hotspotColor` takes a hex literal only: the value lands in an inline style, and arbitrary CSS there would let a query string close the declaration and write into the page.

The `pong` field is optional where `cameras` is required, because the iframe and the SDK are separately deployed and can be versions apart.

## Docs

The embed guide and `@vctrl/embed`'s README carried near-identical method and event tables, and **both were already stale in the same three places** — which is the drift cost of keeping two copies. The guide is now the single reference and the README points at it. Also added: the hotspot props to both viewer references, `SceneHotspots` to the components tables, and five new `claims` lines the CI suite executes.

## Mutations

Twenty-six run across the diff, each going red for the stated reason. Two could not fail, and both found real problems rather than test gaps:

- `readFlag` carried a per-option fallback while both options default to on — dead generality, so the mutation was behaviourally identical. Removed.
- A test asserted `https:///docs` has no host. WHATWG normalizes it to host `docs`, so the branch I had written for it was unreachable. Branch deleted, test premise corrected.

## Verification

- `npx vitest run --root .` — 159 files, **2117 tests**, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vctrl/embed,vectreal-platform` — 10/10 tasks green
- `prettier --check` on every changed file — clean
- New Storybook story `HotspotContent`: body-only, link-only, both, the near-top-edge flip, and a marker whose link the renderer refuses

**Not verified locally:** the integration suite covering the update-in-place upsert. The local Supabase data volume predates an OS collation bump, so the storage container never becomes healthy and `supabase-start` exits 0 without a database. Those cases run in CI against its own Postgres, and `hotspot-upsert-wiring.spec.ts` is the unit-runnable stand-in for the same defect.

## Filed rather than fixed

- The `/preview` exposure: unredacted manifest, no `frame-ancestors`, and a bridge that replies to the first origin to message it. Predates hotspots, already exposes camera names.
- `seek_animation_clip` has no `VectrealEmbed` method — accepted by the guard and executable, unreachable from the SDK class.
- The hover label's placement, named above.