### PR TITLE
refactor(billing): render the plan numbers into the offer descriptions

### DIFF
--- a/apps/vectreal-platform/app/constants/limit-format.spec.ts
+++ b/apps/vectreal-platform/app/constants/limit-format.spec.ts
@@ -1,4 +1,4 @@
-import { formatLimitValue } from './limit-format'
+import { formatLimitCount, formatLimitValue } from './limit-format'
 
 describe('formatLimitValue', () => {
 	it('formats storage_bytes_per_scene as MB', () => {
@@ -20,5 +20,57 @@ describe('formatLimitValue', () => {
 	it('formats count limits plainly and null as Unlimited', () => {
 		expect(formatLimitValue('scenes_total', 200)).toBe('200')
 		expect(formatLimitValue('scenes_total', null)).toBe('Unlimited')
+	})
+})
+
+describe('formatLimitCount', () => {
+	it('drops the plural at one, where three plan limits already sit', () => {
+		expect(formatLimitCount('projects_total', 1, 'project')).toBe('1 project')
+		expect(formatLimitCount('projects_total', 2, 'project')).toBe('2 projects')
+	})
+
+	it('reads an unlimited count as a plural', () => {
+		expect(formatLimitCount('scenes_total', null, 'scene')).toBe(
+			'Unlimited scenes'
+		)
+	})
+
+	/*
+		The offer descriptions are English prose built into the JSON-LD during render
+		on the server and again in the browser, so they pin the locale. Without it a
+		German visitor hydrates a different string than the server sent.
+	*/
+	it('groups digits by the locale it is given, not by the default', () => {
+		expect(formatLimitCount('scenes_total', 2000, 'scene', 'en-US')).toBe(
+			'2,000 scenes'
+		)
+		expect(formatLimitCount('scenes_total', 2000, 'scene', 'de-DE')).toBe(
+			'2.000 scenes'
+		)
+	})
+
+	/*
+		The storage branches format their own number and are the ones the offer
+		descriptions actually reach, through `storage_bytes_total`. No storage tier
+		groups its digits today - 500, 10 and 100 - so dropping the locale there
+		would be invisible until a tier crossed a thousand.
+	*/
+	it('passes the locale into the storage branches too', () => {
+		const tb = 1024 * 1024 * 1024 * 1024
+
+		expect(formatLimitValue('storage_bytes_total', tb, 'en-US')).toBe(
+			'1,024 GB'
+		)
+		expect(formatLimitValue('storage_bytes_total', tb, 'de-DE')).toBe(
+			'1.024 GB'
+		)
+		expect(
+			formatLimitValue('storage_bytes_per_scene', 2000 * 1024 * 1024, 'de-DE')
+		).toBe('2.000 MB')
+
+		// The sub-gigabyte fallback, which is the branch Free's own sentence takes.
+		expect(
+			formatLimitValue('storage_bytes_total', 1000 * 1024 * 1024, 'de-DE')
+		).toBe('1.000 MB')
 	})
 })

--- a/apps/vectreal-platform/app/constants/limit-format.ts
+++ b/apps/vectreal-platform/app/constants/limit-format.ts
@@ -14,21 +14,48 @@
  * and " MB" suffixes. `product-copy.ts`'s own docblock says none of them belong
  * in a component.
  *
- * Moved verbatim. `key` stays a `string` rather than a `LimitKey`; every caller
- * already passes one, so narrowing would compile today, but it is a second
- * change.
+ * `key` stays a `string` rather than a `LimitKey`; every caller already passes
+ * one, so narrowing would compile today, but it is a second change.
+ *
+ * `locale` is optional, and omitting it keeps `toLocaleString`'s default. The
+ * plan cards omit it and render for whoever is looking, which does mean their
+ * numbers can differ between the server render and the browser, which predates
+ * this module and is not decided here. A caller writing a fixed English
+ * sentence passes one, so the published bytes do not depend on the locale of
+ * whichever machine happened to run the render.
  */
 
-export function formatLimitValue(key: string, v: number | null): string {
+export function formatLimitValue(
+	key: string,
+	v: number | null,
+	locale?: string
+): string {
 	if (key === 'storage_bytes_total') {
 		if (v === null) return 'Custom'
 		const gb = v / (1024 * 1024 * 1024)
-		if (gb >= 1) return `${gb.toLocaleString()} GB`
-		return `${(v / (1024 * 1024)).toLocaleString()} MB`
+		if (gb >= 1) return `${gb.toLocaleString(locale)} GB`
+		return `${(v / (1024 * 1024)).toLocaleString(locale)} MB`
 	}
 	if (key === 'storage_bytes_per_scene') {
 		if (v === null) return 'Custom'
-		return `${(v / (1024 * 1024)).toLocaleString()} MB`
+		return `${(v / (1024 * 1024)).toLocaleString(locale)} MB`
 	}
-	return v === null ? 'Unlimited' : v.toLocaleString()
+	return v === null ? 'Unlimited' : v.toLocaleString(locale)
+}
+
+/**
+ * The same value with the thing it counts, so a sentence can interpolate it.
+ *
+ * The plural is the whole reason this exists rather than `${n} scenes` at the
+ * call site: Free's `projects_total` is 1 today, so a count of one is a config
+ * edit away from publishing "1 scenes". `null` reads as unlimited and takes the
+ * plural, which is what "Unlimited scenes" wants.
+ */
+export function formatLimitCount(
+	key: string,
+	v: number | null,
+	noun: string,
+	locale?: string
+): string {
+	return `${formatLimitValue(key, v, locale)} ${noun}${v === 1 ? '' : 's'}`
 }

--- a/apps/vectreal-platform/app/constants/product-copy.spec.ts
+++ b/apps/vectreal-platform/app/constants/product-copy.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { PLAN_OFFER_DESCRIPTIONS } from './product-copy'
+
+/**
+ * The four offer descriptions, pinned whole.
+ *
+ * Nothing guarded these numbers before. The `present` claims over
+ * `plan-config.ts` pin `storage_bytes_per_scene` and `api_keys_per_org`, which
+ * these sentences never mention, and a claim is a whole-file substring test
+ * anyway: it pins a multiset of literals, never a mapping from plan to value.
+ * The numbers are read from `PLAN_LIMITS` now, so the mapping cannot be wrong,
+ * and this is the first thing that has ever asserted the sentences themselves.
+ *
+ * Without it, reading them from the config would rewrite published copy in
+ * silence - these four strings are the `description` of every schema.org
+ * `Offer` and the whole `## Pricing` section of `/llms.txt`. So the red is the
+ * point, and the instruction sits in the assertion message rather than up here,
+ * because that is what a person sees at the moment they update the string.
+ *
+ * It pins numbers, not meaning. Free's sentence advertises community support
+ * and Pro's says the feature set otherwise matches Free; both are entitlement
+ * claims, and flipping the entitlements behind them leaves this green.
+ *
+ * These are byte-identical to the hand-written strings they replaced.
+ */
+describe('PLAN_OFFER_DESCRIPTIONS', () => {
+	it('states the plan numbers the config holds', () => {
+		expect(
+			PLAN_OFFER_DESCRIPTIONS,
+			'A plan number moved. The sentence below already carries the new number, because it reads PLAN_LIMITS - so read the whole sentence before updating this string. The claim wrapped around the number may no longer be true.'
+		).toEqual({
+			free: '10 scenes, 500 MB storage, 3 concurrent published scenes. API access and community support included. Embedded scenes carry a small Vectreal badge. No credit card required.',
+			pro: '200 scenes, 10 GB storage, 50 concurrent published scenes, 20 projects. Removes the Vectreal badge from embedded scenes; otherwise the feature set matches Free.',
+			business:
+				'2,000 scenes, 100 GB storage, 500 concurrent published scenes. Adds team collaboration with role-based access (up to 10 seats) and priority support.',
+			enterprise:
+				'Unlimited scenes, published scenes, projects and seats, with storage sized to your needs. Adds a dedicated support channel. Custom pricing via sales.'
+		})
+	})
+})

--- a/apps/vectreal-platform/app/constants/product-copy.ts
+++ b/apps/vectreal-platform/app/constants/product-copy.ts
@@ -7,12 +7,16 @@
  * removed, so this is now the only place these strings live.
  *
  * Rule: keep every claim here checkable against code. Plan and limit shapes come
- * from ./plan-config; supported formats come from the loader and the file-input
+ * from ./plan-config, and the offer descriptions read its values rather than
+ * restating them; supported formats come from the loader and the file-input
  * accept pattern. Do not inline any of these strings in components.
  *
  * Prices are intentionally absent: they are Stripe-managed and loaded
  * dynamically. Point users to /pricing for current rates.
  */
+
+import { formatLimitCount, formatLimitValue } from './limit-format'
+import { PLAN_LIMITS } from './plan-config'
 
 import type { EntitlementKey, LimitKey, Plan } from './plan-config'
 
@@ -194,11 +198,42 @@ export const PAYMENT_TRUST_COPY = 'Secured by Stripe · Cancel anytime'
 // Plan offer descriptions for schema.org WebApplication.offers and llms.txt
 // ---------------------------------------------------------------------------
 
+/*
+  These sentences are English prose that reaches machine readers: `/llms.txt`
+  renders them verbatim and they are the `description` of every schema.org
+  `Offer`. Neither is rendered for a person with a locale - `/llms.txt` and
+  `/pricing` render per request inside the container, and the pages in the
+  prerender list are rendered during `docker build` - and neither the image nor
+  the build stage declares a `LANG`. So an unpinned `toLocaleString` would let
+  the published number depend on a container default nobody chose.
+  `buildWebSiteJsonLd` already declares `inLanguage: 'en-US'`; this agrees.
+
+  Only one interpolated number groups its digits today (Business's 2,000
+  scenes), but every one of them would change numbering system outside a
+  Latin-digit locale.
+*/
+const OFFER_LOCALE = 'en-US'
+
+const limit = (plan: Plan, key: LimitKey) =>
+	formatLimitValue(key, PLAN_LIMITS[plan][key], OFFER_LOCALE)
+
+const count = (plan: Plan, key: LimitKey, noun: string) =>
+	formatLimitCount(key, PLAN_LIMITS[plan][key], noun, OFFER_LOCALE)
+
+/*
+  The sentences stay hand-written. What moves into an interpolation is a number,
+  its unit, and the noun it counts, so a copy edit is still an ordinary string
+  edit - #828 changed the badge line here and would change it the same way today
+  - though a noun is now an argument to `count` rather than plain text.
+
+  Enterprise is left alone deliberately. Every limit it holds is null, which
+  formats as "Unlimited" or "Custom", and "Custom storage" is not a sentence -
+  which is why that entry was already written differently by hand.
+*/
 export const PLAN_OFFER_DESCRIPTIONS: Record<Plan, string> = {
-	free: '10 scenes, 500 MB storage, 3 concurrent published scenes. API access and community support included. Embedded scenes carry a small Vectreal badge. No credit card required.',
-	pro: '200 scenes, 10 GB storage, 50 concurrent published scenes, 20 projects. Removes the Vectreal badge from embedded scenes; otherwise the feature set matches Free.',
-	business:
-		'2,000 scenes, 100 GB storage, 500 concurrent published scenes. Adds team collaboration with role-based access (up to 10 seats) and priority support.',
+	free: `${count('free', 'scenes_total', 'scene')}, ${limit('free', 'storage_bytes_total')} storage, ${count('free', 'scenes_published_concurrent', 'concurrent published scene')}. API access and community support included. Embedded scenes carry a small Vectreal badge. No credit card required.`,
+	pro: `${count('pro', 'scenes_total', 'scene')}, ${limit('pro', 'storage_bytes_total')} storage, ${count('pro', 'scenes_published_concurrent', 'concurrent published scene')}, ${count('pro', 'projects_total', 'project')}. Removes the Vectreal badge from embedded scenes; otherwise the feature set matches Free.`,
+	business: `${count('business', 'scenes_total', 'scene')}, ${limit('business', 'storage_bytes_total')} storage, ${count('business', 'scenes_published_concurrent', 'concurrent published scene')}. Adds team collaboration with role-based access (up to ${count('business', 'org_seats', 'seat')}) and priority support.`,
 	enterprise:
 		'Unlimited scenes, published scenes, projects and seats, with storage sized to your needs. Adds a dedicated support channel. Custom pricing via sales.'
 }


### PR DESCRIPTION
## Summary

`PLAN_OFFER_DESCRIPTIONS` restated numbers that `plan-config.ts` already owns. They now come from `PLAN_LIMITS`. The sentences stay hand-written and the rendered output is byte-identical to the strings it replaces.

**Stacked on #841**, which moved `formatLimitValue` into a module this file can import. Rebase after that merges.

## Root cause

n/a for behavior - nothing was wrong. The numbers were all correct; I checked every one. What was wrong is that they were correct *by coincidence*, in a constant nothing compared against the config, on a surface that reaches crawlers: `/llms.txt` renders these four strings verbatim under `## Pricing`, and they are the `description` of every schema.org `Offer`. #835 made both visible.

**No claim ever guarded these numbers.** It is worth being precise, because I had it wrong at first: the seven `present` claims over `plan-config.ts` pin `storage_bytes_per_scene` and `api_keys_per_org`, and these four sentences mention neither. So this is not a checkpoint being replaced; it is the first one these sentences have had.

## Changes

- `PLAN_OFFER_DESCRIPTIONS` interpolates through two module-private helpers over `formatLimitValue` and a new `formatLimitCount`. Enterprise is untouched: every limit it holds is `null`, which formats as "Unlimited" or "Custom", and "Custom storage" is not a sentence - which is why that entry was already hand-written differently.
- `formatLimitCount(key, value, noun, locale?)` in `limit-format.ts`. The plural exists because Free's `projects_total` is 1 today, so "1 scenes" is one config edit away.
- Both formatters take an optional `locale`. **Pinned to `en-US` for these sentences.** `/llms.txt` and `/pricing` render per request inside the container, the prerendered pages render during `docker build`, and neither declares a `LANG` - so an unpinned `toLocaleString` would let the published number depend on a container default nobody chose. `buildWebSiteJsonLd` already declares `inLanguage: 'en-US'`. The plan cards keep the default and render for whoever is looking.
- New `product-copy.spec.ts` pins all four sentences whole.

## Type of Change

- [x] Refactor / chore (no functional change)

## Testing

- [x] Unit / integration tests added or updated

Byte-identity proven by execution, not by eye: the working tree and `origin/main` were imported side by side and compared as UTF-8 buffers - free 171, pro 160, business 148, enterprise 149 chars, all identical, key order preserved.

| Mutation | Result |
|---|---|
| `business.scenes_total` 2000 → 3000 | red, whole sentence in the diff |
| Pro's sentence reads Free's scene count | red |
| `OFFER_LOCALE` `en-US` → `de-DE` | red |
| `formatLimitCount` always plural | red: `'1 projects'` vs `'1 project'` |
| Drop `locale` from each of the four `toLocaleString` sites, one at a time | red, individually, all four |

Gates: `typecheck,lint` 8/8 tasks; `npx vitest run --root .` 174 files / 2232 tests; `npx prettier --check .` clean.

## Why the spec pins the sentences whole

Interpolation guarantees the number is right and removes the reason anyone would ever read the sentence again. So the spec pins all four, and the instruction lives in the assertion message rather than a comment, because that is what a person sees at the moment they are about to update the string:

> A plan number moved. The sentence below already carries the new number, because it reads PLAN_LIMITS - so read the whole sentence before updating this string. The claim wrapped around the number may no longer be true.

It pins numbers, not meaning: Free's sentence advertises community support and Pro's says the feature set otherwise matches Free. Both are entitlement claims, and flipping the entitlements behind them leaves this green. The docblock says so.

## Verified, not assumed

Three things the review loop corrected in my own reasoning, recorded because the comments now depend on them:

- **React never patches a mismatched `dangerouslySetInnerHTML`** - the server bytes are kept. My first version of the locale comment claimed a hydration mismatch would publish different numbers to different visitors. It would not. The real exposure is the render *environment's* locale, which is what the comment says now.
- **`/pricing` is not prerendered.** It renders per request, like `/llms.txt`.
- **`node:22-alpine` is a full-ICU build** (`icu_small: false`, ICU 78.2, default locale `en-US`), confirmed by running the image. So the pin behaves identically in the build stage, the container and vitest, and the `de-DE` assertions are meaningful rather than accidentally green.

## Filed, not fixed

The plan cards have the same locale exposure and keep the default: `PLAN_CARD_LIMIT_KEYS` includes `scenes_total` (business 2,000) and `folders_total` (business 5,000), and `/pricing` is server-rendered, so those numbers can differ between the server render and the browser. That predates this branch - the formatter was moved verbatim in #841 - and deciding it is a visible change to a marketing surface, which is its own PR.

Also: `product-copy.ts`'s chunk gains a static import of `plan-config.ts` (~2.4 KB of pure data, zero imports of its own), which reaches every public route through `seo.ts`. Nothing server-only becomes reachable and there is no cycle. The offer strings were already in the client bundle.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes