### PR TITLE
fix(design-system): stop CardTitle deciding copy

### DIFF
--- a/.agents/skills/vectreal-iterative-delivery/SKILL.md
+++ b/.agents/skills/vectreal-iterative-delivery/SKILL.md
@@ -197,9 +197,25 @@ Reinstall before trusting any test result on a dependency-regression bug.
 
 ## Gates
 
+Formatting is a gate and it is the one most often missed, because nothing local
+prompts for it:
+
 ```bash
-pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform
+npx prettier --check .
 ```
+
+CI runs exactly that, repo-wide, at `.github/workflows/ci-quality.yaml`. It has
+failed a branch nine files at a time after a session of otherwise-green
+typecheck, lint and test runs - a class-string edit reorders under the Tailwind
+plugin, and nothing else notices.
+
+```bash
+pnpm nx run-many --target=typecheck,lint -p vctrl/core,vctrl/hooks,vctrl/viewer,vectreal-platform,shared/utils,shared/components
+```
+
+**Six projects, not four.** `shared/utils` and `shared/components` lint on their
+own and are missing from the obvious command; an import-order error in a spec
+under `shared/` passed a four-project run and failed CI.
 
 ```bash
 npx vitest run --root .
@@ -256,6 +272,7 @@ Executed by `apps/vectreal-platform/tests/documented-claims.spec.ts` on every
 CI run.
 
 ```claims
+present  .github/workflows/ci-quality.yaml                    prettier --check
 exists   .agents/hooks/skills-plan-gate.mjs
 present  .claude/settings.json                                  skills-plan-gate.mjs
 present  .github/workflows/ci-quality.yaml                     build-ci

--- a/shared/components/src/ui/card.tsx
+++ b/shared/components/src/ui/card.tsx
@@ -27,11 +27,26 @@ function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
 	)
 }
 
+/*
+  `text-h4`, the panel-heading rung, and nothing else.
+
+  The base used to be `text-xl font-light tracking-wide capitalize`, and all
+  four of those were doing damage. `capitalize` made a copy decision in CSS:
+  every card title in the product rendered title-cased, so "Send a message"
+  reached the reader as "Send A Message" with the article capitalised, and no
+  amount of editing the string could change it. `font-light` (300) and
+  `tracking-wide` (+0.025em) are utilities, so they beat whichever rung a caller
+  passed from `@layer components` - a title asking for `text-h3` got h3's size
+  with 300 weight and positive tracking, the opposite of that rung's spec.
+
+  `text-xl` was merely off-scale, and is the one a caller could already
+  override.
+*/
 function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
 	return (
 		<div
 			data-slot="card-title"
-			className={cn('text-xl font-light tracking-wide capitalize', className)}
+			className={cn('text-h4', className)}
 			{...props}
 		/>
 	)


### PR DESCRIPTION
## Root cause

`CardTitle`'s base classes made decisions that belong to the caller, and made
them in CSS where no caller could see or override them.

`capitalize` is the sharp one. It title-cases every card title in the product,
so copy deliberately written in sentence case reached the reader with its
articles capitalised — "Send a message" rendered as "Send A Message" — and no
amount of editing the string could change it. That is a copy decision taken in a
stylesheet.

`font-light` (300) and `tracking-wide` (+0.025em) are utilities, so they beat
whichever rung a caller passes from `@layer components`. A title asking for
`text-h3` got h3's size at 300 weight with positive tracking, which is the
opposite of that rung's spec. `text-xl` was merely off-scale, and was the one a
caller could already override.

The base is now `text-h4`, the panel-heading rung, and nothing else.

## Scope change

**This no longer touches `basic-card.tsx`.** It previously made the highlight bar
opt-in and removed the pulsing glow behind it. PR #844 removes the bar outright
and deletes the component, so this branch was editing a file that is about to
stop existing — a modify/delete conflict for whichever of the two merged second.
The unguarded `animate-pulse` that fix also addressed is removed there.

Two files remain: the `CardTitle` base, and the delivery skill's gates section.

## Evidence

- `npx prettier --check .` clean
- `nx run-many --target=typecheck,lint -p vectreal-platform,shared/components,shared/utils` — 6/6 tasks
- `npx vitest run --root .` — 176 files, 2258 tests
- Measured on `/contact`, which still renders `CardTitle` on this branch:
  `text-transform: none`, weight 500, tracking −0.24px / −0.18px at 24px and
  18px. Before: title-cased, weight 300, +0.025em.

Rebased onto `main` after #845.
