### PR TITLE
docs(billing): render the plan numbers on the two pages that publish them

### DIFF
--- a/apps/vectreal-platform/app/constants/limit-format.ts
+++ b/apps/vectreal-platform/app/constants/limit-format.ts
@@ -25,6 +25,17 @@
  * whichever machine happened to run the render.
  */
 
+/**
+ * The locale published English prose formats its numbers with.
+ *
+ * The pages that carry these numbers are rendered by a machine, not for a
+ * reader with a locale: `/llms.txt` and `/pricing` per request in the
+ * container, the docs and news pages during `docker build`. Neither declares a
+ * `LANG`, so without this the published number would follow a container default
+ * nobody chose. `buildWebSiteJsonLd` already declares `inLanguage: 'en-US'`.
+ */
+export const PUBLISHED_COPY_LOCALE = 'en-US'
+
 export function formatLimitValue(
 	key: string,
 	v: number | null,

--- a/apps/vectreal-platform/app/constants/product-copy.spec.ts
+++ b/apps/vectreal-platform/app/constants/product-copy.spec.ts
@@ -6,9 +6,12 @@ import { PLAN_OFFER_DESCRIPTIONS } from './product-copy'
  * The four offer descriptions, pinned whole.
  *
  * Nothing guarded these numbers before. The `present` claims over
- * `plan-config.ts` pin `storage_bytes_per_scene` and `api_keys_per_org`, which
- * these sentences never mention, and a claim is a whole-file substring test
- * anyway: it pins a multiset of literals, never a mapping from plan to value.
+ * `plan-config.ts` pinned `storage_bytes_per_scene` and `api_keys_per_org`,
+ * which these sentences never mention, and a claim is a whole-file substring
+ * test anyway: it pins a multiset of literals, never a mapping from plan to
+ * value. All but two are gone now, for that reason. The survivors are the two
+ * `null`s: each of those pages still writes Enterprise's own value by hand,
+ * because it formats as "Custom" or "Unlimited" and neither fits the sentence.
  * The numbers are read from `PLAN_LIMITS` now, so the mapping cannot be wrong,
  * and this is the first thing that has ever asserted the sentences themselves.
  *

--- a/apps/vectreal-platform/app/constants/product-copy.ts
+++ b/apps/vectreal-platform/app/constants/product-copy.ts
@@ -15,7 +15,11 @@
  * dynamically. Point users to /pricing for current rates.
  */
 
-import { formatLimitCount, formatLimitValue } from './limit-format'
+import {
+	formatLimitCount,
+	formatLimitValue,
+	PUBLISHED_COPY_LOCALE
+} from './limit-format'
 import { PLAN_LIMITS } from './plan-config'
 
 import type { EntitlementKey, LimitKey, Plan } from './plan-config'
@@ -201,24 +205,26 @@ export const PAYMENT_TRUST_COPY = 'Secured by Stripe · Cancel anytime'
 /*
   These sentences are English prose that reaches machine readers: `/llms.txt`
   renders them verbatim and they are the `description` of every schema.org
-  `Offer`. Neither is rendered for a person with a locale - `/llms.txt` and
-  `/pricing` render per request inside the container, and the pages in the
-  prerender list are rendered during `docker build` - and neither the image nor
-  the build stage declares a `LANG`. So an unpinned `toLocaleString` would let
-  the published number depend on a container default nobody chose.
-  `buildWebSiteJsonLd` already declares `inLanguage: 'en-US'`; this agrees.
-
-  Only one interpolated number groups its digits today (Business's 2,000
+  `Offer`. Both follow `PUBLISHED_COPY_LOCALE`, which is where the reasoning
+  lives. Only one interpolated number groups its digits today (Business's 2,000
   scenes), but every one of them would change numbering system outside a
   Latin-digit locale.
 */
-const OFFER_LOCALE = 'en-US'
 
-const limit = (plan: Plan, key: LimitKey) =>
-	formatLimitValue(key, PLAN_LIMITS[plan][key], OFFER_LOCALE)
+/**
+ * A plan limit, written the way published copy writes it.
+ *
+ * Exported because two published pages state these numbers in prose and used to
+ * type them by hand: `docs/guides/upload.mdx` and the `api-keys-101` article.
+ * Both are prerendered, so a plan change left them stating a number nobody
+ * served, and the claims blocks that guarded them could only pin that a literal
+ * existed somewhere in `plan-config.ts`, never which plan owned it.
+ */
+export const publishedLimit = (plan: Plan, key: LimitKey) =>
+	formatLimitValue(key, PLAN_LIMITS[plan][key], PUBLISHED_COPY_LOCALE)
 
 const count = (plan: Plan, key: LimitKey, noun: string) =>
-	formatLimitCount(key, PLAN_LIMITS[plan][key], noun, OFFER_LOCALE)
+	formatLimitCount(key, PLAN_LIMITS[plan][key], noun, PUBLISHED_COPY_LOCALE)
 
 /*
   The sentences stay hand-written. What moves into an interpolation is a number,
@@ -231,9 +237,9 @@ const count = (plan: Plan, key: LimitKey, noun: string) =>
   which is why that entry was already written differently by hand.
 */
 export const PLAN_OFFER_DESCRIPTIONS: Record<Plan, string> = {
-	free: `${count('free', 'scenes_total', 'scene')}, ${limit('free', 'storage_bytes_total')} storage, ${count('free', 'scenes_published_concurrent', 'concurrent published scene')}. API access and community support included. Embedded scenes carry a small Vectreal badge. No credit card required.`,
-	pro: `${count('pro', 'scenes_total', 'scene')}, ${limit('pro', 'storage_bytes_total')} storage, ${count('pro', 'scenes_published_concurrent', 'concurrent published scene')}, ${count('pro', 'projects_total', 'project')}. Removes the Vectreal badge from embedded scenes; otherwise the feature set matches Free.`,
-	business: `${count('business', 'scenes_total', 'scene')}, ${limit('business', 'storage_bytes_total')} storage, ${count('business', 'scenes_published_concurrent', 'concurrent published scene')}. Adds team collaboration with role-based access (up to ${count('business', 'org_seats', 'seat')}) and priority support.`,
+	free: `${count('free', 'scenes_total', 'scene')}, ${publishedLimit('free', 'storage_bytes_total')} storage, ${count('free', 'scenes_published_concurrent', 'concurrent published scene')}. API access and community support included. Embedded scenes carry a small Vectreal badge. No credit card required.`,
+	pro: `${count('pro', 'scenes_total', 'scene')}, ${publishedLimit('pro', 'storage_bytes_total')} storage, ${count('pro', 'scenes_published_concurrent', 'concurrent published scene')}, ${count('pro', 'projects_total', 'project')}. Removes the Vectreal badge from embedded scenes; otherwise the feature set matches Free.`,
+	business: `${count('business', 'scenes_total', 'scene')}, ${publishedLimit('business', 'storage_bytes_total')} storage, ${count('business', 'scenes_published_concurrent', 'concurrent published scene')}. Adds team collaboration with role-based access (up to ${count('business', 'org_seats', 'seat')}) and priority support.`,
 	enterprise:
 		'Unlimited scenes, published scenes, projects and seats, with storage sized to your needs. Adds a dedicated support channel. Custom pricing via sales.'
 }

--- a/apps/vectreal-platform/app/routes/docs/guides/upload.mdx
+++ b/apps/vectreal-platform/app/routes/docs/guides/upload.mdx
@@ -1,3 +1,5 @@
+import { publishedLimit } from '../../../constants/product-copy'
+
 # Uploading Models
 
 Everything you need to know about getting 3D files into the Vectreal Publisher.
@@ -39,17 +41,21 @@ The parser identifies the `.gltf` root and resolves all referenced `.bin` and te
 
 ## File size and limits
 
-The Publisher enforces your plan's maximum scene size: 50 MB on Free, 200 MB on Pro, 500 MB on Business, and a custom limit on Enterprise. While a scene is over the limit the Save button becomes **Optimize to Save**, the optimizer opens automatically, and the server rejects the save until the scene fits. Run optimization first for production-grade assets (see [Optimizing & Configuring](/docs/guides/optimize)).
+The Publisher enforces your plan's maximum scene size: {publishedLimit('free', 'storage_bytes_per_scene')} on Free, {publishedLimit('pro', 'storage_bytes_per_scene')} on Pro, {publishedLimit('business', 'storage_bytes_per_scene')} on Business, and a custom limit on Enterprise. While a scene is over the limit the Save button becomes **Optimize to Save**, the optimizer opens automatically, and the server rejects the save until the scene fits. Run optimization first for production-grade assets (see [Optimizing & Configuring](/docs/guides/optimize)).
 
 {/* claims
-  # The three sizes above, tied to the config, and to the gate that applies it.
-  # This page is prerendered, so a plan change would leave it stating numbers
-  # nobody serves.
-  present  apps/vectreal-platform/app/constants/plan-config.ts   storage_bytes_per_scene: 50 * 1024 * 1024
-  present  apps/vectreal-platform/app/constants/plan-config.ts   storage_bytes_per_scene: 200 * 1024 * 1024
-  present  apps/vectreal-platform/app/constants/plan-config.ts   storage_bytes_per_scene: 500 * 1024 * 1024
+  # The three sizes above are read from PLAN_LIMITS now, so the claims that
+  # pinned their literals are gone. They could only prove a number appeared
+  # somewhere in plan-config.ts, never that this page attributed it to the right
+  # plan - exchanging two plans' values kept every one of them green.
+  #
+  # The fourth value is still a word. Enterprise formats as "Custom" and the
+  # sentence wants "a custom limit", so it stays hand-written - and this claim
+  # holds it, because enterprise is the only plan holding null for this key.
+  present  apps/vectreal-platform/app/constants/plan-config.ts   storage_bytes_per_scene: null
 
-  # "the server rejects the save" is the load-bearing half of the sentence.
+  # What rendering cannot replace is the other half of the sentence: that a
+  # server actually refuses the save. These two stay for that.
   present  apps/vectreal-platform/app/lib/domain/scene/server/scene-settings.operations.server.ts   limitKey: 'storage_bytes_per_scene'
   present  apps/vectreal-platform/app/lib/domain/scene/scene-size-limit.ts   isSceneOverSizeLimit
 */}

--- a/apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx
+++ b/apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx
@@ -41,6 +41,8 @@ You are about to ship a Vectreal embed to production. Your security reviewer wan
    1:1 crop derived from cover; 600×600, webp, <60 KB.
    Output: /public/assets/images/newsroom/04/thumbnail-api-keys-101.webp */}
 
+import { publishedLimit } from '../../../constants/product-copy'
+
 ### Before You Begin
 
 Vectreal API keys are managed in your dashboard at [vectreal.com/dashboard/api-keys](https://vectreal.com/dashboard/api-keys). You need to be an **admin** or **owner** of the organization to create or revoke keys - members can use embeds that depend on a key, but they cannot mint new ones.
@@ -212,27 +214,28 @@ You are building a SaaS product where each of your customers gets their own Vect
 - **Expiration:** 90 days, with a renewal job in your provisioning workflow.
 - **Rotation:** revocation becomes part of off-boarding. When a customer cancels, the revoke step is idempotent and immediate - embed traffic from their domain stops on the next request.
 
-This is the layout most likely to grow past plan limits. The current per-org limits are **2 keys (Free), 10 (Pro), 50 (Business), unlimited (Enterprise)**. If you are crossing those thresholds at customer growth scale, the conversation is about tier rather than security model.
+This is the layout most likely to grow past plan limits. The current per-org limits are **{publishedLimit('free', 'api_keys_per_org')} keys (Free), {publishedLimit('pro', 'api_keys_per_org')} (Pro), {publishedLimit('business', 'api_keys_per_org')} (Business), unlimited (Enterprise)**. If you are crossing those thresholds at customer growth scale, the conversation is about tier rather than security model.
 
 {/* claims
-  # The four numbers in the paragraph above, tied to the config they came from.
-  # They were correct when written and nothing would have noticed if a plan
-  # changed underneath them - this article is prerendered and public.
+  # Three of the four numbers in the paragraph above are read from PLAN_LIMITS
+  # now, so the claims that pinned their literals are gone. Those were always
+  # weaker than they looked: a literal is matched as a substring over the whole
+  # file, so `api_keys_per_org: 2` would have matched a future `: 25`, and
+  # exchanging Free's two keys with Business's fifty left all four green while
+  # this paragraph published both numbers against the wrong plans.
   #
-  # A literal is matched as a substring, so `api_keys_per_org: 2` would also
-  # match a future `: 25`. It still catches a rename, a deletion, and any new
-  # value that does not share the old one's prefix.
-  present  apps/vectreal-platform/app/constants/plan-config.ts   api_keys_per_org: 2
-  present  apps/vectreal-platform/app/constants/plan-config.ts   api_keys_per_org: 10
-  present  apps/vectreal-platform/app/constants/plan-config.ts   api_keys_per_org: 50
+  # The fourth is still a word. Enterprise formats as "Unlimited" and the
+  # sentence wants "unlimited", so it stays hand-written - and its claim stays
+  # with it, because enterprise is the only plan holding null for this key, so
+  # giving Enterprise a number would make this literal vanish from the file.
   present  apps/vectreal-platform/app/constants/plan-config.ts   api_keys_per_org: null
 
-  # And that the limit is enforced by counting rows, which is what makes the
-  # sentence "most likely to grow past plan limits" mean anything. It ran
-  # through `checkQuota` until 2026-09-03; that helper read a counter nothing
-  # incremented, so the ceiling did not exist. It has since been deleted, which
-  # is why the paired `absent ... await checkQuota(` claim is gone: it pinned
-  # the absence of a function that can no longer be called.
+  # What rendering cannot replace is that the limit is enforced by counting
+  # rows, which is what makes "most likely to grow past plan limits" mean
+  # anything. It ran through `checkQuota` until 2026-09-03; that helper read a
+  # counter nothing incremented, so the ceiling did not exist. It has since been
+  # deleted, which is why the paired `absent ... await checkQuota(` claim is
+  # gone: it pinned the absence of a function that can no longer be called.
   present  apps/vectreal-platform/app/lib/domain/auth/api-key-repository.server.ts   limitKey: 'api_keys_per_org'
 */}
 

--- a/apps/vectreal-platform/tests/documented-claims.spec.ts
+++ b/apps/vectreal-platform/tests/documented-claims.spec.ts
@@ -106,11 +106,15 @@ const CLAIM_CARRYING_DOCS = [
 	*/
 	'apps/vectreal-platform/app/routes/docs/guides/embed-sdk.mdx',
 	/*
-	  Both of these state plan numbers in prose, hardcoded, with no link to
-	  `plan-config.ts`. Both are prerendered and public. They were accurate when
-	  written, which is the whole problem: nothing would have gone red if a plan
-	  changed underneath them, and nothing did go red through the audit that
-	  found four limits nobody measured and twelve entitlements nobody shipped.
+	  Both of these state plan numbers in prose, and both are prerendered and
+	  public. They used to hardcode those numbers with no link to
+	  `plan-config.ts`, which was the whole problem: nothing would have gone red
+	  if a plan changed underneath them, and nothing did go red through the audit
+	  that found four limits nobody measured and twelve entitlements nobody
+	  shipped. They render the numbers from the config now, so what is left here
+	  is what rendering cannot replace - that a server enforces the limit, and
+	  that Enterprise is still the plan holding `null` for the limit each page
+	  names, which is the one value both pages still write by hand.
 	*/
 	'apps/vectreal-platform/app/routes/docs/guides/upload.mdx',
 	'apps/vectreal-platform/app/routes/news-room-page/articles/04_api-keys-101.mdx'


### PR DESCRIPTION
## Summary

`docs/guides/upload.mdx` and the `api-keys-101` article typed plan numbers by hand. Both read them from `PLAN_LIMITS` now, and the six claims that pinned those literals are deleted.

**Stacked on #842.** Rebase after that merges.

## Root cause

n/a for behavior - every number was correct. The defect is in the guard. A `present` claim is a whole-file substring test, so it pins a *multiset of literals* and never a *mapping from plan to value*.

Proven, not asserted: exchanging Free's `api_keys_per_org: 2` with Business's `: 50` leaves all four literals in the file, all four claims green, and the article publishing both numbers against the wrong plans. The same swap on `storage_bytes_per_scene` does the same to the upload guide. Both pages are prerendered and public.

## Changes

- `publishedLimit(plan, key)` exported from `product-copy.ts`, beside the offer descriptions that already used it privately.
- `PUBLISHED_COPY_LOCALE` promoted into `limit-format.ts` now that a second consumer needs it. One home for the reasoning.
- Both pages interpolate. Six claims deleted: three `storage_bytes_per_scene` literals, three `api_keys_per_org` literals.

**Four claims stay, and the fourth is the interesting one.** Two pin enforcement - that the server refuses an oversized save, and that the key limit is enforced by counting rows. Rendering cannot replace those.

The other two exist because **each page still writes Enterprise's own value by hand**: `formatLimitValue` returns "Custom" and "Unlimited", and neither fits mid-sentence in "a custom limit on Enterprise" or "unlimited (Enterprise)". Enterprise is the only plan holding `null` for either key, so `present ... storage_bytes_per_scene: null` and `present ... api_keys_per_org: null` each go red the moment Enterprise gets a real number - which is exactly when those two hand-written words become false. The review loop caught that I had deleted the api-keys one; the upload one had never existed at all.

## Type of Change

- [x] Documentation update

## Testing

- [x] Unit / integration tests added or updated

**Verified against the built output, not the source.** `CSRF_SECRET=… pnpm nx build vectreal-platform`, then read the prerendered HTML:

| Page | Prerendered text |
|---|---|
| `/docs/guides/upload` | "maximum scene size: 50 MB on Free, 200 MB on Pro, 500 MB on Business, and a custom limit on Enterprise." |
| `/news-room/api-keys-101` | "The current per-org limits are **2 keys (Free), 10 (Pro), 50 (Business), unlimited (Enterprise)**." |

Both byte-identical to the hand-typed prose on `main` after stripping React's `<!-- -->` text separators.

Then the mutation, which is the whole point: with `storage_bytes_per_scene` set to 80 MB and `api_keys_per_org` to 7, a rebuild published **"80 MB on Free"** and **"7 keys (Free)"**. Before this PR those pages would have kept publishing 50 and 2.

| Mutation | Result |
|---|---|
| Enterprise `api_keys_per_org: null` → `500` | red: claim names the file, the literal, and the line |
| Enterprise `storage_bytes_per_scene: null` → a number | red, same |
| Config values changed, rebuild | both published pages follow |

Gates: `typecheck,lint` 8/8 tasks; `npx vitest run --root .` 174 files / 2227 tests; `npx prettier --check .` clean. Claim count 100 → 101.

## Checked, since MDX imports are new to these pages

- Both pages are in the prerender set, and both import paths resolve from their own depth.
- No consumer reads the raw `.mdx` and would now see `{publishedLimit(…)}` instead of a number. The reading-time estimator strips `^import` lines; its count moves 1713 → 1731 words, 18 minutes either way. `/llms.txt` and the JSON-LD use frontmatter excerpts, not the body. The `.data` files carry no prose.
- Zero bundle cost: `product-copy` was already `modulepreload`ed on both pages via root meta.
- No hydration exposure: every value on these pages is under 1000, so no grouping separator is in play, and `PUBLISHED_COPY_LOCALE` pins it regardless.

## Checklist

- [x] My commits follow Conventional Commits
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes