### PR TITLE
fix(billing): make the checkout kill switch fail closed

### DIFF
--- a/apps/vectreal-platform/app/lib/domain/billing/checkout-kill-switch.spec.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/checkout-kill-switch.spec.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	BILLING_CHECKOUT_FLAG,
+	CHECKOUT_GATE_DENIAL,
+	resolveCheckoutGate,
+	type CheckoutFlagSource
+} from './checkout-kill-switch'
+
+/**
+ * The defect these are aimed at is not "the flag was read wrong". It is that
+ * failing to read it counted as permission.
+ *
+ * The guard sat inside `if (posthog)`, so on every production request where
+ * `getPosthogClient()` returned `null` - which was every one of them until the
+ * runtime secrets landed - the switch was skipped rather than consulted, and
+ * checkout ran ungated while it was believed to be held shut.
+ */
+describe('resolveCheckoutGate', () => {
+	const source = (
+		impl: CheckoutFlagSource['isFeatureEnabled']
+	): CheckoutFlagSource => ({ isFeatureEnabled: impl })
+
+	it('allows checkout only when the flag is explicitly on', async () => {
+		const gate = await resolveCheckoutGate(
+			source(async () => true),
+			'user-1'
+		)
+
+		expect(gate).toEqual({ allowed: true })
+	})
+
+	it('passes the flag key and the caller through to the client', async () => {
+		const seen: Array<[string, string]> = []
+		await resolveCheckoutGate(
+			source(async (key, distinctId) => {
+				seen.push([key, distinctId])
+				return true
+			}),
+			'user-42'
+		)
+
+		expect(seen).toEqual([[BILLING_CHECKOUT_FLAG, 'user-42']])
+	})
+
+	// The branch that was the bug: no client meant no guard at all.
+	it('denies when PostHog is not configured', async () => {
+		const gate = await resolveCheckoutGate(undefined, 'user-1')
+
+		expect(gate).toEqual({ allowed: false, reason: 'unconfigured' })
+	})
+
+	/*
+	  One case, deliberately, because posthog-node gives us one value.
+	  `isFeatureEnabled` answers `undefined` both for a flag the project does not
+	  have and for a flag it could not fetch: `getFlags` catches its own network
+	  failure and returns `{ success: false }`, which becomes `undefined` two
+	  frames later. Asserting these three separately would be asserting a
+	  distinction the client cannot make.
+	*/
+	it.each([
+		['the flag is off', false],
+		['the project has no such flag', undefined],
+		['the fetch failed, which arrives as undefined', undefined]
+	])('denies when %s', async (_case, answer) => {
+		const gate = await resolveCheckoutGate(
+			source(async () => answer),
+			'user-1'
+		)
+
+		expect(gate).toEqual({ allowed: false, reason: 'not_enabled' })
+	})
+
+	it('denies rather than propagating when the client itself throws', async () => {
+		const gate = await resolveCheckoutGate(
+			source(async () => {
+				throw new Error('client bug')
+			}),
+			'user-1'
+		)
+
+		expect(gate).toEqual({ allowed: false, reason: 'not_enabled' })
+	})
+
+	/*
+	  A misconfigured deployment is not the same as a switch someone turned off,
+	  and it is the one difference that survives posthog-node: we check for the
+	  client ourselves. 503 says "this deployment is broken", 403 says "no".
+	*/
+	it('separates a broken deployment from a closed switch', () => {
+		expect(CHECKOUT_GATE_DENIAL.unconfigured.status).toBe(503)
+		expect(CHECKOUT_GATE_DENIAL.not_enabled.status).toBe(403)
+	})
+
+	/*
+	  These reach a customer in a banner on the upgrade page. The diagnosis goes
+	  to the server log instead, which is why no message may name PostHog, the
+	  flag, or the deployment's configuration.
+	*/
+	it('keeps infrastructure out of what the reader is shown', () => {
+		for (const { message } of Object.values(CHECKOUT_GATE_DENIAL)) {
+			expect(message.toLowerCase()).not.toContain('posthog')
+			expect(message.toLowerCase()).not.toContain('flag')
+			expect(message.toLowerCase()).not.toContain('deployment')
+		}
+	})
+})
+
+/*
+  Everything above holds with this module called by nothing at all, which is the
+  state the change fixes: the rule was never wrong, it was skipped. Neither
+  route can be imported here - both reach `asset-storage.server.ts`, which calls
+  `getDbClient()` at module scope - so the binding is asserted against source,
+  which is crude and is the only check that fails for the right reason without a
+  running server.
+*/
+describe('the gate is the one both surfaces consult', () => {
+	const source = (relativePath: string) =>
+		readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+
+	const CHECKOUT = '../../../routes/api/billing/checkout.ts'
+	const UPGRADE = '../../../routes/dashboard-page/billing-upgrade.tsx'
+
+	it('is called by the action that enforces it', () => {
+		expect(source(CHECKOUT)).toContain('resolveCheckoutGate(')
+	})
+
+	it('is called by the page that mirrors it', () => {
+		expect(source(UPGRADE)).toContain('resolveCheckoutGate(')
+	})
+
+	/*
+	  An `isFeatureEnabled` call outside this module is a second place deciding
+	  the same thing, and the last two both decided it wrong. The component's
+	  `useFeatureFlagEnabled` is a different symbol on a different layer and is
+	  deliberately still there - it may close the button, never open it.
+	*/
+	it('leaves no surface reading the flag on its own', () => {
+		expect(source(CHECKOUT)).not.toContain('isFeatureEnabled')
+		expect(source(UPGRADE)).not.toContain('.isFeatureEnabled')
+	})
+
+	it('lets the client close the button but never open it', () => {
+		expect(source(UPGRADE)).toContain(
+			'serverCheckoutEnabled && (clientFlagEnabled ?? true)'
+		)
+	})
+})

--- a/apps/vectreal-platform/app/lib/domain/billing/checkout-kill-switch.ts
+++ b/apps/vectreal-platform/app/lib/domain/billing/checkout-kill-switch.ts
@@ -1,0 +1,104 @@
+/**
+ * Whether checkout may proceed, and why not when it may not.
+ *
+ * `billing-checkout` is a kill switch, and a switch that only closes while an
+ * unrelated analytics client happens to be reachable is not one. The guard used
+ * to sit inside `if (posthog)`, which made "the switch could not be consulted"
+ * indistinguishable from "the switch said yes" - so while `getPosthogClient()`
+ * returned `null` on every production request, checkout was not gated at all.
+ * The switch believed to be holding it shut had never been read.
+ *
+ * Only an explicit `true` opens it. Everything else denies.
+ *
+ * There are two denials rather than the three the shape invites, because
+ * posthog-node cannot tell an outage from an off switch. `getFlags` catches its
+ * own network failure and returns `{ success: false }`
+ * (`@posthog/core/dist/posthog-core-stateless.mjs:384`), the caller turns that
+ * into `undefined` (`:478`), and `isFeatureEnabled` passes `undefined` through
+ * (`posthog-node/dist/client.mjs:544`) - the same `undefined` it returns for a
+ * flag the project does not have. A 5xx, a timeout and a deleted flag are one
+ * value by the time they arrive here, so claiming to distinguish them would be
+ * a comment that reads well and is false.
+ *
+ * What is knowable is whether there was a client at all, and that is worth
+ * keeping separate: no client means this deployment is misconfigured, which is
+ * a 503 and somebody's problem, while a switch that did not say yes is a 403
+ * and may well be deliberate.
+ *
+ * Pure, and deliberately not `.server`: the route module that enforces this
+ * cannot be loaded by a test - its import graph reaches
+ * `asset-storage.server.ts`, which calls `getDbClient()` at module scope - so
+ * the decision lives here, where it can be.
+ */
+
+export const BILLING_CHECKOUT_FLAG = 'billing-checkout'
+
+/**
+ * The one method this needs from a PostHog client, so a test can supply it
+ * without a network or a real client.
+ *
+ * `isFeatureEnabled` is deprecated in posthog-node 5.48.1 in favour of
+ * `evaluateFlags`. Kept because it is what both call sites already used and
+ * migrating the API is its own change; the deprecation warning is emitted once
+ * per process.
+ */
+export interface CheckoutFlagSource {
+	isFeatureEnabled(
+		key: string,
+		distinctId: string
+	): Promise<boolean | undefined>
+}
+
+export type CheckoutGateDenial = 'unconfigured' | 'not_enabled'
+
+export type CheckoutGate =
+	{ allowed: true } | { allowed: false; reason: CheckoutGateDenial }
+
+/**
+ * Total, so a new denial reason cannot be added without deciding what it says.
+ *
+ * The messages are deliberately plain. A denial reaches a customer in a banner
+ * on the upgrade page, so it is not the place to name PostHog or the
+ * deployment's configuration; the diagnosis belongs in the server log, and the
+ * action reports it there.
+ */
+export const CHECKOUT_GATE_DENIAL: Record<
+	CheckoutGateDenial,
+	{ status: number; message: string }
+> = {
+	unconfigured: {
+		status: 503,
+		message: 'Billing checkout is temporarily unavailable.'
+	},
+	not_enabled: {
+		status: 403,
+		message: 'Billing checkout is currently disabled.'
+	}
+}
+
+export async function resolveCheckoutGate(
+	flags: CheckoutFlagSource | undefined,
+	distinctId: string
+): Promise<CheckoutGate> {
+	if (!flags) {
+		return { allowed: false, reason: 'unconfigured' }
+	}
+
+	try {
+		const enabled = await flags.isFeatureEnabled(
+			BILLING_CHECKOUT_FLAG,
+			distinctId
+		)
+
+		return enabled === true
+			? { allowed: true }
+			: { allowed: false, reason: 'not_enabled' }
+	} catch {
+		/*
+		  Not reachable through a flag fetch, which swallows its own failures -
+		  see the note above. This covers a programming error inside the client
+		  and exists so that one cannot take the checkout route down with it.
+		*/
+		return { allowed: false, reason: 'not_enabled' }
+	}
+}

--- a/apps/vectreal-platform/app/routes/api/billing/checkout.ts
+++ b/apps/vectreal-platform/app/routes/api/billing/checkout.ts
@@ -34,10 +34,15 @@ import { Route } from './+types/checkout'
 import { getDbClient } from '../../../db/client'
 import { orgSubscriptions } from '../../../db/schema/billing/subscriptions'
 import { loadAuthenticatedUser } from '../../../lib/domain/auth/auth-loader.server'
+import {
+	CHECKOUT_GATE_DENIAL,
+	resolveCheckoutGate
+} from '../../../lib/domain/billing/checkout-kill-switch'
 import { getOrgSubscription } from '../../../lib/domain/billing/entitlement-service.server'
 import { syncSubscriptionFromStripe } from '../../../lib/domain/billing/stripe-subscription-sync.server'
 import { getUserOrganizations } from '../../../lib/domain/user/user-repository.server'
 import { ensureSameOriginMutation } from '../../../lib/http/csrf.server'
+import { reportServerError } from '../../../lib/observability/report-server-error.server'
 import { getStripeClient } from '../../../lib/stripe.server'
 
 import type { PostHogContext } from '../../../lib/posthog/posthog-middleware'
@@ -122,18 +127,37 @@ export async function action({
 		await loadAuthenticatedUser(request)
 	const responseHeaders = new Headers(headers)
 
-	// Feature flag guard - block checkout when billing-checkout is disabled
-	const posthog = (context as PostHogContext).posthog
-	if (posthog) {
-		const checkoutEnabled = await posthog.isFeatureEnabled(
-			'billing-checkout',
-			user.id
-		)
-		if (!checkoutEnabled) {
-			return ApiResponse.forbidden('Billing checkout is currently disabled', {
-				headers: responseHeaders
-			})
+	/*
+	  The kill switch, which now denies when it cannot be read rather than
+	  skipping itself. See `checkout-kill-switch.ts` for why the old
+	  `if (posthog)` meant checkout was never gated in production at all.
+	*/
+	const gate = await resolveCheckoutGate(
+		(context as PostHogContext).posthog,
+		user.id
+	)
+	if (!gate.allowed) {
+		/*
+		  Only the misconfigured case is reported. `not_enabled` is the expected
+		  state while checkout is deliberately held shut, so reporting it would
+		  file one exception per attempt; `unconfigured` means this deployment
+		  lost its PostHog secrets and every checkout is now failing, which is
+		  the outage nobody noticed last time. A returned response never reaches
+		  `handleError`, so without this the sink sees nothing either way.
+		*/
+		if (gate.reason === 'unconfigured') {
+			reportServerError(
+				new Error(
+					'Checkout refused: the billing-checkout kill switch cannot be evaluated because PostHog is not configured on this deployment.'
+				),
+				{ request, properties: { userId: user.id } }
+			)
 		}
+
+		const denial = CHECKOUT_GATE_DENIAL[gate.reason]
+		return ApiResponse.error(denial.message, denial.status, {
+			headers: responseHeaders
+		})
 	}
 
 	let body: { planId?: unknown; priceId?: unknown; billingPeriod?: unknown }

--- a/apps/vectreal-platform/app/routes/dashboard-page/billing-upgrade.tsx
+++ b/apps/vectreal-platform/app/routes/dashboard-page/billing-upgrade.tsx
@@ -40,6 +40,7 @@ import {
 	getCheckoutOptions,
 	loadBillingDashboardData
 } from '../../lib/domain/billing/billing-dashboard-loader.server'
+import { resolveCheckoutGate } from '../../lib/domain/billing/checkout-kill-switch'
 
 import type {
 	BillingCheckoutOptions,
@@ -103,18 +104,22 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 		includeCheckoutOptions: false
 	})
 
-	const posthog = (context as PostHogContext).posthog
-	const checkoutEnabledPromise = posthog
-		? posthog
-				.isFeatureEnabled('billing-checkout', loaderData.user.id)
-				.then((enabled) => enabled ?? false)
-				.catch(() => true)
-		: Promise.resolve(true) // default to enabled when PostHog is not configured (e.g. local dev)
+	/*
+	  The same rule the action enforces, from the same module. This used to
+	  decide separately and fail open twice over - `.catch(() => true)` on an
+	  unreachable PostHog, and `true` outright when it was not configured - so
+	  the page offered a button the action would now refuse.
+	*/
+	const checkoutGatePromise = resolveCheckoutGate(
+		(context as PostHogContext).posthog,
+		loaderData.user.id
+	)
 
-	const [checkoutOptions, checkoutEnabled] = await Promise.all([
+	const [checkoutOptions, checkoutGate] = await Promise.all([
 		checkoutOptionsPromise,
-		checkoutEnabledPromise
+		checkoutGatePromise
 	])
+	const checkoutEnabled = checkoutGate.allowed
 
 	return data(
 		{
@@ -143,11 +148,19 @@ function BillingUpgradeContent({
 	const checkoutFetcher = useFetcher()
 	const posthog = usePostHog()
 
-	// Client-side flag evaluation - undefined while PostHog is loading; fall back
-	// to the server-resolved value so the button state is correct on first render.
+	/*
+	  The client may close this, never open it.
+
+	  It used to be the authority whenever it had an opinion, so a client that
+	  said yes overrode a server that had said no - and the two evaluate against
+	  different inputs often enough for that to happen: the browser token is a
+	  Docker build arg while the server's is a Fly secret, and the client
+	  evaluates anonymously until analytics consent lets it `identify`. The
+	  action denies either way, so this only decides whether the reader is
+	  offered a button that cannot work.
+	*/
 	const clientFlagEnabled = useFeatureFlagEnabled('billing-checkout')
-	const checkoutEnabled =
-		clientFlagEnabled !== undefined ? clientFlagEnabled : serverCheckoutEnabled
+	const checkoutEnabled = serverCheckoutEnabled && (clientFlagEnabled ?? true)
 
 	const requestedPlan = searchParams.get('plan')
 	const initialPlan = requestedPlan === 'business' ? 'business' : 'pro'


### PR DESCRIPTION
## Summary

The `billing-checkout` kill switch only worked while an unrelated analytics
client happened to be reachable. Its guard sat inside `if (posthog)`, so
"the switch could not be consulted" and "the switch said yes" were the same
branch — and for as long as `getPosthogClient()` returned `null` on every
production request, checkout was not gated at all. The switch believed to be
holding it shut had never been read.

Phase 0.5e of the plan-limits work, and the last item in Phase 0.5.

## Root cause

The guard was nested inside a truthiness check on the PostHog client, so the
absence of an answer was treated as permission rather than as a denial.

## Changes

- New pure module `checkout-kill-switch.ts` owns the rule: only an explicit
  `true` opens checkout.
- Both surfaces call it. `billing-upgrade.tsx`'s loader decided separately and
  failed open twice more — `.catch(() => true)` on an unreachable client and
  `Promise.resolve(true)` on an absent one.
- The client-side flag may now close the button but never open it. It was the
  authority whenever it had an opinion, and it evaluates against different
  inputs than the server: the browser token is a Docker build arg while the
  server's is a Fly secret, and the client evaluates anonymously until analytics
  consent lets it `identify`.
- A `unconfigured` denial is reported to the error sink. A returned response
  never reaches `handleError`, so without it a deployment that lost its PostHog
  secrets would 503 every checkout and record nothing — the same silence that
  hid the original defect.

## Two denials, not three

The first draft split `disabled` / `unconfigured` / `unreachable` and gave the
outage its own 503. **Review found that distinction cannot exist**, and the
installed client confirms it:

```
@posthog/core/…/posthog-core-stateless.mjs:384  getFlags(...).catch(() => ({ success: false }))
@posthog/core/…/posthog-core-stateless.mjs:478  if (!result.success) return;   → undefined
posthog-node/dist/client.mjs:544                if (void 0 === result) return; → undefined
```

A 5xx, a timeout, a quota limit and a deleted flag are all `undefined` by the
time they reach us — the same `undefined` as a flag that simply is not there. So
the module now claims only what it can know: whether there was a client at all.
Everything else is one denial. The old shape would have answered a genuine
PostHog outage with **403 "currently disabled"**, which is precisely the operator
confusion it claimed to prevent.

## Lockout risk: checked, not assumed

| PostHog state | Old action | New action | Old button | New button |
| --- | --- | --- | --- | --- |
| flag on | allow | allow | enabled | enabled |
| flag off | 403 | 403 | disabled | disabled |
| flag absent | 403 | 403 | disabled | disabled |
| fetch failed | 403 | 403 | **enabled** | disabled |
| client threw | 500 | 403 | **enabled** | disabled |
| **no client** | **allow, ungated** | **503** | **enabled** | disabled |

Nobody who could check out yesterday is locked out today: flag-off and
flag-absent already denied, identically. The only behavior change on the deny
side is that the three fail-open cases now deny.

`flyctl secrets list` on **both** apps shows `VITE_PUBLIC_POSTHOG_TOKEN` and
`VITE_PUBLIC_POSTHOG_HOST` deployed, so the `unconfigured` branch cannot fire in
production or staging.

## Known consequence: local development

`context.posthog` exists only when both PostHog variables are set, and the
gitignored `.env.development` carries neither. **Local checkout now 503s and the
upgrade button hides**, where both previously worked. That is the honest cost of
a switch with no dev-shaped hole in it — a hole is how the production one got
there. Set the two variables locally to exercise checkout.

Say the word if you would rather gate the `unconfigured` denial on production
only; it is a one-line change and I did not want to make it silently.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit / integration tests added or updated

Gates: `typecheck,lint` across 4 projects, `prettier --check .`, 2225 unit tests,
`build-ci`. The denial strings and `resolveCheckoutGate` are **absent from the
client bundle** and present in `server/index.js`, so the module tree-shakes as a
pure server decision despite being imported by a browser route.

**Mutation gate**, each red on exactly one test:

| Mutation | Test |
| --- | --- |
| fail open on a missing client | denies when PostHog is not configured |
| treat `undefined` as permission | denies when the project has no such flag / when the fetch failed |
| collapse 503 onto 403 | separates a broken deployment from a closed switch |
| leak infrastructure into the banner | keeps infrastructure out of what the reader is shown |
| let the client re-open the button | lets the client close the button but never open it |
| action reads the flag itself | is called by the action / leaves no surface reading the flag |
| page stops consulting the gate | is called by the page that mirrors it |

**Not verified:** the gate end to end in a browser. It sits behind
`loadAuthenticatedUser`, and a signed-in session needs the local Supabase stack,
which does not come up on this machine. The unit tests plus the source-binding
assertions stand in, and the table above is derived from the client's source
rather than from running it.

## Filed, not fixed

- `isFeatureEnabled` is deprecated in posthog-node 5.48.1 in favour of
  `evaluateFlags`, and emits a runtime warning. Migrating the API is its own
  change; the new interface pins the deprecated method because that is what both
  call sites already used.
- `docs/operations/deployment.mdx` labels the PostHog pair "(build-time)" and
  omits it from the runtime-secrets list, so an operator following it ships a
  deployment where every checkout now 503s. **Already fixed in #838** — worth
  merging alongside this.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `lint` passes
- [x] `typecheck` passes
- [x] `test` passes
- [x] I updated documentation where needed
