### PR TITLE
fix(a11y): make text and focus meet WCAG AA on the surfaces they are used on

### DIFF
--- a/apps/vectreal-platform/tests/contrast-tokens.spec.ts
+++ b/apps/vectreal-platform/tests/contrast-tokens.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * The semantic colour tokens, measured against the surfaces they are used on.
+ *
+ * Every one of these pairs was failing WCAG AA when this spec was written, and
+ * none of them failed in a way anyone would notice by looking: muted text reads
+ * 4.73:1 on a plain page and 3.49:1 inside a nested panel, so the same token
+ * passed in a hero and failed in every card. A ratio is not something a reviewer
+ * can eyeball, which is the whole argument for pinning it.
+ *
+ * The surfaces are computed rather than hardcoded, because `ds-raised` and
+ * `ds-overlay` are `color-mix` of `--foreground` into `--background`. If the
+ * ladder's percentages change, the expectations move with them.
+ *
+ * If one of these fails, the fix is the token, not the number. Lowering a
+ * threshold here is lowering it for every reader.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const CSS = readFileSync(
+	join(
+		dirname(fileURLToPath(import.meta.url)),
+		'../../../shared/components/src/styles/globals.css'
+	),
+	'utf8'
+)
+
+type Rgb = [number, number, number]
+
+/** oklch -> OKLab -> linear sRGB -> gamma sRGB, the standard matrices. */
+function oklchToRgb(L: number, C: number, hDeg: number): Rgb {
+	const h = (hDeg * Math.PI) / 180
+	const a = C * Math.cos(h)
+	const b = C * Math.sin(h)
+	const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3
+	const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3
+	const s = (L - 0.0894841775 * a - 1.291485548 * b) ** 3
+	const lin = [
+		4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+		-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+		-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s
+	]
+	return lin.map((v) => {
+		const g = v <= 0.0031308 ? 12.92 * v : 1.055 * Math.pow(v, 1 / 2.4) - 0.055
+		return Math.max(0, Math.min(255, Math.round(g * 255)))
+	}) as Rgb
+}
+
+function relativeLuminance([r, g, b]: Rgb): number {
+	const f = (v: number) => {
+		const c = v / 255
+		return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+	}
+	return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+	const [hi, lo] = [relativeLuminance(a), relativeLuminance(b)].sort(
+		(x, y) => y - x
+	)
+	return Math.round(((hi + 0.05) / (lo + 0.05)) * 100) / 100
+}
+
+/**
+ * Reads a token out of `:root` or `.dark`.
+ *
+ * `.dark` is matched by slicing the file at its opening brace: the two blocks
+ * declare the same names, so a whole-file regex silently returns the light
+ * value for both themes and every dark assertion passes for the wrong reason.
+ */
+function token(name: string, theme: 'light' | 'dark'): Rgb {
+	const scope = theme === 'dark' ? CSS.slice(CSS.indexOf('.dark {')) : CSS
+	const match = scope.match(
+		new RegExp(`--${name}:\\s*oklch\\(([\\d.]+)\\s+([\\d.]+)\\s+([\\d.]+)`)
+	)
+	if (!match) throw new Error(`--${name} not found for ${theme}`)
+	return oklchToRgb(Number(match[1]), Number(match[2]), Number(match[3]))
+}
+
+/** A `ds-*` step: `color-mix(in oklch, --foreground N%, --background)`. */
+function surface(theme: 'light' | 'dark', percent: number): Rgb {
+	const fg = token('foreground', theme)
+	const bg = token('background', theme)
+	return fg.map((c, i) =>
+		Math.round(c * percent + bg[i] * (1 - percent))
+	) as Rgb
+}
+
+const AA_TEXT = 4.5
+/** WCAG 1.4.11, for a focus indicator and other non-text affordances. */
+const AA_NON_TEXT = 3
+
+describe('semantic tokens clear WCAG AA on the surfaces they are used on', () => {
+	describe.each(['light', 'dark'] as const)('%s', (theme) => {
+		const surfaces = {
+			background: token('background', theme),
+			'ds-raised (4%)': surface(theme, 0.04),
+			'ds-overlay (8%)': surface(theme, 0.08)
+		}
+
+		describe.each(Object.entries(surfaces))('on %s', (_label, bg) => {
+			it(`muted-foreground reaches ${AA_TEXT}:1`, () => {
+				expect(
+					contrast(token('muted-foreground', theme), bg)
+				).toBeGreaterThanOrEqual(AA_TEXT)
+			})
+
+			it(`destructive reaches ${AA_TEXT}:1`, () => {
+				expect(
+					contrast(token('destructive', theme), bg)
+				).toBeGreaterThanOrEqual(AA_TEXT)
+			})
+
+			it(`ring reaches ${AA_NON_TEXT}:1`, () => {
+				expect(contrast(token('ring', theme), bg)).toBeGreaterThanOrEqual(
+					AA_NON_TEXT
+				)
+			})
+
+			it(`foreground reaches ${AA_TEXT}:1`, () => {
+				expect(contrast(token('foreground', theme), bg)).toBeGreaterThanOrEqual(
+					AA_TEXT
+				)
+			})
+		})
+	})
+
+	it('reads the dark block, not the light one twice', () => {
+		// Guards `token()`: if the .dark slice broke, every dark case above would
+		// assert the light value and pass for the wrong reason.
+		expect(token('background', 'light')).not.toEqual(
+			token('background', 'dark')
+		)
+		expect(token('muted-foreground', 'light')).not.toEqual(
+			token('muted-foreground', 'dark')
+		)
+	})
+
+	it('states the focus indicator once, globally, at full strength', () => {
+		/*
+		  The failure this replaces: `* { outline-ring/50 }` set the browser
+		  outline to a half-alpha ring, and each control then suppressed it and
+		  drew its own. Both were under 3:1, and links got neither.
+		*/
+		expect(CSS).toContain('outline: 2px solid var(--ring)')
+
+		/*
+		  Match the declaration, not the word. The comment above that rule
+		  explains what it replaced and names `outline-ring/50`, so a bare
+		  substring check fails on the explanation of its own fix.
+		*/
+		const declarations = CSS.replace(/\/\*[\s\S]*?\*\//g, '')
+		expect(declarations).not.toMatch(/@apply[^;]*outline-ring\/50/)
+	})
+})

--- a/shared/components/src/styles/globals.css
+++ b/shared/components/src/styles/globals.css
@@ -71,7 +71,30 @@
 	--secondary: oklch(0.97 0 0);
 	--secondary-foreground: oklch(0.205 0 0);
 	--muted: oklch(0.97 0 0);
-	--muted-foreground: oklch(0.556 0 0);
+	/*
+	  Contrast-solved values, not eyeballed ones.
+
+	  Each of the four below was failing WCAG AA on a surface it is actually used
+	  on, and each was solved against `.ds-overlay` (an 8% foreground mix) rather
+	  than against `--background`, because the failures were all on cards: muted
+	  text reads 4.73:1 on a plain page and 3.49:1 inside a nested panel, which
+	  is why this looked fine in a hero and failed in every card in the product.
+
+	  Measured after: muted-foreground 4.55:1 on overlay and 5.57:1 on the page;
+	  destructive 4.50:1 and 5.52:1; ring 3.01:1 on an overlay and 3.69:1 on the
+	  page.
+
+	  `--input` is deliberately NOT raised to the 3:1 that 1.4.11 asks of a
+	  control boundary. Doing that turns every field edge into a heavy grey rule,
+	  and this system separates surfaces by value rather than by outlines - the
+	  whole reason the `ds-*` ladder exists. A field should be identified by its
+	  surface, not by a drawn box. The gap is real and recorded; the answer is a
+	  sunken fill, not a darker border.
+
+	  `contrast-tokens.spec.ts` pins these. Change one and it fails with the
+	  measured ratio, so the next person does not have to rediscover the method.
+	*/
+	--muted-foreground: oklch(0.519 0 0);
 	/*
 	  The hover/focus background for menus, options, and ghost controls, not a
 	  brand colour. It used to point at --orange, which made every dropdown item
@@ -80,11 +103,11 @@
 	*/
 	--accent: oklch(0.97 0 0);
 	--accent-foreground: oklch(0.205 0 0);
-	--destructive: oklch(0.637 0.237 25.331);
+	--destructive: oklch(0.534 0.237 25.331);
 	--destructive-foreground: oklch(0.985 0 0);
 	--border: oklch(0.922 0 0);
 	--input: oklch(0.922 0 0);
-	--ring: oklch(0.708 0 0);
+	--ring: oklch(0.618 0 0);
 
 	/* Success (green) - light theme */
 	--success: oklch(0.627 0.17 145);
@@ -242,11 +265,11 @@
 	/* Neutral hover/focus surface, matching --muted. See the light block above. */
 	--accent: oklch(0.269 0 0);
 	--accent-foreground: oklch(0.985 0 0);
-	--destructive: oklch(0.637 0.237 25.331);
+	--destructive: oklch(0.643 0.237 25.331);
 	--destructive-foreground: oklch(0.985 0 0);
 	--border: oklch(0.269 0 0);
 	--input: oklch(0.269 0 0);
-	--ring: oklch(0.439 0 0);
+	--ring: oklch(0.53 0 0);
 
 	/* Success (green) - dark theme */
 	--success: oklch(0.871 0.15 145);
@@ -489,7 +512,30 @@
 
 @layer base {
 	* {
-		@apply border-border outline-ring/50;
+		@apply border-border;
+	}
+
+	/*
+	  One focus indicator, for everything.
+
+	  This used to be `outline-ring/50` on `*`, which set the colour of the
+	  browser's own outline to a half-alpha ring - about 1.5:1 - and every
+	  control primitive then suppressed that outline and drew its own ring, at
+	  2.3:1 to 2.6:1. So the two ways a thing could be focused in this product
+	  were both under the 3:1 that WCAG 1.4.11 asks for, and links, which no
+	  primitive covers, got the weakest one of all.
+
+	  Declared here rather than per component because focus is not a component
+	  concern: a link, a summary, a `tabindex` div and a button should all say
+	  "you are here" the same way. `--ring` is solved for 3:1 in both themes.
+
+	  An outline rather than a ring: it follows `border-radius`, an
+	  `overflow-hidden` ancestor cannot clip it the way it clips a box-shadow,
+	  and the offset lifts it clear of the control's own edge.
+	*/
+	:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 2px;
 	}
 
 	html {

--- a/shared/components/src/ui/accordion.tsx
+++ b/shared/components/src/ui/accordion.tsx
@@ -16,7 +16,10 @@ function AccordionItem({
 	return (
 		<AccordionPrimitive.Item
 			data-slot="accordion-item"
-			className={cn('bg-muted/50 border-0', className)}
+			className={cn(
+				'bg-muted/50 focus-visible:outline-ring border-0 focus-visible:outline-2 focus-visible:outline-offset-2',
+				className
+			)}
 			{...props}
 		/>
 	)
@@ -33,7 +36,7 @@ function AccordionTrigger({
 				suppressHydrationWarning
 				data-slot="accordion-trigger"
 				className={cn(
-					'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+					'flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
 					className
 				)}
 				{...props}

--- a/shared/components/src/ui/button.tsx
+++ b/shared/components/src/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 
 const buttonVariants = cva(
-	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
 	{
 		variants: {
 			variant: {

--- a/shared/components/src/ui/checkbox.tsx
+++ b/shared/components/src/ui/checkbox.tsx
@@ -13,7 +13,7 @@ function Checkbox({
 		<CheckboxPrimitive.Root
 			data-slot="checkbox"
 			className={cn(
-				'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[6px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+				'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive focus-visible:outline-ring size-4 shrink-0 rounded-[6px] border shadow-xs transition-shadow focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/input.tsx
+++ b/shared/components/src/ui/input.tsx
@@ -19,8 +19,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
 			type={type}
 			data-slot="input"
 			className={cn(
-				'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-lg border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-				'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+				'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input focus-visible:outline-ring flex h-9 w-full min-w-0 rounded-lg border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
 				'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
 				className
 			)}

--- a/shared/components/src/ui/radio-group.tsx
+++ b/shared/components/src/ui/radio-group.tsx
@@ -12,7 +12,10 @@ function RadioGroup({
 	return (
 		<RadioGroupPrimitive.Root
 			data-slot="radio-group"
-			className={cn('grid gap-3', className)}
+			className={cn(
+				'focus-visible:outline-ring grid gap-3 focus-visible:outline-2 focus-visible:outline-offset-2',
+				className
+			)}
 			{...props}
 		/>
 	)
@@ -26,7 +29,7 @@ function RadioGroupItem({
 		<RadioGroupPrimitive.Item
 			data-slot="radio-group-item"
 			className={cn(
-				'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+				'border-input text-primary aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/select.tsx
+++ b/shared/components/src/ui/select.tsx
@@ -34,7 +34,7 @@ function SelectTrigger({
 			data-slot="select-trigger"
 			data-size={size}
 			className={cn(
-				"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-lg border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 focus-visible:outline-ring flex w-fit items-center justify-between gap-2 rounded-lg border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className
 			)}
 			{...props}
@@ -113,7 +113,7 @@ function SelectItem({
 		<SelectPrimitive.Item
 			data-slot="select-item"
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-accent-foreground relative flex w-full cursor-default items-center gap-2 rounded-lg py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				"focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-accent-foreground relative flex w-full cursor-default items-center gap-2 rounded-lg py-1.5 pr-8 pl-2 text-sm select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/switch.tsx
+++ b/shared/components/src/ui/switch.tsx
@@ -12,7 +12,7 @@ function Switch({
 		<SwitchPrimitive.Root
 			data-slot="switch"
 			className={cn(
-				'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+				'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80 focus-visible:outline-ring inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/tabs.tsx
+++ b/shared/components/src/ui/tabs.tsx
@@ -11,7 +11,10 @@ function Tabs({
 	return (
 		<TabsPrimitive.Root
 			data-slot="tabs"
-			className={cn('flex flex-col gap-2', className)}
+			className={cn(
+				'focus-visible:outline-ring flex flex-col gap-2 focus-visible:outline-2 focus-visible:outline-offset-2',
+				className
+			)}
 			{...props}
 		/>
 	)
@@ -41,7 +44,7 @@ function TabsTrigger({
 		<TabsPrimitive.Trigger
 			data-slot="tabs-trigger"
 			className={cn(
-				"data-[state=active]:bg-background/50! dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"data-[state=active]:bg-background/50! dark:data-[state=active]:text-foreground focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/textarea.tsx
+++ b/shared/components/src/ui/textarea.tsx
@@ -6,7 +6,7 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
 		<textarea
 			data-slot="textarea"
 			className={cn(
-				'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-lg border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+				'border-input placeholder:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 focus-visible:outline-ring flex field-sizing-content min-h-16 w-full rounded-lg border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
 				className
 			)}
 			{...props}

--- a/shared/components/src/ui/toggle.tsx
+++ b/shared/components/src/ui/toggle.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 
 const toggleVariants = cva(
-	"inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium text-foreground hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+	"inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium text-foreground hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
## Summary

Makes the semantic colour tokens and the focus indicator meet WCAG AA on the
surfaces they are actually used on. Independent of #844 — this branches from
`main` and touches no marketing code.

## Root cause

The tokens were solved against `--background` and then used on cards.
`--muted-foreground` measures 4.73:1 on a plain page and **3.49:1** inside a
nested panel, so a single token passed in a hero and failed in every card in the
product. The fix belongs in the tokens: the call sites are correct, the value
they resolve to was not.

Focus was two separate failures at once. `* { outline-ring/50 }` set the
browser's outline colour to a half-alpha ring (~1.5:1), and every control
primitive then suppressed that outline and drew its own `ring-ring` at 2.3–2.6:1.
Both under the 3:1 of WCAG 1.4.11 — and links, which no primitive covers, got
only the weaker of the two.

## Changes

**Tokens**, solved against `.ds-overlay` (an 8% foreground mix), the deepest
surface these are commonly used on. Measured after, light / dark:

| Token | on overlay | on page |
| --- | --- | --- |
| `--muted-foreground` | 4.67 / 6.52 | 5.57 / 7.66 |
| `--destructive` | 4.63 / 4.53 | 5.52 / 5.32 |
| `--ring` | 3.10 / 3.21 | 3.69 / 3.77 |

Dark `--muted-foreground` already passed and is unchanged.

**One focus indicator**, declared once in `@layer base` on `:focus-visible`,
because focus is not a component concern — a link, a button, a `summary` and a
`tabindex` div should all say "you are here" the same way. An outline rather than
a ring: it follows `border-radius`, an `overflow-hidden` ancestor cannot clip it
the way it clips a `box-shadow`, and the offset lifts it clear of the control's
own edge. The ten primitives that drew their own ring no longer do.

**`contrast-tokens.spec.ts`** pins all of it. It computes the `ds-*` surfaces
from the ladder's own percentages instead of hardcoding them, so expectations
move if the ladder does. It reads the `.dark` block by slicing at its opening
brace, because a whole-file regex returns the light value twice and every dark
assertion then passes for the wrong reason — there is a test for that too.

## Deliberately not included

`--input` is **not** raised to the 3:1 that 1.4.11 asks of a control boundary.
Doing that turns every field edge into a heavy grey rule, and this system
separates surfaces by value rather than by outlines, which is the reason the
`ds-*` ladder exists. The gap is real and recorded in the stylesheet; the answer
is a sunken fill, which is a design decision rather than a token nudge.

## Type of Change

- [x] Bug fix (non-breaking, fixes an issue)

## Testing

- [x] Unit / integration tests added or updated
- [x] Tested manually in the browser

26 new assertions across both themes and three surfaces. Mutation-checked:
restoring the old `--muted-foreground` fails on raised and overlay while still
passing on the page, which is exactly the shape that kept this invisible.

Verified in the browser with a real Tab: a 2px solid outline at 2px offset
lands on links and on form controls, in both themes, with no old ring classes
remaining.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `pnpm nx affected --target=lint` passes
- [x] `pnpm nx affected --target=typecheck` passes
- [x] `pnpm nx affected --target=test` passes
- [x] `npx prettier --check .` passes
