### PR TITLE
docs(operations): the PostHog variables are read at runtime too

### DIFF
--- a/apps/vectreal-platform/app/routes/docs/operations/deployment.mdx
+++ b/apps/vectreal-platform/app/routes/docs/operations/deployment.mdx
@@ -82,12 +82,20 @@ Both deploy workflows call the shared `shared-fly-deploy.yaml` workflow. The bui
 | Secret | Description |
 |---|---|
 | `FLY_API_TOKEN` | Fly.io deploy token |
-| `VITE_PUBLIC_POSTHOG_TOKEN` / `VITE_PUBLIC_POSTHOG_HOST` | PostHog analytics config (build-time) |
+| `VITE_PUBLIC_POSTHOG_TOKEN` / `VITE_PUBLIC_POSTHOG_HOST` | PostHog analytics config. Needed in two places, not one: see below |
 | `VITE_PUBLIC_POSTHOG_UI_HOST` | Optional PostHog UI host |
 | `VITE_PUBLIC_VECTREAL_API_KEY_PROD` | Optional public API key for demo scenes |
 | `VITE_PUBLIC_DEMO_SCENE_URL` | Optional demo scene URL |
 
 Application runtime secrets (Supabase URLs/keys, `DATABASE_URL`, `CSRF_SECRET`, Stripe keys, Cloudflare Turnstile keys) are managed on Fly.io via the `setup-fly-secrets` scripts rather than as GitHub secrets.
+
+### The PostHog variables belong in both places
+
+The `VITE_PUBLIC_` prefix reads as build-time only, and this page used to say so. They are also read at runtime on the server: `posthog-client.server.ts` takes `VITE_PUBLIC_POSTHOG_TOKEN` and `VITE_PUBLIC_POSTHOG_HOST` from `process.env` on every request.
+
+Because they were set only as build args, `getPosthogClient()` returned `null` for every production request for most of the product's life, and did it silently: its own docstring calls `null` "the normal state of a local dev environment", so production was indistinguishable from an unconfigured laptop. That disabled server-side analytics, the `billing-checkout` flag guard, and the server error sink - which is why an unrelated Stripe webhook failure went unnoticed for months.
+
+So they are needed twice: as a GitHub secret, which `shared-fly-deploy.yaml` passes to the Docker build for the browser bundle, and as a Fly secret, which `setup-fly-secrets.sh` now provisions for the server.
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/operations/deployment` described `VITE_PUBLIC_POSTHOG_TOKEN` and
`VITE_PUBLIC_POSTHOG_HOST` as "(build-time)". They are needed in **two** places,
and the missing half is the one that mattered.

This misconception is what cost the server error sink for most of the product's
life, and it is on the public docs site.

## Root cause

The `VITE_PUBLIC_` prefix means "inlined into the browser bundle", and this page
generalized that to "build-time only", but `posthog-client.server.ts` reads both
names from `process.env` on every server request — so the page documented one of
the two places they belong and the other was never provisioned.

## Verified against code, not assumed

| Claim | Where |
| --- | --- |
| the server reads them at runtime | `posthog-client.server.ts:21-22`, `process.env` |
| they are a Docker build arg | `shared-fly-deploy.yaml:79-80` |
| they are also a Fly secret | `setup-fly-secrets.sh:198-199`, added in #803 |
| `null` is silent by design | `getPosthogClient`'s own docstring: "the normal state of a local dev environment" |

That last one is why nothing caught it: production was indistinguishable from an
unconfigured laptop. Dead as a result were server-side analytics, the
`billing-checkout` flag guard, and the server error sink — which is why an
unrelated Stripe webhook that had never once verified went unnoticed for months.

## Changes

- The table row stops claiming build-time and points at the explanation.
- A short section stating both places, why the prefix misleads, and what the
  silence cost. The page is public, and the failure is worth writing down where
  the next person provisioning an environment will meet it.

## Type of Change

- [x] Documentation update

## Testing

- [x] No tests required — prose on a docs page

Gates: `typecheck,lint` across 4 projects, `prettier --check .` (`.mdx` is in
`.prettierignore`, so this is unaffected either way), 154 files / 1953 unit tests.

Verified rendered, against the dev server rather than the source: the page
returns 200, the exact string `(build-time)` now appears **0** times, the new
heading and both code references render, and the table cell reads "PostHog
analytics config. Needed in two places, not one: see below".

**Not verified:** a screenshot. The browser pane returned blank images on every
attempt while the DOM was fully populated, which is a capture problem rather than
a page problem. The served-HTML checks above stand in for it; for a prose change
they cover the same ground.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
- [x] I updated documentation where needed
