### PR TITLE
fix(seo): deliver the site's structured data to the site

### DIFF
--- a/apps/vectreal-platform/app/components/site-structured-data.spec.tsx
+++ b/apps/vectreal-platform/app/components/site-structured-data.spec.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { serializeJsonLd, SiteStructuredData } from './site-structured-data'
+
+/**
+ * The nodes were never the problem. Root built Organization, WebSite and
+ * WebApplication on every render and handed them to `meta`, where a leaf
+ * route's own `meta` replaced them - so the prerendered home page carried zero
+ * `application/ld+json` blocks while three well-formed ones were being built for
+ * it. That is the shape these tests are aimed at: whether anything renders.
+ */
+/** Reads a source file, relative to this one. */
+const appSource = (relativePath: string) =>
+	readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+
+describe('SiteStructuredData', () => {
+	const scripts = () => {
+		const { container } = render(<SiteStructuredData />)
+		return Array.from(
+			container.querySelectorAll('script[type="application/ld+json"]')
+		)
+	}
+
+	it('renders one script per site-wide node', () => {
+		const types = scripts().map(
+			(script) => JSON.parse(script.innerHTML)['@type']
+		)
+
+		expect(types).toEqual(['Organization', 'WebSite', 'WebApplication'])
+	})
+
+	it('emits parseable JSON-LD, not a string that merely looks like it', () => {
+		// Asserted over a mapped array rather than inside a loop: a loop body
+		// runs zero times when nothing renders, which is the failure this file
+		// is about.
+		const nodes = scripts().map((script) => JSON.parse(script.innerHTML))
+
+		expect(nodes.map((node) => node['@context'])).toEqual([
+			'https://schema.org',
+			'https://schema.org',
+			'https://schema.org'
+		])
+		for (const node of nodes) {
+			expect(node['@id']).toMatch(/^https?:\/\/.+#/)
+		}
+	})
+
+	/*
+	  The nodes were never the defect; the delivery was. Every assertion above
+	  passes with this component rendered by nothing at all, which is exactly the
+	  state the change fixes - three well-formed nodes reaching zero pages.
+
+	  Asserting on source is crude, and it is the only check that fails for the
+	  right reason without a build. The build is the real proof and it cannot run
+	  here.
+	*/
+	it('is rendered by the layout that wraps the public site', () => {
+		expect(appSource('../routes/layouts/nav-layout.tsx')).toContain(
+			'<SiteStructuredData />'
+		)
+	})
+
+	/*
+	  And nowhere that would put it inside a customer's embed iframe. The root
+	  layout wraps every document, so rendering it there ships Vectreal's pricing
+	  copy into pages the product is embedded in, where it is `noindex` and reaches
+	  nobody.
+	*/
+	it('is not rendered from the root layout, which wraps the embed iframe too', () => {
+		expect(appSource('../root.tsx')).not.toContain('SiteStructuredData')
+	})
+})
+
+/*
+  Tested directly, against an input that actually holds a `<`.
+
+  Asserting this through the component proved nothing: every value it
+  serializes comes from a constant and none contains a `<`, so deleting the
+  escape left all three tests above green. The mutation is what said so.
+*/
+describe('serializeJsonLd', () => {
+	it('escapes < so a value can never close the script tag early', () => {
+		expect(serializeJsonLd({ name: '</script><img src=x>' })).not.toContain('<')
+	})
+
+	it('escapes it reversibly, so the node a crawler parses is unchanged', () => {
+		const name = '</script>'
+
+		expect(JSON.parse(serializeJsonLd({ name })).name).toBe(name)
+	})
+})

--- a/apps/vectreal-platform/app/components/site-structured-data.tsx
+++ b/apps/vectreal-platform/app/components/site-structured-data.tsx
@@ -1,0 +1,43 @@
+import { buildSiteStructuredData } from '../lib/seo-registry'
+
+/**
+ * Site-wide structured data: the Organization, WebSite and WebApplication nodes.
+ *
+ * Rendered from `nav-layout` rather than through a route's `meta`, because
+ * these describe the site rather than any one page and route meta cannot carry
+ * them. A leaf route's `meta` replaces its ancestors', every public route
+ * exports one, and the two layouts that do forward root's descriptors go
+ * through `getRootMeta`, which keeps `og:image` alone. Root built all three
+ * nodes on every render and not one prerendered page carried a single one.
+ *
+ * JSON-LD is valid anywhere in the document, so being in the body rather than
+ * the head costs nothing. What it buys is scope: `nav-layout` wraps the public
+ * site and not the embed iframe.
+ *
+ * A component rather than three lines inside `Layout` so that the delivery has
+ * something a test can hold: the defect this fixes was never in the nodes, only
+ * in whether anything rendered them.
+ */
+export function SiteStructuredData() {
+	return (
+		<>
+			{buildSiteStructuredData().map((node) => (
+				<script
+					key={node['@id']}
+					type="application/ld+json"
+					dangerouslySetInnerHTML={{ __html: serializeJsonLd(node) }}
+				/>
+			))}
+		</>
+	)
+}
+
+/**
+ * `<` is escaped because a `</script>` inside a JSON string would close the tag
+ * early, ending the block in the middle of a node and spilling the rest of it
+ * into the page as text. Every value here comes from a constant today, so this
+ * guards a future edit rather than a live input.
+ */
+export function serializeJsonLd(node: unknown): string {
+	return JSON.stringify(node).replace(/</g, '\\u003c')
+}

--- a/apps/vectreal-platform/app/lib/seo-registry.ts
+++ b/apps/vectreal-platform/app/lib/seo-registry.ts
@@ -173,6 +173,22 @@ export function buildWebApplicationJsonLd() {
 	}
 }
 
+/**
+ * The nodes that describe the site itself rather than any one page.
+ *
+ * Grouped because their delivery is a single decision: they belong in every
+ * public document, so they are rendered from `nav-layout` rather than through a
+ * route's `meta`. See `app/components/site-structured-data.tsx` for why route
+ * meta cannot carry them.
+ */
+export function buildSiteStructuredData() {
+	return [
+		buildOrganizationJsonLd(),
+		buildWebSiteJsonLd(),
+		buildWebApplicationJsonLd()
+	]
+}
+
 function nameToSlug(name: string): string {
 	return name
 		.toLowerCase()

--- a/apps/vectreal-platform/app/lib/seo.ts
+++ b/apps/vectreal-platform/app/lib/seo.ts
@@ -345,6 +345,13 @@ export function buildMeta(
 export function buildPageMeta(
 	page: SeoPageDefinition,
 	rootMeta?: MetaDescriptor[],
+	/*
+	  Every field this helper reads off `page` is omitted here, `structuredData`
+	  included. It was the one that was written from `page` but still accepted
+	  from `options`, so a caller could pass JSON-LD and have it silently
+	  overwritten - which is exactly what the home page did, publishing no
+	  Organization node for as long as the call existed.
+	*/
 	options: Omit<
 		BuildMetaOptions,
 		| 'canonical'
@@ -353,6 +360,7 @@ export function buildPageMeta(
 		| 'imageWidth'
 		| 'imageHeight'
 		| 'type'
+		| 'structuredData'
 		| 'publishedTime'
 		| 'modifiedTime'
 		| 'articleAuthor'

--- a/apps/vectreal-platform/app/root.tsx
+++ b/apps/vectreal-platform/app/root.tsx
@@ -31,11 +31,6 @@ import { isAnonymousCacheableRequest } from './lib/http/cacheable-public-paths.s
 import { useErrorReport } from './lib/observability/use-error-report'
 import { posthogMiddleware } from './lib/posthog/posthog-middleware'
 import { buildMeta } from './lib/seo'
-import {
-	buildOrganizationJsonLd,
-	buildWebApplicationJsonLd,
-	buildWebSiteJsonLd
-} from './lib/seo-registry'
 import { commitValidCsrfToken } from './lib/sessions/csrf-session.server'
 
 import type { ShouldRevalidateFunction } from 'react-router'
@@ -43,14 +38,7 @@ import '@shared/components/styles/globals.css'
 import './styles/view-transitions.css'
 
 export const meta: MetaFunction = () => [
-	...buildMeta([], undefined, {
-		canonical: '/',
-		structuredData: [
-			buildOrganizationJsonLd(),
-			buildWebSiteJsonLd(),
-			buildWebApplicationJsonLd()
-		]
-	})
+	...buildMeta([], undefined, { canonical: '/' })
 ]
 
 export const middleware: Route.MiddlewareFunction[] = [posthogMiddleware]

--- a/apps/vectreal-platform/app/routes/home-page/home-page.tsx
+++ b/apps/vectreal-platform/app/routes/home-page/home-page.tsx
@@ -26,10 +26,7 @@ import {
 import { SectionHeader, Section } from '../../components/home/section'
 import { SUPPORTED_FORMAT_NAMES } from '../../constants/product-copy'
 import { buildPageMeta } from '../../lib/seo'
-import {
-	buildOrganizationJsonLd,
-	PUBLIC_SEO_PAGES
-} from '../../lib/seo-registry'
+import { PUBLIC_SEO_PAGES } from '../../lib/seo-registry'
 
 /*
   Literal colours, deliberately outside the token system.
@@ -52,9 +49,9 @@ const SYNTAX = {
 } as const
 
 export function meta(_: Route.MetaArgs) {
-	return buildPageMeta(PUBLIC_SEO_PAGES.home, undefined, {
-		structuredData: buildOrganizationJsonLd()
-	})
+	// The Organization node this used to pass is rendered across the public site
+	// from `nav-layout` now, and was discarded here in any case.
+	return buildPageMeta(PUBLIC_SEO_PAGES.home)
 }
 
 const SOCIAL_PROOF_ITEMS = [

--- a/apps/vectreal-platform/app/routes/layouts/nav-layout.tsx
+++ b/apps/vectreal-platform/app/routes/layouts/nav-layout.tsx
@@ -5,6 +5,7 @@ import { Outlet, useLocation } from 'react-router'
 import { Footer } from '../../components/footer'
 import { Navigation } from '../../components/navigation'
 import { GlobalNavVisibilityProvider } from '../../components/navigation/global-nav-visibility'
+import { SiteStructuredData } from '../../components/site-structured-data'
 import { CurrentUserProvider } from '../../hooks/use-current-user'
 import { routePageChrome } from '../../lib/navigation/page-chrome'
 
@@ -18,6 +19,13 @@ import { routePageChrome } from '../../lib/navigation/page-chrome'
  *
  * The nav is hidden with a class rather than unmounted for the same reason: a
  * round trip through the publisher should not cost a remount.
+ *
+ * It also carries the site's structured data, because "every route with site
+ * chrome" is the same set as "the public site": everything under here is what a
+ * crawler should see, and the branches outside it - embed, dashboard, preview -
+ * are application surface. Rendering it from the root layout instead would put
+ * Vectreal's own pricing copy inside every customer's embed iframe, where it is
+ * `noindex` and reaches nobody.
  */
 const Layout = () => {
 	const { pathname } = useLocation()
@@ -29,6 +37,7 @@ const Layout = () => {
 	return (
 		<CurrentUserProvider>
 			<GlobalNavVisibilityProvider onHiddenChange={setNavHiddenAtRuntime}>
+				<SiteStructuredData />
 				<div className={cn(!showNav && 'hidden')}>
 					<Navigation />
 				</div>


### PR DESCRIPTION
## Summary

The site's structured data described a site no crawler could see it on.
Organization, WebSite and WebApplication were built on every render in `root.tsx`
and delivered to nothing. Measured against the prerendered build: **0 of 34
pages** carried a single one of those nodes; afterwards, **34 of 34** do.

The home page carried no `application/ld+json` at all, from either source.

## Root cause

Site-wide structured data was expressed as route `meta`, which is the one thing
route meta cannot carry: a leaf route's `meta` replaces its ancestors', every
public route exports one, and the two layouts that do forward root's descriptors
go through `getRootMeta`, which keeps `og:image` alone.

## Changes

- `SiteStructuredData` renders the three nodes from `nav-layout`, whose docblock
  already describes it as owning the chrome for every route that has any. That
  set is the public site.
- `buildSiteStructuredData()` in `seo-registry.ts` names what "site-wide" means.
- `buildPageMeta` no longer *accepts* a `structuredData` it always discarded. It
  was written from `page` but still allowed in `options`, so a caller could pass
  JSON-LD and have it silently overwritten — which is what the home page did.
- `home-page.tsx` stops passing the Organization node that never rendered.

### Why not root's layout

That was the first version, and it is wrong for one reason worth recording:
root's `Layout` wraps **every** document, including `/embed/:projectId/:sceneId`,
which renders inside customers' own pages. That shipped 2,589 bytes of Vectreal's
feature list and all four pricing blurbs into every embed — `noindex`, so read by
nobody, on the product's highest-volume document.

`nav-layout` covers all 34 prerendered pages and excludes embed, dashboard and
preview. Verified by walking bracket depth in `app/routes.tsx` rather than by
eye:

| Layout | Inside `nav-layout` | Site JSON-LD |
| --- | --- | --- |
| publisher | yes | yes |
| preview, embed, dashboard | no | no |

JSON-LD is valid anywhere in the document, so rendering into the body rather than
the head costs nothing and buys the scope.

### Sequencing

This was deliberately held until Phase 2 landed. The WebApplication node carries
`PLAN_OFFER_DESCRIPTIONS`, and delivering it before those descriptions were true
would have started publishing the false ones to crawlers. They are now the
post-Phase-2 text — and they are hand-typed plan numbers, which raises the stakes
on the "render plan numbers instead of re-typing them" work rather than lowering
them.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser

Prerendered build, before and after:

| Pages | Before | After |
| --- | --- | --- |
| home, about, changelog, imprint, privacy, terms, docs index | **0** | 3 |
| docs pages | 1 | 4 |
| news articles | 3 | 6 |

Browser, against the dev server: 3 nodes in the SSR HTML, 3 in the DOM after
hydration, no console errors or hydration mismatch, and still 3 after a
client-side navigation to `/pricing`.

**Mutation gate:**

| Mutation | Test that goes red |
| --- | --- |
| remove from `nav-layout` | is rendered by the layout that wraps the public site |
| add back to `root.tsx` | is not rendered from the root layout |
| render zero nodes | renders one script per node; emits parseable JSON-LD |
| drop the `<` escape | escapes < so a value can never close the tag early |

Two of those tests exist because review caught that the first version had none:
deleting the component's only render site left every test green, which is the
exact defect this PR fixes. Two others exist because the mutation gate caught
tests of mine that could not fail — an escape assertion over values that contain
no `<`, and a loop body that runs zero times on an empty render.

Gates: `typecheck,lint` across 4 projects, 1957 unit tests (`vitest --root .` and
`nx test vectreal-platform`), `prettier --check .`.

## Filed, not fixed

- **`react-router build` fails in a fresh worktree** with `Prerender: Request
  failed for /_.data ... 500`, and the cause is not in the message:
  `csrf-session.server.ts:6` throws at module scope when `NODE_ENV=production`
  without `CSRF_SECRET`, and prerender runs in production mode. The repo's
  gitignored `.env.development` carries only `DATABASE_URL`,
  `SEND_EMAIL_HOOK_SECRET` and `STRIPE_SECRET_KEY`. Every build in this PR was
  run with `CSRF_SECRET` supplied. Reproduces identically on `main`.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
- [x] I updated documentation where needed
