### PR TITLE
fix(viewer): make the publisher canvas tell the truth about a marker

### DIFF
--- a/packages/viewer/src/components/scene/hotspot-canvas-cues.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-canvas-cues.spec.ts
@@ -35,6 +35,14 @@ const styles = readFileSync(
 )
 
 describe('a backstage marker is drawn as one', () => {
+	const internalRule = styles
+		.split('.vctrl-viewer-hotspot[data-internal] .vctrl-hotspot-body::after')[1]
+		?.split('}')[0]
+
+	it('found the rule to read', () => {
+		expect(internalRule).toBeTruthy()
+	})
+
 	it('marks the root with what the resolver worked out', () => {
 		expect(marker).toContain('data-internal={marker.internal || undefined}')
 	})
@@ -47,22 +55,32 @@ describe('a backstage marker is drawn as one', () => {
 		// `hotspotColor` writes the fill as an inline style on the root, and an
 		// inline declaration beats any stylesheet rule for the same property, so
 		// a fill-based cue would vanish on a branded viewer.
-		const rule = styles
-			.split('.vctrl-viewer-hotspot[data-internal]')[1]
-			?.split('}')[0]
+		//
+		// The full declaration, not the word `border`: `border-radius` contains
+		// it, so a rule reduced to `border: 0` or to nothing but a radius passed
+		// while drawing no ring at all.
+		expect(internalRule).toContain('border: 1px dashed')
+		expect(internalRule).toContain('var(--vctrl-hotspot-internal-ring)')
+		expect(internalRule).not.toContain('--vctrl-hotspot-fill')
+	})
 
-		expect(rule).toContain('border')
-		expect(rule).not.toContain('--vctrl-hotspot-fill')
+	it('generates the pseudo-element it draws on', () => {
+		// Without `content` the `::after` never exists, so every other
+		// declaration in the rule is inert.
+		expect(internalRule).toContain("content: ''")
 	})
 
 	it('stays distinct from the hidden cue, which desaturates', () => {
 		// A marker can be both at once, and the two facts have different
-		// remedies, so one treatment must not be the other.
+		// remedies, so one treatment must not be the other. Asserted on the
+		// INTERNAL rule: reading only the hidden one tested untouched CSS and
+		// passed even with the two cues made identical.
 		const hidden = styles
 			.split('.vctrl-viewer-hotspot[data-hidden] .vctrl-hotspot-body')[1]
 			?.split('}')[0]
 
 		expect(hidden).toContain('grayscale')
+		expect(internalRule).not.toContain('grayscale')
 	})
 })
 
@@ -73,6 +91,16 @@ describe('the marker you are standing at says so', () => {
 		expect(layer).toContain('marker.linkedCameraId === activeCameraId')
 	})
 
+	it('reads no camera as nobody being here, rather than everybody', () => {
+		// Without the guard, `activeCameraId` starts null, an unlinked marker's
+		// `linkedCameraId` is null, and `null === null` lights every one of them
+		// on load and whenever the scene camera is active - the exact opposite
+		// of the cue.
+		expect(layer).toContain(
+			'!!activeCameraId && marker.linkedCameraId === activeCameraId'
+		)
+	})
+
 	it('takes the camera from the event, not from the opening prop', () => {
 		// `cameraOptions.activeCameraId` is the opening request. A marker click,
 		// a host command and an interaction all move the camera without it.
@@ -80,9 +108,18 @@ describe('the marker you are standing at says so', () => {
 			.split('const handleInteractionEvent = useCallback')[1]
 			?.split('\t\t[onInteractionEvent]')[0]
 
+		// A real anchor check, not just truthiness: if the closing split stops
+		// matching, `handler` becomes the rest of the file and every assertion
+		// below passes on text from somewhere else entirely.
 		expect(handler).toBeTruthy()
-		expect(handler).toContain("event.type === 'camera_changed'")
-		expect(handler).toContain('setActiveCameraId(event.cameraId)')
+		expect((handler ?? '').length).toBeLessThan(600)
+
+		// The branch and its body together. `setActiveCameraId(event.cameraId)`
+		// appears in both branches, so asserting it alone let the
+		// `camera_changed` branch be gutted with the test still green.
+		expect(handler).toContain(
+			"if (event.type === 'camera_changed') {\n\t\t\t\tsetActiveCameraId(event.cameraId)"
+		)
 		// Still forwarded: intercepting it must not swallow it.
 		expect(handler).toContain('onInteractionEvent?.(event)')
 	})

--- a/packages/viewer/src/components/scene/hotspot-canvas-cues.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-canvas-cues.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * The three canvas cues, pinned by reading the source.
+ *
+ * Two of them - the backstage ring and the you-are-here ring - are CSS on a
+ * `data-*` attribute, and the third is a `pointerEvents` value. None can be
+ * rendered here: this package's runner loads only spec files ending in `.ts`,
+ * under `environment: 'node'`. What can go wrong without a test is the wiring,
+ * which type-checks perfectly while drawing nothing: an attribute set on the
+ * wrong element, a rule whose selector no longer matches it, or a prop
+ * computed and never passed.
+ *
+ * So this asserts that the attribute and the rule that reads it still agree.
+ * It cannot tell a good cue from an ugly one.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const marker = readFileSync(
+	join(import.meta.dirname, 'hotspot-marker.tsx'),
+	'utf8'
+)
+const layer = readFileSync(
+	join(import.meta.dirname, 'scene-hotspots.tsx'),
+	'utf8'
+)
+const viewer = readFileSync(
+	join(import.meta.dirname, '../../vectreal-viewer.tsx'),
+	'utf8'
+)
+const styles = readFileSync(
+	join(import.meta.dirname, '../../styles.css'),
+	'utf8'
+)
+
+describe('a backstage marker is drawn as one', () => {
+	it('marks the root with what the resolver worked out', () => {
+		expect(marker).toContain('data-internal={marker.internal || undefined}')
+	})
+
+	it('has a rule that reads that attribute', () => {
+		expect(styles).toContain('.vctrl-viewer-hotspot[data-internal]')
+	})
+
+	it('rings the marker rather than recolouring it', () => {
+		// `hotspotColor` writes the fill as an inline style on the root, and an
+		// inline declaration beats any stylesheet rule for the same property, so
+		// a fill-based cue would vanish on a branded viewer.
+		const rule = styles
+			.split('.vctrl-viewer-hotspot[data-internal]')[1]
+			?.split('}')[0]
+
+		expect(rule).toContain('border')
+		expect(rule).not.toContain('--vctrl-hotspot-fill')
+	})
+
+	it('stays distinct from the hidden cue, which desaturates', () => {
+		// A marker can be both at once, and the two facts have different
+		// remedies, so one treatment must not be the other.
+		const hidden = styles
+			.split('.vctrl-viewer-hotspot[data-hidden] .vctrl-hotspot-body')[1]
+			?.split('}')[0]
+
+		expect(hidden).toContain('grayscale')
+	})
+})
+
+describe('the marker you are standing at says so', () => {
+	it('compares the live camera, not the hotspot id', () => {
+		// A host activating the camera directly has to light the same marker up
+		// as a visitor clicking it.
+		expect(layer).toContain('marker.linkedCameraId === activeCameraId')
+	})
+
+	it('takes the camera from the event, not from the opening prop', () => {
+		// `cameraOptions.activeCameraId` is the opening request. A marker click,
+		// a host command and an interaction all move the camera without it.
+		const handler = viewer
+			.split('const handleInteractionEvent = useCallback')[1]
+			?.split('\t\t[onInteractionEvent]')[0]
+
+		expect(handler).toBeTruthy()
+		expect(handler).toContain("event.type === 'camera_changed'")
+		expect(handler).toContain('setActiveCameraId(event.cameraId)')
+		// Still forwarded: intercepting it must not swallow it.
+		expect(handler).toContain('onInteractionEvent?.(event)')
+	})
+
+	it('leaves exactly one way out to the host', () => {
+		/*
+		  The funnel exists so that everything the viewer needs to notice about
+		  an interaction is noticed in one place. A second call site puts one
+		  event class outside it, which is invisible until an event carrying
+		  state the funnel tracks takes the wrong path - `hotspot_activated` did
+		  exactly this, harmlessly, because it carries no camera state.
+
+		  Counted rather than located, so it catches a new emitter anywhere in
+		  the file rather than only a change to the one that exists.
+		*/
+		expect(viewer.split('onInteractionEvent?.(').length - 1).toBe(1)
+		expect(viewer).toContain('handleInteractionEvent({')
+	})
+
+	it('reaches the hotspot layer', () => {
+		expect(viewer).toContain('activeCameraId={activeCameraId}')
+		expect(marker).toContain('data-current={current || undefined}')
+		expect(styles).toContain('.vctrl-viewer-hotspot[data-current]')
+	})
+})

--- a/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.spec.ts
@@ -289,4 +289,50 @@ describe('resolveHotspotInteraction', () => {
 			expect(interaction.pointerEvents).toBe('none')
 		})
 	})
+
+	describe('yielding the hit box to an editing gizmo', () => {
+		/**
+		 * The publisher mounts a transform gizmo on the selected hotspot, and the
+		 * marker's own 24px hit box sits directly over the gizmo's centre handle.
+		 * The 24px floor is a deliberate touch target, so the marker gives the
+		 * pointer up rather than shrinking - the click it would have taken is a
+		 * re-selection of the marker already selected.
+		 */
+		it('takes no pointer while it is the selected marker', () => {
+			expect(
+				resolveHotspotInteraction(linked, {
+					occluded: false,
+					canActivate: true,
+					canSelect: true,
+					selected: true
+				}).pointerEvents
+			).toBe('none')
+		})
+
+		it('leaves every other marker live, which is what keeps this narrow', () => {
+			expect(
+				resolveHotspotInteraction(linked, {
+					occluded: false,
+					canActivate: true,
+					canSelect: true,
+					selected: false
+				}).pointerEvents
+			).toBe('auto')
+		})
+
+		it('changes nothing else about the marker', () => {
+			// Not disabled and not dropped from the tab order: it still announces
+			// itself the same way, and a keyboard still reaches it.
+			const selectedMarker = resolveHotspotInteraction(linked, {
+				occluded: false,
+				canActivate: true,
+				canSelect: true,
+				selected: true
+			})
+
+			expect(selectedMarker.role).toBe('button')
+			expect(selectedMarker.action).toBe('select')
+			expect(selectedMarker.focusable).toBe(true)
+		})
+	})
 })

--- a/packages/viewer/src/components/scene/hotspot-interaction.ts
+++ b/packages/viewer/src/components/scene/hotspot-interaction.ts
@@ -62,6 +62,20 @@ export interface HotspotInteraction {
 	 * `none` while occluded. A marker faded almost out of sight must not still
 	 * swallow a click: it would fly the camera somewhere from a target the
 	 * visitor cannot see, and it would pop a label for a marker behind the model.
+	 *
+	 * Also `none` for the marker an editing surface has selected. A surface that
+	 * draws a selection is a surface with an editing affordance at that exact
+	 * point - the publisher mounts a transform gizmo there - and the marker's
+	 * 24px hit box sits on top of the gizmo's centre handle. Shrinking the
+	 * marker is not the fix: 24px is a deliberate touch-target floor.
+	 *
+	 * Two things are given up, not one. The click, which for an already-selected
+	 * marker is only a re-selection. And the hover name: the pointer handlers
+	 * live on the marker root, which is itself `pointer-events-none` and hears
+	 * them only because they bubble up from the body this disables. That is
+	 * acceptable rather than free - the author has just clicked this marker, the
+	 * selection ring says which one it is, and the sidebar names it - and focus
+	 * still shows the label, so a keyboard user loses nothing at all.
 	 */
 	pointerEvents: 'auto' | 'none'
 }
@@ -73,9 +87,17 @@ export function resolveHotspotInteraction(
 		canActivate,
 		canSelect = false,
 		canReveal = false,
-		revealsInPlace = false
+		revealsInPlace = false,
+		selected = false
 	}: {
 		occluded: boolean
+		/**
+		 * Whether an editing surface has this marker picked out, which is also
+		 * where it mounts its gizmo. Only affects the hit box - the role, the
+		 * action and the focus stop are all unchanged, so the marker still
+		 * announces itself the same way and a keyboard can still reach it.
+		 */
+		selected?: boolean
 		/** Whether the viewer was given somewhere to send an activation. */
 		canActivate: boolean
 		/**
@@ -138,6 +160,6 @@ export function resolveHotspotInteraction(
 		// a marker with a name, and focus is what reveals that name where hover
 		// cannot - which is every keyboard, and every touch device.
 		focusable: !occluded,
-		pointerEvents: occluded ? 'none' : 'auto'
+		pointerEvents: occluded || selected ? 'none' : 'auto'
 	}
 }

--- a/packages/viewer/src/components/scene/hotspot-marker.tsx
+++ b/packages/viewer/src/components/scene/hotspot-marker.tsx
@@ -166,6 +166,14 @@ export interface HotspotMarkerProps {
 	occluded: boolean
 	/** Drawn as the one an editing surface has picked out. */
 	selected?: boolean
+	/**
+	 * Drawn as the marker whose linked camera the viewer is looking through.
+	 *
+	 * Derived from live camera state rather than from the stored hotspot, which
+	 * is why it arrives as a prop like `selected` rather than being resolved
+	 * alongside the fields that are persisted.
+	 */
+	current?: boolean
 	/** Overrides the marker fill. Any CSS colour; undefined keeps the default. */
 	color?: string
 	/** Runs when a hotspot carrying a `linkedCameraId` is activated. */
@@ -205,6 +213,7 @@ const HotspotMarker = ({
 	marker,
 	occluded,
 	selected = false,
+	current = false,
 	color,
 	onActivate,
 	onSelect,
@@ -289,7 +298,8 @@ const HotspotMarker = ({
 		// Having something to say makes it a button; whether this viewer draws
 		// the card decides only what it announces.
 		canReveal: !!content,
-		revealsInPlace: !!onReveal
+		revealsInPlace: !!onReveal,
+		selected
 	})
 
 	// A block body, not a concise one. React 19 treats a *function* returned from
@@ -474,6 +484,8 @@ const HotspotMarker = ({
 					style={colorStyle}
 					data-selected={selected || undefined}
 					data-hidden={marker.hidden || undefined}
+					data-internal={marker.internal || undefined}
+					data-current={current || undefined}
 					onPointerEnter={handlePointerEnter}
 					onPointerLeave={handlePointerLeave}
 					onKeyDown={handleKeyDown}

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.spec.ts
@@ -494,6 +494,40 @@ describe('resolveHotspotMarkers', () => {
 		})
 	})
 
+	describe('a marker the author kept backstage', () => {
+		/**
+		 * `internal` was computed and then dropped, so a backstage marker drew
+		 * identically to a shipping one and the canvas contradicted the sidebar
+		 * beside it - which is the one place the author could see the difference.
+		 */
+		it('says so, where an editing surface asked to see it', () => {
+			const [drawn] = resolveHotspotMarkers(
+				[hotspot({ id: 'a', internalOnly: true })],
+				{ includeInternal: true }
+			)
+
+			expect(drawn.internal).toBe(true)
+			// Not hidden. The two are different facts with different remedies.
+			expect(drawn.hidden).toBe(false)
+		})
+
+		it('carries both facts when a marker is internal and hidden at once', () => {
+			const [drawn] = resolveHotspotMarkers(
+				[hotspot({ id: 'a', internalOnly: true, visible: false })],
+				{ includeInternal: true, includeHidden: true }
+			)
+
+			expect(drawn.internal).toBe(true)
+			expect(drawn.hidden).toBe(true)
+		})
+
+		it('is false for a marker a visitor can see', () => {
+			expect(resolveHotspotMarkers([hotspot({ id: 'a' })])[0].internal).toBe(
+				false
+			)
+		})
+	})
+
 	it('does not mutate the settings it was given', () => {
 		const stored = [
 			hotspot({ id: 'b', sequenceIndex: 1 }),

--- a/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
+++ b/packages/viewer/src/components/scene/resolve-hotspot-markers.ts
@@ -41,11 +41,22 @@ export interface HotspotMarker {
 	 * author can find it and unhide it. Never true on a public surface, which
 	 * drops these entirely.
 	 *
-	 * Deliberately not set for `internalOnly`. That is a different fact with a
-	 * different remedy: a hidden hotspot is one the author switched off, an
-	 * internal one is one they meant to keep backstage.
+	 * Deliberately not set for `internalOnly`, which has `internal` of its own:
+	 * a hidden hotspot is one the author switched off, an internal one is one
+	 * they meant to keep backstage, and a marker can be both.
 	 */
 	hidden: boolean
+	/**
+	 * Kept backstage by the author, and drawn only where someone can bring it
+	 * forward - an editing surface asks with `includeInternal`. Never true on a
+	 * public surface, which drops these entirely.
+	 *
+	 * Separate from `hidden` because the two are different facts with different
+	 * remedies: a hidden hotspot is one the author switched off for everyone, an
+	 * internal one is one they meant to keep for themselves. A marker can be
+	 * both, and the canvas has to be able to say so.
+	 */
+	internal: boolean
 	/** Never `image` or `svg` without a `payloadUrl` to go with it. */
 	preset: HotspotStylePreset
 	payloadUrl: string | null
@@ -228,7 +239,7 @@ export function resolveHotspotMarkers(
 }
 
 function toMarker(
-	{ hotspot, id, position, hidden }: DrawableEntry,
+	{ hotspot, id, position, hidden, internal }: DrawableEntry,
 	step: number | null,
 	stepCount: number
 ): HotspotMarker {
@@ -245,6 +256,7 @@ function toMarker(
 		step,
 		stepCount,
 		hidden,
+		internal,
 		// Both payload presets fall back to the dot rather than rendering a broken
 		// image: `payloadUrl` is optional on the type, so an author can pick a
 		// preset and save before choosing the artwork.

--- a/packages/viewer/src/components/scene/scene-hotspots.tsx
+++ b/packages/viewer/src/components/scene/scene-hotspots.tsx
@@ -66,6 +66,12 @@ export interface SceneHotspotsProps {
 	revealContent?: boolean
 	/** The marker drawn as the current one. */
 	selectedId?: string | null
+	/**
+	 * The camera the viewer is looking through, so the hotspot that owns it can
+	 * say so. Null while the scene camera is active, which is every marker's
+	 * "not here".
+	 */
+	activeCameraId?: string | null
 	onActivateCamera?: (cameraId: string) => void
 	onSelect?: (id: string) => void
 	/**
@@ -107,6 +113,7 @@ const SceneHotspots = ({
 	showMarkers = true,
 	revealContent = true,
 	selectedId,
+	activeCameraId,
 	onActivateCamera,
 	onSelect,
 	onHotspotActivated,
@@ -478,6 +485,13 @@ const SceneHotspots = ({
 					marker={marker}
 					occluded={occludedIds.has(marker.id)}
 					selected={marker.id === selectedId}
+					/*
+					  Compared rather than matched by hotspot id, because the camera
+					  is what the viewer is actually looking through: a marker whose
+					  camera a host activated directly lights up the same way one
+					  the visitor clicked does.
+					*/
+					current={!!activeCameraId && marker.linkedCameraId === activeCameraId}
 					color={color}
 					onActivate={onActivateCamera}
 					onSelect={onSelect}

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -60,6 +60,14 @@
 	  behind the model has to be able to say both things at once.
 	*/
 	--vctrl-hotspot-hidden-fill: #a1a1aa;
+	/*
+	  A hotspot the author is keeping backstage, drawn only where they can bring
+	  it forward. Distinct from hidden, because the two facts have different
+	  remedies and a marker can carry both at once: hidden desaturates the
+	  marker, internal rings it. So the ring has to read against the grey fill a
+	  hidden marker takes as well as against the white one.
+	*/
+	--vctrl-hotspot-internal-ring: #6366f1;
 
 	font-family: 'DM Sans Variable', sans-serif;
 }
@@ -294,6 +302,47 @@
 	.vctrl-hotspot-popover {
 		animation: none;
 	}
+}
+
+/*
+  A hotspot the author is keeping backstage.
+
+  A dashed ring outside the marker rather than a colour change, for the same
+  reason the selection is a ring: `hotspotColor` writes the fill as an inline
+  style on the marker root, which beats any stylesheet rule for the same
+  property, so a fill-based cue would vanish on a branded viewer. Dashed, and
+  the hidden cue desaturates, so the two read as different states and a marker
+  that is both shows both.
+
+  Drawn on a pseudo-element rather than as a `box-shadow` on the body, because
+  the body already spends both of its shadow slots on the selection ring and
+  the two states co-occur constantly - the author selects the internal marker
+  in order to change it.
+*/
+.vctrl-viewer-hotspot[data-internal] .vctrl-hotspot-body::after {
+	content: '';
+	position: absolute;
+	inset: -3px;
+	border: 1px dashed var(--vctrl-hotspot-internal-ring);
+	border-radius: 9999px;
+	pointer-events: none;
+}
+
+/*
+  The hotspot whose camera the viewer is looking through: you are standing at
+  this one.
+
+  The resting pulse, held still and opaque, rather than a fourth ring. The
+  animation already draws the eye to every marker equally; stopping it on one
+  is the cheapest way to say "this one", it cannot collide with the selection
+  ring or the internal ring, and it needs no colour of its own - the element
+  already inherits `--vctrl-hotspot-fill`, so it follows a branded viewer.
+*/
+.vctrl-viewer-hotspot[data-current] .vctrl-hotspot-pulse {
+	animation: none;
+	transform: scale(1.5);
+	opacity: 0.9;
+	border-width: 2px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/packages/viewer/src/vectreal-viewer.tsx
+++ b/packages/viewer/src/vectreal-viewer.tsx
@@ -567,6 +567,29 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 		[cameraOptions?.cameras, hotspots]
 	)
 
+	/**
+	 * Which camera the viewer is looking through, so the hotspot that owns it
+	 * can draw itself as the one you are standing at.
+	 *
+	 * Taken from the event the camera layer already emits rather than from
+	 * `cameraOptions.activeCameraId`, because that prop is the opening request,
+	 * not the running state - a marker click, a host command and an interaction
+	 * all move the camera without touching it.
+	 */
+	const [activeCameraId, setActiveCameraId] = useState<null | string>(null)
+
+	const handleInteractionEvent = useCallback(
+		(event: ViewerInteractionEvent) => {
+			if (event.type === 'camera_changed') {
+				setActiveCameraId(event.cameraId)
+			} else if (event.type === 'initial_framing_completed') {
+				setActiveCameraId(event.cameraId)
+			}
+			onInteractionEvent?.(event)
+		},
+		[onInteractionEvent]
+	)
+
 	const handleActivateHotspotCamera = useCallback(
 		(cameraId: string) => {
 			executeViewerCommand({ type: 'activate_camera', cameraId })
@@ -576,9 +599,19 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 
 	const handleHotspotActivated = useCallback(
 		(hotspotId: string, cameraId: string | null) => {
-			onInteractionEvent?.({ type: 'hotspot_activated', hotspotId, cameraId })
+			// Through the funnel, not straight out to the prop. Everything the
+			// viewer needs to notice about an interaction is noticed in one place -
+			// `activeCameraId` is tracked there today - and a second path out
+			// would be the shape that reintroduces the split this replaced.
+			// Harmless for this event, which carries no camera state; the next
+			// event added is the one that would pick the wrong path.
+			handleInteractionEvent({
+				type: 'hotspot_activated',
+				hotspotId,
+				cameraId
+			})
 		},
-		[onInteractionEvent]
+		[handleInteractionEvent]
 	)
 
 	const handleSceneHotspotsExecutorReady = useCallback(
@@ -691,7 +724,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									onCameraSnapshotCaptureReady={onCameraSnapshotCaptureReady}
 									onCommandExecutorReady={handleSceneCameraExecutorReady}
 									onInitialFramingComplete={handleInitialFramingComplete}
-									onInteractionEvent={onInteractionEvent}
+									onInteractionEvent={handleInteractionEvent}
 								/>
 								{model && animations && animation.shouldMount && (
 									<SceneAnimation
@@ -699,7 +732,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 										animations={animations}
 										options={animationOptions}
 										onCommandExecutorReady={animation.registerExecutor}
-										onInteractionEvent={onInteractionEvent}
+										onInteractionEvent={handleInteractionEvent}
 										onPlaybackStatusChange={animation.setStatus}
 									/>
 								)}
@@ -736,6 +769,7 @@ const VectrealViewer = memo(({ model, ...props }: VectrealViewerProps) => {
 									showMarkers={showHotspotMarkers}
 									revealContent={revealHotspotContent}
 									selectedId={selectedHotspotId}
+									activeCameraId={activeCameraId}
 									onActivateCamera={handleActivateHotspotCamera}
 									onSelect={onHotspotSelect}
 									onHotspotActivated={handleHotspotActivated}


### PR DESCRIPTION
## Root causes

Three fixes to the same surface, sharing `hotspot-marker.tsx`, `scene-hotspots.tsx` and `styles.css`. Splitting them would have meant a stack for no gain.

### A backstage marker drew like a shipping one

`resolve-hotspot-markers.ts` computed `internal` and then dropped it on the way into the marker, so a hotspot the author was keeping backstage was indistinguishable on the canvas from one that ships — while the sidebar beside it said otherwise.

**A dashed ring, not a colour change.** `hotspotColor` writes the fill as an inline style on the marker root, and an inline declaration beats any stylesheet rule for the same property, so a fill-based cue would vanish on a branded viewer — the same reason the selection is a ring. It also stays distinct from the hidden cue, which desaturates: a marker can be both at once, and the two facts have different remedies.

### Nothing said which viewpoint you were standing at

The single-renderer change dropped the you-are-here cue on purpose and nothing replaced it, so a scene of eight hotspot cameras gave no indication of which one was live.

**The resting pulse, held still and opaque, rather than a fourth ring.** The animation already draws the eye to every marker equally, so stopping it on one is the cheapest way to say "this one"; it cannot collide with the selection or backstage rings, and it inherits the fill so it follows a branded viewer.

Matched on the **camera**, not the hotspot id, so a host activating a camera directly lights the same marker up as a visitor clicking it. The camera comes from the `camera_changed` event the camera layer already emits, not from `cameraOptions.activeCameraId` — that prop is the opening request, and a marker click, a host command and an interaction all move the camera without touching it.

**This changes what every published scene looks like**, not only the publisher, which is why it is called out rather than folded in quietly.

### The selected marker swallowed clicks meant for its gizmo

With the hotspot tool open every marker is a live 24px target, and the selected one sits directly over the transform gizmo's centre octahedron and plane handles.

The 24px floor is a deliberate touch target, so the marker gives the pointer up rather than shrinking. The click it would have taken is a re-selection of the marker already selected, so nothing is lost. Narrow by construction: only the selected marker, and only its hit box — role, action and focus stop are unchanged, so it still announces itself the same way and a keyboard still reaches it.

## Mutations run

| Mutation | Result |
| --- | --- |
| Hardcode `internal: false` in `toMarker` | 2 failed |
| Hardcode `current={false}` | 1 failed |
| Drop the `selected` clause from the hit-box rule | 1 failed (the unselected case stayed green, which is what proves it narrow) |
| Swallow the intercepted event instead of forwarding it | 1 failed |
| Recolour the backstage marker instead of ringing it | 1 failed |

## Verification

- `npx vitest run --root .` — 154 files, 1964 tests, green
- `pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vctrl/embed,vectreal-platform` — 10/10 tasks green
- `prettier --check` on every changed file — clean

`hotspot-canvas-cues.spec.ts` pins the wiring rather than the appearance: this package's runner cannot render a component, and what goes wrong silently here is an attribute set on the wrong element or a selector that no longer matches it. It says so in its own docblock.

## Relationship to #831

Independent, and also based on `main`. Both touch `resolve-hotspot-markers.ts`, `hotspot-marker.tsx` and `styles.css`, so whichever merges second wants a rebase; neither blocks the other.

---

## Rebased onto `main` after #831

The two changed the same six files, and the conflicts were not the kind a
resolution tool settles: taking either side whole silently reverts the other.
Three decisions worth seeing, since a rebased diff hides them.

**`resolveHotspotInteraction` keeps both models.** #831 replaced `toggles`
with `announces`, added `revealsInPlace`, and widened `focusable` from
`isButton && !occluded` to `!occluded` so a marker with nothing to activate is
still reachable by keyboard for its name. This branch adds `selected` to
`pointerEvents`. Taking this branch's version wholesale - the obvious
resolution - would have reverted all three of #831's changes with nothing
failing. Four mutations now cover it: two that drop #831's contributions, one
that drops this branch's, and one that unpicks the funnel below.

**One way out to the host.** This branch introduced `handleInteractionEvent`
as the single funnel so `activeCameraId` could be tracked in one place. #831
added `handleHotspotActivated`, which called `onInteractionEvent` directly.
Merged, the viewer had two paths to the same prop - harmless for that event,
which carries no camera state, and exactly the shape that reintroduces the
split the funnel replaced. Hotspot activation routes through the funnel now,
and a guard counts the call sites rather than locating them, so a new emitter
anywhere in the file fails.

**A comment that was wrong.** `pointerEvents: 'none'` for a selected marker
also disables its hover name: the pointer handlers sit on the marker root,
which is itself `pointer-events-none` and hears them only by bubbling from the
body this disables. The comment claimed the only thing given up was a
re-selection. It now names both, and says why the trade is acceptable - the
author has just clicked the marker, the ring and the sidebar both identify it,
and focus still shows the label, so a keyboard user loses nothing.
