### PR TITLE
refactor(billing): move the plan-limit formatter out of the pricing card

### DIFF
--- a/apps/vectreal-platform/app/components/dashboard/billing/pricing-cards-section.tsx
+++ b/apps/vectreal-platform/app/components/dashboard/billing/pricing-cards-section.tsx
@@ -27,6 +27,7 @@ import { cn } from '@shared/utils'
 import { Check, Minus, Zap } from 'lucide-react'
 import { Link } from 'react-router'
 
+import { formatLimitValue } from '../../../constants/limit-format'
 import { PLAN_LIMITS, type Plan } from '../../../constants/plan-config'
 import {
 	ANNUAL_DISCOUNT_CLAIM,
@@ -44,22 +45,8 @@ import { BasicCard } from '../../layout-components'
 import type { BillingCheckoutOptions } from '../../../lib/domain/dashboard/dashboard-types'
 
 // ---------------------------------------------------------------------------
-// Limit display config — labels from product-copy, format logic stays here
+// Limit display config — labels and formatting both come from constants
 // ---------------------------------------------------------------------------
-
-export function formatLimitValue(key: string, v: number | null): string {
-	if (key === 'storage_bytes_total') {
-		if (v === null) return 'Custom'
-		const gb = v / (1024 * 1024 * 1024)
-		if (gb >= 1) return `${gb.toLocaleString()} GB`
-		return `${(v / (1024 * 1024)).toLocaleString()} MB`
-	}
-	if (key === 'storage_bytes_per_scene') {
-		if (v === null) return 'Custom'
-		return `${(v / (1024 * 1024)).toLocaleString()} MB`
-	}
-	return v === null ? 'Unlimited' : v.toLocaleString()
-}
 
 const HIGHLIGHTED_LIMITS = PLAN_CARD_LIMIT_KEYS.map((key) => ({
 	key: key as keyof (typeof PLAN_LIMITS)['free'],

--- a/apps/vectreal-platform/app/constants/limit-format.spec.ts
+++ b/apps/vectreal-platform/app/constants/limit-format.spec.ts
@@ -1,4 +1,4 @@
-import { formatLimitValue } from './pricing-cards-section'
+import { formatLimitValue } from './limit-format'
 
 describe('formatLimitValue', () => {
 	it('formats storage_bytes_per_scene as MB', () => {

--- a/apps/vectreal-platform/app/constants/limit-format.ts
+++ b/apps/vectreal-platform/app/constants/limit-format.ts
@@ -1,0 +1,34 @@
+/**
+ * How a plan limit is written for a reader.
+ *
+ * Extracted so `product-copy.ts` can render plan numbers rather than restate
+ * them. It lived inside `pricing-cards-section.tsx`, which `product-copy.ts`
+ * cannot import for two reasons: that component already takes nine names from
+ * `product-copy.ts`, so importing back would close a cycle, and
+ * `product-copy.ts` is read by `llms[.]txt.ts`, `seo.ts` and `seo-registry.ts`,
+ * none of which render anything, so reaching into a `.tsx` module would pull
+ * Radix and lucide into their graphs. The rule is not that a constants module
+ * may not import a component - `constants/dashboard.tsx` does - it is these two.
+ *
+ * Four user-facing strings came with it: "Custom", "Unlimited", and the " GB"
+ * and " MB" suffixes. `product-copy.ts`'s own docblock says none of them belong
+ * in a component.
+ *
+ * Moved verbatim. `key` stays a `string` rather than a `LimitKey`; every caller
+ * already passes one, so narrowing would compile today, but it is a second
+ * change.
+ */
+
+export function formatLimitValue(key: string, v: number | null): string {
+	if (key === 'storage_bytes_total') {
+		if (v === null) return 'Custom'
+		const gb = v / (1024 * 1024 * 1024)
+		if (gb >= 1) return `${gb.toLocaleString()} GB`
+		return `${(v / (1024 * 1024)).toLocaleString()} MB`
+	}
+	if (key === 'storage_bytes_per_scene') {
+		if (v === null) return 'Custom'
+		return `${(v / (1024 * 1024)).toLocaleString()} MB`
+	}
+	return v === null ? 'Unlimited' : v.toLocaleString()
+}


### PR DESCRIPTION
## Summary

`formatLimitValue` decides how a plan limit is written for a reader - "Custom", "Unlimited", "500 MB", "10 GB" - and it lived inside `pricing-cards-section.tsx`. Moved verbatim into a leaf module so `product-copy.ts` can reach it.

No behavior change. The extracted function is byte-identical to what was removed, and the pricing cards call it from its new home.

## Root cause

n/a - pure move, no behavior. Why the function could not stay where it was: `product-copy.ts` needs it, and `product-copy.ts` cannot import `pricing-cards-section.tsx` for two reasons. That component already takes **nine** names from `product-copy.ts`, so importing back would close a cycle. And `product-copy.ts` is read by `llms[.]txt.ts`, `seo.ts` and `seo-registry.ts` - the only three non-`.tsx` importers, none of which render - so reaching into a `.tsx` module would pull Radix and lucide into their graphs.

Note the rule is **not** "a constants module may not import a component": `constants/dashboard.tsx` imports `Skeleton` and renders it 13 times. It is these two reasons specifically, and the module's docblock says so, because the general version is false and was in the plan this PR came from.

## Changes

- New `app/constants/limit-format.ts`. Zero imports, so it cannot cycle and cannot pull anything server-only anywhere.
- `pricing-cards-section.tsx` imports it instead of declaring it. Its section comment changes from "format logic stays here" to match.
- `pricing-card-limit-format.spec.ts` moves to `app/constants/limit-format.spec.ts`, next to the module it now names. Unchanged apart from the import path.

Four user-facing strings came along: "Custom", "Unlimited", and the " GB" and " MB" suffixes. `product-copy.ts`'s docblock already says none of them belong in a component.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated (moved, not added)

Purity check: the function body was extracted from `origin/main` and from the new module and hashed - identical, `97a79663de4cc5418f9fdabb31d6fa1fbba4241f`. Repo-wide grep for `formatLimitValue` returns exactly three hits (definition, spec, component); `pricing-card-limit-format` returns zero.

| Mutation | Result |
|---|---|
| `'Unlimited'` → `'Boundless'` in the new module | red at `limit-format.spec.ts` - the spec reaches the new home |
| Pricing card's `format: (v) => formatLimitValue(key, v)` → `format: () => 'MUTATED'` | **green, all 2227 tests** |

Gates: `typecheck,lint` 8/8 tasks; `npx vitest run --root .` 173 files / 2227 tests; `npx prettier --check .` clean.

## Filed, not fixed

The second mutation above is the honest result: nothing binds the pricing card to the formatter, because no spec renders `PricingCardsSection` at all. That gap predates this PR - the old spec called the function directly too - and closing it means a new component test, which is a second concern.

Three more found while reviewing, all pre-existing:

- `formatCurrency` is duplicated verbatim between `pricing-cards-section.tsx` and `billing-upgrade.tsx:53`.
- `dashboard-overview.tsx:228` formats the same quantity inline as `${Math.round(value / MB)} MB`, so the constants module is not the only home for storage formatting despite the section comment implying it.
- `formatLimitValue`'s sub-1GB branch for `storage_bytes_total` is uncovered; the spec only exercises 10 GB for that key. Visible now only because coverage attributes it to its own file rather than the component's aggregate.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes