### PR TITLE
test(billing): pin the plan ladder as a mapping, not a set of literals

### DIFF
--- a/apps/vectreal-platform/app/constants/plan-config.spec.ts
+++ b/apps/vectreal-platform/app/constants/plan-config.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import { PLAN_LIMITS, type LimitKey, type Plan } from './plan-config'
+
+/**
+ * The plan ladder, asserted as a mapping rather than as a set of literals.
+ *
+ * Two published pages and the four plan descriptions hardcode these numbers.
+ * (The plan cards on `/pricing` and on the upgrade route state them too, but
+ * render them from the config, so they cannot drift.) `upload.mdx` and
+ * `04_api-keys-101.mdx` each carry a claims block pinning the literals they
+ * quote; `PLAN_OFFER_DESCRIPTIONS`, which reaches schema.org and `/llms.txt`,
+ * is pinned by nothing at all. And a claim can only prove that a literal
+ * appears somewhere in `plan-config.ts` - never which plan owns it. Exchange
+ * Free's two API keys with Business's fifty and all four `api_keys_per_org`
+ * claims stay green while the article publishes both numbers against the wrong
+ * plans. Verified before this file existed: that swap left the whole suite
+ * green.
+ *
+ * A higher plan may match the plan below it - Free and Pro both get one seat -
+ * but it may never offer less. That is the property a literal cannot express.
+ * Ordering is all it expresses, though: exchange Free's ten scenes with its
+ * twenty-five folders and nothing inverts, so that swap still passes.
+ */
+
+const PLAN_LADDER: readonly Plan[] = ['free', 'pro', 'business', 'enterprise']
+
+/** `null` is "unlimited" or "custom", so it is the top of the ladder, not zero. */
+function asBound(value: number | null): number {
+	return value === null ? Number.POSITIVE_INFINITY : value
+}
+
+/*
+	Read from the config rather than typed out, so a limit added tomorrow is
+	covered without an edit here, and a limit deleted cannot leave a stale row.
+*/
+const LIMIT_KEYS = Object.keys(PLAN_LIMITS.free) as LimitKey[]
+
+describe('the plan ladder', () => {
+	it('places every plan exactly once', () => {
+		expect([...PLAN_LADDER].sort()).toEqual(Object.keys(PLAN_LIMITS).sort())
+	})
+
+	/*
+		The key list is read off `free` and then cast, so every other plan is taken
+		on trust. Today the `Record<Plan, Record<LimitKey, number | null>>`
+		annotation makes a missing key a compile error - but if that annotation ever
+		weakens, a plan short of a key would read `undefined`, compare false in both
+		directions, and drop that limit out of the ladder test while reporting clean.
+	*/
+	it('compares the same limits on every plan', () => {
+		expect(LIMIT_KEYS.length).toBeGreaterThan(0)
+
+		for (const plan of PLAN_LADDER) {
+			expect(Object.keys(PLAN_LIMITS[plan]).sort()).toEqual(
+				[...LIMIT_KEYS].sort()
+			)
+		}
+	})
+
+	/*
+		The same silent drop, reachable without weakening anything: NaN satisfies
+		`number`, so the annotation and tsc both accept it, and it compares false in
+		every direction. A limit holding one would sit out the ladder test with its
+		key present and the suite green.
+
+		The safe-integer half is `toSafeNumberFromBigInt`'s, because the same limit
+		arriving from an `org_limit_overrides` row has to clear it, and a hardcoded
+		baseline should not be held to less than a value out of the database. The
+		`>= 0` half is this file's own, and it is the one that reaches the ends of
+		the ladder, where nothing sits above or below to compare against: a negative
+		on Free refuses every operation forever, because `assertWithinQuota` can
+		never satisfy `current + adds <= limit`. A fraction is the quieter case - it
+		vanishes into the division on a storage key, and publishes "10.5" scenes on
+		the plan cards for a count.
+	*/
+	it('holds a usable value for every limit', () => {
+		const unusable = PLAN_LADDER.flatMap((plan) =>
+			LIMIT_KEYS.filter((key) => {
+				const value = PLAN_LIMITS[plan][key]
+				return value !== null && !(Number.isSafeInteger(value) && value >= 0)
+			}).map((key) => `${plan}.${key}=${PLAN_LIMITS[plan][key]}`)
+		)
+
+		expect(unusable).toEqual([])
+	})
+
+	it('never lets a plan offer less than the plan below it', () => {
+		const inversions = LIMIT_KEYS.flatMap((key) =>
+			PLAN_LADDER.slice(1)
+				.map((higher, index) => [PLAN_LADDER[index], higher] as const)
+				.filter(
+					([lower, higher]) =>
+						asBound(PLAN_LIMITS[higher][key]) < asBound(PLAN_LIMITS[lower][key])
+				)
+				.map(
+					([lower, higher]) =>
+						`${key}: ${lower}=${PLAN_LIMITS[lower][key]} > ${higher}=${PLAN_LIMITS[higher][key]}`
+				)
+		)
+
+		expect(inversions).toEqual([])
+	})
+})


### PR DESCRIPTION
## Summary

Seven `present` claims pin plan numbers that two published pages quote, and none of them can say which plan owns a number. This asserts the ordering instead: a higher plan may match the plan below it, but it may never offer less.

Nothing here is broken today. Every hand-typed number was checked against `PLAN_LIMITS` and all of them are correct. This is the guard that makes the next three PRs safe to write, because they delete those claims.

## Root cause

n/a - pure test addition, no product code changes. The gap it closes: `documented-claims.spec.ts` matches with `contents.includes(literal)` over a whole file, so a `present` claim pins a *multiset* of literals while the published sentence asserts a *mapping* from plan to value.

## The defect, proven rather than described

Exchanging Free's `api_keys_per_org: 2` with Business's `: 50`:

- `plan-config.ts` still contains `: 2`, `: 10`, `: 50` and `: null`, so all four claims stay green
- `04_api-keys-101.mdx` publishes "2 keys (Free), 10 (Pro), 50 (Business)" - both numbers now against the wrong plans, on a prerendered public page
- **the whole suite stayed green: 2227 passed**

A second mutation, editing `upload.mdx` from "50 MB on Free" to "80 MB on Free", also left 2227 passing. Nothing asserts the prose at all. That half is fixed in a later PR; this one fixes the mapping.

## Changes

- `plan-config.spec.ts`, four tests over `PLAN_LIMITS`:
  - **the ladder never inverts** - `free <= pro <= business <= enterprise` for all eight limits, with `null` read as the top of the ladder rather than zero. Equality is allowed, and load-bearing: Free and Pro both get one seat.
  - **every plan carries the same limit keys** - the key list is read off `free` and cast, so without this a plan short of a key would read `undefined`, compare false in both directions, and drop that limit out of the ladder test while reporting clean.
  - **every limit holds a usable value** - `null`, or a non-negative safe integer. `NaN` satisfies `number` and clears `tsc`, and compares false in every direction, so it is the same silent drop reachable without weakening anything. The safe-integer half is `toSafeNumberFromBigInt`'s, since the same limit arriving from an `org_limit_overrides` row has to clear it; the `>= 0` half is this file's own and covers the ends of the ladder, where nothing sits above or below to compare against.
  - **the ladder lists every plan exactly once** - so a plan added without a place in it cannot be skipped by the other three.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated

Every assertion is mutation-gated. Each mutation was applied to `plan-config.ts`, run, and restored:

| Mutation | Result |
|---|---|
| Swap Free ↔ Business `api_keys_per_org` | red: `api_keys_per_org: free=50 > pro=10`, `pro=10 > business=2` |
| Drop `api_keys_per_org` from `enterprise` | red on the key-set test; the ladder test stayed green, which is the silent drop |
| `business.api_keys_per_org: Number('50 keys')` | red: `business.api_keys_per_org=NaN`; ladder test green |
| `free.org_seats: -1` | red: `free.org_seats=-1` |
| `free.scenes_total: 10.5` | red: `free.scenes_total=10.5` |
| `enterprise.storage_bytes_total: 1e308` | red: `enterprise.storage_bytes_total=1e+308` |
| `free.scenes_total: 0` | **green**, deliberately - a plan may offer none of something |
| `LIMIT_KEYS = []` | red: "has limits to compare" |
| Drop `business` from the ladder | red: "places every plan exactly once" |

Gates: `typecheck,lint` 8/8 tasks green; `npx vitest run --root .` 174 files / 2231 tests; `npx prettier --check .` clean.

## What this does not catch, said plainly

Ordering is all it expresses. Exchange Free's ten scenes with its twenty-five folders and nothing inverts, so that swap still passes - though most within-plan exchanges do invert something and are caught. A limit key deleted from all four plans at once also passes; that one needs the `Record<Plan, Record<LimitKey, number | null>>` annotation to weaken first, and `nx typecheck` is its guard.

## Filed, not fixed

`getQuotaLimit` passes a negative `org_limit_overrides.limitValue` straight through `toSafeNumberFromBigInt`, which only checks safe-integer-ness, so a negative override would reach `assertWithinQuota` and refuse that organization every operation permanently with no recovery path. Latent - both override tables hold zero rows in every environment - and it is product code this PR does not touch.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes