### PR TITLE
fix(billing): let a publish-limit refusal reach the client

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/billing/entitlement-required-error.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/entitlement-required-error.ts
@@ -16,8 +16,10 @@ import type {
  *
  * `billingState` is carried because the answer differs. An entitlement withheld
  * by the plan is a 403 and an upgrade; the same entitlement withheld because
- * billing went read-only is a 402 and a payment. `publishScene` makes exactly
- * that distinction inline, having no error type to throw.
+ * billing went read-only is a 402 and a payment. `publishScene` still makes
+ * that distinction inline and returns the response itself. That is a free
+ * choice rather than a constraint - the route maps this error to the same two
+ * responses, byte for byte - so either shape is correct there.
  */
 export class EntitlementRequiredError extends Error {
 	readonly entitlementKey: EntitlementKey
@@ -44,10 +46,11 @@ export class EntitlementRequiredError extends Error {
 /**
  * The domain errors the scene route knows how to turn into a response.
  *
- * The three upload operations each wrap their body in a catch that flattens
- * everything to `ApiResponse.serverError`. Adding a second `instanceof` to each
- * of them for every new error type is how that catch quietly starts swallowing
- * the next one, so the question is asked once, here.
+ * Seven operations in `scene-settings.operations.server.ts` wrap their body in
+ * a catch that flattens everything to `ApiResponse.serverError`; the four that
+ * can refuse ask this first. Adding a second `instanceof` to each of them for
+ * every new error type is how that catch quietly starts swallowing the next
+ * one, so the question is asked once, here.
  */
 export function isRoutableDomainError(
 	error: unknown

--- a/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
+++ b/apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts
@@ -859,6 +859,27 @@ export async function publishScene(
 
 		return ApiResponse.success({ ...result, sceneId, stats })
 	} catch (error) {
+		/*
+		  As in the three upload operations above, and for the reason recorded on
+		  `isRoutableDomainError`. Two things are specific to this one.
+
+		  The rethrow goes above `reportServerError`, because an organization
+		  reaching its concurrent-publish limit is the guard working: reporting it
+		  would file one exception per refusal. Untagged, at that - this call site
+		  passes no `request`, so `on_critical_path` would be false and no alert
+		  would fire on it either way.
+
+		  And this is the only one of the four reached through
+		  `runWithIdempotentSceneRequest`, which awaits its operation unguarded and
+		  so cannot record the outcome of a throw. The reservation is left
+		  `pending` rather than moved to `failed`. Nothing user-facing turns on it
+		  - both states answer a same-key retry with the same 409, and the client
+		  mints a fresh request id per attempt - so it is filed rather than fixed
+		  here, in the route file this change does not otherwise touch.
+		*/
+		if (isRoutableDomainError(error)) {
+			throw error
+		}
 		reportServerError(error, {
 			properties: { sceneId: request.sceneId || null }
 		})

--- a/apps/vectreal-platform/tests/integration/plan-quota-enforcement.integration.spec.ts
+++ b/apps/vectreal-platform/tests/integration/plan-quota-enforcement.integration.spec.ts
@@ -25,6 +25,8 @@ import { randomUUID } from 'node:crypto'
 import { and, count, eq, inArray, isNull } from 'drizzle-orm'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
+import { QuotaExceededError } from '../../app/lib/domain/billing/quota-exceeded-error'
+
 type Schema = typeof import('../../app/db/schema')
 type ProjectRepo =
 	typeof import('../../app/lib/domain/project/project-repository.server')
@@ -408,5 +410,168 @@ describe('plan limits refuse at the boundary', () => {
 			ownerId
 		)
 		expect(prepared.sceneId).toBeTruthy()
+	})
+
+	/*
+	  `scenes_published_concurrent` is the odd one out in this file. It already
+	  counted rows before the migration off `checkQuota`, and it had no coverage
+	  anywhere - so nothing recorded that its refusal never reached the client.
+	  `publishScene` caught its own `QuotaExceededError` and returned
+	  `ApiResponse.serverError`: a 500 carrying the message and none of the
+	  machine-readable half, so no limit, no plan, no upgrade target, no modal.
+
+	  Hence `rejects` rather than an assertion about a returned `Response`, and
+	  `rejects` specifically rather than settling both paths into one value. The
+	  route's catch is what turns this into a quota response and it can only do
+	  that for an error that leaves the operation, so a test that accepts a
+	  *returned* `QuotaExceededError` would pass while the client stayed broken.
+	*/
+
+	/**
+	 * The GLB every published row in these tests points at. Created per test
+	 * rather than in `beforeEach`, so the tests above keep the fixture they were
+	 * written against.
+	 */
+	const makePublishedAsset = async () => {
+		const assetId = randomUUID()
+		await db.insert(schema.assets).values({
+			id: assetId,
+			folderId,
+			name: 'published.glb',
+			type: 'model',
+			filePath: `quota/${assetId}/published.glb`,
+			ownerId
+		})
+		return assetId
+	}
+
+	/** `howMany` already-published scenes, all pointing at the one asset. */
+	const publishScenes = async (
+		howMany: number,
+		assetId: string,
+		intoProject = projectId
+	) => {
+		for (let i = 0; i < howMany; i += 1) {
+			const publishedSceneId = randomUUID()
+			await db.insert(schema.scenes).values({
+				id: publishedSceneId,
+				projectId: intoProject,
+				folderId: null,
+				name: `published ${i}`
+			})
+			await db.insert(schema.scenePublished).values({
+				sceneId: publishedSceneId,
+				assetId,
+				publishedBy: ownerId
+			})
+		}
+	}
+
+	/** The scene a test then tries to publish, plus the asset it would publish. */
+	const sceneAwaitingPublish = async (intoProject = projectId) => {
+		const sceneId = randomUUID()
+		await db.insert(schema.scenes).values({
+			id: sceneId,
+			projectId: intoProject,
+			folderId: null,
+			name: 'wants publishing'
+		})
+		return sceneId
+	}
+
+	const attemptPublish = (sceneId: string, assetId: string) =>
+		sceneOps.publishScene(
+			{
+				action: 'commit-scene-publish',
+				requestId: randomUUID(),
+				sceneId,
+				publishedAssetId: assetId
+			},
+			ownerId
+		)
+
+	const countPublishedInProject = async (scopeProjectId = projectId) => {
+		const [row] = await db
+			.select({ total: count() })
+			.from(schema.scenePublished)
+			.innerJoin(
+				schema.scenes,
+				eq(schema.scenes.id, schema.scenePublished.sceneId)
+			)
+			.where(eq(schema.scenes.projectId, scopeProjectId))
+		return row?.total ?? 0
+	}
+
+	/*
+	  The free baseline is 3, so this refusal needs no override and deliberately
+	  uses none - an override of 3 would match the default and pass even if
+	  override resolution were broken. The allow test below is where the override
+	  earns its keep, by raising the limit above the default.
+	*/
+	it('refuses a publish at the free plan default, and publishes nothing', async () => {
+		const assetId = await makePublishedAsset()
+		await publishScenes(3, assetId)
+		const sceneId = await sceneAwaitingPublish()
+
+		const attempt = attemptPublish(sceneId, assetId)
+		await expect(attempt).rejects.toBeInstanceOf(QuotaExceededError)
+		/*
+		  The whole payload the upgrade modal is built from. `upgradeTo` is the
+		  one the modal renders its call to action from, so an error carrying
+		  `null` there is a modal with no way out of it.
+		*/
+		await expect(attempt).rejects.toMatchObject({
+			limitKey: 'scenes_published_concurrent',
+			currentValue: 3,
+			limit: 3,
+			plan: 'free',
+			upgradeTo: 'pro'
+		})
+
+		expect(await countPublishedInProject()).toBe(3)
+	})
+
+	it('allows a publish when an override raises the concurrent limit', async () => {
+		const assetId = await makePublishedAsset()
+		await publishScenes(3, assetId)
+		const sceneId = await sceneAwaitingPublish()
+		await setLimit('scenes_published_concurrent', 4)
+
+		const response = await attemptPublish(sceneId, assetId)
+
+		expect(response.status).toBe(200)
+		expect(await countPublishedInProject()).toBe(4)
+	})
+
+	/*
+	  Free is the only plan that scopes this count to the project rather than the
+	  organization, and one project cannot tell the two apart. So the second
+	  project holds published scenes of its own, chosen to straddle the limit:
+	  two per project is under the free cap of 3, while the organization total of
+	  four is over it. Flipping `useProjectScopedLimit` to false fails this test
+	  and nothing else.
+
+	  Inserted directly rather than through `createProject`, which would refuse
+	  on `projects_total` long before this limit came into it.
+	*/
+	it('counts published scenes per project on free, not per organization', async () => {
+		const siblingProjectId = randomUUID()
+		await db.insert(schema.projects).values({
+			id: siblingProjectId,
+			organizationId,
+			name: 'Sibling project',
+			slug: `sibling-${siblingProjectId}`
+		})
+
+		const assetId = await makePublishedAsset()
+		await publishScenes(2, assetId)
+		await publishScenes(2, assetId, siblingProjectId)
+		const sceneId = await sceneAwaitingPublish()
+
+		const response = await attemptPublish(sceneId, assetId)
+
+		expect(response.status).toBe(200)
+		expect(await countPublishedInProject()).toBe(3)
+		expect(await countPublishedInProject(siblingProjectId)).toBe(2)
 	})
 })


### PR DESCRIPTION
## Summary

A free organization that reaches three concurrent published scenes was told the
server had failed. `publishScene` threw its own `QuotaExceededError` and caught
it two lines later, so the refusal arrived as a 500 with no limit, no plan and
no upgrade target — and therefore no upgrade modal, even though the client half
of that path was already built and waiting.

## Root cause

`publishScene`'s catch flattened every failure to `ApiResponse.serverError` so
it could attach an operation-specific fallback message, and that catch cannot
tell a refusal from a fault; `isRoutableDomainError` was introduced to ask the
question once, and `publishScene` is the one operation that never asked it.

## Changes

- `publishScene` rethrows when `isRoutableDomainError(error)`, so the route's
  existing handler maps it. The rethrow sits **above** `reportServerError`: an
  organization hitting its own plan limit is the guard working, not an incident.
- Three integration tests for `scenes_published_concurrent`, which was the only
  enforced limit in the product with no coverage anywhere.
- Two docstrings in `entitlement-required-error.ts` that this change falsifies:
  `publishScene` no longer handles entitlements inline for want of an error type
  to throw, and the count of operations that flatten was stale.

### Notes for review

**No client change was needed.** `ApiResponse.quotaExceeded` is a 403 with the
quota envelope, `createBillingLimitErrorFromResponse` fires on 402/403 and
parses every field, and `publish-options.tsx` already builds the upgrade modal
from it. The server rethrow completes a path that was wired and dead.

**The three tests each earn their keep**, which took two review rounds to get
right:

| Test | What fails without it |
| --- | --- |
| refuses at the free plan default | the guard, and the rethrow |
| allows when an override raises the limit | override resolution |
| counts per project, not per organization | the free plan's project-scoped count |

The refusal test deliberately uses **no** override, because the free default is
already 3 — an override of 3 would pass even with override resolution broken.
That is the discipline this file documents for `projects_total` and it now
applies here.

## Filed, not fixed

- **A publish refusal leaves its idempotency reservation `pending`.**
  `runWithIdempotentSceneRequest` awaits its operation unguarded, so a throw
  skips both the complete and fail bookkeeping. `publishScene` is the first
  operation that can throw through it. Nothing user-facing turns on it: both
  `pending` and `failed` answer a same-key retry with the same 409, and the
  client mints a fresh request id per attempt, so the only difference is a row
  living 24h instead of 1h. Recorded in the code comment. The fix belongs in
  `scenes.$sceneId.ts`, which this change does not otherwise touch.
- **Two pre-existing tests in this file have decorative overrides**, the defect
  review round 1 caught in mine: `allows a new scene when an override raises the
  limit` (free `scenes_total` is 10, the test creates 2) and `counts only live
  keys, so revoking one frees a slot` (free `api_keys_per_org` is 2, one live
  key). Both pass with override resolution disabled.
- **`scenes_published_concurrent` is the last hand-rolled quota guard**, still
  building `getQuotaLimit` + count + `new QuotaExceededError` by hand where the
  same file uses `assertWithinQuota` 470 lines earlier.
- **The free-plan refusal message hardcodes "3"** rather than interpolating the
  resolved limit, so an override makes it lie. Belongs with the wider "render
  plan numbers instead of re-typing them" work.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit / integration tests added or updated
- [ ] Tested manually in the browser
- [x] No tests required for the docstring corrections

Gates: `typecheck,lint` across 4 projects (8/8 tasks), 153 files / 1951 unit
tests, 13 files / 98 integration tests against a local Postgres with the
migrations applied, `prettier --check .`.

**Mutation gate**, five mutations, each red on exactly one test:

| Mutation | Test that goes red |
| --- | --- |
| remove the rethrow | refuses at free default |
| `return error` instead of `throw error` | refuses at free default |
| `useProjectScopedLimit = false` | counts per project |
| disable the guard | refuses at free default |
| drop the allow test's override | allows when an override raises |

The second one matters: the first version of these tests survived it, because
`.then(r => r, e => e)` collapses a rejection and a resolution into one value
and never asks which arrived. Review caught it; the tests now use `rejects`.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
- [x] I updated documentation where needed
