### PR TITLE
docs(design-system): show the heading face in the token story

### DIFF
--- a/shared/components/src/styles/tokens.stories.tsx
+++ b/shared/components/src/styles/tokens.stories.tsx
@@ -12,12 +12,20 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+/*
+  All eleven rungs, in scale order. The list used to hold seven, so the two body
+  rungs, `.text-h4` and `.text-stat` could drift with nothing rendering them.
+*/
 const TYPE = [
+	['text-stat', 'Stat'],
 	['text-display', 'Display'],
 	['text-headline', 'Headline'],
 	['text-h2', 'Heading 2'],
 	['text-h3', 'Heading 3'],
+	['text-h4', 'Heading 4'],
 	['text-body-lg', 'Body large'],
+	['text-body', 'Body'],
+	['text-body-sm', 'Body small'],
 	['text-label-xs', 'Label xs'],
 	['text-eyebrow', 'Eyebrow']
 ] as const
@@ -31,6 +39,42 @@ export const Typography: Story = {
 						.{cls}
 					</p>
 					<p className={cls}>{label}</p>
+				</div>
+			))}
+		</div>
+	)
+}
+
+const FACE_RUNGS = [
+	'text-display',
+	'text-headline',
+	'text-h2',
+	'text-h3'
+] as const
+
+/**
+ * The display face is opt-in, and this is the only place you can see it.
+ *
+ * `--font-heading` is Funnel Display, and it is deliberately *not* baked into
+ * the rungs: `.text-display` and `.text-headline` are worn by dashboard and
+ * publisher headings too - `publisher/shell/drop-zone.tsx` uses `text-headline`
+ * - and putting a family on the rung would change all of them. Marketing
+ * components write `font-heading` beside the rung instead.
+ *
+ * So a rung on its own renders DM Sans, which is correct and looks like a bug
+ * if you have only ever seen the marketing pages. Both halves are here so the
+ * difference is visible rather than surprising.
+ */
+export const HeadingFace: Story = {
+	render: () => (
+		<div className="space-y-6">
+			{FACE_RUNGS.map((cls) => (
+				<div key={cls} className="space-y-1">
+					<p className="text-muted-foreground text-label-xs font-mono">
+						.{cls}
+					</p>
+					<p className={cls}>Body face, no opt-in</p>
+					<p className={`${cls} font-heading`}>Heading face, font-heading</p>
 				</div>
 			))}
 		</div>


### PR DESCRIPTION
## Root cause

The display face is opt-in, and nothing in Storybook opted in — so every heading
there rendered in DM Sans and read as a bug in the type scale rather than as the
rule working.

Storybook loads the same `shared/components/src/styles/globals.css` as the app
(`storybook/.storybook/preview.tsx:8`), and Funnel Display is loaded there. What
was missing was a caller: `font-heading` appeared in **no story in the repo**.

`--font-heading` is deliberately not baked into the rungs. `.text-display` and
`.text-headline` are worn by dashboard and publisher headings too — the publisher
drop zone uses `text-headline` — so putting a family on the rung would change all
of them. Marketing components write `font-heading` beside the rung instead. That
decision is recorded in the typography reference and was invisible in the one
place someone goes to look at type.

## What this does

- Adds a **`HeadingFace`** story rendering four rungs twice, with and without the
  utility, so the difference is visible rather than something you have to be
  told.
- Completes the **`Typography`** story. It listed 7 of the 11 rungs;
  `.text-body`, `.text-body-sm`, `.text-h4` and `.text-stat` had nothing
  rendering them. That is how a rung drifts unnoticed — the docblock above that
  story says exactly that about two tokens which once shipped with no utility
  class at all.

## Evidence

Measured in a running Storybook, not asserted:

- `font-heading` resolves to `"Funnel Display Variable", sans-serif` at all four
  rungs (44px, 32px, 28px, 21.6px).
- The bare rung resolves to `"DM Sans Variable", sans-serif` at the same sizes.
- `document.fonts` reports `Funnel Display Variable: loaded`.

Gates: `prettier --check .` clean; `nx run-many --target=typecheck,lint -p
vectreal-platform,shared/components,shared/utils` 6/6 tasks; `vitest run --root
.` 176 files, 2333 tests.

## Note for review

This adds a story, so Chromatic will want a new baseline accepted.
